### PR TITLE
Add optional IO statistics reporting

### DIFF
--- a/src/DataProtocol.h
+++ b/src/DataProtocol.h
@@ -171,6 +171,15 @@ public:
     virtual void setSocket(int &socket) = 0;
 #endif
 
+    struct PktStat {
+        uint32_t tot;
+        uint32_t lost;
+        uint32_t outOfOrder;
+        uint32_t revived;
+        uint32_t statCount;
+    };
+    virtual bool getStats(PktStat*) {return false;}
+
 signals:
 
     void signalError(const char* error_message);

--- a/src/JackTrip.h
+++ b/src/JackTrip.h
@@ -392,6 +392,8 @@ public:
     void printTextTest() {std::cout << "=== JackTrip PRINT ===" << std::endl;}
     void printTextTest2() {std::cout << "=== JackTrip PRINT2 ===" << std::endl;}
 
+    void startIOStatTimer(int timeout_sec, const std::ostream& log_stream);
+
 public slots:
     /// \brief Slot to stop all the processes and threads
     virtual void slotStopProcesses()
@@ -418,6 +420,7 @@ public slots:
     { std::cout << "=== TESTING ===" << std::endl; }
     void slotReceivedConnectionFromPeer()
     { mReceivedConnection = true; }
+    void onStatTimer();
 
 
 signals:
@@ -509,6 +512,7 @@ private:
     volatile bool mStopped;
 
     bool mConnectDefaultAudioPorts; ///< Connect or not default audio ports
+    std::ostream mIOStatLogStream;
 };
 
 #endif

--- a/src/JackTripWorker.cpp
+++ b/src/JackTripWorker.cpp
@@ -47,6 +47,7 @@
 #include "UdpMasterListener.h"
 #include "NetKS.h"
 #include "LoopBack.h"
+#include "Settings.h"
 #ifdef WAIR // wair
 #include "dcblock2gain.dsp.h"
 #endif // endwhere
@@ -127,6 +128,7 @@ void JackTripWorker::run()
         // Create and setup JackTrip Object
         //JackTrip jacktrip(JackTrip::SERVER, JackTrip::UDP, mNumChans, 2);
         if (gVerboseFlag) cout << "---> JackTripWorker: Creating jacktrip objects..." << endl;
+        Settings* settings = mUdpMasterListener->getSettings();
 
 #ifdef WAIR // WAIR
         // forces    BufferQueueLength to 2
@@ -220,6 +222,9 @@ void JackTripWorker::run()
                     mID
             #endif // endwhere
                     );
+        if (0 != settings->getIOStatTimeout()) {
+            jacktrip.startIOStatTimer(settings->getIOStatTimeout(), settings->getIOStatStream());
+        }
         // if (gVerboseFlag) cout << "---> JackTripWorker: start..." << endl;
         // jacktrip.start(); // ########### JamTest Only #################
 

--- a/src/RingBuffer.cpp
+++ b/src/RingBuffer.cpp
@@ -86,6 +86,8 @@ RingBuffer::RingBuffer(int SlotSize, int NumSlots) :
     mWritePosition = ( (NumSlots/2) * SlotSize ) % mTotalSize;
     // Udpate Full Slots accordingly
     mFullSlots = (NumSlots/2);
+    mUnderruns = 0;
+    mOverflows = 0;
 }
 
 
@@ -226,6 +228,7 @@ void RingBuffer::underrunReset()
     //mFullSlots += mNumSlots/2;
     // There's nothing new to read, so we clear the whole buffer (Set the entire buffer to 0)
     std::memset(mRingBuffer, 0, mTotalSize);
+    ++mUnderruns;
 }
 
 
@@ -237,6 +240,7 @@ void RingBuffer::overflowReset()
     //mReadPosition = ( mWritePosition + ( (mNumSlots/2) * mSlotSize ) ) % mTotalSize;
     mReadPosition = ( mReadPosition + ( (mNumSlots/2) * mSlotSize ) ) % mTotalSize;
     mFullSlots -= mNumSlots/2;
+    mOverflows += mNumSlots/2 + 1;
 }
 
 
@@ -247,4 +251,16 @@ void RingBuffer::debugDump() const
     cout << "mReadPosition = " << mReadPosition << endl;
     cout << "mWritePosition = " << mWritePosition << endl;
     cout <<  "mFullSlots = " << mFullSlots << endl;
+}
+
+//*******************************************************************************
+bool RingBuffer::getStats(RingBuffer::IOStat* stat, bool reset)
+{
+    if (reset) {
+        mUnderruns = 0;
+        mOverflows = 0;
+    }
+    stat->underruns = mUnderruns;
+    stat->overflows = mOverflows;
+    return true;
 }

--- a/src/RingBuffer.h
+++ b/src/RingBuffer.h
@@ -100,6 +100,11 @@ public:
    */
     void readSlotNonBlocking(int8_t* ptrToReadSlot);
 
+    struct IOStat {
+        uint32_t underruns;
+        uint32_t overflows;
+    };
+    virtual bool getStats(IOStat* stat, bool reset);
 
 protected:
 
@@ -139,6 +144,8 @@ private:
     QMutex mMutex; ///< Mutex to protect read and write operations
     QWaitCondition mBufferIsNotFull; ///< Buffer not full condition to monitor threads
     QWaitCondition mBufferIsNotEmpty; ///< Buffer not empty condition to monitor threads
+    std::atomic<uint32_t> mUnderruns;
+    std::atomic<uint32_t> mOverflows;
 };
 
 #endif

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -40,6 +40,7 @@
 #define __SETTINGS_H__
 
 #include <cstdlib>
+#include <fstream>
 
 #include "DataProtocol.h"
 
@@ -69,6 +70,11 @@ public:
     void printUsage();
 
     bool getLoopBack() { return mLoopBack; }
+    int getIOStatTimeout() const {return mIOStatTimeout;}
+    const std::ostream& getIOStatStream() const
+    {
+        return mIOStatStream.is_open() ? (std::ostream&)mIOStatStream : std::cout;
+    }
 
 
 public slots:
@@ -113,6 +119,8 @@ private:
     unsigned int mAudioBufferSize;
     unsigned int mHubConnectionMode;
     bool mConnectDefaultAudioPorts; ///< Connect or not jack audio ports
+    int mIOStatTimeout;
+    std::ofstream mIOStatStream;
 };
 
 #endif

--- a/src/UdpDataProtocol.h
+++ b/src/UdpDataProtocol.h
@@ -142,6 +142,7 @@ public:
    */
     virtual void run();
 
+    virtual bool getStats(PktStat* stat);
 
 private slots:
     void printUdpWaitedTooLong(int wait_msec);
@@ -214,6 +215,12 @@ private:
 
     unsigned int mUdpRedundancyFactor; ///< Factor of redundancy
     static QMutex sUdpMutex; ///< Mutex to make thread safe the binding process
+
+    std::atomic<uint32_t>  mTotCount;
+    std::atomic<uint32_t>  mLostCount;
+    std::atomic<uint32_t>  mOutOfOrderCount;
+    std::atomic<uint32_t>  mRevivedCount;
+    uint32_t  mStatCount;
 };
 
 #endif // __UDPDATAPROTOCOL_H__

--- a/src/UdpMasterListener.h
+++ b/src/UdpMasterListener.h
@@ -53,6 +53,7 @@
 #include "jacktrip_types.h"
 #include "jacktrip_globals.h"
 class JackTripWorker; // forward declaration
+class Settings;
 
 typedef struct {
     QString address;
@@ -82,6 +83,9 @@ public:
     int releaseThread(int id);
 
     void setConnectDefaultAudioPorts(bool connectDefaultAudioPorts) { m_connectDefaultAudioPorts = connectDefaultAudioPorts; }
+
+    void setSettings(Settings* s) {m_settings = s;}
+    Settings* getSettings() const {return m_settings;}
 
 private slots:
     void testReceive()
@@ -141,6 +145,7 @@ private:
     int mBufferQueueLength;
 
     bool m_connectDefaultAudioPorts;
+    Settings* m_settings;
 
 #ifdef WAIR // wair
     bool mWAIR;


### PR DESCRIPTION
Reporting can be turn on with `--iostat` option. It prints collected counters regularly with a specified time interval in stdout or in a separate file (with `--iostatlog`), a record per line. The format is

2020-06-07T22:37:53 172.16.101.115 send: 0/0 recv: 152/3 prot: 153/0/4 tot: 7507 skew: 0

It shows
- send ring buffer underruns / overflows
- recv ring buffer underruns / overflows
- udp packets counters: lost / out-of-order / restored-from-redundant-packets
- total packet counter
- cumulative clock skew estimation (in packets) calculated as recv_underruns - recv_overflows - (lost - restored).
To detect the skew reliably the log should be long enough (at least 30 minutes).

Each UDP protocol instance is reported independently (labeled with the corresponding IP address).