### PR TITLE
Shutdown gracefully when Jack Server stops

### DIFF
--- a/src/JMess.cpp
+++ b/src/JMess.cpp
@@ -370,7 +370,7 @@ void JMess::disconnectAll()
          it != mConnectedPorts.end(); ++it) {
         OutputInput = *it;
 
-        if (jack_disconnect(mClient, OutputInput[0].toLatin1(), OutputInput[1].toLatin1())) {
+        if (jack_disconnect(mClient, OutputInput[0].toUtf8(), OutputInput[1].toUtf8())) {
             cerr << "WARNING: port: " << qPrintable(OutputInput[0])
                     << "and port: " << qPrintable(OutputInput[1])
                     << " could not be disconnected.\n";

--- a/src/JackAudioInterface.cpp
+++ b/src/JackAudioInterface.cpp
@@ -268,7 +268,8 @@ int JackAudioInterface::stopProcess() const
 void JackAudioInterface::jackShutdown (void*)
 {
     //std::cout << "The Jack Server was shut down!" << std::endl;
-    throw std::runtime_error("The Jack Server was shut down!");
+    JackTrip::sJackStopped = true;
+    //throw std::runtime_error("The Jack Server was shut down!");
     //std::cout << "Exiting program..." << std::endl;
     //std::exit(1);
 }

--- a/src/JackAudioInterface.cpp
+++ b/src/JackAudioInterface.cpp
@@ -269,6 +269,7 @@ void JackAudioInterface::jackShutdown (void*)
 {
     //std::cout << "The Jack Server was shut down!" << std::endl;
     JackTrip::sJackStopped = true;
+    std::cout << "The Jack Server was shut down!" << std::endl;
     //throw std::runtime_error("The Jack Server was shut down!");
     //std::cout << "Exiting program..." << std::endl;
     //std::exit(1);

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -704,9 +704,6 @@ void JackTrip::stop(QString errorMessage)
         return;
     }
     mHasShutdown = true;
-    if (sJackStopped) {
-        std::cout << "The Jack Server was shut down!" << std::endl;
-    }
     std::cout << "Stopping JackTrip..." << std::endl;
     
     // Stop The Sender
@@ -721,8 +718,6 @@ void JackTrip::stop(QString errorMessage)
     //mAudioInterface->stopProcess();
     closeAudio();
     
-    // Reset flags in case we're called from the GUI
-
     cout << "JackTrip Processes STOPPED!" << endl;
     cout << gPrintSeparator << endl;
 

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -66,6 +66,7 @@ void sigint_handler(int sig)
 #endif*/
 
 bool JackTrip::sSigInt = false;
+bool JackTrip::sJackStopped = false;
 
 //*******************************************************************************
 JackTrip::JackTrip(jacktripModeT JacktripMode,
@@ -126,6 +127,7 @@ JackTrip::JackTrip(jacktripModeT JacktripMode,
     mIOStatLogStream(std::cout.rdbuf())
 {
     createHeader(mPacketHeaderType);
+    sJackStopped = false;
 }
 
 
@@ -145,7 +147,7 @@ JackTrip::~JackTrip()
 //*******************************************************************************
 void JackTrip::setupAudio(
         #ifdef WAIRTOHUB // WAIR
-        int ID
+        __attribute__((unused)) int ID
         #endif // endwhere
         )
 {
@@ -657,7 +659,7 @@ void JackTrip::receivedDataUDP()
 
 void JackTrip::udpTimerTick()
 {
-    if (mStopped || sSigInt) {
+    if (mStopped || sSigInt || sJackStopped) {
         //Stop everything.
         mUdpSockTemp.close();
         mTimeoutTimer.stop();
@@ -676,7 +678,7 @@ void JackTrip::udpTimerTick()
 
 void JackTrip::tcpTimerTick()
 {
-    if (mStopped || sSigInt) {
+    if (mStopped || sSigInt || sJackStopped) {
         //Stop everything.
         mTcpClient.close();
         mTimeoutTimer.stop();
@@ -702,6 +704,9 @@ void JackTrip::stop(QString errorMessage)
         return;
     }
     mHasShutdown = true;
+    if (sJackStopped) {
+        std::cout << "The Jack Server was shut down!" << std::endl;
+    }
     std::cout << "Stopping JackTrip..." << std::endl;
     
     // Stop The Sender
@@ -715,12 +720,16 @@ void JackTrip::stop(QString errorMessage)
     // Stop the audio processes
     //mAudioInterface->stopProcess();
     closeAudio();
+    
+    // Reset flags in case we're called from the GUI
 
     cout << "JackTrip Processes STOPPED!" << endl;
     cout << gPrintSeparator << endl;
 
     // Emit the jack stopped signal
-    if (errorMessage.isEmpty()) {
+    if (sJackStopped) {
+        emit signalError("The Jack Server was shut down!");
+    } else if (errorMessage.isEmpty()) {
         emit signalProcessesStopped();
     } else {
         emit signalError(errorMessage);

--- a/src/JackTrip.h
+++ b/src/JackTrip.h
@@ -153,6 +153,7 @@ public:
     static void sigIntHandler(__attribute__((unused)) int unused)
     { std::cout << std::endl << "Shutting Down..." << std::endl; sSigInt = true; }
     static bool sSigInt;
+    static bool sJackStopped;
 
     /// \brief Starting point for the thread
     /*virtual void run() {

--- a/src/RingBuffer.cpp
+++ b/src/RingBuffer.cpp
@@ -42,6 +42,7 @@
 #include <cstring>
 #include <cstdlib>
 #include <stdexcept>
+#include "JackTrip.h"
 
 using std::cout; using std::endl;
 
@@ -132,7 +133,10 @@ void RingBuffer::readSlotBlocking(int8_t* ptrToReadSlot)
     // If the Ringbuffer is empty, it waits for the bufferIsNotEmpty condition
     while (mFullSlots == 0) {
         //std::cerr << "READ UNDER-RUN BLOCKING before" << endl;
-        mBufferIsNotEmpty.wait(&mMutex);
+        mBufferIsNotEmpty.wait(&mMutex, 200);
+        if (JackTrip::sJackStopped) {
+            return;
+        }
     }
 
     // Copy mSlotSize bytes to ReadSlot

--- a/src/UdpDataProtocol.cpp
+++ b/src/UdpDataProtocol.cpp
@@ -610,7 +610,7 @@ void UdpDataProtocol::run()
         break; }
 
     case SENDER : {
-        while ( !mStopped && !JackTrip::sSigInt )
+        while ( !mStopped && !JackTrip::sSigInt && !JackTrip::sJackStopped )
         {
             // OLD CODE WITHOUT REDUNDANCY -----------------------------------------------------
             /*


### PR DESCRIPTION
Notify the JackTrip networking thread rather than throwing an error when the Jack Server is shutdown. (Allows the program to either exit gracefully, or simply show an error when run with a GUI.)

Also fix the handling of jack client names with unicode characters in JMess. (Use toUtf8 instead of toLatin1.)