### PR TITLE
Honour custom client names

### DIFF
--- a/src/DataProtocol.h
+++ b/src/DataProtocol.h
@@ -184,7 +184,7 @@ signals:
 
     void signalError(const char* error_message);
     void signalReceivedConnectionFromPeer();
-
+    void signalCeaseTransmission();
 
 protected:
 

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -106,7 +106,7 @@ JackTrip::JackTrip(jacktripModeT JacktripMode,
     mReceiverPeerPort(receiver_peer_port),
     mTcpServerPort(4464),
     mRedundancy(redundancy),
-    mJackClientName("JackTrip"),
+    mJackClientName(gJackDefaultClientName),
     mConnectionMode(JackTrip::NORMAL),
     mReceivedConnection(false),
     mTcpConnectionError(false),
@@ -160,7 +160,7 @@ void JackTrip::setupAudio(
         qDebug() << "mPeerAddress" << mPeerAddress << mPeerAddress.contains(gDOMAIN_TRIPLE);
         QString VARIABLE_AUDIO_NAME = WAIR_AUDIO_NAME; // legacy for WAIR
         //Set our Jack client name if we're a hub server or a custom name hasn't been set
-	if(mPeerAddress.toStdString()!="" && (mJackClientName == "JackTrip" || mJackTripMode == SERVERPINGSERVER)) {
+	if(mPeerAddress.toStdString()!="" && (mJackClientName == gJackDefaultClientName || mJackTripMode == SERVERPINGSERVER)) {
             mJackClientName = QString(mPeerAddress).replace(":", ".").toLatin1().constData();
         }
         std::cout  << "WAIR ID " << ID << " jacktrip client name set to=" <<

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -159,9 +159,10 @@ void JackTrip::setupAudio(
 #ifdef WAIRTOMASTER // WAIR
         qDebug() << "mPeerAddress" << mPeerAddress << mPeerAddress.contains(gDOMAIN_TRIPLE);
         QString VARIABLE_AUDIO_NAME = WAIR_AUDIO_NAME; // legacy for WAIR
-        QByteArray tmp = QString(mPeerAddress).replace(":", ".").toLatin1();
-        if(mPeerAddress.toStdString()!="")
-            mJackClientName = tmp.constData();
+        //Set our Jack client name if we're a hub server or a custom name hasn't been set
+	if(mPeerAddress.toStdString()!="" && (mJackClientName == "JackTrip" || mJackTripMode == SERVERPINGSERVER)) {
+            mJackClientName = QString(mPeerAddress).replace(":", ".").toLatin1().constData();
+        }
         std::cout  << "WAIR ID " << ID << " jacktrip client name set to=" <<
                       mJackClientName << std::endl;
 

--- a/src/JackTripWorker.h
+++ b/src/JackTripWorker.h
@@ -96,8 +96,10 @@ public:
     {
         return mID;
     }
-
-
+    
+    void setIOStatTimeout(int timeout) { mIOStatTimeout = timeout; }
+    void setIOStatStream(QSharedPointer<std::ofstream> statStream) { mIOStatStream = statStream; }
+    
 private slots:
     void slotTest()
     { std::cout << "--- JackTripWorker TEST SLOT ---" << std::endl; }
@@ -105,7 +107,6 @@ private slots:
 
 signals:
     void signalRemoveThread();
-
 
 private:
     int setJackTripFromClientHeader(JackTrip& jacktrip);
@@ -126,6 +127,9 @@ private:
     QMutex mMutex; ///< Mutex to protect mSpawning
     JackTrip::underrunModeT mUnderRunMode;
     int mBufferQueueLength;
+    
+    int mIOStatTimeout;
+    QSharedPointer<std::ofstream> mIOStatStream;
 
     int mID; ///< ID thread number
     int mNumChans; ///< Number of Channels

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -37,22 +37,21 @@
 
 #include "Settings.h"
 #include "LoopBack.h"
-#include "NetKS.h"
+//#include "NetKS.h"
 
 #ifdef WAIR // wair
 #include "ap8x2.dsp.h"
 #include "Stk16.dsp.h"
 #endif // endwhere
 
-#include "UdpMasterListener.h"
-#include "JackTripWorker.h"
+//#include "JackTripWorker.h"
 #include "jacktrip_globals.h"
 
 #include <iostream>
 #include <getopt.h> // for command line parsing
 #include <cstdlib>
 
-#include "ThreadPoolTest.h"
+//#include "ThreadPoolTest.h"
 
 using std::cout; using std::endl;
 
@@ -61,7 +60,6 @@ int gVerboseFlag = 0;
 
 //*******************************************************************************
 Settings::Settings() :
-    mJackTrip(NULL),
     mJackTripMode(JackTrip::SERVER),
     mDataProtocol(JackTrip::UDP),
     mNumChans(2),
@@ -69,7 +67,7 @@ Settings::Settings() :
     mAudioBitResolution(AudioInterface::BIT16),
     mBindPortNum(gDefaultPort), mPeerPortNum(gDefaultPort),
     mClientName(NULL),
-    mUnderrrunZero(false),
+    mUnderrunZero(false),
     mLoopBack(false),
     #ifdef WAIR // WAIR
     mNumNetRevChans(0),
@@ -90,11 +88,7 @@ Settings::Settings() :
 {}
 
 //*******************************************************************************
-Settings::~Settings()
-{
-    stopJackTrip();
-    delete mJackTrip;
-}
+Settings::~Settings() = default;
 
 //*******************************************************************************
 void Settings::parseInput(int argc, char** argv)
@@ -111,48 +105,48 @@ void Settings::parseInput(int argc, char** argv)
     //----------------------------------------------------------------------------
     static struct option longopts[] = {
         // These options don't set a flag.
-    { "numchannels", required_argument, NULL, 'n' }, // Number of input and output channels
+        { "numchannels", required_argument, NULL, 'n' }, // Number of input and output channels
 #ifdef WAIR // WAIR
-    { "wair", no_argument, NULL, 'w' }, // Run in LAIR mode, sets numnetrevchannels
-    { "addcombfilterlength", required_argument, NULL, 'N' }, // added comb filter length
-    { "combfilterfeedback", required_argument, NULL, 'H' }, // comb filter feedback
+        { "wair", no_argument, NULL, 'w' }, // Run in LAIR mode, sets numnetrevchannels
+        { "addcombfilterlength", required_argument, NULL, 'N' }, // added comb filter length
+        { "combfilterfeedback", required_argument, NULL, 'H' }, // comb filter feedback
 #endif // endwhere
-    { "server", no_argument, NULL, 's' }, // Run in server mode
-    { "client", required_argument, NULL, 'c' }, // Run in client mode, set server IP address
-    { "localaddress", required_argument, NULL, 'L' }, // set local address e.g., 127.0.0.2 for second instance on same host
-    { "jacktripserver", no_argument, NULL, 'S' }, // Run in JamLink mode
-    { "pingtoserver", required_argument, NULL, 'C' }, // Run in ping to server mode, set server IP address
-    { "portoffset", required_argument, NULL, 'o' }, // Port Offset from 4464
-    { "bindport", required_argument, NULL, 'B' }, // Port Offset from 4464
-    { "peerport", required_argument, NULL, 'P' }, // Port Offset from 4464
-    { "queue", required_argument, NULL, 'q' }, // Queue Length
-    { "redundancy", required_argument, NULL, 'r' }, // Redundancy
-    { "bitres", required_argument, NULL, 'b' }, // Audio Bit Resolution
-    { "zerounderrun", no_argument, NULL, 'z' }, // Use Underrun to Zeros Mode
-    { "loopback", no_argument, NULL, 'l' }, // Run in loopback mode
-    { "jamlink", no_argument, NULL, 'j' }, // Run in JamLink mode
-    { "emptyheader", no_argument, NULL, 'e' }, // Run in JamLink mode
-    { "clientname", required_argument, NULL, 'J' }, // Run in JamLink mode
-    { "rtaudio", no_argument, NULL, 'R' }, // Run in JamLink mode
-    { "srate", required_argument, NULL, 'T' }, // Set Sample Rate
-    { "deviceid", required_argument, NULL, 'd' }, // Set RTAudio device id to use
-    { "bufsize", required_argument, NULL, 'F' }, // Set buffer Size
-    { "nojackportsconnect" , no_argument, NULL,  'D'}, // Don't connect default Audio Ports
-    { "version", no_argument, NULL, 'v' }, // Version Number
-    { "verbose", no_argument, NULL, 'V' }, // Verbose mode
-    { "hubpatch", required_argument, NULL, 'p' }, // Set hubConnectionMode for auto patch in Jack
-    { "iostat", required_argument, NULL, 'I' }, // Set IO stat timeout
-    { "iostatlog", required_argument, NULL, 'G' }, // Set IO stat log file
-    { "help", no_argument, NULL, 'h' }, // Print Help
-    { NULL, 0, NULL, 0 }
-};
+        { "server", no_argument, NULL, 's' }, // Run in server mode
+        { "client", required_argument, NULL, 'c' }, // Run in client mode, set server IP address
+        { "localaddress", required_argument, NULL, 'L' }, // set local address e.g., 127.0.0.2 for second instance on same host
+        { "jacktripserver", no_argument, NULL, 'S' }, // Run in JamLink mode
+        { "pingtoserver", required_argument, NULL, 'C' }, // Run in ping to server mode, set server IP address
+        { "portoffset", required_argument, NULL, 'o' }, // Port Offset from 4464
+        { "bindport", required_argument, NULL, 'B' }, // Port Offset from 4464
+        { "peerport", required_argument, NULL, 'P' }, // Port Offset from 4464
+        { "queue", required_argument, NULL, 'q' }, // Queue Length
+        { "redundancy", required_argument, NULL, 'r' }, // Redundancy
+        { "bitres", required_argument, NULL, 'b' }, // Audio Bit Resolution
+        { "zerounderrun", no_argument, NULL, 'z' }, // Use Underrun to Zeros Mode
+        { "loopback", no_argument, NULL, 'l' }, // Run in loopback mode
+        { "jamlink", no_argument, NULL, 'j' }, // Run in JamLink mode
+        { "emptyheader", no_argument, NULL, 'e' }, // Run in JamLink mode
+        { "clientname", required_argument, NULL, 'J' }, // Run in JamLink mode
+        { "rtaudio", no_argument, NULL, 'R' }, // Run in JamLink mode
+        { "srate", required_argument, NULL, 'T' }, // Set Sample Rate
+        { "deviceid", required_argument, NULL, 'd' }, // Set RTAudio device id to use
+        { "bufsize", required_argument, NULL, 'F' }, // Set buffer Size
+        { "nojackportsconnect" , no_argument, NULL,  'D'}, // Don't connect default Audio Ports
+        { "version", no_argument, NULL, 'v' }, // Version Number
+        { "verbose", no_argument, NULL, 'V' }, // Verbose mode
+        { "hubpatch", required_argument, NULL, 'p' }, // Set hubConnectionMode for auto patch in Jack
+        { "iostat", required_argument, NULL, 'I' }, // Set IO stat timeout
+        { "iostatlog", required_argument, NULL, 'G' }, // Set IO stat log file
+        { "help", no_argument, NULL, 'h' }, // Print Help
+        { NULL, 0, NULL, 0 }
+    };
 
     // Parse Command Line Arguments
     //----------------------------------------------------------------------------
     /// \todo Specify mandatory arguments
     int ch;
-    while ( (ch = getopt_long(argc, argv,
-                              "n:N:H:sc:SC:o:B:P:q:r:b:zlwjeJ:RTd:F:p:DvVh", longopts, NULL)) != -1 )
+    while ((ch = getopt_long(argc, argv,
+                             "n:N:H:sc:SC:o:B:P:q:r:b:zlwjeJ:RTd:F:p:DvVh", longopts, NULL)) != -1)
         switch (ch) {
 
         case 'n': // Number of input and output channels
@@ -211,19 +205,20 @@ void Settings::parseInput(int argc, char** argv)
             break;
         case 'b':
             //-------------------------------------------------------
-            if      ( atoi(optarg) == 8 ) {
-                mAudioBitResolution = AudioInterface::BIT8; }
-            else if ( atoi(optarg) == 16 ) {
-                mAudioBitResolution = AudioInterface::BIT16; }
-            else if ( atoi(optarg) == 24 ) {
-                mAudioBitResolution = AudioInterface::BIT24; }
-            else if ( atoi(optarg) == 32 ) {
-                mAudioBitResolution = AudioInterface::BIT32; }
-            else {
+            if (atoi(optarg) == 8) {
+                mAudioBitResolution = AudioInterface::BIT8;
+            } else if (atoi(optarg) == 16) {
+                mAudioBitResolution = AudioInterface::BIT16;
+            } else if (atoi(optarg) == 24) {
+                mAudioBitResolution = AudioInterface::BIT24;
+            } else if (atoi(optarg) == 32) {
+                mAudioBitResolution = AudioInterface::BIT32;
+            } else {
                 std::cerr << "--bitres ERROR: Wrong bit resolution: "
                           << atoi(optarg) << " is not supported." << endl;
                 printUsage();
-                std::exit(1); }
+                std::exit(1);
+            }
             break;
         case 'q':
             //-------------------------------------------------------
@@ -247,7 +242,7 @@ void Settings::parseInput(int argc, char** argv)
             break;
         case 'z': // underrun to zero
             //-------------------------------------------------------
-            mUnderrrunZero = true;
+            mUnderrunZero = true;
             break;
         case 'l': // loopback
             //-------------------------------------------------------
@@ -303,21 +298,24 @@ void Settings::parseInput(int argc, char** argv)
             break;
         case 'p':
             //-------------------------------------------------------
-            if      ( atoi(optarg) == 0 ) {
-                mHubConnectionMode = JackTrip::SERVERTOCLIENT; }
-            else if ( atoi(optarg) == 1 ) {
-                mHubConnectionMode = JackTrip::CLIENTECHO; }
-            else if ( atoi(optarg) == 2 ) {
-                mHubConnectionMode = JackTrip::CLIENTFOFI; }
-            else if ( atoi(optarg) == 3 ) {
-                mHubConnectionMode = JackTrip::RESERVEDMATRIX; }
-            else if ( atoi(optarg) == 4 ) {
-                mHubConnectionMode = JackTrip::FULLMIX; }
-            else {
+            if ( atoi(optarg) == 0 ) {
+                mHubConnectionMode = JackTrip::SERVERTOCLIENT;
+            } else if ( atoi(optarg) == 1 ) {
+                mHubConnectionMode = JackTrip::CLIENTECHO;
+            } else if ( atoi(optarg) == 2 ) {
+                mHubConnectionMode = JackTrip::CLIENTFOFI;
+            } else if ( atoi(optarg) == 3 ) {
+                mHubConnectionMode = JackTrip::RESERVEDMATRIX;
+            } else if ( atoi(optarg) == 4 ) {
+                mHubConnectionMode = JackTrip::FULLMIX;
+            } else if ( atoi(optarg) == 5 ) {
+                mHubConnectionMode = JackTrip::NOAUTO;
+            } else {
                 std::cerr << "-p ERROR: Wrong HubConnectionMode: "
                           << atoi(optarg) << " is not supported." << endl;
                 printUsage();
-                std::exit(1); }
+                std::exit(1);
+            }
             break;
         case 'I': // IO Stat timeout
             //-------------------------------------------------------
@@ -330,8 +328,8 @@ void Settings::parseInput(int argc, char** argv)
             break;
         case 'G': // IO Stat log file
             //-------------------------------------------------------
-            mIOStatStream.open(optarg);
-            if (!mIOStatStream.is_open()) {
+            mIOStatStream.reset(new std::ofstream(optarg));
+            if (!mIOStatStream->is_open()) {
                 std::cerr << "--iostatlog FAILED to open " << optarg
                           << " for writing." << endl;
                 printUsage();
@@ -356,7 +354,7 @@ void Settings::parseInput(int argc, char** argv)
         cout << gPrintSeparator << endl;
         cout << "WARINING: The following entered options have no effect." << endl;
         cout << "          They will be ignored!" << endl;
-        cout << "          Type 'jacktrip' to see options." << endl;
+        cout << "          Type 'jacktrip -h' to see options." << endl;
         for( ; optind < argc; optind++) {
             cout << "argument: " << argv[optind] << endl;
         }
@@ -402,7 +400,7 @@ void Settings::printUsage()
     cout << " --bindport        #                      Set only the bind port number (default: 4464)" << endl;
     cout << " --peerport        #                      Set only the Peer port number (default: 4464)" << endl;
     cout << " -b, --bitres      # (8, 16, 24, 32)      Audio Bit Rate Resolutions (default: 16)" << endl;
-    cout << " -p, --hubpatch    # (0, 1, 2, 3, 4)      Hub auto audio patch, only has effect if running HUB SERVER mode, 0=server-to-clients, 1=client loopback, 2=client fan out/in but not loopback, 3=reserved for TUB, 4=full mix (default: 0)" << endl;
+    cout << " -p, --hubpatch    # (0, 1, 2, 3, 4, 5)   Hub auto audio patch, only has effect if running HUB SERVER mode, 0=server-to-clients, 1=client loopback, 2=client fan out/in but not loopback, 3=reserved for TUB, 4=full mix, 5=no auto patching (default: 0)" << endl;
     cout << " -z, --zerounderrun                       Set buffer to zeros when underrun occurs (default: wavetable)" << endl;
     cout << " -l, --loopback                           Run in Loop-Back Mode" << endl;
     cout << " -j, --jamlink                            Run in JamLink Mode (Connect to a JamLink Box)" << endl;
@@ -429,195 +427,163 @@ void Settings::printUsage()
 
 
 //*******************************************************************************
-void Settings::startJackTrip()
+UdpMasterListener *Settings::getConfiguredHubServer()
 {
-
-    /// \todo Change this, just here to test
-    if ( mJackTripServer ) {
-        UdpMasterListener* udpmaster = new UdpMasterListener;
-        udpmaster->setSettings(this);
+    UdpMasterListener *udpMaster = new UdpMasterListener;
+    //udpMaster->setSettings(this);
 #ifdef WAIR // WAIR
-        udpmaster->setWAIR(mWAIR);
+    udpmaster->setWAIR(mWAIR);
 #endif // endwhere
-        udpmaster->setHubPatch(mHubConnectionMode);
-        udpmaster->setConnectDefaultAudioPorts(mConnectDefaultAudioPorts);
-        if (gVerboseFlag) std::cout << "Settings:startJackTrip before udpmaster->start" << std::endl;
-        // Set buffers to zero when underrun
-        if ( mUnderrrunZero ) {
-            cout << "Setting buffers to zero when underrun..." << endl;
-            cout << gPrintSeparator << std::endl;
-            udpmaster->setUnderRunMode(JackTrip::ZEROS);
-        }
-        udpmaster->setBufferQueueLength(mBufferQueueLength);
-        udpmaster->start();
+    udpMaster->setHubPatch(mHubConnectionMode);
+    if (mHubConnectionMode == JackTrip::NOAUTO) {
+        udpMaster->setConnectDefaultAudioPorts(false);
+    } else {
+        udpMaster->setConnectDefaultAudioPorts(mConnectDefaultAudioPorts);
+    }
+    // Set buffers to zero when underrun
+    if ( mUnderrunZero ) {
+        cout << "Setting buffers to zero when underrun..." << endl;
+        cout << gPrintSeparator << std::endl;
+        udpMaster->setUnderRunMode(JackTrip::ZEROS);
+    }
+    udpMaster->setBufferQueueLength(mBufferQueueLength);
+    
+    if (mIOStatTimeout > 0) {
+        udpMaster->setIOStatTimeout(mIOStatTimeout);
+        udpMaster->setIOStatStream(mIOStatStream);
+    }
+    return udpMaster;
+}
 
-        //---Thread Pool Test--------------------------------------------
-        /*
-    cout << "BEFORE START" << endl;
-    ThreadPoolTest* thtest = new ThreadPoolTest();
-    // QThreadPool takes ownership and deletes 'hello' automatically
-    QThreadPool::globalInstance()->start(thtest);
+JackTrip *Settings::getConfiguredJackTrip()
+{
+#ifdef WAIR // WAIR
+    if (gVerboseFlag) std::cout << "Settings:startJackTrip mNumNetRevChans = " << mNumNetRevChans << std::endl;
+#endif // endwhere
+    if (gVerboseFlag) std::cout << "Settings:startJackTrip before new JackTrip" << std::endl;
+    JackTrip *jackTrip = new JackTrip(mJackTripMode, mDataProtocol, mNumChans,
+#ifdef WAIR // wair
+                                      mNumNetRevChans,
+#endif // endwhere
+                                      mBufferQueueLength, mRedundancy, mAudioBitResolution);
+    // Set connect or not default audio ports. Only work for jack
+    jackTrip->setConnectDefaultAudioPorts(mConnectDefaultAudioPorts);
+    
+    // Connect Signals and Slots TODO: check where this should be done.
+    //QObject::connect(mJackTrip, SIGNAL( signalProcessesStopped() ),
+                     //this, SLOT( slotExitProgram() ));
 
-    cout << "AFTER START" << endl;
-    sleep(2);
-    thtest->stop();
-    QThreadPool::globalInstance()->waitForDone();
-    */
-        //---------------------------------------------------------------
+    // Change client name if different from default
+    if (mClientName != NULL) {
+        jackTrip->setClientName(mClientName);
     }
 
-    else {
+    // Set buffers to zero when underrun
+    if (mUnderrunZero) {
+        cout << "Setting buffers to zero when underrun..." << endl;
+        cout << gPrintSeparator << std::endl;
+        jackTrip->setUnderRunMode(JackTrip::ZEROS);
+    }
 
-        //JackTrip jacktrip(mJackTripMode, mDataProtocol, mNumChans,
-        //	    mBufferQueueLength, mAudioBitResolution);
-#ifdef WAIR // WAIR
-        if (gVerboseFlag) std::cout << "Settings:startJackTrip mNumNetRevChans = " << mNumNetRevChans << std::endl;
-#endif // endwhere
-        if (gVerboseFlag) std::cout << "Settings:startJackTrip before new JackTrip" << std::endl;
-        mJackTrip = new JackTrip(mJackTripMode, mDataProtocol, mNumChans,
-                         #ifdef WAIR // wair
-                                 mNumNetRevChans,
-                         #endif // endwhere
-                                 mBufferQueueLength, mRedundancy, mAudioBitResolution);
+    // Set peer address in server mode
+    if (mJackTripMode == JackTrip::CLIENT || mJackTripMode == JackTrip::CLIENTTOPINGSERVER) {
+        jackTrip->setPeerAddress(mPeerAddress.toLatin1().data()); }
+        
+    //        if(mLocalAddress!=QString()) // default
+    //            mJackTrip->setLocalAddress(QHostAddress(mLocalAddress.toLatin1().data()));
+    //        else
+    //            mJackTrip->setLocalAddress(QHostAddress::Any);
 
-        // Set connect or not default audio ports. Only work for jack
-        mJackTrip->setConnectDefaultAudioPorts(mConnectDefaultAudioPorts);
+    // Set Ports
+    //cout << "SETTING ALL PORTS" << endl;
+    if (gVerboseFlag) std::cout << "Settings:startJackTrip before mJackTrip->setBindPorts" << std::endl;
+    jackTrip->setBindPorts(mBindPortNum);
+    if (gVerboseFlag) std::cout << "Settings:startJackTrip before mJackTrip->setPeerPorts" << std::endl;
+    jackTrip->setPeerPorts(mPeerPortNum);
 
-        // Connect Signals and Slots
-        QObject::connect(mJackTrip, SIGNAL( signalProcessesStopped() ),
-                         this, SLOT( slotExitProgram() ));
+    // Set in JamLink Mode
+    if ( mJamLink ) {
+        cout << "Running in JamLink Mode..." << endl;
+        cout << gPrintSeparator << std::endl;
+        jackTrip->setPacketHeaderType(DataProtocol::JAMLINK);
+    }
 
-        // Change client name if different from default
-        if (mClientName != NULL) {
-            mJackTrip->setClientName(mClientName);
-        }
+    // Set in EmptyHeader Mode
+    if (mEmptyHeader) {
+        cout << "Running in EmptyHeader Mode..." << endl;
+        cout << gPrintSeparator << std::endl;
+        jackTrip->setPacketHeaderType(DataProtocol::EMPTY);
+    }
 
-        // Set buffers to zero when underrun
-        if ( mUnderrrunZero ) {
-            cout << "Setting buffers to zero when underrun..." << endl;
-            cout << gPrintSeparator << std::endl;
-            mJackTrip->setUnderRunMode(JackTrip::ZEROS);
-        }
-
-        // Set peer address in server mode
-        if ( mJackTripMode == JackTrip::CLIENT || mJackTripMode == JackTrip::CLIENTTOPINGSERVER ) {
-            mJackTrip->setPeerAddress(mPeerAddress.toLatin1().data()); }
-
-        //        if(mLocalAddress!=QString()) // default
-        //            mJackTrip->setLocalAddress(QHostAddress(mLocalAddress.toLatin1().data()));
-        //        else
-        //            mJackTrip->setLocalAddress(QHostAddress::Any);
-
-        // Set Ports
-        //cout << "SETTING ALL PORTS" << endl;
-        if (gVerboseFlag) std::cout << "Settings:startJackTrip before mJackTrip->setBindPorts" << std::endl;
-        mJackTrip->setBindPorts(mBindPortNum);
-        if (gVerboseFlag) std::cout << "Settings:startJackTrip before mJackTrip->setPeerPorts" << std::endl;
-        mJackTrip->setPeerPorts(mPeerPortNum);
-
-        // Set in JamLink Mode
-        if ( mJamLink ) {
-            cout << "Running in JamLink Mode..." << endl;
-            cout << gPrintSeparator << std::endl;
-            mJackTrip->setPacketHeaderType(DataProtocol::JAMLINK);
-        }
-
-        // Set in EmptyHeader Mode
-        if ( mEmptyHeader ) {
-            cout << "Running in EmptyHeader Mode..." << endl;
-            cout << gPrintSeparator << std::endl;
-            mJackTrip->setPacketHeaderType(DataProtocol::EMPTY);
-        }
-
-        // Set RtAudio
+    // Set RtAudio
 #ifdef __RT_AUDIO__
-        if (!mUseJack) {
-            mJackTrip->setAudiointerfaceMode(JackTrip::RTAUDIO);
-        }
+    if (!mUseJack) {
+        mJackTrip->setAudiointerfaceMode(JackTrip::RTAUDIO);
+    }
 #endif
 
-        // Chanfe default Sampling Rate
-        if (mChanfeDefaultSR) {
-            mJackTrip->setSampleRate(mSampleRate);
-        }
+    // Chanfe default Sampling Rate
+    if (mChanfeDefaultSR) {
+        jackTrip->setSampleRate(mSampleRate);
+    }
 
-        // Chanfe defualt device ID
-        if (mChanfeDefaultID) {
-            mJackTrip->setDeviceID(mDeviceID);
-        }
+    // Chanfe defualt device ID
+    if (mChanfeDefaultID) {
+        jackTrip->setDeviceID(mDeviceID);
+    }
 
-        // Chanfe default Buffer Size
-        if (mChanfeDefaultBS) {
-            mJackTrip->setAudioBufferSizeInSamples(mAudioBufferSize);
-        }
+    // Chanfe default Buffer Size
+    if (mChanfeDefaultBS) {
+        jackTrip->setAudioBufferSizeInSamples(mAudioBufferSize);
+    }
 
-        // Add Plugins
-        if ( mLoopBack ) {
-            cout << "Running in Loop-Back Mode..." << endl;
-            cout << gPrintSeparator << std::endl;
-            //std::tr1::shared_ptr<LoopBack> loopback(new LoopBack(mNumChans));
-            //mJackTrip->appendProcessPlugin(loopback.get());
+    // Add Plugins
+    if (mLoopBack) {
+        cout << "Running in Loop-Back Mode..." << endl;
+        cout << gPrintSeparator << std::endl;
+        //std::tr1::shared_ptr<LoopBack> loopback(new LoopBack(mNumChans));
+        //mJackTrip->appendProcessPlugin(loopback.get());
 
-            LoopBack* loopback = new LoopBack(mNumChans);
-            mJackTrip->appendProcessPlugin(loopback);
+        LoopBack* loopback = new LoopBack(mNumChans);
+        jackTrip->appendProcessPlugin(loopback);
 
-            // ----- Test Karplus Strong -----------------------------------
-            //std::tr1::shared_ptr<NetKS> loopback(new NetKS());
-            //mJackTrip->appendProcessPlugin(loopback);
-            //loopback->play();
-            //NetKS* netks = new NetKS;
-            //mJackTrip->appendProcessPlugin(netks);
-            //netks->play();
-            // -------------------------------------------------------------
-        }
+        // ----- Test Karplus Strong -----------------------------------
+        //std::tr1::shared_ptr<NetKS> loopback(new NetKS());
+        //mJackTrip->appendProcessPlugin(loopback);
+        //loopback->play();
+        //NetKS* netks = new NetKS;
+        //mJackTrip->appendProcessPlugin(netks);
+        //netks->play();
+        // -------------------------------------------------------------
+    }
+    
+    if (mIOStatTimeout > 0) {
+        jackTrip->setIOStatTimeout(mIOStatTimeout);
+        jackTrip->setIOStatStream(mIOStatStream);
+    }
 
 #ifdef WAIR // WAIR
-        if ( mWAIR ) {
-            cout << "Running in WAIR Mode..." << endl;
-            cout << gPrintSeparator << std::endl;
-            switch ( mNumNetRevChans )
-            {
-            case 16 :
-            {
-                mJackTrip->appendProcessPlugin(new ap8x2(mNumChans)); // plugin slot 0
-                /////////////////////////////////////////////////////////
-                Stk16* plugin = new Stk16(mNumNetRevChans);
-                plugin->Stk16::initCombClient(mClientAddCombLen, mClientRoomSize);
-                mJackTrip->appendProcessPlugin(plugin); // plugin slot 1
-            }
-                break;
-            default:
-                throw std::invalid_argument("Settings: mNumNetRevChans doesn't correspond to Faust plugin");
-                break;
-            }
+    if ( mWAIR ) {
+        cout << "Running in WAIR Mode..." << endl;
+        cout << gPrintSeparator << std::endl;
+        switch ( mNumNetRevChans )
+        {
+        case 16 :
+        {
+            jackTrip->appendProcessPlugin(new ap8x2(mNumChans)); // plugin slot 0
+            /////////////////////////////////////////////////////////
+            Stk16* plugin = new Stk16(mNumNetRevChans);
+            plugin->Stk16::initCombClient(mClientAddCombLen, mClientRoomSize);
+            jackTrip->appendProcessPlugin(plugin); // plugin slot 1
         }
+            break;
+        default:
+            throw std::invalid_argument("Settings: mNumNetRevChans doesn't correspond to Faust plugin");
+            break;
+        }
+    }
 #endif // endwhere
 
-        // Start JackTrip
-        if (gVerboseFlag) std::cout << "Settings:startJackTrip before mJackTrip->startProcess" << std::endl;
-        mJackTrip->startProcess(
-            #ifdef WAIRTOMASTER // WAIR
-                    0 // for WAIR compatibility, ID in jack client name
-            #endif // endwhere
-                    );
-        if (0 < getIOStatTimeout()) {
-            mJackTrip->startIOStatTimer(getIOStatTimeout(), getIOStatStream());
-        }
-        //        if (gVerboseFlag) std::cout << "Settings:startJackTrip before mJackTrip->start" << std::endl;
-        // this is a noop
-        //        mJackTrip->start();
-
-        /*
-       sleep(10);
-       cout << "Stoping JackTrip..." << endl;
-       mJackTrip->stop();
-    */
-    }
+    return jackTrip;
 }
 
-
-//*******************************************************************************
-void Settings::stopJackTrip()
-{
-    mJackTrip->stop();
-}

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -49,10 +49,11 @@
 #endif //__NO_JACK__
 
 #include "JackTrip.h"
+#include "UdpMasterListener.h"
 
 /** \brief Class to set usage options and parse settings from input
  */
-class Settings : public QThread
+class Settings : public QObject
 {
     Q_OBJECT;
 
@@ -63,29 +64,16 @@ public:
     /// \brief Parses command line input
     void parseInput(int argc, char** argv);
 
-    void startJackTrip();
-    void stopJackTrip();
+    UdpMasterListener *getConfiguredHubServer();
+    JackTrip *getConfiguredJackTrip();
 
     /// \brief Prints usage help
     void printUsage();
 
     bool getLoopBack() { return mLoopBack; }
-    int getIOStatTimeout() const {return mIOStatTimeout;}
-    const std::ostream& getIOStatStream() const
-    {
-        return mIOStatStream.is_open() ? (std::ostream&)mIOStatStream : std::cout;
-    }
-
-
-public slots:
-    void slotExitProgram()
-    {
-        std::cerr << "Exiting JackTrip..." << std::endl;
-        std::exit(1);
-    }
+    bool isHubServer() { return mJackTripServer; }
 
 private:
-    JackTrip* mJackTrip; ///< JackTrip class
     JackTrip::jacktripModeT mJackTripMode; ///< JackTrip::jacktripModeT
     JackTrip::dataProtocolT mDataProtocol; ///< Data Protocol
     int mNumChans; ///< Number of Channels (inputs = outputs)
@@ -95,7 +83,7 @@ private:
     int mBindPortNum; ///< Bind Port Number
     int mPeerPortNum; ///< Peer Port Number
     char* mClientName; ///< JackClient Name
-    bool mUnderrrunZero; ///< Use Underrun to Zero mode
+    bool mUnderrunZero; ///< Use Underrun to Zero mode
 
 #ifdef WAIR // wair
     int mNumNetRevChans; ///< Number of Network Audio Channels (net comb filters)
@@ -120,7 +108,7 @@ private:
     unsigned int mHubConnectionMode;
     bool mConnectDefaultAudioPorts; ///< Connect or not jack audio ports
     int mIOStatTimeout;
-    std::ofstream mIOStatStream;
+    QSharedPointer<std::ofstream> mIOStatStream;
 };
 
 #endif

--- a/src/UdpDataProtocol.cpp
+++ b/src/UdpDataProtocol.cpp
@@ -51,7 +51,7 @@
 #include <winsock2.h> //cc need SD_SEND
 #include <ws2tcpip.h> // for IPv6
 #endif
-#if defined (__LINUX__) || (__MAC__OSX__)
+#if defined (__LINUX__) || (__MAC_OSX__)
 #include <sys/socket.h> // for POSIX Sockets
 #endif
 
@@ -101,7 +101,7 @@ UdpDataProtocol::~UdpDataProtocol()
 void UdpDataProtocol::setPeerAddress(const char* peerHostOrIP)
 {
     // Get DNS Address
-#if defined (__LINUX__) || (__MAC__OSX__)
+#if defined (__LINUX__) || (__MAC_OSX__)
     //Don't make the following code conditional on windows
     //(Addresses a weird timing bug when in hub client mode)
     if (!mPeerAddress.setAddress(peerHostOrIP)) {
@@ -113,7 +113,7 @@ void UdpDataProtocol::setPeerAddress(const char* peerHostOrIP)
         }
         //cout << "UdpDataProtocol::setPeerAddress IP Address Number: "
         //    << mPeerAddress.toString().toStdString() << endl;
-#if defined (__LINUX__) || (__MAC__OSX__)
+#if defined (__LINUX__) || (__MAC_OSX__)
     }
 #endif
 
@@ -576,7 +576,7 @@ void UdpDataProtocol::run()
         break; }
 
     case SENDER : {
-        while ( !mStopped )
+        while ( !mStopped && !JackTrip::sSigInt )
         {
             // OLD CODE WITHOUT REDUNDANCY -----------------------------------------------------
             /*
@@ -592,6 +592,7 @@ void UdpDataProtocol::run()
                                  full_redundant_packet_size,
                                  full_packet_size);
         }
+        emit signalCeaseTransmission();
         break; }
     }
 }
@@ -634,7 +635,7 @@ void UdpDataProtocol::printUdpWaitedTooLong(int wait_msec)
 {
     int wait_time = 30; // msec
     if ( !(wait_msec%wait_time) ) {
-        std::cerr << "UDP waiting too long (more than " << wait_time << "ms)..." << endl;
+        std::cerr << "UDP waiting too long (more than " << wait_time << "ms) for " << mPeerAddress.toString().toStdString() << "..." << endl;
     }
 }
 

--- a/src/UdpMasterListener.h
+++ b/src/UdpMasterListener.h
@@ -40,6 +40,7 @@
 
 #include <iostream>
 #include <stdexcept>
+#include <fstream>
 
 #include <QThread>
 #include <QThreadPool>
@@ -83,9 +84,8 @@ public:
     int releaseThread(int id);
 
     void setConnectDefaultAudioPorts(bool connectDefaultAudioPorts) { m_connectDefaultAudioPorts = connectDefaultAudioPorts; }
-
-    void setSettings(Settings* s) {m_settings = s;}
-    Settings* getSettings() const {return m_settings;}
+    
+    static void sigIntHandler(int unused) { std::cout << std::endl << "Shutting Down..." << std::endl; sSigInt = true; }
 
 private slots:
     void testReceive()
@@ -95,6 +95,7 @@ signals:
     void Listening();
     void ClientAddressSet();
     void signalRemoveThread(int id);
+    void signalStopped();
 
 
 private:
@@ -124,6 +125,8 @@ private:
     * is not in the pool yet, returns -1.
     */
     int getPoolID(QString address, uint16_t port);
+    
+    void stopAllThreads();
 
     //QUdpSocket mUdpMasterSocket; ///< The UDP socket
     //QHostAddress mPeerAddress; ///< The Peer Address
@@ -139,14 +142,17 @@ private:
 
     /// Boolean stop the execution of the thread
     volatile bool mStopped;
+    static bool sSigInt;
     int mTotalRunningThreads; ///< Number of Threads running in the pool
     QMutex mMutex;
     JackTrip::underrunModeT mUnderRunMode;
     int mBufferQueueLength;
 
     bool m_connectDefaultAudioPorts;
-    Settings* m_settings;
 
+    int mIOStatTimeout;
+    QSharedPointer<std::ofstream> mIOStatStream;
+    
 #ifdef WAIR // wair
     bool mWAIR;
     void connectMesh(bool spawn);
@@ -163,6 +169,9 @@ public :
 
     void setUnderRunMode(JackTrip::underrunModeT UnderRunMode) { mUnderRunMode = UnderRunMode; }
     void setBufferQueueLength(int BufferQueueLength) { mBufferQueueLength = BufferQueueLength; }
+    
+    void setIOStatTimeout(int timeout) { mIOStatTimeout = timeout; }
+    void setIOStatStream(QSharedPointer<std::ofstream> statStream) { mIOStatStream = statStream; }
 };
 
 

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -122,6 +122,7 @@ extern int gVerboseFlag; ///< Verbose mode flag declaration
 /// \name JackAudio
 //@{
 const int gJackBitResolution = 32; ///< Audio Bit Resolution of the Jack Server
+const char* const gJackDefaultClientName = "JackTrip";
 //@}
 
 


### PR DESCRIPTION
Patch to honour custom client names set via the --clientname command option. (Unless running in hub server mode.)
Partial fix for #73