### PR TITLE
Use outgoing limiter at client by default

### DIFF
--- a/src/Effects.h
+++ b/src/Effects.h
@@ -90,12 +90,10 @@ private:
 
 public:
 
-  Effects() :
+  Effects(bool outGoingLimiterOn=true) :
     mNumIncomingChans(2),
     mNumOutgoingChans(2),
-    // JOS recommends: mLimit(LIMITER_OUTGOING),
-    // Paranoid choice:
-    mLimit(LIMITER_NONE),
+    mLimit(outGoingLimiterOn ? LIMITER_OUTGOING : LIMITER_NONE),
     mNumClientsAssumed(2)
   {}
 

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -97,6 +97,7 @@ Settings::Settings() :
     mHubConnectionMode(JackTrip::SERVERTOCLIENT),
     mConnectDefaultAudioPorts(true),
     mIOStatTimeout(0),
+    mEffects(true), // outgoing limiter ON by default
     mSimulatedLossRate(0.0),
     mSimulatedJitterRate(0.0),
     mSimulatedDelayRel(0.0),


### PR DESCRIPTION
I feel very strongly that we should have an outgoing limiter on by default (from the client).  While we recently added hard-clipping (which is better than wrap-around), it didn't help as much as I expected when there is no limiter (I plan to investigate this further - it sounds to me like the hard-clipping might not be working as expected).  I have another PR (presently suspended) that warns about and summarizes hard-clipping in the console, but if this PR is accepted, I would like to change that PR to propose warning instead about exceeding -6 dB, which is where the limiter begins compressing toward clipping.  The limiter-compression threshold can of course be set to anything; I think -3dB is the most aggressive I've seen, but I prefer the more graceful transition to clipping starting at -6dB - we can of course make this a user-settable parameter if there is any disagreement about the value.  So, this PR needs to be decided before the suspended one can be resumed.