### PR TITLE
Set QT5 dependency in build script

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -32,10 +32,10 @@ To build using QtCreator (tested using QtCreator 4.11 and macOS 10.13.6):
 ---
 Fedora installation (also tested on Ubuntu Studio):
 
-To install on Fedora (and possibly other Linux distributions), you need qt5, jack-audio-connection-kit-devel, and rtaudio.
+To install on Fedora (and possibly other Linux distributions), you need qt5, qtchooser, jack-audio-connection-kit-devel, and rtaudio.
 
 How to install qt5 and other needed tools on Fedora: 
-dnf install qt5-devel
+dnf install qt5-devel qtchooser
 dnf groupinstall "C Development Tools and Libraries"
 dnf groupinstall "Development Tools"
 dnf install jack-audio-connection-kit-devel alsa-lib-devel iperf qjackctl audacity git

--- a/INSTALL_meson.md
+++ b/INSTALL_meson.md
@@ -3,10 +3,10 @@
 ## Install Dependencies
 
 Fedora:
-dnf install meson qt5-qtbase-devel rtaudio-devel jack-audio-connection-kit-devel
+dnf install meson qt5-qtbase-devel rtaudio-devel jack-audio-connection-kit-devel qtchooser
 
 Debian/Ubuntu:
-apt install meson build-essential qtbase5-dev librtaudio-dev libjack-jackd2-dev
+apt install meson build-essential qtbase5-dev librtaudio-dev libjack-jackd2-dev qtchooser
 
 MacOS with brew (not tested):
 brew install meson qt rt-audio jack

--- a/src/build
+++ b/src/build
@@ -14,13 +14,7 @@ fi
 
 # Set qmake command name
 if [[ $platform == 'linux' ]]; then
-    if hash qmake-qt5 2>/dev/null; then
-	echo "Using qmake-qt5"
-	QCMD=qmake-qt5
-    elif hash qmake 2>/dev/null; then #in case qt was compiled by user
-	echo "Using qmake"
-	QCMD=qmake
-    fi
+    QCMD='qtchooser -run-tool=qmake -qt=5'
     QSPEC=linux-g++
 elif [[ $platform == 'macosx' ]]; then
     QCMD=qmake


### PR DESCRIPTION
Updated build script to select QT5 build tools when 4 and 5 are installed. Resolves #105