### PR TITLE
Updates required qt dependency to 5.15

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -67,7 +67,7 @@ $ sudo make install
 Dependencies:
 
 You need to have installed the libraries in your system:
-Qt 5.3 or higher
+Qt 5.15 or higher
 jack-audio-connection-kit-devel
 rtaudio
 
@@ -77,7 +77,7 @@ and install qt from the qt site.
 
 If you want to build on MacOS X, you need JackOSX
 http://www.jackosx.com/
-and Qt 5.3 or higher.
+and Qt 5.15 or higher.
 
 It is also possible to build without jack, see below.
 


### PR DESCRIPTION
I tried compiling jacktrip 1.2 (as per the tag) against QT 5.3 on a debian stable box, and it fails. It looks like one of the network methods jacktrip 1.2 calls:
https://github.com/jacktrip/jacktrip/blob/v1.2/src/JackTrip.cpp#L553

was only introduced in QT 5.15:
https://github.com/qt/qtbase/commit/775d04f97ec1723c01c12f8faab05236686b9b05

I'm really excited about the possibilities for hub mode, as I have a large group I'd like to try this with, and I doubt that all of us have enough bandwidth for a full mesh network!