### PR TITLE
Don't nullptr jack server name when creating jack client

### DIFF
--- a/src/JackAudioInterface.cpp
+++ b/src/JackAudioInterface.cpp
@@ -102,7 +102,6 @@ void JackAudioInterface::setup()
 //*******************************************************************************
 void JackAudioInterface::setupClient()
 {
-    const char* server_name = NULL;
     QByteArray clientName = mClientName.toUtf8();
 #ifdef __MAC_OSX__
     //Jack seems to have an issue with client names over 27 bytes in OS X
@@ -130,9 +129,9 @@ void JackAudioInterface::setupClient()
     {
         QMutexLocker locker(&sJackMutex);
 #ifndef WAIR // WAIR
-        mClient = jack_client_open (clientName.constData(), options, &status, server_name);
+        mClient = jack_client_open (clientName.constData(), options, &status);
 #else
-        mClient = jack_client_open (clientName.constData(), JackUseExactName, &status, server_name);
+        mClient = jack_client_open (clientName.constData(), JackUseExactName, &status);
 #endif // endwhere
     }
 


### PR DESCRIPTION
Setting the jack server name null may be unintended here.