### PR TITLE
reverted a change to UdpDataProtocol.cpp, jacktrip used to give a cle…

### DIFF
--- a/src/UdpDataProtocol.cpp
+++ b/src/UdpDataProtocol.cpp
@@ -576,9 +576,6 @@ void UdpDataProtocol::run()
         break; }
 
     case SENDER : {
-        //Make sure we don't start sending packets too soon.
-        QThread::msleep(100);
-        //-----------------------------------------------------------------------------------
         while ( !mStopped )
         {
             // OLD CODE WITHOUT REDUNDANCY -----------------------------------------------------


### PR DESCRIPTION
…ar error message when a client connection attempt fails due to a mismatch between the client's buffer size in jack and the setting on the server side.  This message is now missing--the connection attempt fails silently.