### PR TITLE
print error message when hard-clipping and say by how much

### DIFF
--- a/src/AudioInterface.cpp
+++ b/src/AudioInterface.cpp
@@ -556,7 +556,7 @@ void AudioInterface::fromSampleToBitConversion
           if (mClipCount==mNextWarning) {
             double mPeakMagnitudeDB = 20.0 * std::log10(mPeakMagnitude);
             std::cerr << "*** AudioInterface.cpp: Audio HARD-CLIPPED on output to Internet!\n"
-                      << "\tReduce your input level(s) by " << mPeakMagnitudeDB << " dB FS.\n";
+                      << "\tReduce your input level(s) by " << mPeakMagnitudeDB << " dB.\n";
             if (mClipCount>1) {
               std::cerr << "\tMaximum amplitude over the last "
                       << mNextWarning << " audio samples was "

--- a/src/AudioInterface.cpp
+++ b/src/AudioInterface.cpp
@@ -560,7 +560,7 @@ void AudioInterface::fromSampleToBitConversion
             if (mClipCount>1) {
               std::cerr << "\tMaximum amplitude over the last "
                       << mNextWarning << " audio samples was "
-                        << mPeakMagnitude << ", or " << mPeakMagnitudeDB << " dB FS\n";
+                        << mPeakMagnitude << ", or " << mPeakMagnitudeDB << " dBFS\n";
             }
             mPeakMagnitude = 0.0; // reset for next group measurement
             if (mNextWarning < 1000) { // don't let it stop reporting for too long

--- a/src/AudioInterface.h
+++ b/src/AudioInterface.h
@@ -245,6 +245,9 @@ private:
     int8_t* mOutputPacket;  ///< Packet containing all the channels to send to the RingBuffer
     bool mLoopBack;
     AudioTester* mAudioTesterP { nullptr };
+    static uint32_t mClipCount;   // must be static as long as fromSampleToBitConversion() is
+    static uint32_t mNextWarning; // must be static as long as fromSampleToBitConversion() is
+    static double mPeakMagnitude; // must be static as long as fromSampleToBitConversion() is
 protected:
     bool mProcessingAudio;  ///< Set when processing an audio callback buffer pair
     const uint32_t MAX_AUDIO_BUFFER_SIZE = 8192;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -598,7 +598,7 @@ void Settings::printUsage()
     cout << endl;
     cout << "OPTIONAL SIGNAL PROCESSING: " << endl;
     cout << " -f, --effects # | paramString | help     Turn on incoming and/or outgoing compressor and/or reverb in Client - see `-f help' for details" << endl;
-    cout << " -O, --overflowlimiting  i|o|io|n|help    Turn on audio limiter in Client, i=incoming from network, o=outgoing to network, io=both, n=no limiters (default=o)" << endl;
+    cout << " -O, --overflowlimiting  i|o|io|n|help    Turn on audio limiter in Client, i=incoming from network, o=outgoing to network, io=both, n=no limiters (default=n)" << endl;
     cout << " -a, --assumednumclients help|# (1,2,...) Assumed number of Clients (sources) mixing at Hub Server (otherwise 2 assumed by -O)" << endl;
     cout << endl;
     cout << "ARGUMENTS TO USE JACKTRIP WITHOUT JACK:" << endl;

--- a/src/UdpHubListener.cpp
+++ b/src/UdpHubListener.cpp
@@ -56,6 +56,7 @@ bool UdpHubListener::sSigInt = false;
 //*******************************************************************************
 UdpHubListener::UdpHubListener(int server_port, int server_udp_port) :
     //mJTWorker(NULL),
+    mTcpServer(this),
     mServerPort(server_port),
     mServerUdpPort(server_udp_port),//final udp base port number
     mStopped(false),
@@ -131,150 +132,156 @@ UdpHubListener::~UdpHubListener()
 // the client is already on the thread pool, it means that a new connection is
 // requested (the old was desconnected). So we have to remove that thread from
 // the pool and then connect again.
-void UdpHubListener::run()
+void UdpHubListener::start()
 {
     mStopped = false;
 
-    QHostAddress PeerAddress; // Object to store peer address
-    int peer_udp_port; // Peer listening port
-    int server_udp_port; // Server assigned udp port
-
-    // Create and bind the TCP server
+    // Bind the TCP server
     // ------------------------------
-    QTcpServer TcpServer;
-    if ( !TcpServer.listen(QHostAddress::Any, mServerPort) ) {
-        QString error_message = QString("TCP Socket Server on Port %1 ERROR: %2").arg(mServerPort).arg(TcpServer.errorString());
+    QObject::connect(&mTcpServer, &QTcpServer::newConnection, this, &UdpHubListener::receivedNewConnection);
+    if ( !mTcpServer.listen(QHostAddress::Any, mServerPort) ) {
+        QString error_message = QString("TCP Socket Server on Port %1 ERROR: %2").arg(mServerPort).arg(mTcpServer.errorString());
         std::cerr << error_message.toStdString() << endl;
         emit signalError(error_message);
         return;
     }
+    
+    cout << "JackTrip HUB SERVER: Waiting for client connections..." << endl;
+    cout << "JackTrip HUB SERVER: Hub auto audio patch setting = " << mHubPatch 
+         << " (" << mHubPatchDescriptions.at(mHubPatch).toStdString() << ")" << endl;
+    cout << "=======================================================" << endl;
+    
+    // Start our monitoring timer
+    mStopCheckTimer.setInterval(200);
+    connect(&mStopCheckTimer, &QTimer::timeout, this, &UdpHubListener::stopCheck);
+    mStopCheckTimer.start();
+}
+    
+void UdpHubListener::receivedNewConnection()
+{
+    QTcpSocket *clientSocket = mTcpServer.nextPendingConnection();
+    connect(clientSocket, &QAbstractSocket::readyRead, this, &UdpHubListener::receivedClientInfo);
+    cout << "JackTrip HUB SERVER: Client Connection Received!" << endl;
+}
 
-    const int tcpTimeout = 5*1000;
+void UdpHubListener::receivedClientInfo()
+{
+    QTcpSocket* clientConnection = static_cast<QTcpSocket*>(QObject::sender());
+    
+    QHostAddress PeerAddress = clientConnection->peerAddress();
+    cout << "JackTrip HUB SERVER: Client Connect Received from Address : "
+         << PeerAddress.toString().toStdString() << endl;
+         
+    // Get UDP port from client
+    // ------------------------
+    QString clientName = QString();
+    cout << "JackTrip HUB SERVER: Reading UDP port from Client..." << endl;
+    if (clientConnection->bytesAvailable() < (int)sizeof(uint16_t)) {
+        // We don't have enough data. Wait for the next readyRead notification.
+        return;
+    }
+    int peer_udp_port = readClientUdpPort(clientConnection, clientName);
+    //TODO: Check if this is the best way to handle this now that we've refactored this code.
+    if ( peer_udp_port == 0 ) { return; }
+    cout << "JackTrip HUB SERVER: Client UDP Port is = " << peer_udp_port << endl;
+    
+    // Check is client is new or not
+    // -----------------------------
+    // Check if Address is not already in the thread pool
+    // check by comparing address strings (To handle IPv4 and IPv6.)
+    int id = isNewAddress(PeerAddress.toString(), peer_udp_port);
+    // If the address is not new, we need to remove the client from the pool
+    // before re-starting the connection
 
-    cout << "JackTrip HUB SERVER: TCP Server Listening in Port = " << TcpServer.serverPort() << endl;
-    while (!mStopped && !sSigInt)
-    {
-        cout << "JackTrip HUB SERVER: Waiting for client connections..." << endl;
-        cout << "JackTrip HUB SERVER: Hub auto audio patch setting = " << mHubPatch 
-             << " (" << mHubPatchDescriptions.at(mHubPatch).toStdString() << ")" << endl;
-        cout << "=======================================================" << endl;
-        while (  !TcpServer.hasPendingConnections() && !TcpServer.waitForNewConnection(1000) ) {
-            if (mStopped || sSigInt) {
-                stopAllThreads();
-                emit signalStopped();
-                return;
-            }
-        } // block until a new connection is received
-        cout << "JackTrip HUB SERVER: Client Connection Received!" << endl;
+    if (id == -1) {
+        int id_remove;
+        id_remove = getPoolID(PeerAddress.toString(), peer_udp_port);
+        // stop the thread
+        mJTWorkers->at(id_remove)->stopThread();
+        // block until the thread has been removed from the pool
+        while ( isNewAddress(PeerAddress.toString(), peer_udp_port) == -1 ) {
+            cout << "JackTrip HUB SERVER: Removing JackTripWorker from pool..." << endl;
+            QThread::msleep(10);
+        }
+        // Get a new ID for this client
+        //id = isNewAddress(PeerAddress.toIPv4Address(), peer_udp_port);
+        id = getPoolID(PeerAddress.toString(), peer_udp_port);
+    }
+    // Assign server port and send it to Client
+    int server_udp_port = mBasePort+id;
+    cout << "JackTrip HUB SERVER: Sending Final UDP Port to Client: " << server_udp_port << endl;
+    
+     if ( sendUdpPort(clientConnection, server_udp_port) == 0 ) {
+        clientConnection->close();
+        clientConnection->deleteLater();
+        releaseThread(id);
+        return;
+    }
+    
+    // Close and mark socket for deletion
+    // ----------------------------------
+    clientConnection->close();
+    clientConnection->deleteLater();
+    cout << "JackTrip HUB SERVER: Client TCP Connection Closed!" << endl;
 
-        // Control loop to be able to exit if UDPs or TCPs error ocurr
-        for (int dum = 0; dum<1; dum++) {
-            QTcpSocket *clientConnection = TcpServer.nextPendingConnection();
-            if ( !clientConnection->waitForConnected(tcpTimeout) ) {
-                std::cerr << clientConnection->errorString().toStdString() << endl;
-                break;
-            }
-            PeerAddress = clientConnection->peerAddress();
-            cout << "JackTrip HUB SERVER: Client Connect Received from Address : "
-                 << PeerAddress.toString().toStdString() << endl;
-
-            // Get UDP port from client
-            // ------------------------
-            QString clientName = QString();
-            peer_udp_port = readClientUdpPort(clientConnection, clientName);
-            if ( peer_udp_port == 0 ) { break; }
-            cout << "JackTrip HUB SERVER: Client UDP Port is = " << peer_udp_port << endl;
-
-            // Check is client is new or not
-            // -----------------------------
-            // Check if Address is not already in the thread pool
-            // check by comparing address strings (To handle IPv4 and IPv6.)
-            int id = isNewAddress(PeerAddress.toString(), peer_udp_port);
-            // If the address is not new, we need to remove the client from the pool
-            // before re-starting the connection
-
-            if (id == -1) {
-                int id_remove;
-                id_remove = getPoolID(PeerAddress.toString(), peer_udp_port);
-                // stop the thread
-                mJTWorkers->at(id_remove)->stopThread();
-                // block until the thread has been removed from the pool
-                while ( isNewAddress(PeerAddress.toString(), peer_udp_port) == -1 ) {
-                    cout << "JackTrip HUB SERVER: Removing JackTripWorker from pool..." << endl;
-                    QThread::msleep(10);
-                }
-                // Get a new ID for this client
-                //id = isNewAddress(PeerAddress.toIPv4Address(), peer_udp_port);
-                id = getPoolID(PeerAddress.toString(), peer_udp_port);
-            }
-            // Assign server port and send it to Client
-            server_udp_port = mBasePort+id;
-            cout << "JackTrip HUB SERVER: Sending Final UDP Port to Client: " << server_udp_port << endl;
-
-            if ( sendUdpPort(clientConnection, server_udp_port) == 0 ) {
-                clientConnection->close();
-                delete clientConnection;
-                releaseThread(id);
-                break;
-            }
-
-            // Close and Delete the socket
-            // ---------------------------
-            clientConnection->close();
-            delete clientConnection;
-            cout << "JackTrip HUB SERVER: Client TCP Connection Closed!" << endl;
-
-            // Spawn Thread to Pool
-            // --------------------
-            // Register JackTripWorker with the hub listener
-            delete mJTWorkers->at(id); // just in case the Worker was previously created
-            mJTWorkers->replace(id, new JackTripWorker(this, mBufferQueueLength, mUnderRunMode, clientName));
-            if (mIOStatTimeout > 0) {
-                mJTWorkers->at(id)->setIOStatTimeout(mIOStatTimeout);
-                mJTWorkers->at(id)->setIOStatStream(mIOStatStream);
-            }
+    // Spawn Thread to Pool
+    // --------------------
+    // Register JackTripWorker with the hub listener
+    delete mJTWorkers->at(id); // just in case the Worker was previously created
+    mJTWorkers->replace(id, new JackTripWorker(this, mBufferQueueLength, mUnderRunMode, clientName));
+    if (mIOStatTimeout > 0) {
+        mJTWorkers->at(id)->setIOStatTimeout(mIOStatTimeout);
+        mJTWorkers->at(id)->setIOStatStream(mIOStatStream);
+    }
              mJTWorkers->at(id)->setBufferStrategy(mBufferStrategy);
              mJTWorkers->at(id)->setNetIssuesSimulation(mSimulatedLossRate,
                 mSimulatedJitterRate, mSimulatedDelayRel);
              mJTWorkers->at(id)->setBroadcast(mBroadcastQueue);
              mJTWorkers->at(id)->setUseRtUdpPriority(mUseRtUdpPriority);
-            // redirect port and spawn listener
-            cout << "JackTrip HUB SERVER: Spawning JackTripWorker..." << endl;
-            {
-                QMutexLocker lock(&mMutex);
-                mJTWorkers->at(id)->setJackTrip(id,
-                                                mActiveAddress[id].address,
-                                                server_udp_port,
-                                                mActiveAddress[id].port,
-                                                1,
-                                                m_connectDefaultAudioPorts
-                                               ); /// \todo temp default to 1 channel
+    // redirect port and spawn listener
+    cout << "JackTrip HUB SERVER: Spawning JackTripWorker..." << endl;
+    {
+        QMutexLocker lock(&mMutex);
+        mJTWorkers->at(id)->setJackTrip(id,
+                                        mActiveAddress[id].address,
+                                        server_udp_port,
+                                        mActiveAddress[id].port,
+                                        1,
+                                        m_connectDefaultAudioPorts
+                                        ); /// \todo temp default to 1 channel
 
-                //qDebug() << "mPeerAddress" << id <<  mActiveAddress[id].address << mActiveAddress[id].port;
-            }
-            //send one thread to the pool
-            cout << "JackTrip HUB SERVER: Starting JackTripWorker..." << endl;
-            mThreadPool.start(mJTWorkers->at(id), QThread::TimeCriticalPriority);
-            // wait until one is complete before another spawns
-            while (mJTWorkers->at(id)->isSpawning()) { QThread::msleep(10); }
-            //mTotalRunningThreads++;
-            cout << "JackTrip HUB SERVER: Total Running Threads:  " << mTotalRunningThreads << endl;
-            cout << "===============================================================" << endl;
-            QThread::msleep(100);
+        //qDebug() << "mPeerAddress" << id <<  mActiveAddress[id].address << mActiveAddress[id].port;
+    }
+    //send one thread to the pool
+    cout << "JackTrip HUB SERVER: Starting JackTripWorker..." << endl;
+    mThreadPool.start(mJTWorkers->at(id), QThread::TimeCriticalPriority);
+    // wait until one is complete before another spawns
+    while (mJTWorkers->at(id)->isSpawning()) { QThread::msleep(10); }
+    //mTotalRunningThreads++;
+    cout << "JackTrip HUB SERVER: Total Running Threads:  " << mTotalRunningThreads << endl;
+    cout << "===============================================================" << endl;
+    QThread::msleep(100);
 #ifdef WAIR // WAIR
-            if (isWAIR()) connectMesh(true); // invoked with -Sw
+    if (isWAIR()) connectMesh(true); // invoked with -Sw
 #endif // endwhere
 
-            //qDebug() << "mPeerAddress" << mActiveAddress[id].address << mActiveAddress[id].port;
+    //qDebug() << "mPeerAddress" << mActiveAddress[id].address << mActiveAddress[id].port;
 
-            connectPatch(true);
-        }
+    connectPatch(true);
+}
+
+void UdpHubListener::stopCheck()
+{
+    if (mStopped || sSigInt) {
+        cout << "JackTrip HUB SERVER: Stopped" << endl;
+        mStopCheckTimer.stop();
+        mTcpServer.close();
+        stopAllThreads();
+        emit signalStopped();
     }
-    
-    stopAllThreads();
-    emit signalStopped();
+}
 
-    /*
+    /* From Old Runloop code
   // Create objects on the stack
   QUdpSocket HubUdpSocket;
   QHostAddress PeerAddress;
@@ -323,24 +330,11 @@ void UdpHubListener::run()
     QThread::msleep(100);
   }
   */
-}
-
 
 //*******************************************************************************
 // Returns 0 on error
 int UdpHubListener::readClientUdpPort(QTcpSocket* clientConnection, QString &clientName)
 {
-    // Read the size of the package
-    // ----------------------------
-    //tcpClient.waitForReadyRead();
-    cout << "JackTrip HUB SERVER: Reading UDP port from Client..." << endl;
-    while (clientConnection->bytesAvailable() < (int)sizeof(uint16_t)) {
-        if (!clientConnection->waitForReadyRead()) {
-            std::cerr << "TCP Socket ERROR: " << clientConnection->errorString().toStdString() <<  endl;
-            return 0;
-        }
-    }
-
     if (gVerboseFlag) cout << "Ready To Read From Client!" << endl;
     // Read UDP Port Number from Server
     // --------------------------------

--- a/src/UdpHubListener.h
+++ b/src/UdpHubListener.h
@@ -66,7 +66,7 @@ typedef struct {
  * This creates a server that will listen on the well know port (the server port) and will
  * spawn JackTrip threads into the Thread pool. Clients request a connection.
  */
-class UdpHubListener : public QThread
+class UdpHubListener : public QObject
 {
     Q_OBJECT;
 
@@ -74,9 +74,8 @@ public:
     UdpHubListener(int server_port = gServerUdpPort, int server_udp_port = 0);
     virtual ~UdpHubListener();
 
-    /// \brief Implements the Thread Loop. To start the thread, call start()
-    /// ( DO NOT CALL run() )
-    void run();
+    /// \brief Starts the TCP server
+    void start();
 
     /// \brief Stops the execution of the Thread
     void stop() { mStopped = true; }
@@ -91,6 +90,9 @@ public:
 private slots:
     void testReceive()
     { std::cout << "========= TEST RECEIVE SLOT ===========" << std::endl; }
+    void receivedNewConnection();
+    void receivedClientInfo();
+    void stopCheck();
 
 signals:
     void Listening();
@@ -136,6 +138,7 @@ private:
     QVector<JackTripWorker*>* mJTWorkers; ///< Vector of JackTripWorker s
     QThreadPool mThreadPool; ///< The Thread Pool
 
+    QTcpServer mTcpServer;
     int mServerPort; //< Server known port number
     int mServerUdpPort; //< Server udp base port number
     int mBasePort;
@@ -145,6 +148,7 @@ private:
     /// Boolean stop the execution of the thread
     volatile bool mStopped;
     static bool sSigInt;
+    QTimer mStopCheckTimer;
     int mTotalRunningThreads; ///< Number of Threads running in the pool
     QMutex mMutex;
     JackTrip::underrunModeT mUnderRunMode;

--- a/src/jacktrip.pro
+++ b/src/jacktrip.pro
@@ -137,7 +137,7 @@ HEADERS += DataProtocol.h \
            JackTripThread.h \
            JackTripWorker.h \
            JackTripWorkerMessages.h \
-           JitterBuffer.cpp \
+           JitterBuffer.h \
            LoopBack.h \
            NetKS.h \
            PacketHeader.h \


### PR DESCRIPTION
This tiny PR was suggested by Sarah Weaver's experience with musicians having multichannel audio interfaces that were being mixed down to mono in JACK by connecting multiple "system capture" channels to one JackTrip input channel.  In this situation, the audio interface output does not clip, and local monitoring looks good and sounds fine, but the JackTrip channel often overflows because the input channels were summed without dividing by the number of channels.   In dev we now hard-clip instead of wrapping around as in main, which helps, and offer a limiter, but this PR adds sparse notification of the clipping in stderr and says by how much it was in each block so it is then known how far input levels need to be reduced.