### PR TITLE
Add GitHub Actions

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -8,6 +8,8 @@ jobs:
       fail-fast: false # don't abort if one of the build failse
       matrix:
         include:
+          - name: Linux
+            runs-on: ubuntu-18.04
           - name: macOS
             runs-on: macos-10.15
 
@@ -16,7 +18,11 @@ jobs:
       BUILD_PATH: ${{ github.workspace }}/builddir
     steps:
       - uses: actions/checkout@v2
-      - name: install dependencies on macOS
+      - name: install dependencies for Linux
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get install --yes libjack-dev qt5-default qt5-qmake qttools5-dev
+      - name: install dependencies for macOS
         if: runner.os == 'macOS'
         env:
           HOMEBREW_NO_ANALYTICS: 1

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -1,0 +1,39 @@
+name: build
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ${{ matrix.runs-on }}
+    name: ${{ matrix.name }}
+    strategy:
+      fail-fast: false # don't abort if one of the build failse
+      matrix:
+        include:
+          - name: macOS
+            runs-on: macos-10.15
+
+    env:
+      SRC_PATH: ${{ github.workspace }}/src
+      BUILD_PATH: ${{ github.workspace }}/builddir
+    steps:
+      - uses: actions/checkout@v2
+      - name: install dependencies on macOS
+        if: runner.os == 'macOS'
+        env:
+          HOMEBREW_NO_ANALYTICS: 1
+          HOMEBREW_NO_AUTO_UPDATE: 1
+          HOMEBREW_NO_INSTALL_CLEANUP: 1
+        run: |
+          brew install qt5 jack
+          brew link qt5 --force
+      - name: build
+        env:
+          DEVELOPER_DIR: '/Applications/Xcode_11.7.app/Contents/Developer' # specify XCode version on macOS
+        run: |
+          cd $SRC_PATH
+          ./build
+      - name: upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: JackTrip-${{ matrix.name }} # version number could be added here
+          path: ${{ env.BUILD_PATH }}
+          retention-days: 30 # remove artifacts after 30 days


### PR DESCRIPTION
This PR adds builds using GitHub Actions on Linux and macOS. The build artifacts are uploaded to GitHub Actions for introspection.

This PR includes:
- building JackTrip on Linux
- building JackTrip on macOS
- uploading build artifacts to GitHub Actions (expire after 30 days, can be adjusted)

This PR does _not_ include:
- building static Qt on macOS for making distributable binaries
- caching (should be definitely implemented especially if static qt build will be added)
- automatic deployment of tagged builds to github releases
- version numbers in the artifact name
- tests

I don't think GitHub Actions will run until this PR is merged. You can see it running on my fork: https://github.com/dyfer/jacktrip/actions/runs/488972949