### PR TITLE
Define PREFIX variable for installation path (Defaults to /usr/local)

### DIFF
--- a/src/build
+++ b/src/build
@@ -37,8 +37,8 @@ if [[ $1 == 'nojack' ]]; then
     $QCMD -spec $QSPEC -config nojack ../src/jacktrip.pro
     make release
 else
-    $QCMD -spec $QSPEC ../src/jacktrip.pro
+    $QCMD -spec $QSPEC ../src/jacktrip.pro $@
     make clean
-    $QCMD -spec $QSPEC ../src/jacktrip.pro
+    $QCMD -spec $QSPEC ../src/jacktrip.pro $@
     make release
 fi

--- a/src/jacktrip.pro
+++ b/src/jacktrip.pro
@@ -110,7 +110,13 @@ win32 {
 
 DESTDIR = .
 QMAKE_CLEAN += -r ./jacktrip ./jacktrip_debug ./release ./debug
-target.path = /usr/bin
+
+# isEmpty(PREFIX) will allow path to be changed during the command line
+# call to qmake, e.g. qmake PREFIX=/usr
+isEmpty(PREFIX) {
+ PREFIX = /usr/local
+}
+target.path = $${PREFIX}/bin/
 INSTALLS += target
 
 # for plugins

--- a/src/jacktrip.pro
+++ b/src/jacktrip.pro
@@ -116,7 +116,7 @@ QMAKE_CLEAN += -r ./jacktrip ./jacktrip_debug ./release ./debug
 isEmpty(PREFIX) {
  PREFIX = /usr/local
 }
-target.path = $${PREFIX}/bin/
+target.path = $$PREFIX/bin/
 INSTALLS += target
 
 # for plugins


### PR DESCRIPTION
- This forwards all parameters of the build script to qmake
- './build PREFIX=/usr; make install' installs jacktrip in /usr/bin
- './build; make install' installs jacktrip in /usr/local/bin, so it doesn't conflict with a packaged installation of jacktrip