### PR TITLE
Meson build support

### DIFF
--- a/INSTALL_meson.md
+++ b/INSTALL_meson.md
@@ -1,0 +1,23 @@
+# Build and Installation Instructions with Meson
+
+## Install Dependencies
+
+Fedora:
+dnf install meson qt5-qtbase-devel rtaudio-devel jack-audio-connection-kit-devel
+
+Debian/Ubuntu:
+apt install meson build-essential qtbase5-dev librtaudio-dev libjack-jackd2-dev
+
+MacOS with brew (not tested):
+brew install meson qt rt-audio jack
+
+## Build
+
+Prepare your build directory (by default debug and nonoptimized):
+meson builddir
+
+Now build with:
+ninja -C builddir
+
+Install with:
+ninja -C builddir install

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('jacktrip', 'cpp')
+project('jacktrip', 'cpp', version: '1.2')
 qt5 = import('qt5')
 qt5_dep = dependency('qt5', modules: ['Core', 'Network'])
 jack_dep = dependency('jack')
@@ -42,4 +42,4 @@ src = ['src/DataProtocol.cpp',
 	'src/AudioInterface.cpp',
 	'src/JackAudioInterface.cpp']
 
-executable('jacktrip', src, moc_files, dependencies: [qt5_dep, jack_dep, rtaudio_dep], cpp_args: defines )
+executable('jacktrip', src, moc_files, dependencies: [qt5_dep, jack_dep, rtaudio_dep], cpp_args: defines, install: true )

--- a/meson.build
+++ b/meson.build
@@ -21,7 +21,6 @@ moc_h = ['src/DataProtocol.h',
 	'src/NetKS.h',
 	'src/PacketHeader.h',
 	'src/Settings.h',
-	'src/ThreadPoolTest.h',
 	'src/UdpDataProtocol.h',
 	'src/UdpMasterListener.h']
 moc_files = qt5.preprocess(moc_headers : moc_h)

--- a/meson.build
+++ b/meson.build
@@ -3,6 +3,7 @@ qt5 = import('qt5')
 qt5_dep = dependency('qt5', modules: ['Core', 'Network'])
 jack_dep = dependency('jack')
 rtaudio_dep = dependency('rtaudio')
+thread_dep = dependency('threads')
 
 defines = []
 if host_machine.system() == 'linux'
@@ -42,4 +43,4 @@ src = ['src/DataProtocol.cpp',
 	'src/AudioInterface.cpp',
 	'src/JackAudioInterface.cpp']
 
-executable('jacktrip', src, moc_files, dependencies: [qt5_dep, jack_dep, rtaudio_dep], cpp_args: defines, install: true )
+executable('jacktrip', src, moc_files, dependencies: [qt5_dep, jack_dep, rtaudio_dep, thread_dep], cpp_args: defines, install: true )

--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,7 @@ defines = []
 if host_machine.system() == 'linux'
 	defines += '-D__LINUX__'
 elif host_machine.system() == 'osx'
-	defines += '-D__MAC_OS_X__'
+	defines += '-D__MAC_OSX__'
 elif host_machine.system() == 'windows'
 	defines += '-D__WIN_32__'
 endif

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,45 @@
+project('jacktrip', 'cpp')
+qt5 = import('qt5')
+qt5_dep = dependency('qt5', modules: ['Core', 'Network'])
+jack_dep = dependency('jack')
+rtaudio_dep = dependency('rtaudio')
+
+defines = []
+if host_machine.system() == 'linux'
+	defines += '-D__LINUX__'
+elif host_machine.system() == 'osx'
+	defines += '-D__MAC_OS_X__'
+elif host_machine.system() == 'windows'
+	defines += '-D__WIN_32__'
+endif
+
+moc_h = ['src/DataProtocol.h',
+	'src/JackTrip.h',
+	'src/JackTripWorker.h',
+	'src/JackTripWorkerMessages.h',
+	'src/NetKS.h',
+	'src/PacketHeader.h',
+	'src/Settings.h',
+	'src/ThreadPoolTest.h',
+	'src/UdpDataProtocol.h',
+	'src/UdpMasterListener.h']
+moc_files = qt5.preprocess(moc_headers : moc_h)
+
+src = ['src/DataProtocol.cpp',
+	'src/JMess.cpp',
+	'src/JackTrip.cpp',
+	'src/jacktrip_globals.cpp',
+	'src/jacktrip_main.cpp',
+	'src/JackTripThread.cpp',
+	'src/JackTripWorker.cpp',
+	'src/LoopBack.cpp',
+	'src/PacketHeader.cpp',
+	'src/ProcessPlugin.cpp',
+	'src/RingBuffer.cpp',
+	'src/Settings.cpp',
+	'src/UdpDataProtocol.cpp',
+	'src/UdpMasterListener.cpp',
+	'src/AudioInterface.cpp',
+	'src/JackAudioInterface.cpp']
+
+executable('jacktrip', src, moc_files, dependencies: [qt5_dep, jack_dep, rtaudio_dep], cpp_args: defines )


### PR DESCRIPTION
This adds meson as alternative to building jacktrip with qmake. It's tested with Fedora Linux. Other Linux distributions should just work. I would be very interested in the experience under Windows and MacOS.
Meson should be installed by default with recent Linux distributions. For Windows and Mac you can look [here](https://mesonbuild.com/Getting-meson.html).

Following commands build jacktrip (debug and unoptimized by default):
cd jacktrip
meson builddir
ninja -C builddir

To install in default location (e.g. /usr/local/bin):
ninja -C builddir install
