### PR TITLE
Add option to disable hub server autopatch

### DIFF
--- a/src/JackTrip.h
+++ b/src/JackTrip.h
@@ -111,7 +111,8 @@ public:
         CLIENTECHO,  ///< Client Echo (client self-to-self)
         CLIENTFOFI,  ///< Client Fan Out to Clients and Fan In from Clients (but not self-to-self)
         RESERVEDMATRIX,  ///< Reserved for custom patch matrix (for TUB ensemble)
-        FULLMIX  ///< Client Fan Out to Clients and Fan In from Clients (including self-to-self)
+        FULLMIX,  ///< Client Fan Out to Clients and Fan In from Clients (including self-to-self)
+        NONE  ///< Do not disconnect/connect any Clients
     };
     //---------------------------------------------------------
 

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -313,6 +313,8 @@ void Settings::parseInput(int argc, char** argv)
                 mHubConnectionMode = JackTrip::RESERVEDMATRIX; }
             else if ( atoi(optarg) == 4 ) {
                 mHubConnectionMode = JackTrip::FULLMIX; }
+            else if ( atoi(optarg) == 5 ) {
+                mHubConnectionMode = JackTrip::NONE; }
             else {
                 std::cerr << "-p ERROR: Wrong HubConnectionMode: "
                           << atoi(optarg) << " is not supported." << endl;
@@ -402,7 +404,7 @@ void Settings::printUsage()
     cout << " --bindport        #                      Set only the bind port number (default: 4464)" << endl;
     cout << " --peerport        #                      Set only the Peer port number (default: 4464)" << endl;
     cout << " -b, --bitres      # (8, 16, 24, 32)      Audio Bit Rate Resolutions (default: 16)" << endl;
-    cout << " -p, --hubpatch    # (0, 1, 2, 3, 4)      Hub auto audio patch, only has effect if running HUB SERVER mode, 0=server-to-clients, 1=client loopback, 2=client fan out/in but not loopback, 3=reserved for TUB, 4=full mix (default: 0)" << endl;
+    cout << " -p, --hubpatch    # (0, 1, 2, 3, 4, 5)      Hub auto audio patch, only has effect if running HUB SERVER mode, 0=server-to-clients, 1=client loopback, 2=client fan out/in but not loopback, 3=reserved for TUB, 4=full mix, 5=disable auto-patch (default: 0)" << endl;
     cout << " -z, --zerounderrun                       Set buffer to zeros when underrun occurs (default: wavetable)" << endl;
     cout << " -l, --loopback                           Run in Loop-Back Mode" << endl;
     cout << " -j, --jamlink                            Run in JamLink Mode (Connect to a JamLink Box)" << endl;

--- a/src/UdpMasterListener.cpp
+++ b/src/UdpMasterListener.cpp
@@ -457,7 +457,10 @@ void UdpMasterListener::enumerateRunningThreadIDs()
 #include "JMess.h"
 void UdpMasterListener::connectPatch(bool spawn)
 {
-    cout << ((spawn)?"spawning":"releasing") << " jacktripWorker so change patch" << endl;
+    if (getHubPatch() == JackTrip::NONE)
+      cout << "Hub server auto patch disabled" << endl;
+    else
+      cout << ((spawn)?"spawning":"releasing") << " jacktripWorker so change patch" << endl;
     JMess tmp;
     // default is patch 0, which connects server audio to all clients
     // these are the other cases:


### PR DESCRIPTION
* this is so that we can manage patches ourselves in our own simple scripts, without having to interact with the C++ server
* disadvantage is that when a client disconnects, its input is left dangling, leading to noise
* ideally the hub server would have a mechanism to notify external scripts that the client connection status has changed