### PR TITLE
build in a subdirectory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 # QtCreator user files
 *.pro.user
 *.pro.user.*
+
+# build directory
+builddir/

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -103,7 +103,7 @@ $ qmake -config nojack jacktrip.pro
 $ make release
 
 
-If you want to install (using Terminal): on the /src directory type:
+If you want to install (using Terminal): on the /builddir directory type:
 
 $ sudo cp jacktrip /usr/local/bin/
   (enter your password when prompted)

--- a/src/build
+++ b/src/build
@@ -28,15 +28,17 @@ elif [[ $platform == 'macosx' ]]; then
 fi
 
 # Build
+mkdir -p ../builddir
+cd ../builddir
 if [[ $1 == 'nojack' ]]; then
     echo "Building without Jack"
-    $QCMD -spec $QSPEC -config nojack jacktrip.pro
+    $QCMD -spec $QSPEC -config nojack ../src/jacktrip.pro
     make clean
-    $QCMD -spec $QSPEC -config nojack jacktrip.pro
+    $QCMD -spec $QSPEC -config nojack ../src/jacktrip.pro
     make release
 else
-    $QCMD -spec $QSPEC jacktrip.pro
+    $QCMD -spec $QSPEC ../src/jacktrip.pro
     make clean
-    $QCMD -spec $QSPEC jacktrip.pro
+    $QCMD -spec $QSPEC ../src/jacktrip.pro
     make release
 fi


### PR DESCRIPTION
Currently running the `./build` script generates artifacts in the `src` directory, being intermingled with source files and showing up as uncommitted changes in the git repository.

In this PR I propose to create the `build` subdirectory, add its contents to `.gitignore` and change the build script to output files there. 

With my limited experience I'm not sure if this is the best approach, I'm looking forward to getting some feedback on this!