### PR TITLE
Fix reorder warnings

### DIFF
--- a/src/JackTripWorker.h
+++ b/src/JackTripWorker.h
@@ -120,12 +120,13 @@ private:
     /// Client Outgoing Port. By convention, the receving port will be <tt>mClientPort -1</tt>
     uint16_t mClientPort;
 
+    int mBufferQueueLength;
+    JackTrip::underrunModeT mUnderRunMode;
+
     /// Thread spawning internal lock.
     /// If true, the prototype is working on creating (spawning) a new thread
     volatile bool mSpawning;
     QMutex mMutex; ///< Mutex to protect mSpawning
-    JackTrip::underrunModeT mUnderRunMode;
-    int mBufferQueueLength;
 
     int mID; ///< ID thread number
     int mNumChans; ///< Number of Channels


### PR DESCRIPTION
Just some reordering to get rid of these compilation warnings.