### PR TITLE
Fix all warnings

### DIFF
--- a/src/JMess.cpp
+++ b/src/JMess.cpp
@@ -177,7 +177,7 @@ void JMess::connectSpawnedPorts(int nChans, int hubPatch)
     QString IPS[gMAX_WAIRS];
     int ctr = 0;
 
-    const char **ports, **connections; //vector of ports and connections
+    const char **ports; //vector of ports
     QVector<QString> OutputInput(2); //helper variable
 
     //Get active output ports.

--- a/src/JackTripWorker.h
+++ b/src/JackTripWorker.h
@@ -120,12 +120,13 @@ private:
     /// Client Outgoing Port. By convention, the receving port will be <tt>mClientPort -1</tt>
     uint16_t mClientPort;
 
+    int mBufferQueueLength;
+    JackTrip::underrunModeT mUnderRunMode;
+
     /// Thread spawning internal lock.
     /// If true, the prototype is working on creating (spawning) a new thread
     volatile bool mSpawning;
     QMutex mMutex; ///< Mutex to protect mSpawning
-    JackTrip::underrunModeT mUnderRunMode;
-    int mBufferQueueLength;
 
     int mID; ///< ID thread number
     int mNumChans; ///< Number of Channels

--- a/src/UdpDataProtocol.cpp
+++ b/src/UdpDataProtocol.cpp
@@ -319,7 +319,14 @@ int UdpDataProtocol::bindSocket()
 int UdpDataProtocol::receivePacket(QUdpSocket& UdpSocket, char* buf, const size_t n)
 {
     // Block until There's something to read
-    while ( (UdpSocket.pendingDatagramSize() < n) && !mStopped ) { QThread::usleep(100); }
+    while(
+        //TODO: Use a constant for maxPacketSize
+        ( (UdpSocket.pendingDatagramSize() < 0) || static_cast<uint64_t>(UdpSocket.pendingDatagramSize()) < n) &&
+        !mStopped
+        )
+    {
+        QThread::usleep(100);
+    }
     int n_bytes = UdpSocket.readDatagram(buf, n);
     return n_bytes;
 }


### PR DESCRIPTION
Fixes all compilation warnings.

Could somebody look at the fix for the sign compare warning. This was undefined behavior because nobody knows what the compiler casts. Maybe it wasn't a problem because of implicit boundaries. I'm sure there are some and we should make them explicit.