### PR TITLE
Fix for hubserver failure with concurrent connections

### DIFF
--- a/src/UdpHubListener.cpp
+++ b/src/UdpHubListener.cpp
@@ -136,7 +136,7 @@ void UdpHubListener::run()
         cout << "JackTrip HUB SERVER: Waiting for client connections..." << endl;
         cout << "JackTrip HUB SERVER: Hub auto audio patch setting = " << mHubPatch << endl;
         cout << "=======================================================" << endl;
-        while ( !TcpServer.waitForNewConnection(1000) )
+        while ( !TcpServer.hasPendingConnections() && !TcpServer.waitForNewConnection(1000) )
         { if (mStopped) { return; } } // block until a new connection is received
         cout << "JackTrip HUB SERVER: Client Connection Received!" << endl;
 

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -137,7 +137,7 @@ void setRealtimeProcessPriority();
 /// \name JackTrip Server parameters
 //@{
 /// Maximum Threads that can be run at the same time
-const int gMaxThreads = 290; // some pthread limit around 297?
+const int gMaxThreads = 1024;
 
 /// Public well-known UDP port to where the clients will connect
 const int gServerUdpPort = 4464;


### PR DESCRIPTION
TcpServer was not checking for pending connections before waiting to receive new ones. This was causing it to fail when more than 1 client connected to a hub server at the same time.

Also bumping pthreads limit -- this was tested at scale of 500 with no issues