### PR TITLE
Add -x (--examine-audio-delay) feature

### DIFF
--- a/src/AudioInterface.h
+++ b/src/AudioInterface.h
@@ -40,6 +40,7 @@
 
 #include "ProcessPlugin.h"
 #include "jacktrip_types.h"
+#include "AudioTester.h"
 
 #include <QVarLengthArray>
 #include <QVector>
@@ -176,6 +177,7 @@ public:
     /// \brief Set Client Name to something different that the default (JackTrip)
     virtual void setClientName(QString ClientName) = 0;
     virtual void setLoopBack(bool b) { mLoopBack = b; }
+    virtual void setAudioTesterP(AudioTester* atp) { mAudioTesterP = atp; }
     //------------------------------------------------------------------
 
     //--------------GETTERS---------------------------------------------
@@ -239,6 +241,7 @@ private:
     int8_t* mInputPacket; ///< Packet containing all the channels to read from the RingBuffer
     int8_t* mOutputPacket;  ///< Packet containing all the channels to send to the RingBuffer
     bool mLoopBack;
+    AudioTester* mAudioTesterP { nullptr };
 protected:
     bool mProcessingAudio;  ///< Set when processing an audio callback buffer pair
     const uint32_t MAX_AUDIO_BUFFER_SIZE = 8192;

--- a/src/AudioTester.cpp
+++ b/src/AudioTester.cpp
@@ -1,0 +1,165 @@
+//*****************************************************************
+/*
+  JackTrip: A System for High-Quality Audio Network Performance
+  over the Internet
+
+  Copyright (c) 2020 Julius Smith, Juan-Pablo Caceres, Chris Chafe.
+  SoundWIRE group at CCRMA, Stanford University.
+
+  Permission is hereby granted, free of charge, to any person
+  obtaining a copy of this software and associated documentation
+  files (the "Software"), to deal in the Software without
+  restriction, including without limitation the rights to use,
+  copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the
+  Software is furnished to do so, subject to the following
+  conditions:
+
+  The above copyright notice and this permission notice shall be
+  included in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+  OTHER DEALINGS IN THE SOFTWARE.
+*/
+//*****************************************************************
+
+/**
+ * \file AudioTester.cpp
+ * \author Julius Smith
+ * \date August 2020
+ */
+
+#include "AudioTester.h"
+
+// Called 1st in Audiointerface.cpp
+void AudioTester::lookForReturnPulse(QVarLengthArray<sample_t*>& out_buffer,
+                                     unsigned int n_frames) {
+  if (not enabled) {
+    std::cerr << "*** AudioTester.h: lookForReturnPulse: NOT ENABLED\n";
+    return;
+  }
+  if (impulsePending) { // look for return impulse in channel 0:
+    assert(sendChannel<out_buffer.size());
+    for (uint n=0; n<n_frames; n++) {
+      float amp = out_buffer[sendChannel][n];
+      if (amp > 0.5 * ampCellHeight) { // got something
+        int cellNum =  getImpulseCellNum(out_buffer[sendChannel][n]);
+        if (cellNum != pendingCell) { // not our impulse!
+          std::cerr <<
+            "*** AudioTester.h: computeProcessFromNetwork: Received pulse amplitude "
+                    << amp << " (cell " << cellNum << ") while looking for cell "
+                    << pendingCell << " - ABORTING CURRENT PULSE\n";
+          impulsePending = false;
+        } else { // found our impulse:
+          int64_t elapsedSamples = -1;
+          if (n >= n_frames-1) {
+            // Impulse timestamp didn't make it so we skip this one.
+          } else {
+            float sampleCountWhenImpulseSent = - 32768.0f * out_buffer[sendChannel][n+1];
+            elapsedSamples = sampleCountSinceImpulse + n - int64_t(sampleCountWhenImpulseSent);
+            sampleCountSinceImpulse = 1; // reset sample counter between impulses
+            roundTripCount += 1.0;
+          }
+          // int64_t curTimeUS = timeMicroSec(); // time since launch in us
+          // int64_t impulseDelayUS = curTimeUS - ImpulseTimeUS;
+          // float impulseDelaySec = float(impulseDelayUS) * 1.0e-6;
+          // float impulseDelayBuffers = impulseDelaySec / (float(n_frames)/float(sampleRate));
+          // int64_t impulseDelayMS = (int64_t)round(double(impulseDelayUS)/1000.0);
+          if (elapsedSamples > 0) { // found impulse and reset, time to print buffer results:
+            double elapsedSamplesMS = 1000.0 * double(elapsedSamples)/double(sampleRate); // ms
+            if (roundTripCount > 1.0) {
+              double prevSum = roundTripMean * (roundTripCount-1.0); // undo previous normalization
+              roundTripMean = (prevSum + elapsedSamplesMS) / roundTripCount; // add latest and renormalize
+              double prevSumSq = roundTripMeanSquare * (roundTripCount-1.0); // undo previous normalization
+
+              roundTripMeanSquare = (prevSumSq + elapsedSamplesMS*elapsedSamplesMS) / roundTripCount;
+            } else { // just getting started:
+              roundTripMean = elapsedSamplesMS;
+              roundTripMeanSquare = elapsedSamplesMS * elapsedSamplesMS;
+            }
+            if (roundTripCount == 1.0) {
+              printf("JackTrip Test Mode (option -x printIntervalInSeconds=%0.3f)\n",printIntervalSec);
+              printf("\tA test impulse-train is output on channel %d (from 0) with repeatedly ramping amplitude\n",
+                     sendChannel);
+              if (printIntervalSec == 0.0) {
+                printf("\tPrinting each audio buffer round-trip latency in ms followed by cumulative (mean and [standard deviation])");
+              } else {
+                printf("\tPrinting cumulative mean and [standard deviation] of audio round-trip latency in ms");
+                printf(" every %0.3f seconds", printIntervalSec);
+              }
+              printf(" after skipping first %d buffers:\n", bufferSkipStart);
+              // not printing this presently: printf("( * means buffer skipped due missing timestamp or lost impulse)\n");
+              lastPrintTimeUS = timeMicroSec();
+            }
+            //printf("%d (%d) ", elapsedSamplesMS, impulseDelayMS); // measured time is "buffer time" not sample time
+            int64_t curTimeUS = timeMicroSec(); // time since launch in us
+            double timeSinceLastPrintUS = double(curTimeUS - lastPrintTimeUS);
+            double stdDev = sqrt(std::max(0.0, (roundTripMeanSquare - (roundTripMean*roundTripMean))));
+            if (timeSinceLastPrintUS >= printIntervalSec * 1.0e6) {
+              if (printIntervalSec == 0.0) { printf("%0.1f (", elapsedSamplesMS); }
+              printf("%0.1f [%0.1f]", roundTripMean, stdDev);
+              if (printIntervalSec == 0.0) { printf(") "); } else { printf(" "); }
+              lastPrintTimeUS = curTimeUS;
+            }
+            std::cout << std::flush;
+          } else {
+            // not printing this presently: printf("* "); // we got the impulse but lost its timestamp in samples
+          }
+          impulsePending = false;
+        } // found our impulse
+          // remain pending until timeout, hoping to find our return pulse
+      } // got something
+    } // loop over samples
+    sampleCountSinceImpulse += n_frames; // gets reset to 1 when impulse is found, counts freely until then
+  } // ImpulsePending
+}
+
+// Called 2nd in Audiointerface.cpp
+void AudioTester::writeImpulse(QVarLengthArray<sample_t*>& mInBufCopy,
+                               QVarLengthArray<sample_t*>& in_buffer,
+                               unsigned int n_frames) {
+  if (not enabled) {
+    std::cerr << "*** AudioTester.h: writeImpulse: NOT ENABLED\n";
+    return;
+  }
+  if (bufferSkip <= 0) { // send test signals (-x option)
+    bool sendImpulse;
+    if (impulsePending) {
+      sendImpulse = false; // unless:
+      const uint64_t timeOut = 500e3; // time out after waiting 500 ms
+      if (timeMicroSec() > (impulseTimeUS + timeOut)) {
+        sendImpulse = true;
+        std::cout << "\n*** TEST MODE (-x): TIMED OUT waiting for return impulse *** sending a new one\n";
+      }
+    } else { // time for the next repeating impulse:
+      sendImpulse = true;
+    }
+    if (sendImpulse) {
+      assert(sendChannel < in_buffer.size());
+      assert(sendChannel < mInBufCopy.size());
+      mInBufCopy[sendChannel][0] = getImpulseAmp();
+      impulsePending = true;
+      impulseTimeUS = timeMicroSec();
+      impulseTimeSamples = sampleCountSinceImpulse; // timer in samples for current impulse loopback test
+      // Also send impulse time:
+      if (n_frames>1) { // always true?
+        mInBufCopy[sendChannel][1] = -float(impulseTimeSamples)/32768.0f; // survives if there is no digital processing at the server
+      } else {
+        std::cerr << "\n*** AudioTester.h: Timestamp cannot fit into a lenth " << n_frames << " buffer ***\n";
+      }
+    } else {
+      mInBufCopy[sendChannel][0] = 0.0f; // send zeros until a new impulse is needed
+      if (n_frames>1) {
+        mInBufCopy[sendChannel][1] = 0.0f;
+      }
+    }
+  } else {
+    bufferSkip--;
+  }
+}

--- a/src/AudioTester.cpp
+++ b/src/AudioTester.cpp
@@ -36,6 +36,7 @@
  */
 
 #include "AudioTester.h"
+#include <assert.h>
 
 // Called 1st in Audiointerface.cpp
 void AudioTester::lookForReturnPulse(QVarLengthArray<sample_t*>& out_buffer,

--- a/src/AudioTester.h
+++ b/src/AudioTester.h
@@ -1,0 +1,130 @@
+//*****************************************************************
+/*
+  JackTrip: A System for High-Quality Audio Network Performance
+  over the Internet
+
+  Copyright (c) 2020 Julius Smith, Juan-Pablo Caceres, Chris Chafe.
+  SoundWIRE group at CCRMA, Stanford University.
+
+  Permission is hereby granted, free of charge, to any person
+  obtaining a copy of this software and associated documentation
+  files (the "Software"), to deal in the Software without
+  restriction, including without limitation the rights to use,
+  copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the
+  Software is furnished to do so, subject to the following
+  conditions:
+
+  The above copyright notice and this permission notice shall be
+  included in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+  OTHER DEALINGS IN THE SOFTWARE.
+*/
+//*****************************************************************
+
+/**
+ * \file AudioTester.h
+ * \author Julius Smith
+ * \date August 2020
+ */
+
+#pragma once
+
+#include "jacktrip_types.h" // sample_t
+
+#include <iostream>
+//#include <ctime>
+#include <chrono>
+#include <cstdint>
+#include <cmath>
+
+#include <QVarLengthArray>
+
+class AudioTester
+{
+  bool enabled { false };
+  float printIntervalSec { 1.0f };
+  int sendChannel { 0 };
+
+  bool impulsePending { false };
+  int64_t lastPrintTimeUS { 0 };
+  int64_t impulseTimeUS { 0 };
+  int64_t impulseTimeSamples { 0 };
+  uint64_t sampleCountSinceImpulse { 1 }; // 0 not used
+  double roundTripMean { 0.0 };
+  double roundTripMeanSquare { 0.0 };
+  double roundTripCount { 0.0 };
+  const int bufferSkipStart { 100 };
+  int bufferSkip { bufferSkipStart };
+  static constexpr float impulseAmplitude { 0.1f };
+  static constexpr int numAmpCells { 10 };
+  static constexpr float ampCellHeight { impulseAmplitude/numAmpCells };
+
+  int pendingCell { 0 }; // 0 is not used
+  float sampleRate { 48000.0f };
+
+public:
+  AudioTester() {}
+  ~AudioTester() = default;
+
+  void lookForReturnPulse(QVarLengthArray<sample_t*>& out_buffer,
+                                       unsigned int n_frames);
+
+  void writeImpulse(QVarLengthArray<sample_t*>& mInBufCopy,
+                    QVarLengthArray<sample_t*>& in_buffer,
+                    unsigned int n_frames);
+
+  bool getEnabled() { return enabled; }
+  void setEnabled(bool e) { enabled = e; }
+  void setPrintIntervalSec(float s) { printIntervalSec = s; }
+  void setSendChannel(int c) { sendChannel = c; }
+  int getPendingCell() { return pendingCell; }
+  void setPendingCell(int pc) { pendingCell = pc; }
+  void setSampleRate(float fs) { sampleRate = fs; }
+  int getBufferSkip() { return bufferSkip; } // used for debugging breakpoints
+
+private:
+
+  float getImpulseAmp() {
+    pendingCell += 1; // only called when no impulse is pending
+    if (pendingCell >= numAmpCells) {
+      pendingCell = 1; // wrap-around, not using zero
+    }
+    float imp = float(pendingCell) * (impulseAmplitude/float(numAmpCells));
+    return imp;
+  }
+
+  int getImpulseCellNum(float amp) {
+    float ch = ampCellHeight;
+    float cell = amp / ch;
+    int iCell = int(std::floor(0.5f + cell));
+    if (iCell > numAmpCells - 1) {
+      std::cerr << "*** AudioTester.h: getImpulseCellNum("<<amp<<"): Return pulse amplitude is beyond maximum expected\n";
+      iCell = numAmpCells-1;
+    } else if (iCell < 0) {
+      std::cerr << "*** AudioTester.h: getImpulseCellNum("<<amp<<"): Return pulse amplitude is below minimum expected\n";
+      iCell = 0;
+    }
+    return iCell;
+  }
+
+  uint64_t timeMicroSec() {
+#if 1
+    using namespace std::chrono;
+    // return duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+    return duration_cast<microseconds>(high_resolution_clock::now().time_since_epoch()).count();
+#else
+    clock_t tics_since_launch = std::clock();
+    double timeUS = double(tics_since_launch)/double(CLOCKS_PER_SEC);
+    return (uint64_t)timeUS;
+#endif
+  }
+
+};

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -123,7 +123,8 @@ JackTrip::JackTrip(jacktripModeT JacktripMode,
     mHasShutdown(false),
     mConnectDefaultAudioPorts(true),
     mIOStatTimeout(0),
-    mIOStatLogStream(std::cout.rdbuf())
+    mIOStatLogStream(std::cout.rdbuf()),
+    mAudioTesterP(nullptr)
 {
     createHeader(mPacketHeaderType);
 }
@@ -211,6 +212,10 @@ void JackTrip::setupAudio(
     }
 
     mAudioInterface->setLoopBack(mLoopBack);
+    if (mAudioTesterP) { // if we're a hub server, this will be a nullptr - MAJOR REFACTOR NEEDED, in my opinion
+      mAudioTesterP->setSampleRate(mSampleRate);
+    }
+    mAudioInterface->setAudioTesterP(mAudioTesterP);
 
     std::cout << "The Sampling Rate is: " << mSampleRate << std::endl;
     std::cout << gPrintSeparator << std::endl;
@@ -465,15 +470,15 @@ void JackTrip::completeConnection()
     QThread::msleep(1);
     if (gVerboseFlag) std::cout << "step 5" << std::endl;
     if (gVerboseFlag) std::cout << "  JackTrip:startProcess before mAudioInterface->startProcess" << std::endl;
-    mAudioInterface->startProcess();
-
     for (int i = 0; i < mProcessPluginsFromNetwork.size(); ++i) {
         mAudioInterface->appendProcessPluginFromNetwork(mProcessPluginsFromNetwork[i]);
     }
     for (int i = 0; i < mProcessPluginsToNetwork.size(); ++i) {
         mAudioInterface->appendProcessPluginToNetwork(mProcessPluginsToNetwork[i]);
     }
-    mAudioInterface->initPlugins(); // mSampleRate assumed settled now
+    mAudioInterface->initPlugins();  // mSampleRate known now, which plugins require
+    mAudioInterface->startProcess(); // Tell JACK server we are ready for audio flow now
+
     if (mConnectDefaultAudioPorts) {  mAudioInterface->connectDefaultPorts(); }
     
     //Start our IO stat timer
@@ -510,6 +515,9 @@ void JackTrip::onStatTimer()
 
     static QMutex mutex;
     QMutexLocker locker(&mutex);
+    if (mAudioTesterP && mAudioTesterP->getEnabled()) {
+      mIOStatLogStream << "\n";
+    }
     mIOStatLogStream << now.toLocal8Bit().constData()
       << " " << getPeerAddress().toLocal8Bit().constData()
       << " send: "

--- a/src/JackTrip.h
+++ b/src/JackTrip.h
@@ -57,6 +57,7 @@
 
 #include "PacketHeader.h"
 #include "RingBuffer.h"
+#include "AudioTester.h"
 
 //#include <signal.h>
 /** \brief Main class to creates a SERVER (to listen) or a CLIENT (to connect
@@ -294,6 +295,7 @@ public:
     { mAudioInterface = AudioInterface; }
     virtual void setLoopBack(bool b)
     { mLoopBack = b; }
+    virtual void setAudioTesterP(AudioTester* atp) { mAudioTesterP = atp; }
 
     void setSampleRate(uint32_t sample_rate)
     { mSampleRate = sample_rate; }
@@ -556,6 +558,8 @@ private:
     QSharedPointer<std::ofstream> mIOStatStream;
     int mIOStatTimeout;
     std::ostream mIOStatLogStream;
+
+    AudioTester* mAudioTesterP;
 };
 
 #endif

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -146,6 +146,7 @@ void Settings::parseInput(int argc, char** argv)
         { "overflowlimiting", required_argument, NULL, 'O' }, // Turn On limiter, cases 'i', 'o', 'io'
         { "assumednumclients", required_argument, NULL, 'a' }, // assumed number of clients (sound sources) (otherwise 2)
         { "help", no_argument, NULL, 'h' }, // Print Help
+        { "examine-audio-delay", required_argument, NULL, 'x' }, // test mode - measure audio round-trip latency statistics
         { NULL, 0, NULL, 0 }
     };
 
@@ -154,7 +155,7 @@ void Settings::parseInput(int argc, char** argv)
     /// \todo Specify mandatory arguments
     int ch;
     while ((ch = getopt_long(argc, argv,
-                             "n:N:H:sc:SC:o:B:P:U:q:r:b:ztlwjeJ:K:RTd:F:p:DvVhI:G:f:O:a:", longopts, NULL)) != -1)
+                             "n:N:H:sc:SC:o:B:P:U:q:r:b:ztlwjeJ:K:RTd:F:p:DvVhI:G:f:O:a:x:", longopts, NULL)) != -1)
         switch (ch) {
 
         case 'n': // Number of input and output channels
@@ -389,6 +390,16 @@ void Settings::parseInput(int argc, char** argv)
             exit(1);
           }
           break; }
+        case 'x': { // examine connection (test mode)
+          //-------------------------------------------------------
+          mAudioTester.setEnabled(true);
+          if (optarg == 0 || optarg[0] == '-' || optarg[0] == 0) { // happens when no -f argument specified
+            printUsage();
+            std::cerr << "--examine-audio-delay (-x) ERROR: Print-interval argument REQUIRED (set to 0.0 to see every delay)\n";
+            std::exit(1);
+          }
+          mAudioTester.setPrintIntervalSec(atof(optarg));
+          break; }
         case ':': {
           printf("\t*** Missing option argument\n");
           break; }
@@ -414,8 +425,25 @@ void Settings::parseInput(int argc, char** argv)
         }
         cout << gPrintSeparator << endl;
     }
-}
 
+    assert(mNumChans>0);
+    mAudioTester.setSendChannel(mNumChans-1); // use top channel - channel 0 is a clap track on CCRMA loopback servers
+
+    // Exit if options are incompatible
+    //----------------------------------------------------------------------------
+    bool haveSomeServerMode = not ((mJackTripMode == JackTrip::CLIENT) || (mJackTripMode == JackTrip::CLIENTTOPINGSERVER));
+    if (mAudioTester.getEnabled() && haveSomeServerMode) {
+      std::cerr << "*** --examine-audio-delay (-x) ERROR: Audio latency measurement not supported in server modes (-S and -s)\n\n";
+      std::exit(1);
+    }
+    if (mAudioTester.getEnabled()
+        && (mAudioBitResolution != AudioInterface::BIT16)
+        && (mAudioBitResolution != AudioInterface::BIT32) ) { // BIT32 not tested but should be ok
+      // BIT24 should work also, but there's a comment saying it's broken right now, so exclude it
+      std::cerr << "*** --examine-audio-delay (-x) ERROR: Only --bitres (-b) 16 and 32 presently supported for audio latency measurement.\n\n";
+      std::exit(1);
+    }
+}
 
 //*******************************************************************************
 void Settings::printUsage()
@@ -427,10 +455,10 @@ void Settings::printUsage()
     cout << "SoundWIRE group at CCRMA, Stanford University" << endl;
     cout << "VERSION: " << gVersion << endl;
     cout << "" << endl;
-    cout << "Usage: jacktrip [-s|-c host] [options]" << endl;
+    cout << "Usage: jacktrip [-s|-c|-S|-C hostIPAddressOrURL] [options]" << endl;
     cout << "" << endl;
     cout << "Options: " << endl;
-    cout << "REQUIRED ARGUMENTS: " << endl;
+    cout << "REQUIRED ARGUMENTS: One of:" << endl;
     cout << " -s, --server                             Run in P2P Server Mode" << endl;
     cout << " -c, --client <peer_hostname_or_IP_num>   Run in P2P Client Mode" << endl;
     cout << " -S, --jacktripserver                     Run in Hub Server Mode" << endl;
@@ -479,6 +507,7 @@ void Settings::printUsage()
     cout << "ARGUMENTS TO DISPLAY IO STATISTICS:" << endl;
     cout << " -I, --iostat <time_in_secs>              Turn on IO stat reporting with specified interval (in seconds)" << endl;
     cout << " -G, --iostatlog <log_file>               Save stat log into a file (default: print in stdout)" << endl;
+    cout << " -x, --examine-audio-delay #              Print round-trip audio delay statistics every # sec" << endl;
     cout << endl;
     cout << "HELP ARGUMENTS: " << endl;
     cout << " -v, --version                            Prints Version Number" << endl;
@@ -510,7 +539,7 @@ UdpHubListener *Settings::getConfiguredHubServer()
         udpHub->setUnderRunMode(mUnderrunMode);
     }
     udpHub->setBufferQueueLength(mBufferQueueLength);
-    
+
     if (mIOStatTimeout > 0) {
         udpHub->setIOStatTimeout(mIOStatTimeout);
         udpHub->setIOStatStream(mIOStatStream);
@@ -544,7 +573,7 @@ JackTrip *Settings::getConfiguredJackTrip()
     if (!mClientName.isEmpty()) {
         jackTrip->setClientName(mClientName);
     }
-    
+
     if (!mRemoteClientName.isEmpty() && (mJackTripMode == JackTrip::CLIENTTOPINGSERVER)) {
         jackTrip->setRemoteClientName(mRemoteClientName);
     }
@@ -554,13 +583,13 @@ JackTrip *Settings::getConfiguredJackTrip()
         cout << "Setting buffers to zero when underrun..." << endl;
         cout << gPrintSeparator << std::endl;
     }
-    
+
     jackTrip->setStopOnTimeout(mStopOnTimeout);
 
     // Set peer address in server mode
     if (mJackTripMode == JackTrip::CLIENT || mJackTripMode == JackTrip::CLIENTTOPINGSERVER) {
         jackTrip->setPeerAddress(mPeerAddress); }
-        
+
     //        if(mLocalAddress!=QString()) // default
     //            mJackTrip->setLocalAddress(QHostAddress(mLocalAddress.toLatin1().data()));
     //        else
@@ -632,12 +661,15 @@ JackTrip *Settings::getConfiguredJackTrip()
         //netks->play();
         // -------------------------------------------------------------
     }
-    
+
     if (mIOStatTimeout > 0) {
         jackTrip->setIOStatTimeout(mIOStatTimeout);
         jackTrip->setIOStatStream(mIOStatStream);
     }
 
+    jackTrip->setAudioTesterP(&mAudioTester);
+
+    if (not mAudioTester.getEnabled()) { // No effects plugins allowed while testing:
     // Allocate audio effects in client, if any:
     mEffects.allocateEffects(mNumChans);
 
@@ -652,6 +684,7 @@ JackTrip *Settings::getConfiguredJackTrip()
     // Limiters go last in the plugin sequence:
     jackTrip->appendProcessPluginFromNetwork( mEffects.getInLimiter() );
     jackTrip->appendProcessPluginToNetwork( mEffects.getOutLimiter() );
+    }
 
 #ifdef WAIR // WAIR
     if ( mWAIR ) {
@@ -682,4 +715,3 @@ JackTrip *Settings::getConfiguredJackTrip()
 
     return jackTrip;
 }
-

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -52,6 +52,7 @@
 #include "UdpHubListener.h"
 
 #include "Effects.h"
+#include "AudioTester.h"
 
 /** \brief Class to set usage options and parse settings from input
  */
@@ -115,6 +116,7 @@ private:
     int mIOStatTimeout;
     QSharedPointer<std::ofstream> mIOStatStream;
     Effects mEffects;
+    AudioTester mAudioTester;
 };
 
 #endif

--- a/src/jacktrip.pro
+++ b/src/jacktrip.pro
@@ -130,6 +130,7 @@ HEADERS += DataProtocol.h \
            Compressor.h \
            Limiter.h \
            Reverb.h \
+           AudioTester.h \
            jacktrip_globals.h \
            jacktrip_types.h \
            JackTripThread.h \
@@ -160,6 +161,7 @@ SOURCES += DataProtocol.cpp \
            Compressor.cpp \
            Limiter.cpp \
            Reverb.cpp \
+           AudioTester.cpp \
            jacktrip_globals.cpp \
            jacktrip_main.cpp \
            jacktrip_tests.cpp \


### PR DESCRIPTION
Adds a new command line option "-x printInterval" which runs a jacktrip client in a special test mode for measuring audio latency down to sample accuracy, printing the mean and standard deviation in ms at the specified time interval in seconds.