### PR TITLE
jos branch Aaron/Anton/JOS bugfix PR

### DIFF
--- a/src/Effects.h
+++ b/src/Effects.h
@@ -69,7 +69,7 @@ class Effects
   Reverb* inFreeverbP = nullptr;
   Reverb* outFreeverbP = nullptr;
   int parenLevel = 0;
-  char lastEffect = NULL;
+  char lastEffect = '\0';
   float compressorInLevelChange = 0;
   float compressorOutLevelChange = 0;
   float zitarevInLevel = 1.0f; // "Level" = wetness from 0 to 1
@@ -87,14 +87,23 @@ public:
     mLimit(LIMITER_NONE),
     mNumClientsAssumed(2)
   {}
-     
+
   ~Effects() {
-    if (inCompressor) { delete inCompressorP; }
-    if (outCompressor) { delete outCompressorP; }
-    if (inZitarev) { delete inZitarevP; }
-    if (outZitarev) { delete outZitarevP; }
-    if (inFreeverb) { delete inFreeverbP; }
-    if (outFreeverb) { delete outFreeverbP; }
+    /*
+      Plugin ownership presently passes to JackTrip,
+      and deletion occurs in AudioInterface.cpp. See
+        delete mProcessPluginsFromNetwork[i];
+        delete mProcessPluginsToNetwork[i];
+      there.  If/when we ever do it here:
+	if (inCompressor) { delete inCompressorP; }
+	if (outCompressor) { delete outCompressorP; }
+	if (inZitarev) { delete inZitarevP; }
+	if (outZitarev) { delete outZitarevP; }
+	if (inFreeverb) { delete inFreeverbP; }
+	if (outFreeverb) { delete outFreeverbP; }
+      but if everyone can compile C++11,
+      let's switch to using std::unique_ptr.
+    */
   }
 
   unsigned int getNumClientsAssumed() { return mNumClientsAssumed; }
@@ -165,23 +174,23 @@ public:
     char c = optarg[0];
     if (not isalpha(c)) { // backward compatibility why not?, e.g., "-f 0.5"
       // -f reverbLevelFloat
-      mReverbLevel = atof(optarg); 
+      mReverbLevel = atof(optarg);
       outCompressor = true;
       inZitarev = mReverbLevel > 1.0;
       inFreeverb = mReverbLevel <= 1.0;
       if (inZitarev) {
         zitarevInLevel = mReverbLevel - 1.0; // wetness from 0 to 1
-      } 
+      }
       if (inFreeverb) {
         freeverbInLevel = mReverbLevel; // wetness from 0 to 1
-      } 
+      }
     } else {
       // -f "i:[c][f|z][(reverbLevel)]], o:[c][f|z][(rl)]"
       if (gVerboseFlag) {
         std::cout << "-f (--effects) arg = " << optarg << std::endl;
       }
       ulong nac = strlen(optarg);
-    
+
       for (ulong i=0; i<nac; i++) {
         if (optarg[i]!=')' && parenLevel>0) { continue; }
         switch(optarg[i]) {
@@ -240,7 +249,7 @@ public:
     }
     return returnCode;
   }
-  
+
   int parseLimiterOptArg(char* optarg) {
     char c1 = tolower(optarg[0]);
     if (c1 == '-') {
@@ -248,7 +257,7 @@ public:
       return 1;
     }
     char c2 = (strlen(optarg)>1 ? tolower(optarg[1]) : '\0');
-    if ((c1 == 'i' && c2 == 'o') || (c1 == 'o' && c2 == 'i')) { 
+    if ((c1 == 'i' && c2 == 'o') || (c1 == 'o' && c2 == 'i')) {
       mLimit = LIMITER_BOTH;
       if (gVerboseFlag) {
         std::cout << "Set up Overflow Limiter for both INCOMING and OUTGOING\n";
@@ -280,9 +289,9 @@ public:
     mNumClientsAssumed = atoi(optarg);
     if(mNumClientsAssumed < 1) {
       std::cerr << "-p ERROR: Must have at least one assumed sound source: "
-                << atoi(optarg) << " is not supported." << endl;
+                << atoi(optarg) << " is not supported." << std::endl;
       return 1;
     }
+    return 0;
   }
 };
-

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -112,7 +112,7 @@ void Settings::parseInput(int argc, char** argv)
     // options descriptor
     //----------------------------------------------------------------------------
     static struct option longopts[] = {
-        // These options don't set a flag.
+    // These options don't set a flag.
     { "numchannels", required_argument, NULL, 'n' }, // Number of input and output channels
 #ifdef WAIR // WAIR
     { "wair", no_argument, NULL, 'w' }, // Run in LAIR mode, sets numnetrevchannels
@@ -157,7 +157,7 @@ void Settings::parseInput(int argc, char** argv)
     //----------------------------------------------------------------------------
     /// \todo Specify mandatory arguments
     int ch;
-    while ( (ch = getopt_long(argc, argv,
+    while ((ch = getopt_long(argc, argv,
                               "n:N:H:sc:SC:o:B:P:U:q:r:b:zlwjeJ:RTd:F:p:DvVhIGf:O:a:", longopts, NULL)) != -1 )
         switch (ch) {
 
@@ -408,8 +408,6 @@ void Settings::parseInput(int argc, char** argv)
         cout << gPrintSeparator << endl;
     }
 
-    // Perform allocation that depends on options:
-    mEffects.allocateEffects(mNumChans);
 }
 
 
@@ -642,19 +640,22 @@ void Settings::startJackTrip()
             // -------------------------------------------------------------
         }
 
-    }
+	// Allocate audio effects in client, if any:
+	mEffects.allocateEffects(mNumChans);
 
-    // Outgoing/Incoming Compressor and/or Reverb:
-    mJackTrip->appendProcessPluginToNetwork( mEffects.getOutCompressor() );
-    mJackTrip->appendProcessPluginFromNetwork( mEffects.getInCompressor() );
-    mJackTrip->appendProcessPluginToNetwork( mEffects.getOutZitarev() );
-    mJackTrip->appendProcessPluginFromNetwork( mEffects.getInZitarev() );
-    mJackTrip->appendProcessPluginToNetwork( mEffects.getOutFreeverb() );
-    mJackTrip->appendProcessPluginFromNetwork( mEffects.getInFreeverb() );
+	// Outgoing/Incoming Compressor and/or Reverb:
+	mJackTrip->appendProcessPluginToNetwork( mEffects.getOutCompressor() );
+	mJackTrip->appendProcessPluginFromNetwork( mEffects.getInCompressor() );
+	mJackTrip->appendProcessPluginToNetwork( mEffects.getOutZitarev() );
+	mJackTrip->appendProcessPluginFromNetwork( mEffects.getInZitarev() );
+	mJackTrip->appendProcessPluginToNetwork( mEffects.getOutFreeverb() );
+	mJackTrip->appendProcessPluginFromNetwork( mEffects.getInFreeverb() );
 
-    // Limiters go last in the plugin sequence:
-    mJackTrip->appendProcessPluginFromNetwork( mEffects.getInLimiter() );
-    mJackTrip->appendProcessPluginToNetwork( mEffects.getOutLimiter() );
+	// Limiters go last in the plugin sequence:
+	mJackTrip->appendProcessPluginFromNetwork( mEffects.getInLimiter() );
+	mJackTrip->appendProcessPluginToNetwork( mEffects.getOutLimiter() );
+
+    } // end creation of mJackTrip client
 
 #ifdef WAIR // WAIR
         if ( mWAIR ) {


### PR DESCRIPTION
Bugfix PR for commit Jos (#135): 

Aaron: 
  - allocate Faust audio effects during mJackTrip client creation only (not server).
  - do not deallocate effects in Effects.cpp because AudioInterface.cpp is doing it.
  - return 0 upon successful parsing of --assumednumclients
  - reduce compiler warnings

Anton:
  - load allocated audio effects during mJackTrip client creation only (not server).

jos: 
 - add explanatory comments
 - reduce compiler warnings
