### PR TITLE
add help to --examine-audio-delay (-x) and slightly refine algorithm for return impulse detection

### DIFF
--- a/src/AudioTester.cpp
+++ b/src/AudioTester.cpp
@@ -32,7 +32,8 @@
 /**
  * \file AudioTester.cpp
  * \author Julius Smith
- * \date August 2020
+ * \license MIT
+ * \date Aug-Oct 2020
  */
 
 #include "AudioTester.h"
@@ -55,8 +56,14 @@ void AudioTester::lookForReturnPulse(QVarLengthArray<sample_t*>& out_buffer,
           std::cerr <<
             "*** AudioTester.h: computeProcessFromNetwork: Received pulse amplitude "
                     << amp << " (cell " << cellNum << ") while looking for cell "
-                    << pendingCell << " - ABORTING CURRENT PULSE\n";
-          impulsePending = false;
+                    << pendingCell << "\n";
+
+          if (cellNum > pendingCell) { // we missed it
+            std::cerr << " - ABORTING CURRENT PULSE\n";
+            impulsePending = false;
+          } else { // somehow we got the previous pulse again - repeated packet or underrun-caused repetition (old buffer)
+            std::cerr << " - IGNORING FOUND PULSE WAITING FURTHER\n";
+          }
         } else { // found our impulse:
           int64_t elapsedSamples = -1;
           if (n >= n_frames-1) {
@@ -166,4 +173,22 @@ void AudioTester::writeImpulse(QVarLengthArray<sample_t*>& mInBufCopy,
   } else {
     bufferSkip--;
   }
+}
+
+void AudioTester::printHelp(char* command, [[maybe_unused]] char helpCase) {
+  std::cout << "HELP for \"" << command << " printIntervalSec\" // (end-of-line comments start with `//'):\n";
+  std::cout << "\n";
+  std::cout << "Print roundtrip audio delay statistics for the highest-numbered audio channel every printIntervalSec seconds,\n";
+  std::cout << "including an ASCII latency histogram if printIntervalSec is 1.0 or more.\n";
+  std::cout << "\n";
+  std::cout << "A test impulse is sent to the server in the last audio channel,\n";
+  std::cout << "  the number of samples until it returns is measured, and this repeats.\n";
+  std::cout << "The jacktrip server must provide audio loopback (e.g., -p4).\n";
+  std::cout << "The cumulative mean and standard-deviation (\"statistics\") are computed for the measured loopback times,\n";
+  std::cout << "  and printed every printIntervalSec seconds.\n";
+  std::cout << "If printIntervalSec is zero, the roundtrip-time and statistics in milliseconds are printed for each individual impulse.\n";
+  std::cout << "If printIntervalSec is positive, statistics are printed after each print interval, with no individual measurements.\n";
+  std::cout << "If printIntervalSec is 1.0 or larger, a cumulative histogram of all impulse roundtrip-times is printed as well.\n";
+  std::cout << "The first 100 audio buffers are skipped in order to measure only steady-state network-audio-delay performance.\n";
+  std::cout << "Lower audio channels are not affected, enabling latency measurement and display during normal operation.\n";
 }

--- a/src/AudioTester.h
+++ b/src/AudioTester.h
@@ -32,7 +32,8 @@
 /**
  * \file AudioTester.h
  * \author Julius Smith
- * \date August 2020
+ * \license MIT
+ * \date Aug-Oct 2020
  */
 
 #pragma once
@@ -97,6 +98,7 @@ public:
   void setPendingCell(int pc) { pendingCell = pc; }
   void setSampleRate(float fs) { sampleRate = fs; }
   int getBufferSkip() { return bufferSkip; } // used for debugging breakpoints
+  void printHelp(char* command, char helpCase);
 
 private:
 

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -411,10 +411,15 @@ void Settings::parseInput(int argc, char** argv)
           break; }
         case 'x': { // examine connection (test mode)
           //-------------------------------------------------------
+          char cmd[] { "--examine-audio-delay (-x)" };
+          if (tolower(optarg[0])=='h') {
+            mAudioTester.printHelp(cmd,ch);
+            std::exit(0);
+          }
           mAudioTester.setEnabled(true);
           if (optarg == 0 || optarg[0] == '-' || optarg[0] == 0) { // happens when no -f argument specified
             printUsage();
-            std::cerr << "--examine-audio-delay (-x) ERROR: Print-interval argument REQUIRED (set to 0.0 to see every delay)\n";
+            std::cerr << cmd << " ERROR: Print-interval argument REQUIRED (set to 0.0 to see every delay)\n";
             std::exit(1);
           }
           mAudioTester.setPrintIntervalSec(atof(optarg));
@@ -536,20 +541,21 @@ void Settings::printUsage()
     cout << " -D, --nojackportsconnect                 Don't connect default audio ports in jack" << endl;
     cout << endl;
     cout << "OPTIONAL SIGNAL PROCESSING: " << endl;
-    cout << " -f, --effects    #|paramString|help      Turn on incoming and/or outgoing compressor and/or reverb in Client - see `-f help' for details" << endl;
-    cout << " -O, --overflowlimiting  i|o|io|n|help      Turn on audio limiter in Client, i=incoming from network, o=outgoing to network, io=both, n=no limiters (default=o)" << endl;
+    cout << " -f, --effects # | paramString | help     Turn on incoming and/or outgoing compressor and/or reverb in Client - see `-f help' for details" << endl;
+    cout << " -O, --overflowlimiting  i|o|io|n|help    Turn on audio limiter in Client, i=incoming from network, o=outgoing to network, io=both, n=no limiters (default=o)" << endl;
     cout << " -a, --assumednumclients help|# (1,2,...) Assumed number of Clients (sources) mixing at Hub Server (otherwise 2 assumed by -O)" << endl;
     cout << endl;
     cout << "ARGUMENTS TO USE JACKTRIP WITHOUT JACK:" << endl;
-    cout << " -R, --rtaudio                                Use system's default sound system instead of Jack" << endl;
-    cout << " -T, --srate         #                      Set the sampling rate, works on --rtaudio mode only (default: 48000)" << endl;
-    cout << " -F, --bufsize       #                      Set the buffer size, works on --rtaudio mode only (default: 128)" << endl;
-    cout << " -d, --deviceid      #                      The rtaudio device id --rtaudio mode only (default: 0)" << endl;
+    cout << " -R, --rtaudio                            Use system's default sound system instead of Jack" << endl;
+    cout << " -T, --srate         #                    Set the sampling rate, works on --rtaudio mode only (default: 48000)" << endl;
+    cout << " -F, --bufsize       #                    Set the buffer size, works on --rtaudio mode only (default: 128)" << endl;
+    cout << " -d, --deviceid      #                    The rtaudio device id --rtaudio mode only (default: 0)" << endl;
     cout << endl;
     cout << "ARGUMENTS TO DISPLAY IO STATISTICS:" << endl;
     cout << " -I, --iostat <time_in_secs>              Turn on IO stat reporting with specified interval (in seconds)" << endl;
     cout << " -G, --iostatlog <log_file>               Save stat log into a file (default: print in stdout)" << endl;
-    cout << " -x, --examine-audio-delay #              Print round-trip audio delay statistics, for last audio channel, every # sec, including an ASCII latency histogram if # >= 1.0" << endl;
+    cout << " -x, --examine-audio-delay <print_interval_in_secs> | help\n";
+    cout << "                                          Print round-trip audio delay statistics. See `-x help' for details." << endl;
     cout << endl;
     cout << "HELP ARGUMENTS: " << endl;
     cout << " -v, --version                            Prints Version Number" << endl;


### PR DESCRIPTION
This small PR supports "jacktrip -x help" to explain what is measured and how it is displayed.  Additionally, a small refinement was made to the algorithm used to detect return impulses.  Minor string formatting improvements included.