### PR TITLE
Hublistener loop fix

### DIFF
--- a/src/JackTripWorker.cpp
+++ b/src/JackTripWorker.cpp
@@ -65,6 +65,7 @@ JackTripWorker::JackTripWorker(UdpHubListener* udphublistener, int BufferQueueLe
     mUnderRunMode(UnderRunMode),
     mClientName(clientName),
     mSpawning(false),
+    mStopped(false),
     mID(0),
     mNumChans(1),
     mIOStatTimeout(0)
@@ -123,7 +124,14 @@ void JackTripWorker::run()
     This is not supported, exceptions thrown in worker threads must be
     caught before control returns to Qt Concurrent.'*/
 
-    { QMutexLocker locker(&mMutex); mSpawning = true; }
+    {
+        //Check if we still need to run this.
+        QMutexLocker locker(&mMutex);
+        if (mStopped) {
+            mSpawning = false;
+            mUdpHubListener->releaseThread(mID);
+        }
+    }
 
     //QHostAddress ClientAddress;
 
@@ -230,7 +238,7 @@ void JackTripWorker::run()
 
         if (gVerboseFlag) cout << "---> JackTripWorker: setJackTripFromClientHeader..." << endl;
         int PeerConnectionMode = setJackTripFromClientHeader(jacktrip);
-        if ( PeerConnectionMode == -1 ) {
+        if ( PeerConnectionMode == -1 || mStopped ) {
             mUdpHubListener->releaseThread(mID);
             { QMutexLocker locker(&mMutex); mSpawning = false; }
             return;
@@ -243,11 +251,20 @@ void JackTripWorker::run()
                     mID
             #endif // endwhere
                     );
+        mAssignedClientName = jacktrip.getAssignedClientName();
         // if (gVerboseFlag) cout << "---> JackTripWorker: start..." << endl;
         // jacktrip.start(); // ########### JamTest Only #################
 
         // Thread is already spawning, so release the lock
-        { QMutexLocker locker(&mMutex); mSpawning = false; }
+        {
+            QMutexLocker lock(&mMutex);
+            mSpawning = false;
+            if (mStopped) {
+                jacktrip.slotStopProcesses();
+                mUdpHubListener->releaseThread(mID);
+                return;
+            }
+        }
 
         event_loop.exec(); // Excecution will block here until exit() the QEventLoop
         //--------------------------------------------------------------------------
@@ -354,5 +371,6 @@ bool JackTripWorker::isSpawning()
 void JackTripWorker::stopThread()
 {
     QMutexLocker locker(&mMutex);
+    mStopped = true;
     emit signalRemoveThread();
 }

--- a/src/JackTripWorker.cpp
+++ b/src/JackTripWorker.cpp
@@ -251,7 +251,6 @@ void JackTripWorker::run()
                     mID
             #endif // endwhere
                     );
-        mAssignedClientName = jacktrip.getAssignedClientName();
         // if (gVerboseFlag) cout << "---> JackTripWorker: start..." << endl;
         // jacktrip.start(); // ########### JamTest Only #################
 

--- a/src/JackTripWorker.h
+++ b/src/JackTripWorker.h
@@ -110,8 +110,6 @@ public:
     void setIOStatTimeout(int timeout) { mIOStatTimeout = timeout; }
     void setIOStatStream(QSharedPointer<std::ofstream> statStream) { mIOStatStream = statStream; }
     
-    QString getAssignedClientName() { return mAssignedClientName; }
-    
 private slots:
     void slotTest()
     { std::cout << "--- JackTripWorker TEST SLOT ---" << std::endl; }
@@ -136,7 +134,6 @@ private:
     int mBufferQueueLength;
     JackTrip::underrunModeT mUnderRunMode;
     QString mClientName;
-    QString mAssignedClientName;
 
     /// Thread spawning internal lock.
     /// If true, the prototype is working on creating (spawning) a new thread

--- a/src/JackTripWorker.h
+++ b/src/JackTripWorker.h
@@ -110,6 +110,8 @@ public:
     void setIOStatTimeout(int timeout) { mIOStatTimeout = timeout; }
     void setIOStatStream(QSharedPointer<std::ofstream> statStream) { mIOStatStream = statStream; }
     
+    QString getAssignedClientName() { return mAssignedClientName; }
+    
 private slots:
     void slotTest()
     { std::cout << "--- JackTripWorker TEST SLOT ---" << std::endl; }
@@ -134,10 +136,12 @@ private:
     int mBufferQueueLength;
     JackTrip::underrunModeT mUnderRunMode;
     QString mClientName;
+    QString mAssignedClientName;
 
     /// Thread spawning internal lock.
     /// If true, the prototype is working on creating (spawning) a new thread
     volatile bool mSpawning;
+    bool mStopped;
     QMutex mMutex; ///< Mutex to protect mSpawning
 
     int mID; ///< ID thread number


### PR DESCRIPTION
Hopefully fixes an issue where the UdpHubListener gets stuck in an infinite loop while waiting for a previous JackTripWorker instance to finish.