### PR TITLE
rework handling of JACK client name

### DIFF
--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -159,14 +159,14 @@ void JackTrip::setupAudio(
 #ifdef WAIRTOHUB // WAIR
         //Set our Jack client name if we're a hub server or a custom name hasn't been set
 	      if ( mPeerAddress.toStdString() != "" &&
-	          (mJackClientName == gJackDefaultClientName || mJackTripMode == SERVERPINGSERVER)) {
-            mJackClientName = QString(mPeerAddress).replace(":", ".").toLatin1().constData();
+	          (mJackClientName.constData() == gJackDefaultClientName.constData() || mJackTripMode == SERVERPINGSERVER)) {
+	          mJackClientName = QString(mPeerAddress).replace(":", ".");
         }
 //        std::cout  << "WAIR ID " << ID << " jacktrip client name set to=" <<
 //                      mJackClientName << std::endl;
 #endif // endwhere
 
-        mAudioInterface->setClientName(mJackClientName);
+        mAudioInterface->setClientName(mJackClientName.toLatin1().constData());
 
         if (gVerboseFlag) std::cout << "  JackTrip:setupAudio before mAudioInterface->setup" << std::endl;
         mAudioInterface->setup();

--- a/src/JackTrip.h
+++ b/src/JackTrip.h
@@ -227,7 +227,7 @@ public:
     }
     /// \brief Set Client Name to something different that the default (JackTrip)
     virtual void setClientName(const char* ClientName)
-    { mJackClientName = ClientName; }
+    { mJackClientName = QString(ClientName); }
     /// \brief Set the number of audio channels
     virtual void setNumChannels(int num_chans)
     { mNumChans = num_chans; }
@@ -500,7 +500,7 @@ private:
     int mTcpServerPort;
 
     unsigned int mRedundancy; ///< Redundancy factor in network data
-    const char* mJackClientName; ///< JackAudio Client Name
+    QString mJackClientName; ///< JackAudio Client Name
 
     JackTrip::connectionModeT mConnectionMode; ///< Connection Mode
     JackTrip::hubConnectionModeT mHubConnectionModeT; ///< Hub Server Jack Audio Patch Connection Mode

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -123,7 +123,7 @@ extern int gVerboseFlag; ///< Verbose mode flag declaration
 /// \name JackAudio
 //@{
 const int gJackBitResolution = 32; ///< Audio Bit Resolution of the Jack Server
-const char* const gJackDefaultClientName = "JackTrip";
+const QString gJackDefaultClientName = "JackTrip";
 //@}
 
 


### PR DESCRIPTION
Per discussion in #102, here's a proposal to use `QString` for JACK client name.