### PR TITLE
Fix short form IO stat options

### DIFF
--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -154,7 +154,7 @@ void Settings::parseInput(int argc, char** argv)
     /// \todo Specify mandatory arguments
     int ch;
     while ((ch = getopt_long(argc, argv,
-                             "n:N:H:sc:SC:o:B:P:U:q:r:b:ztlwjeJ:K:RTd:F:p:DvVhIGf:O:a:", longopts, NULL)) != -1)
+                             "n:N:H:sc:SC:o:B:P:U:q:r:b:ztlwjeJ:K:RTd:F:p:DvVhI:G:f:O:a:", longopts, NULL)) != -1)
         switch (ch) {
 
         case 'n': // Number of input and output channels


### PR DESCRIPTION
The short form of the IO stat options weren't configured to take a parameter, so segfaulted when used.