### PR TITLE
Minor Faust-related changes

### DIFF
--- a/faust-src/Makefile
+++ b/faust-src/Makefile
@@ -1,3 +1,12 @@
+h headers :
+	install -d headersdir
+	$(MAKE) DEST='headersdir/' ARCH='faust2header.cpp' -f Makefile.headers
+
+ih hi installheaders : headers
+	install headersdir/*.h ../src/
+
+# The JackTrip project does not need the remaining make targets, except "clean" is nice to have:
+
 all : jackgtk
 
 test: jackgtk alsagtk jackqt alsaqt ladspa ossgtk bench plot sndfile jackconsole
@@ -92,13 +101,6 @@ supercollider :
 jackconsole :
 	install -d jackconsoledir
 	$(MAKE) DEST='jackconsoledir/' ARCH='jack-console.cpp' LIB='`pkg-config --cflags --libs jack `' -f Makefile.compile
-
-h headers :
-	install -d headersdir
-	$(MAKE) DEST='headersdir/' ARCH='faust2header.cpp' -f Makefile.headers
-
-ih hi installheaders : headers
-	install headersdir/*.h ../src/
 
 clean :
 	-rm -rf alsagtkdir jackgtkdir alsaqtdir jackqtdir vecalsagtkdir vecjackgtkdir ladspadir jackwxdir ossgtkdir osswxdir pagtkdir pawxdir moduledir bundledir mspdir vstdir benchdir sndfiledir plotdir benchdir supercolliderdir puredatadir qdir plotdir jackconsoledir matlabplotdir *-ps *-svg headersdir

--- a/faust-src/Makefile.headers
+++ b/faust-src/Makefile.headers
@@ -3,10 +3,18 @@ headers  := $(addprefix $(DEST), $(dspsrc:.dsp=.h))
 
 all :  $(headers)
 
+FAUST = faust --inline-architecture-files --in-place
+# --in-place (-inpl) means the input signal array can be used
+#           as the output signal array in the compute() function.
+# --inline-architecture-files (-i) means that all Faust headers
+#           and include files get included in the output C++ file
+#           so that it can be compiled without a Faust installation
+#           on the compiling machine.
+
 $(DEST)%.h : %.dsp
-	   faust -i -inpl $(VEC) -cn $(<:.dsp=) -a $(ARCH) $< -o $(DEST)$(<:.dsp=).h
-	   #(cat $(@:.h=).cpp | sed -e s/mydsp/$(<:.dsp=)/g) > $@
-	   #/bin/rm $(@:.h=).cpp
+	$(FAUST) $(VEC) -cn $(<:.dsp=) -a $(ARCH) $< -o $(DEST)$(<:.dsp=).h
+	#(cat $(@:.h=).cpp | sed -e s/mydsp/$(<:.dsp=)/g) > $@
+	#/bin/rm $(@:.h=).cpp
 
 # Probably needed for headers after the first: (cat $(@:.h=).cpp | sed -e /template/d | sed -e s/mydsp/$(<:.dsp=)/g) > $@
 

--- a/faust-src/compressordsp.dsp
+++ b/faust-src/compressordsp.dsp
@@ -3,6 +3,7 @@ declare version "0.0";
 declare author "Julius Smith";
 declare license "MIT Style STK-4.2";
 declare description "Compressor demo application, adapted from the Faust Library's dm.compressor_demo in demos.lib";
+declare documentation "https://faustlibraries.grame.fr/libs/compressors/#cocompressor_mono";
 
 import("stdfaust.lib");
 
@@ -17,56 +18,56 @@ import("stdfaust.lib");
 //------------------------------------------------------------
 compressor_demo = ba.bypass1(cbp,compressor_mono_demo)
 with {
-	comp_group(x) = vgroup("COMPRESSOR [tooltip: Reference:
-		http://en.wikipedia.org/wiki/Dynamic_range_compression]", x);
+        comp_group(x) = vgroup("COMPRESSOR [tooltip: References:
+                https://faustlibraries.grame.fr/libs/compressors/
+                http://en.wikipedia.org/wiki/Dynamic_range_compression]", x);
 
-	meter_group(x)	= comp_group(hgroup("[0]", x));
-	knob_group(x)  = comp_group(hgroup("[1]", x));
+        meter_group(x)  = comp_group(hgroup("[0]", x));
+        knob_group(x)  = comp_group(hgroup("[1]", x));
 
-	cbp = meter_group(checkbox("[0] Bypass	[tooltip: When this is checked, the compressor
-		has no effect]"));
-	gainview = co.compression_gain_mono(ratio,threshold,attack,release) : ba.linear2db :
-	meter_group(hbargraph("[1] Compressor Gain [unit:dB] [tooltip: Current gain of
-	the compressor in dB]",-50,+10));
+        cbp = meter_group(checkbox("[0] Bypass  [tooltip: When this is checked, the compressor
+                has no effect]"));
+        gainview = co.compression_gain_mono(ratio,threshold,attack,release) : ba.linear2db :
+        meter_group(hbargraph("[1] Compressor Gain [unit:dB] [tooltip: Compressor gain in dB]",-50,+10));
 
-	displaygain = _ <: _,abs : _,gainview : attach;
+        displaygain = _ <: _,abs : _,gainview : attach;
 
-	compressor_stereo_demo =
-	displaygain(co.compressor_stereo(ratio,threshold,attack,release)) :
-	*(makeupgain), *(makeupgain);
+        compressor_stereo_demo =
+        displaygain(co.compressor_stereo(ratio,threshold,attack,release)) :
+        *(makeupgain), *(makeupgain);
 
-	compressor_mono_demo =
-	displaygain(co.compressor_mono(ratio,threshold,attack,release)) :
-	*(makeupgain);
+        compressor_mono_demo =
+        displaygain(co.compressor_mono(ratio,threshold,attack,release)) :
+        *(makeupgain);
 
-	ctl_group(x)  = knob_group(hgroup("[3] Compression Control", x));
+        ctl_group(x)  = knob_group(hgroup("[3] Compression Control", x));
 
-	ratio = ctl_group(hslider("[0] Ratio [style:knob]
-	[tooltip: A compression Ratio of N means that for each N dB increase in input
-	signal level above Threshold, the output level goes up 1 dB]",
-	2, 1, 20, 0.1));
+        ratio = ctl_group(hslider("[0] Ratio [style:knob]
+        [tooltip: A compression Ratio of N means that for each N dB increase in input
+        signal level above Threshold, the output level goes up 1 dB]",
+        2, 1, 20, 0.1));
 
-	threshold = ctl_group(hslider("[1] Threshold [unit:dB] [style:knob]
-	[tooltip: When the signal level exceeds the Threshold (in dB), its level
-	is compressed according to the Ratio]",
-	-24, -100, 10, 0.1));
+        threshold = ctl_group(hslider("[1] Threshold [unit:dB] [style:knob]
+        [tooltip: When the signal level exceeds the Threshold (in dB), its level
+        is compressed according to the Ratio]",
+        -24, -100, 10, 0.1));
 
-	env_group(x)  = knob_group(hgroup("[4] Compression Response", x));
+        env_group(x)  = knob_group(hgroup("[4] Compression Response", x));
 
-	attack = env_group(hslider("[1] Attack [unit:ms] [style:knob] [scale:log]
-	[tooltip: Time constant in ms (1/e smoothing time) for the compression gain
-	to approach (exponentially) a new lower target level (the compression
-	`kicking in')]", 15, 1, 1000, 0.1)) : *(0.001) : max(1/ma.SR);
+        attack = env_group(hslider("[1] Attack [unit:ms] [style:knob] [scale:log]
+        [tooltip: Time constant in ms (1/e smoothing time) for the compression gain
+        to approach (exponentially) a new lower target level (the compression
+        `kicking in')]", 15, 1, 1000, 0.1)) : *(0.001) : max(1/ma.SR);
 
-	release = env_group(hslider("[2] Release [unit:ms] [style: knob] [scale:log]
-	[tooltip: Time constant in ms (1/e smoothing time) for the compression gain
-	to approach (exponentially) a new higher target level (the compression
-	'releasing')]", 40, 1, 1000, 0.1)) : *(0.001) : max(1/ma.SR);
+        release = env_group(hslider("[2] Release [unit:ms] [style: knob] [scale:log]
+        [tooltip: Time constant in ms (1/e smoothing time) for the compression gain
+        to approach (exponentially) a new higher target level (the compression
+        'releasing')]", 40, 1, 1000, 0.1)) : *(0.001) : max(1/ma.SR);
 
-	makeupgain = comp_group(hslider("[5] Makeup Gain [unit:dB]
-	[tooltip: The compressed-signal output level is increased by this amount
-	(in dB) to make up for the level lost due to compression]",
-	2, -96, 96, 0.1)) : ba.db2linear;
+        makeupgain = comp_group(hslider("[5] MakeUpGain [unit:dB]
+        [tooltip: The compressed-signal output level is increased by this amount
+        (in dB) to make up for the level lost due to compression]",
+        2, -96, 96, 0.1)) : ba.db2linear;
 };
 
 process = _ : compressor_demo : _;

--- a/faust-src/tests/compressor-limiter-test.dsp
+++ b/faust-src/tests/compressor-limiter-test.dsp
@@ -1,0 +1,21 @@
+// Doc: https://faustlibraries.grame.fr/libs/compressors/
+
+cs = hslider("Compressor [style:radio{'1':0; '2': 1 }]", 0,0,1,1);
+
+c1 = component("compressordsp.dsp");  // ./compressordsp.dsp
+c2 = component("compressor2dsp.dsp"); // ./compressor2dsp.dsp
+compressor(cs) = _ <: select2(cs,c1,c2);
+
+limiter_group(x) = vgroup("LIMITER [tooltip: https://faustlibraries.grame.fr/libs/compressors/#functions-reference]",x);
+
+process = _ : compressor(cs) : limiter_group(component("limiterdsp.dsp")) <: _,_;
+
+/*
+ * My present conclusion is to continue with c1, because it uses the
+ * more standard 'ratio' parameter, while c2 uses 'strength', which becomes
+ * hard-clipping at strength=1.  Also, I hear no compelling difference sonically
+ * (after laboriously finding a strength value that is roughly comparable to ratio).
+ *
+ * Also, c2 is GPL license, which cannot go into closed-source products,
+ * while c1 can be freely used as desired (STK-4.2 license).
+ */

--- a/faust-src/tests/compressor2dsp.dsp
+++ b/faust-src/tests/compressor2dsp.dsp
@@ -1,0 +1,82 @@
+declare name "compressor2"; // more modern feedback-compressor with release-to-threshold
+declare version "0.0";
+declare author "Julius Smith";
+declare license "MIT Style STK-4.2"; // but using GPLv3
+declare description "adapted from ./compressordsp.dsp adding use of co.FBFFcompressor_N_chan";
+declare documentation "https://faustlibraries.grame.fr/libs/compressors/#cofffbcompressor_n_chan";
+
+import("stdfaust.lib");
+
+// #### Usage
+//
+// ```
+// _ : compressor2_mono_demo : _;
+// ```
+//------------------------------------------------------------
+compressor2_demo = ba.bypass1(cbp,compressor2_mono_demo)
+with {
+	comp_group(x) = vgroup("COMPRESSOR2 [tooltip: Reference:
+		http://en.wikipedia.org/wiki/Dynamic_range_compression]", x);
+
+	meter_group(x)	= comp_group(hgroup("[0]", x));
+	knob_group(x)  = comp_group(hgroup("[1]", x));
+
+	cbp = meter_group(checkbox("[0] Bypass	[tooltip: When this is checked, the compressor2
+		has no effect]"));
+
+	// API: co.FBFFcompressor_N_chan(strength,thresh,att,rel,knee,prePost,link,FBFF,meter,N)
+	// strength = min(ratio-1.0,5)/5.0; // crude hack - will be wrong
+	knee = 5; // dB window about threshold for knee
+	prePost = 1; // level detector location: 0 for input, 1 for output (for feedback compressor)
+	link = 0; // linkage between channels (irrelevant for mono)
+	FBFF = 1; // cross-fade between feedforward (0) and feedback (1) compression
+	maxGR = -50; // dB - Max Gain Reduction (only affects display)
+	meter = _<:(_, (ba.linear2db:max(maxGR):meter_group((hbargraph("[1] Compressor Gain [unit:dB][tooltip: Compressor gain in dB]", maxGR, 10))))):attach;
+	//meter = _; // use gainview below instead to look more like compressordsp.dsp
+	NChans = 1;
+
+	// compressordsp.dsp: gainview = co.compression_gain_mono(strength,threshold,attack,release) 
+	// threshold gets doubled for the feedback case, but not for feedforward (see compressors.lib):
+	gainview = co.peak_compression_gain_N_chan(strength,2*threshold,attack,release,knee,prePost,link,NChans)
+	: ba.linear2db : max(maxGR) :
+	meter_group(hbargraph("[1] Compressor2 Gain [unit:dB] [tooltip: Current gain of
+	the compressor2 in dB]",maxGR,+10));
+
+	// use built-in gain display:
+	displaygain = _;
+	// not the same: displaygain = _ <: _,abs : _,gainview : attach;
+
+	compressor2_mono_demo =
+	displaygain(co.FBFFcompressor_N_chan(strength,threshold,attack,release,knee,prePost,link,FBFF,meter,NChans)) :
+	*(makeupgain);
+
+	ctl_group(x)  = knob_group(hgroup("[3] Compression Control", x));
+
+	strength = ctl_group(hslider("[0] Strength [style:knob]
+	[tooltip: A compression Strength of 0 means no compression, while 1 yields infinit compression (hard limiting)]",
+	0.1, 0, 1, 0.01)); // 0.1 seems to be pretty close to ratio == 2, based on watching the gain displays
+
+	threshold = ctl_group(hslider("[1] Threshold [unit:dB] [style:knob]
+	[tooltip: When the signal level exceeds the Threshold (in dB), its level
+	is compressed according to the Strength]",
+	-24, -100, 10, 0.1));
+
+	env_group(x)  = knob_group(hgroup("[4] Compression Response", x));
+
+	attack = env_group(hslider("[1] Attack [unit:ms] [style:knob] [scale:log]
+	[tooltip: Time constant in ms (1/e smoothing time) for the compression gain
+	to approach (exponentially) a new lower target level (the compression
+	`kicking in')]", 15, 1, 1000, 0.1)) : *(0.001) : max(1/ma.SR);
+
+	release = env_group(hslider("[2] Release [unit:ms] [style: knob] [scale:log]
+	[tooltip: Time constant in ms (1/e smoothing time) for the compression gain
+	to approach (exponentially) a new higher target level (the compression
+	'releasing')]", 40, 1, 1000, 0.1)) : *(0.001) : max(1/ma.SR);
+
+	makeupgain = comp_group(hslider("[5] MakeUpGain [unit:dB]
+	[tooltip: The compressed-signal output level is increased by this amount
+	(in dB) to make up for the level lost due to compression]",
+	2, -96, 96, 0.1)) : ba.db2linear;
+};
+
+process = _ : compressor2_demo : _;

--- a/src/compressordsp.h
+++ b/src/compressordsp.h
@@ -3,7 +3,7 @@ author: "Julius Smith"
 license: "MIT Style STK-4.2"
 name: "compressor"
 version: "0.0"
-Code generated with Faust 2.28.1 (https://faust.grame.fr)
+Code generated with Faust 2.28.5 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -scal -ftz 0
 ------------------------------------------------------------ */
 
@@ -1612,6 +1612,7 @@ class compressordsp : public dsp {
 		m->declare("compressors.lib/name", "Faust Compressor Effect Library");
 		m->declare("compressors.lib/version", "0.0");
 		m->declare("description", "Compressor demo application, adapted from the Faust Library's dm.compressor_demo in demos.lib");
+		m->declare("documentation", "https://faustlibraries.grame.fr/libs/compressors/#cocompressor_mono");
 		m->declare("filename", "compressordsp.dsp");
 		m->declare("license", "MIT Style STK-4.2");
 		m->declare("maths.lib/author", "GRAME");
@@ -1719,15 +1720,15 @@ class compressordsp : public dsp {
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
-		ui_interface->declare(0, "tooltip", "Reference:   http://en.wikipedia.org/wiki/Dynamic_range_compression");
+		ui_interface->declare(0, "tooltip", "References:                 https://faustlibraries.grame.fr/libs/compressors/                 http://en.wikipedia.org/wiki/Dynamic_range_compression");
 		ui_interface->openVerticalBox("COMPRESSOR");
 		ui_interface->declare(0, "0", "");
 		ui_interface->openHorizontalBox("0x00");
 		ui_interface->declare(&fCheckbox0, "0", "");
-		ui_interface->declare(&fCheckbox0, "tooltip", "When this is checked, the compressor   has no effect");
+		ui_interface->declare(&fCheckbox0, "tooltip", "When this is checked, the compressor                 has no effect");
 		ui_interface->addCheckButton("Bypass", &fCheckbox0);
 		ui_interface->declare(&fHbargraph0, "1", "");
-		ui_interface->declare(&fHbargraph0, "tooltip", "Current gain of  the compressor in dB");
+		ui_interface->declare(&fHbargraph0, "tooltip", "Compressor gain in dB");
 		ui_interface->declare(&fHbargraph0, "unit", "dB");
 		ui_interface->addHorizontalBargraph("Compressor Gain", &fHbargraph0, -50.0f, 10.0f);
 		ui_interface->closeBox();
@@ -1737,11 +1738,11 @@ class compressordsp : public dsp {
 		ui_interface->openHorizontalBox("Compression Control");
 		ui_interface->declare(&fHslider2, "0", "");
 		ui_interface->declare(&fHslider2, "style", "knob");
-		ui_interface->declare(&fHslider2, "tooltip", "A compression Ratio of N means that for each N dB increase in input  signal level above Threshold, the output level goes up 1 dB");
+		ui_interface->declare(&fHslider2, "tooltip", "A compression Ratio of N means that for each N dB increase in input         signal level above Threshold, the output level goes up 1 dB");
 		ui_interface->addHorizontalSlider("Ratio", &fHslider2, 2.0f, 1.0f, 20.0f, 0.100000001f);
 		ui_interface->declare(&fHslider4, "1", "");
 		ui_interface->declare(&fHslider4, "style", "knob");
-		ui_interface->declare(&fHslider4, "tooltip", "When the signal level exceeds the Threshold (in dB), its level  is compressed according to the Ratio");
+		ui_interface->declare(&fHslider4, "tooltip", "When the signal level exceeds the Threshold (in dB), its level         is compressed according to the Ratio");
 		ui_interface->declare(&fHslider4, "unit", "dB");
 		ui_interface->addHorizontalSlider("Threshold", &fHslider4, -24.0f, -100.0f, 10.0f, 0.100000001f);
 		ui_interface->closeBox();
@@ -1750,21 +1751,21 @@ class compressordsp : public dsp {
 		ui_interface->declare(&fHslider1, "1", "");
 		ui_interface->declare(&fHslider1, "scale", "log");
 		ui_interface->declare(&fHslider1, "style", "knob");
-		ui_interface->declare(&fHslider1, "tooltip", "Time constant in ms (1/e smoothing time) for the compression gain  to approach (exponentially) a new lower target level (the compression  `kicking in')");
+		ui_interface->declare(&fHslider1, "tooltip", "Time constant in ms (1/e smoothing time) for the compression gain         to approach (exponentially) a new lower target level (the compression         `kicking in')");
 		ui_interface->declare(&fHslider1, "unit", "ms");
 		ui_interface->addHorizontalSlider("Attack", &fHslider1, 15.0f, 1.0f, 1000.0f, 0.100000001f);
 		ui_interface->declare(&fHslider3, "2", "");
 		ui_interface->declare(&fHslider3, "scale", "log");
 		ui_interface->declare(&fHslider3, "style", "knob");
-		ui_interface->declare(&fHslider3, "tooltip", "Time constant in ms (1/e smoothing time) for the compression gain  to approach (exponentially) a new higher target level (the compression  'releasing')");
+		ui_interface->declare(&fHslider3, "tooltip", "Time constant in ms (1/e smoothing time) for the compression gain         to approach (exponentially) a new higher target level (the compression         'releasing')");
 		ui_interface->declare(&fHslider3, "unit", "ms");
 		ui_interface->addHorizontalSlider("Release", &fHslider3, 40.0f, 1.0f, 1000.0f, 0.100000001f);
 		ui_interface->closeBox();
 		ui_interface->closeBox();
 		ui_interface->declare(&fHslider0, "5", "");
-		ui_interface->declare(&fHslider0, "tooltip", "The compressed-signal output level is increased by this amount  (in dB) to make up for the level lost due to compression");
+		ui_interface->declare(&fHslider0, "tooltip", "The compressed-signal output level is increased by this amount         (in dB) to make up for the level lost due to compression");
 		ui_interface->declare(&fHslider0, "unit", "dB");
-		ui_interface->addHorizontalSlider("Makeup Gain", &fHslider0, 2.0f, -96.0f, 96.0f, 0.100000001f);
+		ui_interface->addHorizontalSlider("MakeUpGain", &fHslider0, 2.0f, -96.0f, 96.0f, 0.100000001f);
 		ui_interface->closeBox();
 	}
 	

--- a/src/freeverbdsp.h
+++ b/src/freeverbdsp.h
@@ -3,7 +3,7 @@ author: "Romain Michon"
 license: "LGPL"
 name: "freeverb"
 version: "0.0"
-Code generated with Faust 2.28.1 (https://faust.grame.fr)
+Code generated with Faust 2.28.5 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -scal -ftz 0
 ------------------------------------------------------------ */
 
@@ -1678,7 +1678,7 @@ class freeverbdsp : public dsp {
 		m->declare("filters.lib/allpass_comb:author", "Julius O. Smith III");
 		m->declare("filters.lib/allpass_comb:copyright", "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
 		m->declare("filters.lib/allpass_comb:license", "MIT-style STK-4.3 license");
-		m->declare("filters.lib/lowpass0_highpass1", "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
+		m->declare("filters.lib/lowpass0_highpass1", "MIT-style STK-4.3 license");
 		m->declare("filters.lib/name", "Faust Filters Library");
 		m->declare("license", "LGPL");
 		m->declare("maths.lib/author", "GRAME");

--- a/src/freeverbmonodsp.h
+++ b/src/freeverbmonodsp.h
@@ -1,6 +1,6 @@
 /* ------------------------------------------------------------
 name: "freeverbmonodsp"
-Code generated with Faust 2.28.1 (https://faust.grame.fr)
+Code generated with Faust 2.28.5 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -scal -ftz 0
 ------------------------------------------------------------ */
 

--- a/src/limiterdsp.h
+++ b/src/limiterdsp.h
@@ -1,6 +1,6 @@
 /* ------------------------------------------------------------
 name: "limiterdsp"
-Code generated with Faust 2.28.1 (https://faust.grame.fr)
+Code generated with Faust 2.28.5 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -scal -ftz 0
 ------------------------------------------------------------ */
 

--- a/src/zitarevdsp.h
+++ b/src/zitarevdsp.h
@@ -1,6 +1,6 @@
 /* ------------------------------------------------------------
 name: "zitarevdsp"
-Code generated with Faust 2.28.1 (https://faust.grame.fr)
+Code generated with Faust 2.28.5 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -scal -ftz 0
 ------------------------------------------------------------ */
 

--- a/src/zitarevmonodsp.h
+++ b/src/zitarevmonodsp.h
@@ -1,6 +1,6 @@
 /* ------------------------------------------------------------
 name: "zitarevmonodsp"
-Code generated with Faust 2.28.1 (https://faust.grame.fr)
+Code generated with Faust 2.28.5 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -scal -ftz 0
 ------------------------------------------------------------ */
 


### PR DESCRIPTION
Minor Faust-related changes.
Update to latest Faust compiler (v2.28.5 on branch master-dev).
Changes can only affect limiter, compressor, or reverb, all of which are off by default.