### PR TITLE
Create INSTALL_mac.md

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -1,35 +1,11 @@
-Jacktrip : Build Instructions for Linux and MacOS X
+Jacktrip : Build Instructions for Linux and Windows
 
 JackTrip: A System for High-Quality Audio Network Performance over the Internet.
 
----
-MacOS X (10.9 or higher) installation:
-
-If you are installing on MacOS X, a binary is provided with each release (download the latest release from https://github.com/jacktrip/jacktrip/releases before proceeding).
-You need to have a working jack installation on your machine (see below).
-
-To install (using Terminal):
-
-$ git clone https://github.com/jacktrip/jacktrip.git
-$ cd jacktrip/src
-$ sudo cp jacktrip /usr/local/bin/
-  (enter your password when prompted)
-
-$ sudo chmod 755 /usr/local/bin/jacktrip
-  (now you can run jacktrip from any directory using Terminal)
-
-
-
-To build using QtCreator (tested using QtCreator 4.11 and macOS 10.13.6):
-
-  * Open jacktrip.pro using QtCreator
-  * Choose a correctly configured Kit
-  * Install Jack:
-    brew install jack
-    brew install qjackctl
-
+Note: For macOS 10.9 or higher, see the file INSTALL_mac.md
 
 ---
+
 Fedora installation (also tested on Ubuntu Studio):
 
 To install on Fedora (and possibly other Linux distributions), you need qt5, jack-audio-connection-kit-devel, and rtaudio.
@@ -85,7 +61,7 @@ It is also possible to build without jack, see below.
 ---
 Build:
 
-If you're on Mac OS X or Fedora Linux and have all the dependencies installed,
+If you're on Fedora Linux and have all the dependencies installed,
 you can build by simply going to the /src directory and typing the following:
     ./build
 
@@ -101,15 +77,6 @@ $ make release
 Or without Jack support:
 $ qmake -config nojack jacktrip.pro
 $ make release
-
-
-If you want to install (using Terminal): on the /src directory type:
-
-$ sudo cp jacktrip /usr/local/bin/
-  (enter your password when prompted)
-
-$ sudo chmod 755 /usr/local/bin/jacktrip
-  (now you can run jacktrip from any directory using Terminal)
 
 
 ---

--- a/INSTALL_mac.md
+++ b/INSTALL_mac.md
@@ -6,19 +6,19 @@ JackTrip: A System for High-Quality Audio Network Performance over the Internet
 
 ### Step 1: Install JACK
 
-Running JackTrip requires that you also install JACK for macOS. Select the JACK2 OSX binary (0.92_b3) at <https://jackaudio.org/downloads/>. Run the installer, which will install Jack (in System directories) and will also create a directory in Applications which will contain the apps JackPilot and Qjackctl.
+Download and install the JACK2 OSX binary (0.92_b3) at <https://jackaudio.org/downloads/>. In addition to installing Jack in System directories, the installer will create a directory in Applications with the apps JackPilot and Qjackctl.
 
 ### Step 2: Install JackTrip
 
-If you are installing on macOS, a binary is provided with each release. Download the latest release (i.e. "jacktrip-1.1-osx.zip") and double click to unzip. The resulting folder "jacktrip" can be used from any directory, but for the instructions below it is assumed that you will place it in /Applications.
+A binary for macOS is provided with each release. For the instructions below it is assumed that you will place the folder "jacktrip" in /Applications.
 
 ### Step 3: Set permissions on JackTrip binary
 
-In Terminal, change directory to /jacktrip/bin/, i.e. enter
+In Terminal, change directory to /jacktrip/bin/ as follows:
 
 cd /Applications/jacktrip/bin/
 
-Set the permissions for the jacktrip binary located there:
+Set the permissions for the jacktrip binary there:
 
 sudo chmod 755 jacktrip
 
@@ -28,9 +28,13 @@ Enter your password when requested (it will not display). You can now use JackTr
 
 ### Running from /jacktrip/bin
 
-Earlier versions of JackTrip installation instructions for macOS included a sudo command to copy the jacktrip binary to a default location in System files so that users could run JackTrip from a Terminal window from any location. Recent changes to macOS, including System Integrity Protection since 10.11 and the use of a read-only partition for system files starting on 10.15, have made this much more difficult. A simpler solution is to use JackTrip from the directory where the binary is located, i.e.  prior to entering any JackTrip command, move to that directory by entering the command
+Earlier versions of JackTrip installation instructions for macOS included a sudo command to copy the jacktrip binary to a default location in System files so that users could run JackTrip from a Terminal window from any location. Recent changes to macOS have made this step very difficult. A solution is to use JackTrip from the directory where the binary is located. Prior to entering any JackTrip command, move to that directory by entering the command
 
 cd /Applications/jacktrip/bin/
+
+To run the local build of JackTrip from this directory, place ./ in front of the command, i.e.
+
+./jacktrip -s
 
 ### Viewing the help page
 
@@ -40,23 +44,20 @@ jacktrip -h
 
 ### Starting JACK
 
-On macOS 10.14 and earlier, the app JackPilot (installed with JACK) can be used to set Jack preferences (input/output device, sample rate, buffer size, etc.) and to start the Jack audio server, after which JackTrip can be used to establish connections.
+On macOS 10.14 and earlier, the app JackPilot (installed with JACK) can be used to set Jack preferences (input/output device, sample rate, buffer size, etc.) and to start the Jack audio server.
 
-Beginning with macOS 10.15, JackPilot no longer works. Users must instead start Jack using Qjackctl. Open the "setup" window of Qjackctl and select the sample rate, buffer size ("frames/period") and interface. Under "server path," enter the following path:
+Beginning with macOS 10.15, JackPilot no longer works. Users must instead start Jack using Qjackctl. Open the "setup" window of Qjackctl and select the sample rate, buffer size ("frames/period") and interface. Under "server path," enter one of the following paths, then click OK to save the settings then click "Start" in the main window. 
 
-/usr/local/bin/jackdmp
-
-Click OK to save these settings, and in the main window, click Start. If you receive an error message, quit and restart Qjackctl, return to the setup window, and under "server path," enter the following path instead:
-
+/usr/local/bin/jackdmp   
 /usr/local/bin/jackd
 
-Most 10.15 Catalina users report that one of these two server paths enables Qjackctl to start Jack audio server, after which JackTrip can be used to establish connections.
+10.15 Catalina users report that one of these two server paths enables Qjackctl to start the Jack server, after which JackTrip can be used to establish connections.
 
 Further instructions for JackTrip usage: <http://ccrma.stanford.edu/groups/soundwire/software/jacktrip/>
 
 ### JackRouter on macOS
 
-On macOS 10.14 and earlier, enabling "virtual input/output channels" in the JackPilot preferences establishes JackRouter, a virtual audio device that is available to any audio application that allows for selecting core audio devices (i.e. DAWs), and that has been launched after the Jack server was started. If the DAW was launched prior to Jack audio server being started, or if the DAW is launched and attempts to change to a previously saved sample rate, this will crash Jack; simply set the sample rate in the DAW software to match Jack and restart both apps in the correct order (JackPilot first). DAWs using JackRouter will appear in the QJackctl "connections" window with the number of inputs/outputs corresponding to the numbers set under virtual inputs/outputs in the JackRouter preferences, enabling multi-track recording of a JackTrip session, for example.
+On macOS 10.14 and earlier, enabling "virtual input/output channels" in the JackPilot preferences establishes JackRouter, a virtual audio device that is available to any audio application that allows for selecting core audio devices (i.e. DAWs), and that has been launched after the Jack server was started. If the DAW was launched prior to Jack audio server being started, or if the DAW is launched and attempts to change to a previously saved sample rate, this will crash Jack; simply set the sample rate in the DAW software to match Jack and restart both apps in the correct order (Jack first). DAWs using JackRouter will appear in the QJackctl "connections" window with the number of inputs/outputs corresponding to the numbers set under virtual inputs/outputs in the JackRouter preferences, enabling multi-track recording of a JackTrip session, for example.
 
 Beginning with macOS 10.15, JackRouter no longer works.
 
@@ -66,7 +67,7 @@ macOS users who wish to build JackTrip can do so via one of the following method
 
 ### To build using QtCreator
 
-(Tested using QtCreator 4.11 and macOS 10.13.6) Open jacktrip.pro using QtCreator, and compile with a correctly configured Kit, then build. To run jacktrip from within the build directory, use the command ./jacktrip
+(Tested using QtCreator 4.11 and macOS 10.13.6) Open jacktrip.pro using QtCreator, and compile with a correctly configured Kit, then build.
 
 ### To build in Terminal
 

--- a/INSTALL_mac.md
+++ b/INSTALL_mac.md
@@ -22,7 +22,7 @@ Set the permissions for the jacktrip binary there:
 
 sudo chmod 755 jacktrip
 
-Enter your password when requested (it will not display). You can now use JackTrip from the /jacktrip/bin directory. 
+Enter your password when requested (it will not display). You can now use JackTrip from the /Applications/jacktrip/bin directory. 
 
 ## Usage notes
 

--- a/INSTALL_mac.md
+++ b/INSTALL_mac.md
@@ -1,0 +1,77 @@
+# Instructions for macOS (10.9 or higher)
+
+JackTrip: A System for High-Quality Audio Network Performance over the Internet
+
+## Installation
+
+### Step 1: Install JACK
+
+Running JackTrip requires that you also install JACK for macOS. Select the JACK2 OSX binary (0.92_b3) at <https://jackaudio.org/downloads/>. Run the installer, which will install Jack (in System directories) and will also create a directory in Applications which will contain the apps JackPilot and Qjackctl.
+
+### Step 2: Install JackTrip
+
+If you are installing on macOS, a binary is provided with each release. Download the latest release (i.e. "jacktrip-1.1-osx.zip") and double click to unzip. The resulting folder "jacktrip" can be used from any directory, but for the instructions below it is assumed that you will place it in /Applications.
+
+### Step 3: Set permissions on JackTrip binary
+
+In Terminal, change directory to /jacktrip/bin/, i.e. enter
+
+cd /Applications/jacktrip/bin/
+
+Set the permissions for the jacktrip binary located there:
+
+sudo chmod 755 jacktrip
+
+Enter your password when requested (it will not display). You can now use JackTrip from the /jacktrip/bin directory. 
+
+## Usage notes
+
+### Running from /jacktrip/bin
+
+Earlier versions of JackTrip installation instructions for macOS included a sudo command to copy the jacktrip binary to a default location in System files so that users could run JackTrip from a Terminal window from any location. Recent changes to macOS, including System Integrity Protection since 10.11 and the use of a read-only partition for system files starting on 10.15, have made this much more difficult. A simpler solution is to use JackTrip from the directory where the binary is located, i.e.  prior to entering any JackTrip command, move to that directory by entering the command
+
+cd /Applications/jacktrip/bin/
+
+### Viewing the help page
+
+To view a help page listing all required and optional arguments, enter
+
+jacktrip -h
+
+### Starting JACK
+
+On macOS 10.14 and earlier, the app JackPilot (installed with JACK) can be used to set Jack preferences (input/output device, sample rate, buffer size, etc.) and to start the Jack audio server, after which JackTrip can be used to establish connections.
+
+Beginning with macOS 10.15, JackPilot no longer works. Users must instead start Jack using Qjackctl. Open the "setup" window of Qjackctl and select the sample rate, buffer size ("frames/period") and interface. Under "server path," enter the following path:
+
+/usr/local/bin/jackdmp
+
+Click OK to save these settings, and in the main window, click Start. If you receive an error message, quit and restart Qjackctl, return to the setup window, and under "server path," enter the following path instead:
+
+/usr/local/bin/jackd
+
+Most 10.15 Catalina users report that one of these two server paths enables Qjackctl to start Jack audio server, after which JackTrip can be used to establish connections.
+
+Further instructions for JackTrip usage: <http://ccrma.stanford.edu/groups/soundwire/software/jacktrip/>
+
+### JackRouter on macOS
+
+On macOS 10.14 and earlier, enabling "virtual input/output channels" in the JackPilot preferences establishes JackRouter, a virtual audio device that is available to any audio application that allows for selecting core audio devices (i.e. DAWs), and that has been launched after the Jack server was started. If the DAW was launched prior to Jack audio server being started, or if the DAW is launched and attempts to change to a previously saved sample rate, this will crash Jack; simply set the sample rate in the DAW software to match Jack and restart both apps in the correct order (JackPilot first). DAWs using JackRouter will appear in the QJackctl "connections" window with the number of inputs/outputs corresponding to the numbers set under virtual inputs/outputs in the JackRouter preferences, enabling multi-track recording of a JackTrip session, for example.
+
+Beginning with macOS 10.15, JackRouter no longer works.
+
+## Building on macOS
+
+macOS users who wish to build JackTrip can do so via one of the following methods (note that JACK must also be installed):
+
+### To build using QtCreator
+
+(Tested using QtCreator 4.11 and macOS 10.13.6) Open jacktrip.pro using QtCreator, and compile with a correctly configured Kit, then build. To run jacktrip from within the build directory, use the command ./jacktrip
+
+### To build in Terminal
+
+This option requires that Qt 5.3 or higher be installed. In the /src directory, enter
+
+./build
+
+


### PR DESCRIPTION
I'm not sure sure if you all ultimately want separate install.md files for each platform, but that was suggested in the issue #60 , so I created one for macOS here. This text could work for the current version as well as the upcoming 1.2. It adds explanations for some install/usage details on macOS that are now necessary for using JackTrip given OS changes in recent years. I've been helping a lot of people get jacktrip working on Macs and these added details are all the things I have to explain to them, so I hope this is helpful somehow.

Sorry if I'm making any errors in how I'm doing this PR, I'm new to all this. Thanks!