### PR TITLE
Hard-clip outgoing conversion from floats to fixed-point

### DIFF
--- a/src/AudioInterface.cpp
+++ b/src/AudioInterface.cpp
@@ -507,11 +507,8 @@ void AudioInterface::fromSampleToBitConversion
  const AudioInterface::audioBitResolutionT targetBitResolution)
 {
     int8_t tmp_8;
-    uint8_t tmp_u8; // unsigned to quantize the remainder in 24bits
     int16_t tmp_16;
     double tmp_sample;
-    sample_t tmp_sample16;
-    sample_t tmp_sample8;
     switch (targetBitResolution)
     {
     case BIT8 :

--- a/src/AudioInterface.cpp
+++ b/src/AudioInterface.cpp
@@ -488,16 +488,6 @@ void AudioInterface::computeProcessToNetwork(QVarLengthArray<sample_t*>& in_buff
     mJackTrip->sendNetworkPacket( mInputPacket );
 } // /computeProcessToNetwork
 
-bool is_big_endian(void)
-{
-    union {
-        uint32_t i;
-        char c[4];
-    } bint = {0x01020304};
-
-    return bint.c[0] == 1;  // 1 if bigEndine, 4 if littleEndian
-}
-
 //*******************************************************************************
 // This function quantize from 32 bit to a lower bit resolution
 // 24 bit is not working yet
@@ -507,8 +497,11 @@ void AudioInterface::fromSampleToBitConversion
  const AudioInterface::audioBitResolutionT targetBitResolution)
 {
     int8_t tmp_8;
+    uint8_t tmp_u8; // unsigned to quantize the remainder in 24bits
     int16_t tmp_16;
     double tmp_sample;
+    sample_t tmp_sample16;
+    sample_t tmp_sample8;
     switch (targetBitResolution)
     {
     case BIT8 :
@@ -524,17 +517,23 @@ void AudioInterface::fromSampleToBitConversion
         tmp_16 = static_cast<int16_t>(tmp_sample);
         std::memcpy(output, &tmp_16, 2); // 2 bytes output in Little Endian order (LSB -> smallest address)
         break;
-    case BIT24 : {
-        // tmp_sample = (*input) * 32768.0; // 2^15 = 32768.0
-        tmp_sample = std::max(-8388607.0, std::min(8388607.0, std::round( (*input) * 8388607.0 ))); // 2^23 = 8388608
-        union {
-          uint32_t tmp32;
-          char tmp32c[4];
-        } tmp32u;
-        tmp32u.tmp32 = tmp_sample;
-        int offset = ( is_big_endian() ? 1 : 0 );
-        std::memcpy(output, &(tmp32u.tmp32c[offset]), 3); // 24bits = 3 bytes
-        break; }
+   case BIT24 :
+        // To convert to 24 bits, we first quantize the number to 16bit
+        tmp_sample = (*input) * 32768.0; // 2^15 = 32768.0
+        tmp_sample16 = floor(tmp_sample);
+        tmp_16 = static_cast<int16_t>(tmp_sample16);
+
+        // Then we compute the remainder error, and quantize that part into an 8bit number
+        // Note that this remainder is always positive, so we use an unsigned integer
+        tmp_sample8 = floor ((tmp_sample - tmp_sample16)  //this is a positive number, between 0.0-1.0
+                             * 256.0);
+        tmp_u8 = static_cast<uint8_t>(tmp_sample8);
+
+        // Finally, we copy the 16bit number in the first 2 bytes,
+        // and the 8bit number in the third bite
+        std::memcpy(output, &tmp_16, 2); // 16bits = 2 bytes
+        std::memcpy(output+2, &tmp_u8, 1); // 8bits = 1 bytes
+        break;
     case BIT32 :
         tmp_sample = *input;
         // not necessary yet:

--- a/src/AudioInterface.cpp
+++ b/src/AudioInterface.cpp
@@ -488,6 +488,16 @@ void AudioInterface::computeProcessToNetwork(QVarLengthArray<sample_t*>& in_buff
     mJackTrip->sendNetworkPacket( mInputPacket );
 } // /computeProcessToNetwork
 
+bool is_big_endian(void)
+{
+    union {
+        uint32_t i;
+        char c[4];
+    } bint = {0x01020304};
+
+    return bint.c[0] == 1;  // 1 if bigEndine, 4 if littleEndian
+}
+
 //*******************************************************************************
 // This function quantize from 32 bit to a lower bit resolution
 // 24 bit is not working yet
@@ -499,42 +509,38 @@ void AudioInterface::fromSampleToBitConversion
     int8_t tmp_8;
     uint8_t tmp_u8; // unsigned to quantize the remainder in 24bits
     int16_t tmp_16;
-    sample_t tmp_sample;
+    double tmp_sample;
     sample_t tmp_sample16;
     sample_t tmp_sample8;
     switch (targetBitResolution)
     {
     case BIT8 :
         // 8bit integer between -128 to 127
-        tmp_sample = floor( (*input) * 128.0 ); // 2^7 = 128.0
+        tmp_sample = std::max(-127.0, std::min(127.0, std::round( (*input) * 127.0 ))); // 2^7 = 128
         tmp_8 = static_cast<int8_t>(tmp_sample);
         std::memcpy(output, &tmp_8, 1); // 8bits = 1 bytes
         break;
     case BIT16 :
         // 16bit integer between -32768 to 32767
-        tmp_sample = floor( (*input) * 32768.0 ); // 2^15 = 32768.0
+        // tmp_sample = floor( (*input) * 32768.0 ); // 2^15 = 32768.0
+        tmp_sample = std::max(-32767.0, std::min(32767.0, std::round( (*input) * 32767.0 ))); // 2^15 = 32768
         tmp_16 = static_cast<int16_t>(tmp_sample);
-        std::memcpy(output, &tmp_16, 2); // 16bits = 2 bytes
+        std::memcpy(output, &tmp_16, 2); // 2 bytes output in Little Endian order (LSB -> smallest address)
         break;
-    case BIT24 :
-        // To convert to 24 bits, we first quantize the number to 16bit
-        tmp_sample = (*input) * 32768.0; // 2^15 = 32768.0
-        tmp_sample16 = floor(tmp_sample);
-        tmp_16 = static_cast<int16_t>(tmp_sample16);
-
-        // Then we compute the remainder error, and quantize that part into an 8bit number
-        // Note that this remainder is always positive, so we use an unsigned integer
-        tmp_sample8 = floor ((tmp_sample - tmp_sample16)  //this is a positive number, between 0.0-1.0
-                             * 256.0);
-        tmp_u8 = static_cast<uint8_t>(tmp_sample8);
-
-        // Finally, we copy the 16bit number in the first 2 bytes,
-        // and the 8bit number in the third bite
-        std::memcpy(output, &tmp_16, 2); // 16bits = 2 bytes
-        std::memcpy(output+2, &tmp_u8, 1); // 8bits = 1 bytes
-        break;
+    case BIT24 : {
+        // tmp_sample = (*input) * 32768.0; // 2^15 = 32768.0
+        tmp_sample = std::max(-8388607.0, std::min(8388607.0, std::round( (*input) * 8388607.0 ))); // 2^23 = 8388608
+        union {
+          uint32_t tmp32;
+          char tmp32c[4];
+        } tmp32u;
+        tmp32u.tmp32 = tmp_sample;
+        int offset = ( is_big_endian() ? 1 : 0 );
+        std::memcpy(output, &(tmp32u.tmp32c[offset]), 3); // 24bits = 3 bytes
+        break; }
     case BIT32 :
-        std::memcpy(output, input, 4); // 32bit = 4 bytes
+        tmp_sample = std::max(-1.0f, std::min(1.0f, *input));
+        std::memcpy(output, &tmp_sample, 4); // 32bit = 4 bytes
         break;
     }
 }

--- a/src/AudioInterface.cpp
+++ b/src/AudioInterface.cpp
@@ -512,7 +512,7 @@ void AudioInterface::fromSampleToBitConversion
         break;
     case BIT16 :
         // 16bit integer between -32768 to 32767
-        // tmp_sample = floor( (*input) * 32768.0 ); // 2^15 = 32768.0
+        // original scaling: tmp_sample = floor( (*input) * 32768.0 ); // 2^15 = 32768.0
         tmp_sample = std::max(-32767.0, std::min(32767.0, std::round( (*input) * 32767.0 ))); // 2^15 = 32768
         tmp_16 = static_cast<int16_t>(tmp_sample);
         std::memcpy(output, &tmp_16, 2); // 2 bytes output in Little Endian order (LSB -> smallest address)
@@ -537,7 +537,7 @@ void AudioInterface::fromSampleToBitConversion
     case BIT32 :
         tmp_sample = *input;
         // not necessary yet:
-        // tmp_sample = std::max(-1.0f, std::min(1.0f, tmp_sample));
+        // tmp_sample = std::max(-1.0, std::min(1.0, tmp_sample));
         std::memcpy(output, &tmp_sample, 4); // 32bit = 4 bytes
         break;
     }

--- a/src/AudioInterface.cpp
+++ b/src/AudioInterface.cpp
@@ -536,7 +536,9 @@ void AudioInterface::fromSampleToBitConversion
         std::memcpy(output, &(tmp32u.tmp32c[offset]), 3); // 24bits = 3 bytes
         break; }
     case BIT32 :
-        tmp_sample = std::max(-1.0f, std::min(1.0f, *input));
+        tmp_sample = *input;
+        // not necessary yet:
+        // tmp_sample = std::max(-1.0f, std::min(1.0f, tmp_sample));
         std::memcpy(output, &tmp_sample, 4); // 32bit = 4 bytes
         break;
     }

--- a/src/AudioInterface.cpp
+++ b/src/AudioInterface.cpp
@@ -517,7 +517,7 @@ void AudioInterface::fromSampleToBitConversion
         tmp_16 = static_cast<int16_t>(tmp_sample);
         std::memcpy(output, &tmp_16, 2); // 2 bytes output in Little Endian order (LSB -> smallest address)
         break;
-   case BIT24 :
+    case BIT24 :
         // To convert to 24 bits, we first quantize the number to 16bit
         tmp_sample = (*input) * 32768.0; // 2^15 = 32768.0
         tmp_sample16 = floor(tmp_sample);


### PR DESCRIPTION
This is not needed when there is a limiter, but since limiters are off by default (I think an outgoing limiter should be ON by default in every audio channel unless -b 32 is in use), it makes sense to at least hard-clip instead of wrap around in two's complement.  Wrap-around is much noisier than clipping.

There was another pull request about this, which I approved subject to comments, but it never got completed, so I wrote this based on that discussion.