### PR TITLE
 generalize --examine-audio-delay (-x) to allow normal jacktrip usage in audio channels below test channel

### DIFF
--- a/src/AudioInterface.cpp
+++ b/src/AudioInterface.cpp
@@ -590,11 +590,14 @@ void AudioInterface::fromBitToSampleConversion
 void AudioInterface::appendProcessPluginToNetwork(ProcessPlugin* plugin)
 {
   if (not plugin) { return; }
-  if (plugin->getNumInputs() < mNumInChans) {
+  int nTestChans = (mAudioTesterP && mAudioTesterP->getEnabled()) ? 1 : 0;
+  int nPluginChans = mNumInChans - nTestChans;
+  assert(nTestChans==0 || (mAudioTesterP->getSendChannel() == mNumInChans-1));
+  if (plugin->getNumInputs() < nPluginChans) {
     std::cerr << "*** AudioInterface.cpp: appendProcessPluginToNetwork: ProcessPlugin "
               << typeid(plugin).name() << " REJECTED due to having "
               << plugin->getNumInputs() << " inputs, while the audio to JACK needs "
-              << mNumInChans << " inputs\n";
+              << nPluginChans << " inputs\n";
     return;
   }
   mProcessPluginsToNetwork.append(plugin);
@@ -603,11 +606,14 @@ void AudioInterface::appendProcessPluginToNetwork(ProcessPlugin* plugin)
 void AudioInterface::appendProcessPluginFromNetwork(ProcessPlugin* plugin)
 {
   if (not plugin) { return; }
-  if (plugin->getNumOutputs() > mNumOutChans) {
-    std::cerr << "*** AudioInterface.cpp: appendProcessPluginToNetwork: ProcessPlugin "
+  int nTestChans = (mAudioTesterP && mAudioTesterP->getEnabled()) ? 1 : 0;
+  int nPluginChans = mNumOutChans - nTestChans;
+  assert(nTestChans==0 || (mAudioTesterP->getSendChannel() == mNumOutChans-1));
+  if (plugin->getNumOutputs() > nPluginChans) {
+    std::cerr << "*** AudioInterface.cpp: appendProcessPluginFromNetwork: ProcessPlugin "
               << typeid(plugin).name() << " REJECTED due to having "
               << plugin->getNumOutputs() << " inputs, while the JACK audio output requires "
-              << mNumOutChans << " outputs\n";
+              << nPluginChans << " outputs\n";
     return;
   }
   mProcessPluginsFromNetwork.append(plugin);

--- a/src/AudioInterface.cpp
+++ b/src/AudioInterface.cpp
@@ -39,6 +39,7 @@
 #include "JackTrip.h"
 #include <iostream>
 #include <cmath>
+#include <assert.h>
 
 using std::cout; using std::endl;
 

--- a/src/AudioTester.cpp
+++ b/src/AudioTester.cpp
@@ -45,7 +45,7 @@ void AudioTester::lookForReturnPulse(QVarLengthArray<sample_t*>& out_buffer,
     std::cerr << "*** AudioTester.h: lookForReturnPulse: NOT ENABLED\n";
     return;
   }
-  if (impulsePending) { // look for return impulse in channel 0:
+  if (impulsePending) { // look for return impulse in channel sendChannel:
     assert(sendChannel<out_buffer.size());
     for (uint n=0; n<n_frames; n++) {
       float amp = out_buffer[sendChannel][n];

--- a/src/AudioTester.h
+++ b/src/AudioTester.h
@@ -85,6 +85,7 @@ public:
   void setEnabled(bool e) { enabled = e; }
   void setPrintIntervalSec(float s) { printIntervalSec = s; }
   void setSendChannel(int c) { sendChannel = c; }
+  int getSendChannel() { return sendChannel; }
   int getPendingCell() { return pendingCell; }
   void setPendingCell(int pc) { pendingCell = pc; }
   void setSampleRate(float fs) { sampleRate = fs; }

--- a/src/Effects.h
+++ b/src/Effects.h
@@ -123,6 +123,10 @@ public:
     gVerboseFlag = v;
   }
 
+  int getNumChans() {
+    return mNumChans;
+  }
+
   void allocateEffects(int nc) {
     mNumChans = nc;
     if (inCompressor) {

--- a/src/Effects.h
+++ b/src/Effects.h
@@ -41,6 +41,7 @@
 #include "Limiter.h"
 #include "Compressor.h"
 #include "Reverb.h"
+#include <assert.h>
 
 class Effects
 {
@@ -130,26 +131,32 @@ public:
   void allocateEffects(int nc) {
     mNumChans = nc;
     if (inCompressor) {
+      assert(inCompressorP == nullptr);
       inCompressorP = new Compressor(mNumChans);
       if (gVerboseFlag) { std::cout << "Set up INCOMING COMPRESSOR\n"; }
     }
     if (outCompressor) {
+      assert(outCompressorP == nullptr);
       outCompressorP = new Compressor(mNumChans);
       if (gVerboseFlag) { std::cout << "Set up OUTGOING COMPRESSOR\n"; }
     }
     if (inZitarev) {
+      assert(inZitarevP == nullptr);
       inZitarevP = new Reverb(mNumChans,mNumChans, 1.0 + zitarevInLevel);
       if (gVerboseFlag) { std::cout << "Set up INCOMING REVERB (Zitarev)\n"; }
     }
     if (outZitarev) {
+      assert(outZitarevP == nullptr);
       outZitarevP = new Reverb(mNumChans, mNumChans, 1.0 + zitarevOutLevel);
       if (gVerboseFlag) { std::cout << "Set up OUTGOING REVERB (Zitarev)\n"; }
     }
     if (inFreeverb) {
+      assert(inFreeverbP == nullptr);
       inFreeverbP = new Reverb(mNumChans, mNumChans, freeverbInLevel);
       if (gVerboseFlag) { std::cout << "Set up INCOMING REVERB (Freeverb)\n"; }
     }
     if (outFreeverb) {
+      assert(outFreeverbP == nullptr);
       outFreeverbP = new Reverb(mNumChans, mNumChans, freeverbOutLevel);
       if (gVerboseFlag) { std::cout << "Set up OUTGOING REVERB (Freeverb)\n"; }
     }
@@ -160,6 +167,7 @@ public:
                     << mNumChans << " output channels and "
                     << mNumClientsAssumed << " assumed client(s) ...\n";
         }
+        assert(outLimiterP == nullptr);
         outLimiterP = new Limiter(mNumChans,mNumClientsAssumed);
         // do not have mSampleRate yet, so cannot call limiter->init(mSampleRate) here
       }
@@ -167,6 +175,7 @@ public:
         if (gVerboseFlag) {
           std::cout << "Set up INCOMING LIMITER for " << mNumChans << " input channels\n";
         }
+        assert(inLimiterP == nullptr);
         inLimiterP = new Limiter(mNumChans,1); // mNumClientsAssumed not needed this direction
       }
     }

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -676,7 +676,6 @@ JackTrip *Settings::getConfiguredJackTrip()
     jackTrip->setAudioTesterP(&mAudioTester);
 
     // Allocate audio effects in client, if any:
-    mEffects.allocateEffects(mNumChans);
     int nReservedChans = mAudioTester.getEnabled() ? 1 : 0; // no fx allowed on tester channel
     mEffects.allocateEffects(mNumChans-nReservedChans);
     

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -427,7 +427,12 @@ void Settings::parseInput(int argc, char** argv)
     }
 
     assert(mNumChans>0);
-    mAudioTester.setSendChannel(mNumChans-1); // use top channel - channel 0 is a clap track on CCRMA loopback servers
+    mAudioTester.setSendChannel(mNumChans-1); // use last channel for latency testing
+    // Originally, testing only in the last channel was adopted
+    // because channel 0 ("left") was a clap track on CCRMA loopback
+    // servers.  Now, however, we also do it in order to easily keep
+    // effects in all but the last channel, enabling silent testing
+    // in the last channel in parallel with normal operation of the others.
 
     // Exit if options are incompatible
     //----------------------------------------------------------------------------
@@ -507,7 +512,7 @@ void Settings::printUsage()
     cout << "ARGUMENTS TO DISPLAY IO STATISTICS:" << endl;
     cout << " -I, --iostat <time_in_secs>              Turn on IO stat reporting with specified interval (in seconds)" << endl;
     cout << " -G, --iostatlog <log_file>               Save stat log into a file (default: print in stdout)" << endl;
-    cout << " -x, --examine-audio-delay #              Print round-trip audio delay statistics every # sec" << endl;
+    cout << " -x, --examine-audio-delay #              Print round-trip audio delay statistics every # sec for last audio channel" << endl;
     cout << endl;
     cout << "HELP ARGUMENTS: " << endl;
     cout << " -v, --version                            Prints Version Number" << endl;
@@ -669,22 +674,23 @@ JackTrip *Settings::getConfiguredJackTrip()
 
     jackTrip->setAudioTesterP(&mAudioTester);
 
-    if (not mAudioTester.getEnabled()) { // No effects plugins allowed while testing:
-      // Allocate audio effects in client, if any:
-      mEffects.allocateEffects(mNumChans);
+    // Allocate audio effects in client, if any:
+    mEffects.allocateEffects(mNumChans);
+    int nReservedChans = mAudioTester.getEnabled() ? 1 : 0; // no fx allowed on tester channel
+    mEffects.allocateEffects(mNumChans-nReservedChans);
 
-      // Outgoing/Incoming Compressor and/or Reverb:
-      jackTrip->appendProcessPluginToNetwork( mEffects.getOutCompressor() );
-      jackTrip->appendProcessPluginFromNetwork( mEffects.getInCompressor() );
-      jackTrip->appendProcessPluginToNetwork( mEffects.getOutZitarev() );
-      jackTrip->appendProcessPluginFromNetwork( mEffects.getInZitarev() );
-      jackTrip->appendProcessPluginToNetwork( mEffects.getOutFreeverb() );
-      jackTrip->appendProcessPluginFromNetwork( mEffects.getInFreeverb() );
 
-      // Limiters go last in the plugin sequence:
-      jackTrip->appendProcessPluginFromNetwork( mEffects.getInLimiter() );
-      jackTrip->appendProcessPluginToNetwork( mEffects.getOutLimiter() );
-    }
+    // Outgoing/Incoming Compressor and/or Reverb:
+    jackTrip->appendProcessPluginToNetwork( mEffects.getOutCompressor() );
+    jackTrip->appendProcessPluginFromNetwork( mEffects.getInCompressor() );
+    jackTrip->appendProcessPluginToNetwork( mEffects.getOutZitarev() );
+    jackTrip->appendProcessPluginFromNetwork( mEffects.getInZitarev() );
+    jackTrip->appendProcessPluginToNetwork( mEffects.getOutFreeverb() );
+    jackTrip->appendProcessPluginFromNetwork( mEffects.getInFreeverb() );
+
+    // Limiters go last in the plugin sequence:
+    jackTrip->appendProcessPluginFromNetwork( mEffects.getInLimiter() );
+    jackTrip->appendProcessPluginToNetwork( mEffects.getOutLimiter() );
 
 #ifdef WAIR // WAIR
     if ( mWAIR ) {

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -513,7 +513,6 @@ void Settings::printUsage()
     cout << "ARGUMENTS TO DISPLAY IO STATISTICS:" << endl;
     cout << " -I, --iostat <time_in_secs>              Turn on IO stat reporting with specified interval (in seconds)" << endl;
     cout << " -G, --iostatlog <log_file>               Save stat log into a file (default: print in stdout)" << endl;
-    cout << " -x, --examine-audio-delay #              Print round-trip audio delay statistics every # sec for last audio channel" << endl;
     cout << " -x, --examine-audio-delay #              Print round-trip audio delay statistics, for last audio channel, every # sec, including an ASCII latency histogram if # >= 1.0" << endl;
     cout << endl;
     cout << "HELP ARGUMENTS: " << endl;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -675,23 +675,22 @@ JackTrip *Settings::getConfiguredJackTrip()
 
     jackTrip->setAudioTesterP(&mAudioTester);
 
-      // Allocate audio effects in client, if any:
-      mEffects.allocateEffects(mNumChans);
+    // Allocate audio effects in client, if any:
+    mEffects.allocateEffects(mNumChans);
     int nReservedChans = mAudioTester.getEnabled() ? 1 : 0; // no fx allowed on tester channel
     mEffects.allocateEffects(mNumChans-nReservedChans);
+    
+    // Outgoing/Incoming Compressor and/or Reverb:
+    jackTrip->appendProcessPluginToNetwork( mEffects.getOutCompressor() );
+    jackTrip->appendProcessPluginFromNetwork( mEffects.getInCompressor() );
+    jackTrip->appendProcessPluginToNetwork( mEffects.getOutZitarev() );
+    jackTrip->appendProcessPluginFromNetwork( mEffects.getInZitarev() );
+    jackTrip->appendProcessPluginToNetwork( mEffects.getOutFreeverb() );
+    jackTrip->appendProcessPluginFromNetwork( mEffects.getInFreeverb() );
 
-
-      // Outgoing/Incoming Compressor and/or Reverb:
-      jackTrip->appendProcessPluginToNetwork( mEffects.getOutCompressor() );
-      jackTrip->appendProcessPluginFromNetwork( mEffects.getInCompressor() );
-      jackTrip->appendProcessPluginToNetwork( mEffects.getOutZitarev() );
-      jackTrip->appendProcessPluginFromNetwork( mEffects.getInZitarev() );
-      jackTrip->appendProcessPluginToNetwork( mEffects.getOutFreeverb() );
-      jackTrip->appendProcessPluginFromNetwork( mEffects.getInFreeverb() );
-
-      // Limiters go last in the plugin sequence:
-      jackTrip->appendProcessPluginFromNetwork( mEffects.getInLimiter() );
-      jackTrip->appendProcessPluginToNetwork( mEffects.getOutLimiter() );
+    // Limiters go last in the plugin sequence:
+    jackTrip->appendProcessPluginFromNetwork( mEffects.getInLimiter() );
+    jackTrip->appendProcessPluginToNetwork( mEffects.getOutLimiter() );
 
 #ifdef WAIR // WAIR
     if ( mWAIR ) {

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -51,6 +51,7 @@
 #include <iostream>
 #include <getopt.h> // for command line parsing
 #include <cstdlib>
+#include <assert.h>
 
 //#include "ThreadPoolTest.h"
 


### PR DESCRIPTION
Generalize --examine-audio-delay (-x) to support normal JackTrip usage in audio channels below the last, which is dedicated to latency testing, and need not be hooked up to JACK.  Thus, we can have continuous silent latency testing on an extra audio channel in parallel with normal JackTrip usage.