### PR TITLE
first pass: Travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ language:
   - cpp
 
 dist: bionic
-osx_image: xcode11.6
 
 branches:
   - master
@@ -14,7 +13,6 @@ branches:
 
 env:
   global:
-  - PKGS_LINUX="qt5-default qttools5-dev-tools libjack-dev librtaudio-dev"
   - PKGS_OSX="jack qt rt-audio"
   
 addons:
@@ -25,33 +23,19 @@ addons:
       - qttools5-dev-tools
       - libjack-dev 
       - librtaudio-dev
-  homebrew:
-    # update: true
-    packages:
-      - jack
-      - qt
-      - rt-audio
 
-script: 
-  # # linux: force gcc-6
-  # - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-  #     sudo update-alternatives --remove-all gcc;
-  #     sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 90 --slave /usr/bin/g++ g++ /usr/bin/g++-6;
-  #   fi
-  # mac: workaround for homebrew-installed headers
+before_script:
+  # manually install brew packages as homebrew is broken in the default osx image
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then 
-      export C_INCLUDE_PATH="/usr/local/include";
-      export CPLUS_INCLUDE_PATH="/usr/local/include";
-      export LIBRARY_PATH="/usr/local/lib";
+      brew install $PKGS_OSX
     fi
   # mac: workaround for homebrew qmake not being symlinked into $PATH
   # see https://stackoverflow.com/questions/48847505/why-cant-i-use-qmake-on-mac-after-installing-it
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then 
       export PATH="/usr/local/opt/qt/bin:$PATH";
     fi
-  - ls /usr/local/include
-  - qmake-qt5 --version
-  - gcc -v && g++ -v
+
+script: 
   - cd src
   - ./build
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,13 +32,13 @@ addons:
 script: 
   # linux: force gcc-6
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then 
-      sudo update-alternatives --remove-all gcc
-      sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 90 --slave /usr/bin/g++ g++ /usr/bin/g++-6
+      sudo update-alternatives --remove-all gcc;
+      sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 90 --slave /usr/bin/g++ g++ /usr/bin/g++-6;
     fi
   # mac: workaround for homebrew-installed headers
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then 
-      export C_INCLUDE_PATH="/usr/local/include"
-      export CPLUS_INCLUDE_PATH="/usr/local/include"
+      export C_INCLUDE_PATH="/usr/local/include";
+      export CPLUS_INCLUDE_PATH="/usr/local/include";
       export LIBRARY_PATH="/usr/local/lib";
     fi
   # mac: workaround for homebrew qmake not being symlinked into $PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ os:
 language: 
   - cpp
 
+dist: bionic
+
 branches:
   - master
   - travis
@@ -18,7 +20,6 @@ addons:
   apt:
     update: true
     packages:
-      - g++-6
       - qt5-default
       - qttools5-dev-tools
       - libjack-dev 
@@ -30,11 +31,11 @@ addons:
       - rt-audio
 
 script: 
-  # linux: force gcc-6
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then 
-      sudo update-alternatives --remove-all gcc;
-      sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 90 --slave /usr/bin/g++ g++ /usr/bin/g++-6;
-    fi
+  # # linux: force gcc-6
+  # - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
+  #     sudo update-alternatives --remove-all gcc;
+  #     sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 90 --slave /usr/bin/g++ g++ /usr/bin/g++-6;
+  #   fi
   # mac: workaround for homebrew-installed headers
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then 
       export C_INCLUDE_PATH="/usr/local/include";
@@ -43,7 +44,10 @@ script:
     fi
   # mac: workaround for homebrew qmake not being symlinked into $PATH
   # see https://stackoverflow.com/questions/48847505/why-cant-i-use-qmake-on-mac-after-installing-it
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export PATH="/usr/local/opt/qt/bin:$PATH"; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then 
+      export PATH="/usr/local/opt/qt/bin:$PATH";
+    fi
+
   - gcc -v && g++ -v
   - cd src
   - ./build

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ script:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then 
       export PATH="/usr/local/opt/qt/bin:$PATH";
     fi
-
+  - ls /usr/local/include
   - gcc -v && g++ -v
   - cd src
   - ./build

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,15 +31,18 @@ addons:
 
 before_install:
   # linux: use gcc-6
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export CC=gcc-6; export CXX=g++-6; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export CC="gcc-6"; export CXX="g++-6"; fi
+  - gcc -v && g++ -v
   # mac: workaround for homebrew-installed headers
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export C_INCLUDE_PATH="/usr/local/include"; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export CPLUS_INCLUDE_PATH="/usr/local/include"; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export LIBRARY_PATH="/usr/local/lib"; fi
   # mac: workaround for homebrew qmake not being symlinked into $PATH
   # see https://stackoverflow.com/questions/48847505/why-cant-i-use-qmake-on-mac-after-installing-it
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export PATH="/usr/local/opt/qt/bin:$PATH"; fi
 
 script: 
+  - gcc -v && g++ -v
   - cd src
   - ./build
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ branches:
 
 env:
   global:
-  - PKGS_LINUX=qt5-default qttools5-dev-tools jack-audio-connection-kit-devel rtaudio
-  - PKGS_OSX=jack qt rt-audio
+  - PKGS_LINUX="qt5-default qttools5-dev-tools libjack-dev librtaudio-dev"
+  - PKGS_OSX="jack qt rt-audio"
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get update; sudo apt-get install $PKGS_LINUX; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
 language: 
   - cpp
 
+# force updated ubuntu distribution with up-to-date gcc
 dist: bionic
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language:
   - cpp
 
 branches:
-  - main
+  - master
   - travis
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+os:
+  - linux
+  - osx
+
+language: 
+  - cpp
+
+branches:
+  - main
+  - travis
+
+env:
+  global:
+  - PKGS_LINUX=qt5-default qttools5-dev-tools jack-audio-connection-kit-devel rtaudio
+  - PKGS_OSX=jack qt rt-audio
+
+before_install:
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get update; sudo apt-get install $PKGS_LINUX; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update; brew install $PKGS_OSX; fi
+
+script: 
+  - cd src
+  - ./build
+  
+after_success:
+  - echo "Success!"
+
+after_failure:
+  - echo "Something went wrong :("

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,12 @@ addons:
       - rt-audio
 
 before_install:
-  # workaround for homebrew qmake not being symlinked into $PATH
+  # linux: use gcc-6
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export CC=gcc-6; export CXX=g++-6; fi
+  # mac: workaround for homebrew-installed headers
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export C_INCLUDE_PATH="/usr/local/include"; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export LIBRARY_PATH="/usr/local/lib"; fi
+  # mac: workaround for homebrew qmake not being symlinked into $PATH
   # see https://stackoverflow.com/questions/48847505/why-cant-i-use-qmake-on-mac-after-installing-it
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export PATH="/usr/local/opt/qt/bin:$PATH"; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,15 +30,17 @@ addons:
       - rt-audio
 
 script: 
-  # linux: use gcc-6
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export CC="gcc-6"; export CXX="g++-6"; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo ln -s /usr/bin/gcc-6 /usr/local/bin/gcc; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo ln -s /usr/bin/g++-6 /usr/local/bin/g++; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export PATH="/usr/local/bin:$PATH"; fi
+  # linux: force gcc-6
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then 
+      sudo update-alternatives --remove-all gcc
+      sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 90 --slave /usr/bin/g++ g++ /usr/bin/g++-6
+    fi
   # mac: workaround for homebrew-installed headers
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export C_INCLUDE_PATH="/usr/local/include"; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export CPLUS_INCLUDE_PATH="/usr/local/include"; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export LIBRARY_PATH="/usr/local/lib"; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then 
+      export C_INCLUDE_PATH="/usr/local/include"
+      export CPLUS_INCLUDE_PATH="/usr/local/include"
+      export LIBRARY_PATH="/usr/local/lib";
+    fi
   # mac: workaround for homebrew qmake not being symlinked into $PATH
   # see https://stackoverflow.com/questions/48847505/why-cant-i-use-qmake-on-mac-after-installing-it
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export PATH="/usr/local/opt/qt/bin:$PATH"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,11 @@ addons:
       - qt
       - rt-audio
 
-before_install:
+script: 
   # linux: use gcc-6
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export CC="gcc-6"; export CXX="g++-6"; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo ln -s /usr/bin/gcc-6 /usr/bin/gcc; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo ln -s /usr/bin/g++-6 /usr/bin/g++; fi
-  - gcc -v && g++ -v
   # mac: workaround for homebrew-installed headers
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export C_INCLUDE_PATH="/usr/local/include"; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export CPLUS_INCLUDE_PATH="/usr/local/include"; fi
@@ -42,8 +41,6 @@ before_install:
   # mac: workaround for homebrew qmake not being symlinked into $PATH
   # see https://stackoverflow.com/questions/48847505/why-cant-i-use-qmake-on-mac-after-installing-it
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export PATH="/usr/local/opt/qt/bin:$PATH"; fi
-
-script: 
   - gcc -v && g++ -v
   - cd src
   - ./build

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
   apt:
     update: true
     packages:
-      - g++-7
+      - g++-6
       - qt5-default
       - qttools5-dev-tools
       - libjack-dev 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ addons:
       - librtaudio-dev
 
 before_script:
-  # manually install brew packages as homebrew is broken in the default osx image
+  # manually install brew packages as addon: homebrew is broken in the default osx image
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then 
-      brew install $PKGS_OSX
+      brew install $PKGS_OSX;
     fi
   # mac: workaround for homebrew qmake not being symlinked into $PATH
   # see https://stackoverflow.com/questions/48847505/why-cant-i-use-qmake-on-mac-after-installing-it

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
   apt:
     update: true
     packages:
-      - g++-9
+      - g++-7
       - qt5-default
       - qttools5-dev-tools
       - libjack-dev 
@@ -32,7 +32,7 @@ addons:
 before_install:
   # workaround for homebrew qmake not being symlinked into $PATH
   # see https://stackoverflow.com/questions/48847505/why-cant-i-use-qmake-on-mac-after-installing-it
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export PATH="/usr/local/opt/qt/bin:$PATH" fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export PATH="/usr/local/opt/qt/bin:$PATH"; fi
 
 script: 
   - cd src

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ addons:
 before_install:
   # linux: use gcc-6
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export CC="gcc-6"; export CXX="g++-6"; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo ln -s /usr/bin/gcc-6 /usr/local/bin/gcc; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo ln -s /usr/bin/g++-6 /usr/local/bin/g++; fi
   - gcc -v && g++ -v
   # mac: workaround for homebrew-installed headers
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export C_INCLUDE_PATH="/usr/local/include"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ addons:
       - libjack-dev 
       - librtaudio-dev
   homebrew:
+    update: true
     packages:
       - jack
       - qt
@@ -48,6 +49,7 @@ script:
       export PATH="/usr/local/opt/qt/bin:$PATH";
     fi
   - ls /usr/local/include
+  - qmake-qt5 --version
   - gcc -v && g++ -v
   - cd src
   - ./build

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,26 @@ env:
   global:
   - PKGS_LINUX="qt5-default qttools5-dev-tools libjack-dev librtaudio-dev"
   - PKGS_OSX="jack qt rt-audio"
+  
+addons:
+  apt:
+    update: true
+    packages:
+      - g++-9
+      - qt5-default
+      - qttools5-dev-tools
+      - libjack-dev 
+      - librtaudio-dev
+  homebrew:
+    packages:
+      - jack
+      - qt
+      - rt-audio
 
 before_install:
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get update; sudo apt-get install $PKGS_LINUX; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update; brew install $PKGS_OSX; fi
+  # workaround for homebrew qmake not being symlinked into $PATH
+  # see https://stackoverflow.com/questions/48847505/why-cant-i-use-qmake-on-mac-after-installing-it
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export PATH="/usr/local/opt/qt/bin:$PATH" fi
 
 script: 
   - cd src

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ language:
   - cpp
 
 dist: bionic
+osx_image: xcode11.6
 
 branches:
   - master
@@ -25,7 +26,7 @@ addons:
       - libjack-dev 
       - librtaudio-dev
   homebrew:
-    update: true
+    # update: true
     packages:
       - jack
       - qt

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ addons:
 before_install:
   # linux: use gcc-6
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export CC="gcc-6"; export CXX="g++-6"; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo ln -s /usr/bin/gcc-6 /usr/local/bin/gcc; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo ln -s /usr/bin/g++-6 /usr/local/bin/g++; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo ln -s /usr/bin/gcc-6 /usr/bin/gcc; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo ln -s /usr/bin/g++-6 /usr/bin/g++; fi
   - gcc -v && g++ -v
   # mac: workaround for homebrew-installed headers
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export C_INCLUDE_PATH="/usr/local/include"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,11 @@ addons:
       - librtaudio-dev
 
 before_script:
-  # manually install brew packages as addon: homebrew is broken in the default osx image
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then 
+      # manually install brew packages as addon: homebrew is broken in the default osx image
       brew install $PKGS_OSX;
-    fi
-  # mac: workaround for homebrew qmake not being symlinked into $PATH
-  # see https://stackoverflow.com/questions/48847505/why-cant-i-use-qmake-on-mac-after-installing-it
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then 
+      # mac: workaround for homebrew qmake not being symlinked into $PATH
+      # see https://stackoverflow.com/questions/48847505/why-cant-i-use-qmake-on-mac-after-installing-it
       export PATH="/usr/local/opt/qt/bin:$PATH";
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,9 @@ addons:
 script: 
   # linux: use gcc-6
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export CC="gcc-6"; export CXX="g++-6"; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo ln -s /usr/bin/gcc-6 /usr/bin/gcc; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo ln -s /usr/bin/g++-6 /usr/bin/g++; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo ln -s /usr/bin/gcc-6 /usr/local/bin/gcc; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo ln -s /usr/bin/g++-6 /usr/local/bin/g++; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export PATH="/usr/local/bin:$PATH"; fi
   # mac: workaround for homebrew-installed headers
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export C_INCLUDE_PATH="/usr/local/include"; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export CPLUS_INCLUDE_PATH="/usr/local/include"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ dist: bionic
 
 branches:
   - master
-  - travis
 
 env:
   global:

--- a/src/RingBuffer.h
+++ b/src/RingBuffer.h
@@ -44,6 +44,8 @@
 
 #include "jacktrip_types.h"
 
+#include <atomic>
+
 //using namespace JackTripNamespace;
 
 

--- a/src/build
+++ b/src/build
@@ -17,9 +17,6 @@ if [[ $platform == 'linux' ]]; then
     if hash qmake-qt5 2>/dev/null; then
 	echo "Using qmake-qt5"
 	QCMD=qmake-qt5
-    elif hash qmake-qt4 2>/dev/null; then
-	echo "Using qmake-qt4"
-	QCMD=qmake-qt4
     elif hash qmake 2>/dev/null; then #in case qt was compiled by user
 	echo "Using qmake"
 	QCMD=qmake

--- a/src/jacktrip.pro
+++ b/src/jacktrip.pro
@@ -55,7 +55,7 @@ macx {
 
 linux-g++ | linux-g++-64 {
 #   LIBS += -lasound -lrtaudio
-  QMAKE_CXXFLAGS += -std=c++11 -D__LINUX_ALSA__ #-D__LINUX_OSS__ #RtAudio Flags
+  QMAKE_CXXFLAGS += -D__LINUX_ALSA__ #-D__LINUX_OSS__ #RtAudio Flags
 
 FEDORA = $$system(cat /proc/version | grep -o fc)
 

--- a/src/jacktrip.pro
+++ b/src/jacktrip.pro
@@ -43,7 +43,7 @@ INCLUDEPATH += ../faust-src-lair/stk
 
 macx {
   message(Building on MAC OS X)
-  QMAKE_CXXFLAGS += -D__MACOSX_CORE__ #-D__UNIX_JACK__ #RtAudio Flags
+  QMAKE_CXXFLAGS += -I/usr/local/include -D__MACOSX_CORE__ #-D__UNIX_JACK__ #RtAudio Flags
   QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.9
   #QMAKE_MAC_SDK = macosx10.9
   CONFIG -= app_bundle
@@ -55,7 +55,7 @@ macx {
 
 linux-g++ | linux-g++-64 {
 #   LIBS += -lasound -lrtaudio
-  QMAKE_CXXFLAGS += -D__LINUX_ALSA__ #-D__LINUX_OSS__ #RtAudio Flags
+  QMAKE_CXXFLAGS += -std=c++11 -D__LINUX_ALSA__ #-D__LINUX_OSS__ #RtAudio Flags
 
 FEDORA = $$system(cat /proc/version | grep -o fc)
 

--- a/src/jacktrip.pro
+++ b/src/jacktrip.pro
@@ -43,7 +43,7 @@ INCLUDEPATH += ../faust-src-lair/stk
 
 macx {
   message(Building on MAC OS X)
-  QMAKE_CXXFLAGS += -I/usr/local/include -D__MACOSX_CORE__ #-D__UNIX_JACK__ #RtAudio Flags
+  QMAKE_CXXFLAGS += -D__MACOSX_CORE__ #-D__UNIX_JACK__ #RtAudio Flags
   QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.9
   #QMAKE_MAC_SDK = macosx10.9
   CONFIG -= app_bundle


### PR DESCRIPTION
Basic Travis Continuous Integration support. Adds a `.travis.yml` to the repo and fixes a few things that were preventing it from compiling on Travis' Linux VM.

Currently this simply compiles jacktrip on Linux + Mac to ensure that it compiles on both. A test suite + Windows + installer generation can be added on top of this foundation.  

To close the loop, Travis also needs to be added to the jacktrip repo, which needs to be done by someone with read/write permission to the repo (I can do this if you add me). 

Note: please use "squash and merge" when merging as there are a lot of pointless commits to test Travis functionality; squashing will reduce these down to a single commit. 
