### PR TITLE
Fix OSX defines in UdpDataProtocol

### DIFF
--- a/src/UdpDataProtocol.cpp
+++ b/src/UdpDataProtocol.cpp
@@ -51,7 +51,7 @@
 #include <winsock2.h> //cc need SD_SEND
 #include <ws2tcpip.h> // for IPv6
 #endif
-#if defined (__LINUX__) || (__MAC__OSX__)
+#if defined (__LINUX__) || (__MAC_OSX__)
 #include <sys/socket.h> // for POSIX Sockets
 #endif
 
@@ -101,7 +101,7 @@ UdpDataProtocol::~UdpDataProtocol()
 void UdpDataProtocol::setPeerAddress(const char* peerHostOrIP)
 {
     // Get DNS Address
-#if defined (__LINUX__) || (__MAC__OSX__)
+#if defined (__LINUX__) || (__MAC_OSX__)
     //Don't make the following code conditional on windows
     //(Addresses a weird timing bug when in hub client mode)
     if (!mPeerAddress.setAddress(peerHostOrIP)) {
@@ -113,7 +113,7 @@ void UdpDataProtocol::setPeerAddress(const char* peerHostOrIP)
         }
         //cout << "UdpDataProtocol::setPeerAddress IP Address Number: "
         //    << mPeerAddress.toString().toStdString() << endl;
-#if defined (__LINUX__) || (__MAC__OSX__)
+#if defined (__LINUX__) || (__MAC_OSX__)
     }
 #endif
 


### PR DESCRIPTION
Removed an extra _ in a couple of defines.