### PR TITLE
it's fine / possible to leave both branch names in the .travis.yml wi…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,9 @@ language:
 dist: bionic
 
 branches:
+  - main
   - dev
-
+  
 env:
   global:
   - PKGS_OSX="jack qt rt-audio"


### PR DESCRIPTION
…thin both branches. In other words: branches - dev - main is fine to leave in both dev and main branches, and in my experience can reduce confusion and also merge issues when syncing the two branches