### PR TITLE
Fix nojack build

### DIFF
--- a/src/UdpHubListener.cpp
+++ b/src/UdpHubListener.cpp
@@ -227,13 +227,13 @@ void UdpHubListener::run()
             cout << "JackTrip HUB SERVER: Total Running Threads:  " << mTotalRunningThreads << endl;
             cout << "===============================================================" << endl;
             QThread::msleep(100);
+#ifndef __NO_JACK__
 #ifdef WAIR // WAIR
             if (isWAIR()) connectMesh(true); // invoked with -Sw
 #endif // endwhere
-
-//            qDebug() << "mPeerAddress" << mActiveAddress[id].address << mActiveAddress[id].port;
-
+//            qDebug(j) << "mPeerAddress" << mActiveAddress[id].address << mActiveAddress[id].port;
             connectPatch(true);
+#endif //__NO_JACK__
         }
     }
 
@@ -432,13 +432,16 @@ int UdpHubListener::releaseThread(int id)
     mActiveAddress[id].address = "";
     mActiveAddress[id].port = 0;
     mTotalRunningThreads--;
+#ifndef __NO_JACK__
 #ifdef WAIR // wair
     if (isWAIR()) connectMesh(false); // invoked with -Sw
 #endif // endwhere
     if (getHubPatch()) connectPatch(false); // invoked with -p > 0
+#endif //__NO_JACK__
     return 0; /// \todo Check if we really need to return an argument here
 }
 
+#ifndef __NO_JACK__
 #ifdef WAIR // wair
 #include "JMess.h"
 //*******************************************************************************
@@ -462,7 +465,6 @@ void UdpHubListener::enumerateRunningThreadIDs()
 }
 #endif // endwhere
 
-#include "JMess.h"
 void UdpHubListener::connectPatch(bool spawn)
 {
     if(m_connectDefaultAudioPorts) {
@@ -481,6 +483,7 @@ void UdpHubListener::connectPatch(bool spawn)
         tmp.connectSpawnedPorts(gDefaultNumInChannels,getHubPatch());
     // FIXME: need change to gDefaultNumInChannels if more than stereo
 }
+#endif //__NO_JACK__
 
 // TODO:
 // USE bool QAbstractSocket::isValid () const to check if socket is connect. if not, exit loop

--- a/src/UdpHubListener.h
+++ b/src/UdpHubListener.h
@@ -147,6 +147,7 @@ private:
     bool m_connectDefaultAudioPorts;
     Settings* m_settings;
 
+#ifndef __NO_JACK__
 #ifdef WAIR // wair
     bool mWAIR;
     void connectMesh(bool spawn);
@@ -156,6 +157,7 @@ public :
     bool isWAIR() {return mWAIR;}
 #endif // endwhere
     void connectPatch(bool spawn);
+#endif //__NO_JACK__
 public :
     unsigned int mHubPatch;
     void setHubPatch(unsigned int p) {mHubPatch = p;}

--- a/src/jacktrip.pro
+++ b/src/jacktrip.pro
@@ -118,7 +118,6 @@ INCLUDEPATH += ../faust-src-lair
 
 # Input
 HEADERS += DataProtocol.h \
-           JMess.h \
            JackTrip.h \
            jacktrip_globals.h \
            jacktrip_types.h \
@@ -139,10 +138,10 @@ HEADERS += DataProtocol.h \
            AudioInterface.h
 
 !nojack {
-HEADERS += JackAudioInterface.h
+HEADERS += JackAudioInterface.h \
+           JMess.h
 }
 SOURCES += DataProtocol.cpp \
-           JMess.cpp \
            JackTrip.cpp \
            jacktrip_globals.cpp \
            jacktrip_main.cpp \
@@ -159,7 +158,8 @@ SOURCES += DataProtocol.cpp \
            AudioInterface.cpp
 
 !nojack {
-SOURCES += JackAudioInterface.cpp
+SOURCES += JackAudioInterface.cpp \
+           JMess.cpp
 }
 
 # RtAduio Input


### PR DESCRIPTION
The introduction of `JMess` broke `build nojack` builds - This PR fixes the issue by using the existing `__NO_JACK__` definition to avoid referencing `JMess` when building with `nojack`.