### PR TITLE
[Main] Meson: Fix MacOS detection, set C++11 as default

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,14 +1,16 @@
-project('jacktrip', 'cpp', version: '1.2')
+project('jacktrip', 'cpp', version: '1.2',
+	default_options: ['cpp_std=c++11'])
 qt5 = import('qt5')
-qt5_dep = dependency('qt5', modules: ['Core', 'Network'])
-jack_dep = dependency('jack')
-rtaudio_dep = dependency('rtaudio')
-thread_dep = dependency('threads')
+
+dependencies = [
+	dependency('qt5', modules: ['Core', 'Network']),
+	dependency('jack'),
+	dependency('threads')]
 
 defines = []
 if host_machine.system() == 'linux'
 	defines += '-D__LINUX__'
-elif host_machine.system() == 'osx'
+elif host_machine.system() == 'darwin'
 	defines += '-D__MAC_OSX__'
 elif host_machine.system() == 'windows'
 	defines += '-D__WIN_32__'
@@ -42,4 +44,4 @@ src = ['src/DataProtocol.cpp',
 	'src/AudioInterface.cpp',
 	'src/JackAudioInterface.cpp']
 
-executable('jacktrip', src, moc_files, dependencies: [qt5_dep, jack_dep, rtaudio_dep, thread_dep], cpp_args: defines, install: true )
+executable('jacktrip', src, moc_files, dependencies: dependencies, cpp_args: defines, install: true)


### PR DESCRIPTION
This fixes meson build for MacOS for the 'main' branch. The meson.build file will look different for the 'dev' branch. Another PR will follow.

- set the MacOS variable
- set C++11 as default
- remove rtaudio dependency