### PR TITLE
outgoing limiter more clearly turned off by default

### DIFF
--- a/src/Effects.h
+++ b/src/Effects.h
@@ -90,12 +90,10 @@ private:
 
 public:
 
-  Effects() :
+  Effects(bool outGoingLimiterOn=true) :
     mNumIncomingChans(2),
     mNumOutgoingChans(2),
-    // JOS recommends: mLimit(LIMITER_OUTGOING),
-    // Paranoid choice:
-    mLimit(LIMITER_NONE),
+    mLimit(outGoingLimiterOn ? LIMITER_OUTGOING : LIMITER_NONE),
     mNumClientsAssumed(2)
   {}
 

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -97,6 +97,7 @@ Settings::Settings() :
     mHubConnectionMode(JackTrip::SERVERTOCLIENT),
     mConnectDefaultAudioPorts(true),
     mIOStatTimeout(0),
+    mEffects(true), // outgoing limiter ON by default
     mSimulatedLossRate(0.0),
     mSimulatedJitterRate(0.0),
     mSimulatedDelayRel(0.0),

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -97,7 +97,7 @@ Settings::Settings() :
     mHubConnectionMode(JackTrip::SERVERTOCLIENT),
     mConnectDefaultAudioPorts(true),
     mIOStatTimeout(0),
-    mEffects(true), // outgoing limiter ON by default
+    mEffects(false), // outgoing limiter OFF by default
     mSimulatedLossRate(0.0),
     mSimulatedJitterRate(0.0),
     mSimulatedDelayRel(0.0),


### PR DESCRIPTION
This is the PR for turning on the limiter by default modified to turn it OFF instead.  Thus, it is a no-op, but it makes it more clear that the outgoing limiter is intentionally being turned off, overriding the recommended default in Effects.h.  It also saves the general code improvements associated with the deleted PR wanting to turn it on, and makes it easier to turn it back on, should that ever be desired.
