### PR TITLE
support audio latency testing in silent channel during normal operation

### DIFF
--- a/src/AudioTester.cpp
+++ b/src/AudioTester.cpp
@@ -133,7 +133,6 @@ void AudioTester::lookForReturnPulse(QVarLengthArray<sample_t*>& out_buffer,
 
 // Called 2nd in Audiointerface.cpp
 void AudioTester::writeImpulse(QVarLengthArray<sample_t*>& mInBufCopy,
-                               QVarLengthArray<sample_t*>& in_buffer,
                                unsigned int n_frames) {
   if (not enabled) {
     std::cerr << "*** AudioTester.h: writeImpulse: NOT ENABLED\n";
@@ -152,9 +151,11 @@ void AudioTester::writeImpulse(QVarLengthArray<sample_t*>& mInBufCopy,
       sendImpulse = true;
     }
     if (sendImpulse) {
-      assert(sendChannel < in_buffer.size());
       assert(sendChannel < mInBufCopy.size());
       mInBufCopy[sendChannel][0] = getImpulseAmp();
+      for (uint n=1; n<n_frames; n++) {
+	mInBufCopy[sendChannel][n] = 0;
+      }
       impulsePending = true;
       impulseTimeUS = timeMicroSec();
       impulseTimeSamples = sampleCountSinceImpulse; // timer in samples for current impulse loopback test

--- a/src/AudioTester.cpp
+++ b/src/AudioTester.cpp
@@ -154,7 +154,7 @@ void AudioTester::writeImpulse(QVarLengthArray<sample_t*>& mInBufCopy,
       assert(sendChannel < mInBufCopy.size());
       mInBufCopy[sendChannel][0] = getImpulseAmp();
       for (uint n=1; n<n_frames; n++) {
-	mInBufCopy[sendChannel][n] = 0;
+        mInBufCopy[sendChannel][n] = 0;
       }
       impulsePending = true;
       impulseTimeUS = timeMicroSec();

--- a/src/AudioTester.h
+++ b/src/AudioTester.h
@@ -86,7 +86,6 @@ public:
                                        unsigned int n_frames);
 
   void writeImpulse(QVarLengthArray<sample_t*>& mInBufCopy,
-                    QVarLengthArray<sample_t*>& in_buffer,
                     unsigned int n_frames);
 
   bool getEnabled() { return enabled; }


### PR DESCRIPTION
This completes support of audio latency testing in a (silent) highest-numbered channel while using the lower-numbered channels normally.