### PR TITLE
Add clang-format coding style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,182 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: true
+AlignConsecutiveAssignments: true
+AlignConsecutiveBitFields: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Linux
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeComma
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeComma
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     90
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: false
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+      - ParseTestProto
+      - ParsePartialTestProto
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+ReflowComments:  false
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Auto
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+...
+

--- a/documentation/documentation.cpp
+++ b/documentation/documentation.cpp
@@ -35,7 +35,6 @@
  * \date July 2008
  */
 
-
 // Main Page Documentation
 //-----------------------------------------------------------------
 /**
@@ -120,5 +119,3 @@ will be transmitted to your peer. You'll receive what your peer sends you on the
 \image html jack_routing.png
 
 */
-
-

--- a/faust-src/faust2header.cpp
+++ b/faust-src/faust2header.cpp
@@ -6,7 +6,6 @@
 // See the Makefile for how to use it.
 
 #include <faust/dsp/dsp.h>
-
 #include <faust/gui/APIUI.h>
 
 // NOTE: "faust -scn name" changes the last line above to
@@ -16,6 +15,6 @@
 //  FAUST Generated Code
 //----------------------------------------------------------------------------
 
-<<includeIntrinsic>>
+<< includeIntrinsic >>
 
-<<includeclass>>
+    << includeclass >>

--- a/faust-src/faust2header.cpp
+++ b/faust-src/faust2header.cpp
@@ -14,7 +14,9 @@
 //----------------------------------------------------------------------------
 //  FAUST Generated Code
 //----------------------------------------------------------------------------
+// clang-format off
+<<includeIntrinsic>>
 
-<< includeIntrinsic >>
+    <<includeclass>>
 
-    << includeclass >>
+    // clang-format on

--- a/faust-src/minimal.cpp
+++ b/faust-src/minimal.cpp
@@ -22,9 +22,11 @@ inline void* aligned_calloc(size_t nmemb, size_t size)
     return (void*)((size_t)(calloc((nmemb * size) + 15, sizeof(char))) + 15 & ~15);
 }
 
-<< includeIntrinsic >>
+// clang-format off
+<<includeIntrinsic>>
+// clang-format on
 
-    /******************************************************************************
+/******************************************************************************
 *******************************************************************************
 
 			ABSTRACT USER INTERFACE
@@ -93,5 +95,6 @@ class dsp
 //----------------------------------------------------------------------------
 //  FAUST generated signal processor
 //----------------------------------------------------------------------------
-
-<< includeclass >>
+// clang-format off
+<<includeclass>>
+// clang-format on

--- a/faust-src/minimal.cpp
+++ b/faust-src/minimal.cpp
@@ -1,13 +1,12 @@
 #ifdef __GNUC__
 
-#define max(x,y) (((x)>(y)) ? (x) : (y))
-#define min(x,y) (((x)<(y)) ? (x) : (y))
+#define max(x, y) (((x) > (y)) ? (x) : (y))
+#define min(x, y) (((x) < (y)) ? (x) : (y))
 
 // abs is now predefined
 //template<typename T> T abs (T a)			{ return (a<T(0)) ? -a : a; }
 
-
-inline int		lsr (int x, int n)			{ return int(((unsigned int)x) >> n); }
+inline int lsr(int x, int n) { return int(((unsigned int)x) >> n); }
 
 /******************************************************************************
 *******************************************************************************
@@ -18,11 +17,14 @@ inline int		lsr (int x, int n)			{ return int(((unsigned int)x) >> n); }
 *******************************************************************************/
 
 //inline void *aligned_calloc(size_t nmemb, size_t size) { return (void*)((unsigned)(calloc((nmemb*size)+15,sizeof(char)))+15 & 0xfffffff0); }
-inline void *aligned_calloc(size_t nmemb, size_t size) { return (void*)((size_t)(calloc((nmemb*size)+15,sizeof(char)))+15 & ~15); }
+inline void* aligned_calloc(size_t nmemb, size_t size)
+{
+    return (void*)((size_t)(calloc((nmemb * size) + 15, sizeof(char))) + 15 & ~15);
+}
 
-<<includeIntrinsic>>
+<< includeIntrinsic >>
 
-/******************************************************************************
+    /******************************************************************************
 *******************************************************************************
 
 			ABSTRACT USER INTERFACE
@@ -30,35 +32,35 @@ inline void *aligned_calloc(size_t nmemb, size_t size) { return (void*)((size_t)
 *******************************************************************************
 *******************************************************************************/
 
-class UI
+    class UI
 {
-	bool	fStopped;
-public:
-		
-	UI() : fStopped(false) {}
-	virtual ~UI() {}
-	
-	virtual void addButton(char* label, float* zone) = 0;
-	virtual void addToggleButton(char* label, float* zone) = 0;
-	virtual void addCheckButton(char* label, float* zone) = 0;
-	virtual void addVerticalSlider(char* label, float* zone, float init, float min, float max, float step) = 0;
-	virtual void addHorizontalSlider(char* label, float* zone, float init, float min, float max, float step) = 0;
-	virtual void addNumEntry(char* label, float* zone, float init, float min, float max, float step) = 0;
-	
-	virtual void openFrameBox(char* label) = 0;
-	virtual void openTabBox(char* label) = 0;
-	virtual void openHorizontalBox(char* label) = 0;
-	virtual void openVerticalBox(char* label) = 0;
-	virtual void closeBox() = 0;
-	
-	virtual void run() = 0;
-	
-	void stop()	{ fStopped = true; }
-	bool stopped() 	{ return fStopped; }
+    bool fStopped;
+
+   public:
+    UI() : fStopped(false) {}
+    virtual ~UI() {}
+
+    virtual void addButton(char* label, float* zone)        = 0;
+    virtual void addToggleButton(char* label, float* zone)  = 0;
+    virtual void addCheckButton(char* label, float* zone)   = 0;
+    virtual void addVerticalSlider(char* label, float* zone, float init, float min,
+                                   float max, float step)   = 0;
+    virtual void addHorizontalSlider(char* label, float* zone, float init, float min,
+                                     float max, float step) = 0;
+    virtual void addNumEntry(char* label, float* zone, float init, float min, float max,
+                             float step)                    = 0;
+
+    virtual void openFrameBox(char* label)      = 0;
+    virtual void openTabBox(char* label)        = 0;
+    virtual void openHorizontalBox(char* label) = 0;
+    virtual void openVerticalBox(char* label)   = 0;
+    virtual void closeBox()                     = 0;
+
+    virtual void run() = 0;
+
+    void stop() { fStopped = true; }
+    bool stopped() { return fStopped; }
 };
-
-
-
 
 /******************************************************************************
 *******************************************************************************
@@ -68,30 +70,28 @@ public:
 *******************************************************************************
 *******************************************************************************/
 
-
-
 //----------------------------------------------------------------
 //  abstract definition of a signal processor
 //----------------------------------------------------------------
-			
-class dsp {
- protected:
-	int fSamplingFreq;
- public:
-	dsp() {}
-	virtual ~dsp() {}
 
-	virtual int getNumInputs() 						= 0;
-	virtual int getNumOutputs() 					= 0;
-	virtual void buildUserInterface(UI* interface) 	= 0;
-	virtual void init(int samplingRate) 			= 0;
- 	virtual void compute(int len, float** inputs, float** outputs) 	= 0;
+class dsp
+{
+   protected:
+    int fSamplingFreq;
+
+   public:
+    dsp() {}
+    virtual ~dsp() {}
+
+    virtual int getNumInputs()                                     = 0;
+    virtual int getNumOutputs()                                    = 0;
+    virtual void buildUserInterface(UI* interface)                 = 0;
+    virtual void init(int samplingRate)                            = 0;
+    virtual void compute(int len, float** inputs, float** outputs) = 0;
 };
-		
 
 //----------------------------------------------------------------------------
 //  FAUST generated signal processor
 //----------------------------------------------------------------------------
-		
 
-<<includeclass>>
+<< includeclass >>

--- a/faust-src/minimal.cpp
+++ b/faust-src/minimal.cpp
@@ -24,9 +24,9 @@ inline void* aligned_calloc(size_t nmemb, size_t size)
 
 // clang-format off
 <<includeIntrinsic>>
-// clang-format on
+    // clang-format on
 
-/******************************************************************************
+    /******************************************************************************
 *******************************************************************************
 
 			ABSTRACT USER INTERFACE
@@ -97,4 +97,4 @@ class dsp
 //----------------------------------------------------------------------------
 // clang-format off
 <<includeclass>>
-// clang-format on
+    // clang-format on

--- a/src/AudioInterface.cpp
+++ b/src/AudioInterface.cpp
@@ -36,29 +36,39 @@
  */
 
 #include "AudioInterface.h"
-#include "JackTrip.h"
-#include <iostream>
-#include <cmath>
+
 #include <assert.h>
 
-using std::cout; using std::endl;
+#include <cmath>
+#include <iostream>
+
+#include "JackTrip.h"
+
+using std::cout;
+using std::endl;
 
 //*******************************************************************************
-AudioInterface::AudioInterface(JackTrip* jacktrip,
-                               int NumInChans, int NumOutChans,
-                               #ifdef WAIR // wair
+AudioInterface::AudioInterface(JackTrip* jacktrip, int NumInChans, int NumOutChans,
+#ifdef WAIR  // wair
                                int NumNetRevChans,
-                               #endif // endwhere
-                               audioBitResolutionT AudioBitResolution) :
-    mJackTrip(jacktrip),
-    mNumInChans(NumInChans), mNumOutChans(NumOutChans),
-    #ifdef WAIR // WAIR
-    mNumNetRevChans(NumNetRevChans),
-    #endif // endwhere
-    mAudioBitResolution(AudioBitResolution*8),
-    mBitResolutionMode(AudioBitResolution),
-    mSampleRate(gDefaultSampleRate), mBufferSizeInSamples(gDefaultBufferSizeInSamples),
-    mInputPacket(NULL), mOutputPacket(NULL), mLoopBack(false), mProcessingAudio(false)
+#endif  // endwhere
+                               audioBitResolutionT AudioBitResolution)
+    : mJackTrip(jacktrip)
+    , mNumInChans(NumInChans)
+    , mNumOutChans(NumOutChans)
+    ,
+#ifdef WAIR  // WAIR
+    mNumNetRevChans(NumNetRevChans)
+    ,
+#endif  // endwhere
+    mAudioBitResolution(AudioBitResolution * 8)
+    , mBitResolutionMode(AudioBitResolution)
+    , mSampleRate(gDefaultSampleRate)
+    , mBufferSizeInSamples(gDefaultBufferSizeInSamples)
+    , mInputPacket(NULL)
+    , mOutputPacket(NULL)
+    , mLoopBack(false)
+    , mProcessingAudio(false)
 {
 #ifndef WAIR
     //cc
@@ -66,73 +76,50 @@ AudioInterface::AudioInterface(JackTrip* jacktrip,
     mInProcessBuffer.resize(mNumInChans);
     mOutProcessBuffer.resize(mNumOutChans);
     // Set pointer to NULL
-    for (int i = 0; i < mNumInChans; i++) {
-        mInProcessBuffer[i] = NULL;
-    }
-    for (int i = 0; i < mNumOutChans; i++) {
-        mOutProcessBuffer[i] = NULL;
-    }
-#else // WAIR
+    for (int i = 0; i < mNumInChans; i++) { mInProcessBuffer[i] = NULL; }
+    for (int i = 0; i < mNumOutChans; i++) { mOutProcessBuffer[i] = NULL; }
+#else  // WAIR
     int iCnt = (mNumInChans > mNumNetRevChans) ? mNumInChans : mNumNetRevChans;
     int oCnt = (mNumOutChans > mNumNetRevChans) ? mNumOutChans : mNumNetRevChans;
     int aCnt = (mNumNetRevChans) ? mNumInChans : 0;
-    for (int i = 0; i < iCnt; i++) {
-        mInProcessBuffer[i] = NULL;
-    }
-    for (int i = 0; i < oCnt; i++) {
-        mOutProcessBuffer[i] = NULL;
-    }
-    for (int i = 0; i < aCnt; i++) {
-        mAPInBuffer[i] = NULL;
-    }
-#endif // endwhere
+    for (int i = 0; i < iCnt; i++) { mInProcessBuffer[i] = NULL; }
+    for (int i = 0; i < oCnt; i++) { mOutProcessBuffer[i] = NULL; }
+    for (int i = 0; i < aCnt; i++) { mAPInBuffer[i] = NULL; }
+#endif  // endwhere
 
     mInBufCopy.resize(mNumInChans);
-    for (int i=0; i<mNumInChans; i++) {
-      mInBufCopy[i] = new sample_t[MAX_AUDIO_BUFFER_SIZE]; // required for processing audio input
+    for (int i = 0; i < mNumInChans; i++) {
+        mInBufCopy[i] =
+            new sample_t[MAX_AUDIO_BUFFER_SIZE];  // required for processing audio input
     }
 }
-
 
 //*******************************************************************************
 AudioInterface::~AudioInterface()
 {
     delete[] mInputPacket;
     delete[] mOutputPacket;
-#ifndef WAIR // NOT WAIR:
-    for (int i = 0; i < mNumInChans; i++) {
-        delete[] mInProcessBuffer[i];
-    }
+#ifndef WAIR  // NOT WAIR:
+    for (int i = 0; i < mNumInChans; i++) { delete[] mInProcessBuffer[i]; }
 
-    for (int i = 0; i < mNumOutChans; i++) {
-        delete[] mOutProcessBuffer[i];
-    }
-#else // WAIR
+    for (int i = 0; i < mNumOutChans; i++) { delete[] mOutProcessBuffer[i]; }
+#else  // WAIR
     int iCnt = (mNumInChans > mNumNetRevChans) ? mNumInChans : mNumNetRevChans;
     int oCnt = (mNumOutChans > mNumNetRevChans) ? mNumOutChans : mNumNetRevChans;
     int aCnt = (mNumNetRevChans) ? mNumInChans : 0;
-    for (int i = 0; i < iCnt; i++) {
-        delete[] mInProcessBuffer[i];
-    }
-    for (int i = 0; i < oCnt; i++) {
-        delete[] mOutProcessBuffer[i];
-    }
-    for (int i = 0; i < aCnt; i++) {
-        delete[] mAPInBuffer[i];
-    }
-#endif // endwhere
+    for (int i = 0; i < iCnt; i++) { delete[] mInProcessBuffer[i]; }
+    for (int i = 0; i < oCnt; i++) { delete[] mOutProcessBuffer[i]; }
+    for (int i = 0; i < aCnt; i++) { delete[] mAPInBuffer[i]; }
+#endif  // endwhere
 
     for (int i = 0; i < mProcessPluginsFromNetwork.size(); i++) {
-      delete mProcessPluginsFromNetwork[i];
+        delete mProcessPluginsFromNetwork[i];
     }
     for (int i = 0; i < mProcessPluginsToNetwork.size(); i++) {
-      delete mProcessPluginsToNetwork[i];
+        delete mProcessPluginsToNetwork[i];
     }
-    for (int i=0; i<mNumInChans; i++) {
-      delete mInBufCopy[i];
-    }
+    for (int i = 0; i < mNumInChans; i++) { delete mInBufCopy[i]; }
 }
-
 
 //*******************************************************************************
 void AudioInterface::setup()
@@ -142,26 +129,25 @@ void AudioInterface::setup()
 
     int size_input  = mSizeInBytesPerChannel * getNumInputChannels();
     int size_output = mSizeInBytesPerChannel * getNumOutputChannels();
-#ifdef WAIR // WAIR
-    if(mNumNetRevChans) // else don't change sizes
+#ifdef WAIR  // WAIR
+    if (mNumNetRevChans)  // else don't change sizes
     {
         size_input  = mSizeInBytesPerChannel * mNumNetRevChans;
         size_output = mSizeInBytesPerChannel * mNumNetRevChans;
     }
-#endif // endwhere
-    mInputPacket = new int8_t[size_input];
+#endif  // endwhere
+    mInputPacket  = new int8_t[size_input];
     mOutputPacket = new int8_t[size_output];
 
     // Initialize and asign memory for ProcessPlugins Buffers
-#ifdef WAIR // WAIR
-    if(mNumNetRevChans)
-    {
+#ifdef WAIR  // WAIR
+    if (mNumNetRevChans) {
         mInProcessBuffer.resize(mNumNetRevChans);
         mOutProcessBuffer.resize(mNumNetRevChans);
         mAPInBuffer.resize(mNumInChans);
         mNetInBuffer.resize(mNumNetRevChans);
-    } else // don't change sizes
-#endif // endwhere
+    } else  // don't change sizes
+#endif  // endwhere
     {
         mInProcessBuffer.resize(mNumInChans);
         mOutProcessBuffer.resize(mNumOutChans);
@@ -169,7 +155,7 @@ void AudioInterface::setup()
 
     int nframes = getBufferSizeInSamples();
 
-#ifndef WAIR // NOT WAIR:
+#ifndef WAIR  // NOT WAIR:
     for (int i = 0; i < mNumInChans; i++) {
         mInProcessBuffer[i] = new sample_t[nframes];
         // set memory to 0
@@ -180,18 +166,18 @@ void AudioInterface::setup()
         // set memory to 0
         std::memset(mOutProcessBuffer[i], 0, sizeof(sample_t) * nframes);
     }
-#else // WAIR
-    for (int i = 0; i < ((mNumNetRevChans)?mNumNetRevChans:mNumInChans); i++) {
+#else  // WAIR
+    for (int i = 0; i < ((mNumNetRevChans) ? mNumNetRevChans : mNumInChans); i++) {
         mInProcessBuffer[i] = new sample_t[nframes];
         // set memory to 0
         std::memset(mInProcessBuffer[i], 0, sizeof(sample_t) * nframes);
     }
-    for (int i = 0; i < ((mNumNetRevChans)?mNumNetRevChans:mNumOutChans); i++) {
+    for (int i = 0; i < ((mNumNetRevChans) ? mNumNetRevChans : mNumOutChans); i++) {
         mOutProcessBuffer[i] = new sample_t[nframes];
         // set memory to 0
         std::memset(mOutProcessBuffer[i], 0, sizeof(sample_t) * nframes);
     }
-    for (int i = 0; i < ((mNumNetRevChans)?mNumInChans:0); i++) {
+    for (int i = 0; i < ((mNumNetRevChans) ? mNumInChans : 0); i++) {
         mAPInBuffer[i] = new sample_t[nframes];
         // set memory to 0
         std::memset(mAPInBuffer[i], 0, sizeof(sample_t) * nframes);
@@ -201,17 +187,14 @@ void AudioInterface::setup()
         // set memory to 0
         std::memset(mNetInBuffer[i], 0, sizeof(sample_t) * nframes);
     }
-#endif // endwhere
-
+#endif  // endwhere
 }
-
 
 //*******************************************************************************
 size_t AudioInterface::getSizeInBytesPerChannel() const
 {
-    return (getBufferSizeInSamples() * getAudioBitResolution()/8);
+    return (getBufferSizeInSamples() * getAudioBitResolution() / 8);
 }
-
 
 //*******************************************************************************
 void AudioInterface::callback(QVarLengthArray<sample_t*>& in_buffer,
@@ -223,16 +206,16 @@ void AudioInterface::callback(QVarLengthArray<sample_t*>& in_buffer,
     // 1) First, process incoming packets
     // ----------------------------------
 
-#ifdef WAIR // WAIR
+#ifdef WAIR  // WAIR
     //    qDebug() << "--" << mProcessPluginsFromNetwork.size();
     bool client = (mProcessPluginsFromNetwork.size() == 2);
-#define COMBDSP 1 // client
-#define APDSP 0 // client
-#define DCBDSP 0 // server
+#define COMBDSP 1  // client
+#define APDSP   0  // client
+#define DCBDSP  0  // server
     for (int i = 0; i < mNumNetRevChans; i++) {
         std::memset(mNetInBuffer[i], 0, sizeof(sample_t) * n_frames);
     }
-#endif // endwhere
+#endif  // endwhere
 
     // ==== RECEIVE AUDIO CHANNELS FROM NETWORK ====
     computeProcessFromNetwork(out_buffer, n_frames);
@@ -243,12 +226,12 @@ void AudioInterface::callback(QVarLengthArray<sample_t*>& in_buffer,
 
     // mAudioTesterP will be nullptr for hub server's JackTripWorker instances
     if (mAudioTesterP && mAudioTesterP->getEnabled()) {
-      mAudioTesterP->lookForReturnPulse(out_buffer, n_frames);
+        mAudioTesterP->lookForReturnPulse(out_buffer, n_frames);
     }
 
-#ifdef WAIR // WAIR
+#ifdef WAIR  // WAIR
     // nib16 result now in mNetInBuffer
-#endif // endwhere
+#endif  // endwhere
 
     // 2) Dynamically allocate ProcessPlugin processes
     // -----------------------------------------------
@@ -256,74 +239,80 @@ void AudioInterface::callback(QVarLengthArray<sample_t*>& in_buffer,
     /// \todo Implement for more than one process plugin, now it just works propertely with one.
     /// do it chaining outputs to inputs in the buffers. May need a tempo buffer
 
-#ifndef WAIR // NOT WAIR:
+#ifndef WAIR  // NOT WAIR:
     for (int i = 0; i < mProcessPluginsFromNetwork.size(); i++) {
-      ProcessPlugin* p = mProcessPluginsFromNetwork[i];
-      if (p->getInited()) {
-        p->compute(n_frames, out_buffer.data(), out_buffer.data());
-      }
+        ProcessPlugin* p = mProcessPluginsFromNetwork[i];
+        if (p->getInited()) {
+            p->compute(n_frames, out_buffer.data(), out_buffer.data());
+        }
     }
-#else // WAIR:
-    for (int i = 0; i < ((mNumNetRevChans)?mNumNetRevChans:mNumOutChans); i++) {
+#else  // WAIR:
+    for (int i = 0; i < ((mNumNetRevChans) ? mNumNetRevChans : mNumOutChans); i++) {
         std::memset(mOutProcessBuffer[i], 0, sizeof(sample_t) * n_frames);
     }
-    for (int i = 0; i < ((mNumNetRevChans)?mNumNetRevChans:mNumInChans); i++) {
+    for (int i = 0; i < ((mNumNetRevChans) ? mNumNetRevChans : mNumInChans); i++) {
         std::memset(mInProcessBuffer[i], 0, sizeof(sample_t) * n_frames);
-        if (mNumNetRevChans)
-        {
+        if (mNumNetRevChans) {
             if (client)
-                std::memcpy(mInProcessBuffer[i], mNetInBuffer[i], sizeof(sample_t) * n_frames);
+                std::memcpy(mInProcessBuffer[i], mNetInBuffer[i],
+                            sizeof(sample_t) * n_frames);
             else
-                std::memcpy(mOutProcessBuffer[i], mNetInBuffer[i], sizeof(sample_t) * n_frames);
+                std::memcpy(mOutProcessBuffer[i], mNetInBuffer[i],
+                            sizeof(sample_t) * n_frames);
         }
     }
     // nib16 to cib16
 
     if (mNumNetRevChans && client) {
-      mProcessPluginsFromNetwork[COMBDSP]->compute(n_frames, mInProcessBuffer.data(), mOutProcessBuffer.data());
+        mProcessPluginsFromNetwork[COMBDSP]->compute(n_frames, mInProcessBuffer.data(),
+                                                     mOutProcessBuffer.data());
     }
     // compute cob16
-#endif // endwhere
+#endif  // endwhere
 
     // 3) Send packets to network:
     // mAudioTesterP will be nullptr for hub server's JackTripWorker instances:
     bool audioTesting = (mAudioTesterP && mAudioTesterP->getEnabled());
-    int nop = mProcessPluginsToNetwork.size(); // number of OUTGOING processing modules
-    if (nop>0 || audioTesting) { // cannot modify in_buffer, so make a copy
-      // in_buffer is "in" from local audio hardware via JACK
-      if (mInBufCopy.size() < mNumInChans) { // created in constructor above
-        std::cerr << "*** AudioInterface.cpp: Number of Input Channels changed - insufficient room reserved\n";
-        exit(1);
-      }
-      if (MAX_AUDIO_BUFFER_SIZE < n_frames) { // allocated in constructor above
-        std::cerr << "*** AudioInterface.cpp: n_frames = " << n_frames
-                  << " larger than expected max = " << MAX_AUDIO_BUFFER_SIZE << "\n";
-        exit(1);
-      }
-      for (int i=0; i<mNumInChans; i++) {
-        std::memcpy(mInBufCopy[i], in_buffer[i], sizeof(sample_t) * n_frames);
-      }
-      for (int i = 0; i < nop; i++) {
-        // process all outgoing channels with ProcessPlugins:
-        ProcessPlugin* p = mProcessPluginsToNetwork[i];
-        if (p->getInited()) {
-          p->compute(n_frames, mInBufCopy.data(), mInBufCopy.data());
+    int nop = mProcessPluginsToNetwork.size();  // number of OUTGOING processing modules
+    if (nop > 0 || audioTesting) {              // cannot modify in_buffer, so make a copy
+        // in_buffer is "in" from local audio hardware via JACK
+        if (mInBufCopy.size() < mNumInChans) {  // created in constructor above
+            std::cerr << "*** AudioInterface.cpp: Number of Input Channels changed - "
+                         "insufficient room reserved\n";
+            exit(1);
         }
-      }
-      if (audioTesting) {
-        mAudioTesterP->writeImpulse(mInBufCopy, n_frames); // writes last channel of mInBufCopy with test impulse
-      }
-      computeProcessToNetwork(mInBufCopy, n_frames);
-    } else { // copy saved if no plugins and no audio testing in progress:
-      computeProcessToNetwork(in_buffer, n_frames); // send processed input audio to network - OUTGOING
+        if (MAX_AUDIO_BUFFER_SIZE < n_frames) {  // allocated in constructor above
+            std::cerr << "*** AudioInterface.cpp: n_frames = " << n_frames
+                      << " larger than expected max = " << MAX_AUDIO_BUFFER_SIZE << "\n";
+            exit(1);
+        }
+        for (int i = 0; i < mNumInChans; i++) {
+            std::memcpy(mInBufCopy[i], in_buffer[i], sizeof(sample_t) * n_frames);
+        }
+        for (int i = 0; i < nop; i++) {
+            // process all outgoing channels with ProcessPlugins:
+            ProcessPlugin* p = mProcessPluginsToNetwork[i];
+            if (p->getInited()) {
+                p->compute(n_frames, mInBufCopy.data(), mInBufCopy.data());
+            }
+        }
+        if (audioTesting) {
+            mAudioTesterP->writeImpulse(
+                mInBufCopy,
+                n_frames);  // writes last channel of mInBufCopy with test impulse
+        }
+        computeProcessToNetwork(mInBufCopy, n_frames);
+    } else {  // copy saved if no plugins and no audio testing in progress:
+        computeProcessToNetwork(
+            in_buffer, n_frames);  // send processed input audio to network - OUTGOING
     }
 
-#ifdef WAIR // WAIR
+#ifdef WAIR  // WAIR
     // aib2 + cob16 to nob16
-#endif // endwhere
+#endif  // endwhere
 
-#ifdef WAIR // WAIR
-    if (mNumNetRevChans) // else not wair, so skip all this
+#ifdef WAIR  // WAIR
+    if (mNumNetRevChans)  // else not wair, so skip all this
     {
         ///////////////////////////////////////////////////////////////////////////////
 #define AP
@@ -333,28 +322,29 @@ void AudioInterface::callback(QVarLengthArray<sample_t*>& in_buffer,
             std::memset(out_buffer[i], 0, sizeof(sample_t) * n_frames);
         }
         for (int i = 0; i < mNumNetRevChans; i++) {
-            sample_t* mix_sample = out_buffer[i%mNumOutChans];
-            sample_t* tmp_sample = mNetInBuffer[i]; //mNetInBuffer
-            for (int j = 0; j < (int)n_frames; j++) {mix_sample[j] += tmp_sample[j];}
-        }                                         // nib6 to aob2
-        ///////////////////////////////////////////////////////////////////////////////
-#else // AP
-        ///////////////////////////////////////////////////////////////////////////////
-        // output through all-pass cascade
-        // AP2 is 2 channel, mixes inputs to mono, then splits to two parallel AP chains
-        // AP8 is 2 channel, two parallel AP chains
+            sample_t* mix_sample = out_buffer[i % mNumOutChans];
+            sample_t* tmp_sample = mNetInBuffer[i];  //mNetInBuffer
+            for (int j = 0; j < (int)n_frames; j++) { mix_sample[j] += tmp_sample[j]; }
+        }  // nib6 to aob2
+           ///////////////////////////////////////////////////////////////////////////////
+#else  // AP                                                                            \
+       ///////////////////////////////////////////////////////////////////////////////  \
+       // output through all-pass cascade                                               \
+       // AP2 is 2 channel, mixes inputs to mono, then splits to two parallel AP chains \
+       // AP8 is 2 channel, two parallel AP chains
         for (int i = 0; i < mNumInChans; i++) {
             std::memset(mAPInBuffer[i], 0, sizeof(sample_t) * n_frames);
         }
         for (int i = 0; i < mNumNetRevChans; i++) {
-            sample_t* mix_sample = mAPInBuffer[i%mNumOutChans];
+            sample_t* mix_sample = mAPInBuffer[i % mNumOutChans];
             sample_t* tmp_sample = mNetInBuffer[i];
-            for (int j = 0; j < n_frames; j++) {mix_sample[j] += tmp_sample[j];}
-        }                                         // nib16 to apib2
+            for (int j = 0; j < n_frames; j++) { mix_sample[j] += tmp_sample[j]; }
+        }  // nib16 to apib2
         for (int i = 0; i < mNumOutChans; i++) {
             std::memset(out_buffer[i], 0, sizeof(sample_t) * n_frames);
         }
-        mProcessPluginsFromNetwork[APDSP]->compute(n_frames, mAPInBuffer.data(), out_buffer.data());
+        mProcessPluginsFromNetwork[APDSP]->compute(n_frames, mAPInBuffer.data(),
+                                                   out_buffer.data());
         // compute ap2 into aob2
 
         //#define ADD_DIRECT
@@ -362,14 +352,14 @@ void AudioInterface::callback(QVarLengthArray<sample_t*>& in_buffer,
         for (int i = 0; i < mNumInChans; i++) {
             sample_t* mix_sample = out_buffer[i];
             sample_t* tmp_sample = in_buffer[i];
-            for (int j = 0; j < n_frames; j++) {mix_sample[j] += tmp_sample[j];}
+            for (int j = 0; j < n_frames; j++) { mix_sample[j] += tmp_sample[j]; }
         }
         // add aib2 to aob2
-#endif // ADD_DIRECT
-#endif // AP
-        ///////////////////////////////////////////////////////////////////////////////
+#endif  // ADD_DIRECT
+#endif  // AP \
+    ///////////////////////////////////////////////////////////////////////////////
     }
-#endif // endwhere
+#endif  // endwhere
 
     ///************PROTOTYPE FOR CELT**************************
     ///********************************************************
@@ -385,30 +375,30 @@ void AudioInterface::callback(QVarLengthArray<sample_t*>& in_buffer,
 
     ///********************************************************
     ///********************************************************
-
 }
 
 //*******************************************************************************
 void AudioInterface::broadcastCallback(QVarLengthArray<sample_t*>& mon_buffer,
-                                               unsigned int n_frames)
+                                       unsigned int n_frames)
 {
     /// \todo cast *mInBuffer[i] to the bit resolution
     // Output Process (from NETWORK to JACK)
     // ----------------------------------------------------------------
     // Read Audio buffer from RingBuffer (read from incoming packets)
     mJackTrip->receiveBroadcastPacket(mOutputPacket);
-        // Extract separate channels to send to Jack
-        for (int i = 0; i < mNumOutChans; i++) {
-            sample_t* tmp_sample = mon_buffer[i]; //sample buffer for channel i
-            for (unsigned int j = 0; j < n_frames; j++) {
-                // Change the bit resolution on each sample
-                fromBitToSampleConversion(
-                            // use interleaved channel layout
-                            //&mOutputPacket[(i*mSizeInBytesPerChannel) + (j*mBitResolutionMode)],
-                            &mOutputPacket[(j*mBitResolutionMode*mNumOutChans) + (i*mBitResolutionMode)],
-                        &tmp_sample[j], mBitResolutionMode );
-            }
+    // Extract separate channels to send to Jack
+    for (int i = 0; i < mNumOutChans; i++) {
+        sample_t* tmp_sample = mon_buffer[i];  //sample buffer for channel i
+        for (unsigned int j = 0; j < n_frames; j++) {
+            // Change the bit resolution on each sample
+            fromBitToSampleConversion(
+                // use interleaved channel layout
+                //&mOutputPacket[(i*mSizeInBytesPerChannel) + (j*mBitResolutionMode)],
+                &mOutputPacket[(j * mBitResolutionMode * mNumOutChans)
+                               + (i * mBitResolutionMode)],
+                &tmp_sample[j], mBitResolutionMode);
         }
+    }
 }
 
 //*******************************************************************************
@@ -422,24 +412,25 @@ void AudioInterface::computeProcessFromNetwork(QVarLengthArray<sample_t*>& out_b
     // Output Process (from NETWORK to JACK)
     // ----------------------------------------------------------------
     // Read Audio buffer from RingBuffer (read from incoming packets)
-    mJackTrip->receiveNetworkPacket( mOutputPacket );
+    mJackTrip->receiveNetworkPacket(mOutputPacket);
 
-#ifdef WAIR // WAIR
+#ifdef WAIR  // WAIR
     if (mNumNetRevChans)
         // Extract separate channels
         for (int i = 0; i < mNumNetRevChans; i++) {
-            sample_t* tmp_sample = mNetInBuffer[i]; //sample buffer for channel i
+            sample_t* tmp_sample = mNetInBuffer[i];  //sample buffer for channel i
             for (unsigned int j = 0; j < n_frames; j++) {
                 // Change the bit resolution on each sample
                 fromBitToSampleConversion(
-                            // use interleaved channel layout
-                            //&mOutputPacket[(i*mSizeInBytesPerChannel) + (j*mBitResolutionMode)],
-                            &mOutputPacket[(j*mBitResolutionMode*mNumOutChans) + (i*mBitResolutionMode)],
-                        &tmp_sample[j], mBitResolutionMode );
+                    // use interleaved channel layout
+                    //&mOutputPacket[(i*mSizeInBytesPerChannel) + (j*mBitResolutionMode)],
+                    &mOutputPacket[(j * mBitResolutionMode * mNumOutChans)
+                                   + (i * mBitResolutionMode)],
+                    &tmp_sample[j], mBitResolutionMode);
             }
         }
-    else // not wair
-#endif // endwhere
+    else  // not wair
+#endif  // endwhere
 
         // Extract separate channels to send to Jack
         for (int i = 0; i < mNumOutChans; i++) {
@@ -448,18 +439,18 @@ void AudioInterface::computeProcessFromNetwork(QVarLengthArray<sample_t*>& out_b
             //std::memcpy(mOutBuffer[i], &mOutputPacket[i*mSizeInBytesPerChannel],
             //         mSizeInBytesPerChannel);
             //--------
-            sample_t* tmp_sample = out_buffer[i]; //sample buffer for channel i
+            sample_t* tmp_sample = out_buffer[i];  //sample buffer for channel i
             for (unsigned int j = 0; j < n_frames; j++) {
                 // Change the bit resolution on each sample
                 fromBitToSampleConversion(
-                            // use interleaved channel layout
-                            //&mOutputPacket[(i*mSizeInBytesPerChannel) + (j*mBitResolutionMode)],
-                            &mOutputPacket[(j*mBitResolutionMode*mNumOutChans) + (i*mBitResolutionMode)],
-                        &tmp_sample[j], mBitResolutionMode );
+                    // use interleaved channel layout
+                    //&mOutputPacket[(i*mSizeInBytesPerChannel) + (j*mBitResolutionMode)],
+                    &mOutputPacket[(j * mBitResolutionMode * mNumOutChans)
+                                   + (i * mBitResolutionMode)],
+                    &tmp_sample[j], mBitResolutionMode);
             }
         }
 }
-
 
 //*******************************************************************************
 void AudioInterface::computeProcessToNetwork(QVarLengthArray<sample_t*>& in_buffer,
@@ -469,28 +460,32 @@ void AudioInterface::computeProcessToNetwork(QVarLengthArray<sample_t*>& in_buff
     // ----------------------------------------------------------------
     // Concatenate  all the channels from jack to form packet
 
-#ifdef WAIR // WAIR
+#ifdef WAIR  // WAIR
     if (mNumNetRevChans)
         for (int i = 0; i < mNumNetRevChans; i++) {
-            sample_t* tmp_sample = in_buffer[i%mNumInChans]; //sample buffer for channel i
-            sample_t* tmp_process_sample = mOutProcessBuffer[i]; //sample buffer from the output process
+            sample_t* tmp_sample =
+                in_buffer[i % mNumInChans];  //sample buffer for channel i
+            sample_t* tmp_process_sample =
+                mOutProcessBuffer[i];  //sample buffer from the output process
             sample_t tmp_result;
             for (unsigned int j = 0; j < n_frames; j++) {
                 // Change the bit resolution on each sample
                 // Add the input jack buffer to the buffer resulting from the output process
-#define INGAIN (0.9999) // 0.9999 because 1.0 can saturate the fixed pt rounding on output
+#define INGAIN \
+    (0.9999)  // 0.9999 because 1.0 can saturate the fixed pt rounding on output
 #define COMBGAIN (1.0)
-                tmp_result = INGAIN*tmp_sample[j] + COMBGAIN*tmp_process_sample[j];
+                tmp_result = INGAIN * tmp_sample[j] + COMBGAIN * tmp_process_sample[j];
                 fromSampleToBitConversion(
-                            &tmp_result,
-                            // use interleaved channel layout
-                            //&mInputPacket[(i*mSizeInBytesPerChannel) + (j*mBitResolutionMode)],
-                            &mInputPacket[(j*mBitResolutionMode*mNumOutChans) + (i*mBitResolutionMode)],
-                        mBitResolutionMode );
+                    &tmp_result,
+                    // use interleaved channel layout
+                    //&mInputPacket[(i*mSizeInBytesPerChannel) + (j*mBitResolutionMode)],
+                    &mInputPacket[(j * mBitResolutionMode * mNumOutChans)
+                                  + (i * mBitResolutionMode)],
+                    mBitResolutionMode);
             }
         }
-    else // not wair
-#endif // endwhere
+    else  // not wair
+#endif  // endwhere
 
         for (int i = 0; i < mNumInChans; i++) {
             //--------
@@ -498,86 +493,89 @@ void AudioInterface::computeProcessToNetwork(QVarLengthArray<sample_t*>& in_buff
             //std::memcpy(&mInputPacket[i*mSizeInBytesPerChannel], mInBuffer[i],
             //         mSizeInBytesPerChannel);
             //--------
-            sample_t* tmp_sample = in_buffer[i]; //sample buffer for channel i
-            sample_t* tmp_process_sample = mOutProcessBuffer[i]; //sample buffer from the output process
+            sample_t* tmp_sample = in_buffer[i];  //sample buffer for channel i
+            sample_t* tmp_process_sample =
+                mOutProcessBuffer[i];  //sample buffer from the output process
             sample_t tmp_result;
             for (unsigned int j = 0; j < n_frames; j++) {
                 // Change the bit resolution on each sample
                 // Add the input jack buffer to the buffer resulting from the output process
                 tmp_result = tmp_sample[j] + tmp_process_sample[j];
                 fromSampleToBitConversion(
-                            &tmp_result,
-                            // use interleaved channel layout
-                            //&mInputPacket[(i*mSizeInBytesPerChannel) + (j*mBitResolutionMode)],
-                            &mInputPacket[(j*mBitResolutionMode*mNumOutChans) + (i*mBitResolutionMode)],
-                        mBitResolutionMode );
+                    &tmp_result,
+                    // use interleaved channel layout
+                    //&mInputPacket[(i*mSizeInBytesPerChannel) + (j*mBitResolutionMode)],
+                    &mInputPacket[(j * mBitResolutionMode * mNumOutChans)
+                                  + (i * mBitResolutionMode)],
+                    mBitResolutionMode);
             }
         }
     // Send Audio buffer to Network
-    mJackTrip->sendNetworkPacket( mInputPacket );
-} // /computeProcessToNetwork
+    mJackTrip->sendNetworkPacket(mInputPacket);
+}  // /computeProcessToNetwork
 
 //*******************************************************************************
 // This function quantize from 32 bit to a lower bit resolution
 // 24 bit is not working yet
-void AudioInterface::fromSampleToBitConversion
-(const sample_t* const input,
- int8_t* output,
- const AudioInterface::audioBitResolutionT targetBitResolution)
+void AudioInterface::fromSampleToBitConversion(
+    const sample_t* const input, int8_t* output,
+    const AudioInterface::audioBitResolutionT targetBitResolution)
 {
     int8_t tmp_8;
-    uint8_t tmp_u8; // unsigned to quantize the remainder in 24bits
+    uint8_t tmp_u8;  // unsigned to quantize the remainder in 24bits
     int16_t tmp_16;
     double tmp_sample;
     sample_t tmp_sample16;
     sample_t tmp_sample8;
-    switch (targetBitResolution)
-    {
-    case BIT8 :
+    switch (targetBitResolution) {
+    case BIT8:
         // 8bit integer between -128 to 127
-        tmp_sample = std::max(-127.0, std::min(127.0, std::round( (*input) * 127.0 ))); // 2^7 = 128
+        tmp_sample =
+            std::max(-127.0, std::min(127.0, std::round((*input) * 127.0)));  // 2^7 = 128
         tmp_8 = static_cast<int8_t>(tmp_sample);
-        std::memcpy(output, &tmp_8, 1); // 8bits = 1 bytes
+        std::memcpy(output, &tmp_8, 1);  // 8bits = 1 bytes
         break;
-    case BIT16 :
+    case BIT16:
         // 16bit integer between -32768 to 32767
         // original scaling: tmp_sample = floor( (*input) * 32768.0 ); // 2^15 = 32768.0
-        tmp_sample = std::max(-32767.0, std::min(32767.0, std::round( (*input) * 32767.0 ))); // 2^15 = 32768
+        tmp_sample = std::max(
+            -32767.0, std::min(32767.0, std::round((*input) * 32767.0)));  // 2^15 = 32768
         tmp_16 = static_cast<int16_t>(tmp_sample);
-        std::memcpy(output, &tmp_16, 2); // 2 bytes output in Little Endian order (LSB -> smallest address)
+        std::memcpy(
+            output, &tmp_16,
+            2);  // 2 bytes output in Little Endian order (LSB -> smallest address)
         break;
-    case BIT24 :
+    case BIT24:
         // To convert to 24 bits, we first quantize the number to 16bit
-        tmp_sample = (*input) * 32768.0; // 2^15 = 32768.0
+        tmp_sample   = (*input) * 32768.0;  // 2^15 = 32768.0
         tmp_sample16 = floor(tmp_sample);
-        tmp_16 = static_cast<int16_t>(tmp_sample16);
+        tmp_16       = static_cast<int16_t>(tmp_sample16);
 
         // Then we compute the remainder error, and quantize that part into an 8bit number
         // Note that this remainder is always positive, so we use an unsigned integer
-        tmp_sample8 = floor ((tmp_sample - tmp_sample16)  //this is a positive number, between 0.0-1.0
-                             * 256.0);
+        tmp_sample8 = floor(
+            (tmp_sample - tmp_sample16)  //this is a positive number, between 0.0-1.0
+            * 256.0);
         tmp_u8 = static_cast<uint8_t>(tmp_sample8);
 
         // Finally, we copy the 16bit number in the first 2 bytes,
         // and the 8bit number in the third bite
-        std::memcpy(output, &tmp_16, 2); // 16bits = 2 bytes
-        std::memcpy(output+2, &tmp_u8, 1); // 8bits = 1 bytes
+        std::memcpy(output, &tmp_16, 2);      // 16bits = 2 bytes
+        std::memcpy(output + 2, &tmp_u8, 1);  // 8bits = 1 bytes
         break;
-    case BIT32 :
+    case BIT32:
         tmp_sample = *input;
         // not necessary yet:
         // tmp_sample = std::max(-1.0, std::min(1.0, tmp_sample));
-        std::memcpy(output, &tmp_sample, 4); // 32bit = 4 bytes
+        std::memcpy(output, &tmp_sample, 4);  // 32bit = 4 bytes
         break;
     }
 }
 
-
 //*******************************************************************************
-void AudioInterface::fromBitToSampleConversion
-(const int8_t* const input,
- sample_t* output,
- const AudioInterface::audioBitResolutionT sourceBitResolution)
+void AudioInterface::fromBitToSampleConversion(
+    const int8_t* const input, sample_t* output,
+    const AudioInterface::audioBitResolutionT sourceBitResolution)
 {
     int8_t tmp_8;
     uint8_t tmp_u8;
@@ -585,82 +583,82 @@ void AudioInterface::fromBitToSampleConversion
     sample_t tmp_sample;
     sample_t tmp_sample16;
     sample_t tmp_sample8;
-    switch (sourceBitResolution)
-    {
-    case BIT8 :
-        tmp_8 = *input;
+    switch (sourceBitResolution) {
+    case BIT8:
+        tmp_8      = *input;
         tmp_sample = static_cast<sample_t>(tmp_8) / 128.0;
-        std::memcpy(output, &tmp_sample, 4); // 4 bytes
+        std::memcpy(output, &tmp_sample, 4);  // 4 bytes
         break;
-    case BIT16 :
-        tmp_16 = *( reinterpret_cast<const int16_t*>(input) ); // *((int16_t*) input);
+    case BIT16:
+        tmp_16     = *(reinterpret_cast<const int16_t*>(input));  // *((int16_t*) input);
         tmp_sample = static_cast<sample_t>(tmp_16) / 32768.0;
-        std::memcpy(output, &tmp_sample, 4); // 4 bytes
+        std::memcpy(output, &tmp_sample, 4);  // 4 bytes
         break;
-    case BIT24 :
+    case BIT24:
         // We first extract the 16bit and 8bit number from the 3 bytes
-        tmp_16 = *( reinterpret_cast<const int16_t*>(input) );
-        tmp_u8 = *( reinterpret_cast<const uint8_t*>(input+2) );
+        tmp_16 = *(reinterpret_cast<const int16_t*>(input));
+        tmp_u8 = *(reinterpret_cast<const uint8_t*>(input + 2));
 
         // Then we recover the number
         tmp_sample16 = static_cast<sample_t>(tmp_16);
-        tmp_sample8 = static_cast<sample_t>(tmp_u8) / 256.0;
-        tmp_sample =  (tmp_sample16 +  tmp_sample8) / 32768.0;
-        std::memcpy(output, &tmp_sample, 4); // 4 bytes
+        tmp_sample8  = static_cast<sample_t>(tmp_u8) / 256.0;
+        tmp_sample   = (tmp_sample16 + tmp_sample8) / 32768.0;
+        std::memcpy(output, &tmp_sample, 4);  // 4 bytes
         break;
-    case BIT32 :
-        std::memcpy(output, input, 4); // 4 bytes
+    case BIT32:
+        std::memcpy(output, input, 4);  // 4 bytes
         break;
     }
 }
-
 
 //*******************************************************************************
 void AudioInterface::appendProcessPluginToNetwork(ProcessPlugin* plugin)
 {
-  if (not plugin) { return; }
-  int nTestChans = (mAudioTesterP && mAudioTesterP->getEnabled()) ? 1 : 0;
-  int nPluginChans = mNumInChans - nTestChans;
-  assert(nTestChans==0 || (mAudioTesterP->getSendChannel() == mNumInChans-1));
-  if (plugin->getNumInputs() < nPluginChans) {
-    std::cerr << "*** AudioInterface.cpp: appendProcessPluginToNetwork: ProcessPlugin "
-              << typeid(plugin).name() << " REJECTED due to having "
-              << plugin->getNumInputs() << " inputs, while the audio to JACK needs "
-              << nPluginChans << " inputs\n";
-    return;
-  }
-  mProcessPluginsToNetwork.append(plugin);
+    if (not plugin) { return; }
+    int nTestChans   = (mAudioTesterP && mAudioTesterP->getEnabled()) ? 1 : 0;
+    int nPluginChans = mNumInChans - nTestChans;
+    assert(nTestChans == 0 || (mAudioTesterP->getSendChannel() == mNumInChans - 1));
+    if (plugin->getNumInputs() < nPluginChans) {
+        std::cerr
+            << "*** AudioInterface.cpp: appendProcessPluginToNetwork: ProcessPlugin "
+            << typeid(plugin).name() << " REJECTED due to having "
+            << plugin->getNumInputs() << " inputs, while the audio to JACK needs "
+            << nPluginChans << " inputs\n";
+        return;
+    }
+    mProcessPluginsToNetwork.append(plugin);
 }
 
 void AudioInterface::appendProcessPluginFromNetwork(ProcessPlugin* plugin)
 {
-  if (not plugin) { return; }
-  int nTestChans = (mAudioTesterP && mAudioTesterP->getEnabled()) ? 1 : 0;
-  int nPluginChans = mNumOutChans - nTestChans;
-  assert(nTestChans==0 || (mAudioTesterP->getSendChannel() == mNumOutChans-1));
-  if (plugin->getNumOutputs() > nPluginChans) {
-    std::cerr << "*** AudioInterface.cpp: appendProcessPluginFromNetwork: ProcessPlugin "
-              << typeid(plugin).name() << " REJECTED due to having "
-              << plugin->getNumOutputs() << " inputs, while the JACK audio output requires "
-              << nPluginChans << " outputs\n";
-    return;
-  }
-  mProcessPluginsFromNetwork.append(plugin);
+    if (not plugin) { return; }
+    int nTestChans   = (mAudioTesterP && mAudioTesterP->getEnabled()) ? 1 : 0;
+    int nPluginChans = mNumOutChans - nTestChans;
+    assert(nTestChans == 0 || (mAudioTesterP->getSendChannel() == mNumOutChans - 1));
+    if (plugin->getNumOutputs() > nPluginChans) {
+        std::cerr
+            << "*** AudioInterface.cpp: appendProcessPluginFromNetwork: ProcessPlugin "
+            << typeid(plugin).name() << " REJECTED due to having "
+            << plugin->getNumOutputs() << " inputs, while the JACK audio output requires "
+            << nPluginChans << " outputs\n";
+        return;
+    }
+    mProcessPluginsFromNetwork.append(plugin);
 }
 
 void AudioInterface::initPlugins()
 {
-  int nPlugins = mProcessPluginsFromNetwork.size() + mProcessPluginsToNetwork.size();
-  if (nPlugins > 0) {
-    std::cout << "Initializing Faust plugins (have " << nPlugins
-              << ") at sampling rate " << mSampleRate << "\n";
-    for (ProcessPlugin* plugin : mProcessPluginsFromNetwork) {
-      plugin->init(mSampleRate);
+    int nPlugins = mProcessPluginsFromNetwork.size() + mProcessPluginsToNetwork.size();
+    if (nPlugins > 0) {
+        std::cout << "Initializing Faust plugins (have " << nPlugins
+                  << ") at sampling rate " << mSampleRate << "\n";
+        for (ProcessPlugin* plugin : mProcessPluginsFromNetwork) {
+            plugin->init(mSampleRate);
+        }
+        for (ProcessPlugin* plugin : mProcessPluginsToNetwork) {
+            plugin->init(mSampleRate);
+        }
     }
-    for (ProcessPlugin* plugin : mProcessPluginsToNetwork) {
-      plugin->init(mSampleRate);
-    }
-  }
 }
 
 //*******************************************************************************
@@ -668,20 +666,21 @@ AudioInterface::samplingRateT AudioInterface::getSampleRateType() const
 {
     int32_t rate = getSampleRate();
 
-    if      ( 100 > qAbs(rate - 22050) ) {
-        return AudioInterface::SR22; }
-    else if ( 100 > qAbs(rate - 32000) ) {
-        return AudioInterface::SR32; }
-    else if ( 100 > qAbs(rate - 44100) ) {
-        return AudioInterface::SR44; }
-    else if ( 100 > qAbs(rate - 48000) ) {
-        return AudioInterface::SR48; }
-    else if ( 100 > qAbs(rate - 88200) ) {
-        return AudioInterface::SR88; }
-    else if ( 100 > qAbs(rate - 96000) ) {
-        return AudioInterface::SR96; }
-    else if ( 100 > qAbs(rate - 19200) ) {
-        return AudioInterface::SR192; }
+    if (100 > qAbs(rate - 22050)) {
+        return AudioInterface::SR22;
+    } else if (100 > qAbs(rate - 32000)) {
+        return AudioInterface::SR32;
+    } else if (100 > qAbs(rate - 44100)) {
+        return AudioInterface::SR44;
+    } else if (100 > qAbs(rate - 48000)) {
+        return AudioInterface::SR48;
+    } else if (100 > qAbs(rate - 88200)) {
+        return AudioInterface::SR88;
+    } else if (100 > qAbs(rate - 96000)) {
+        return AudioInterface::SR96;
+    } else if (100 > qAbs(rate - 19200)) {
+        return AudioInterface::SR192;
+    }
 
     return AudioInterface::UNDEF;
 }
@@ -690,33 +689,32 @@ AudioInterface::samplingRateT AudioInterface::getSampleRateType() const
 int AudioInterface::getSampleRateFromType(samplingRateT rate_type)
 {
     int sample_rate = 0;
-    switch (rate_type)
-    {
-    case SR22 :
+    switch (rate_type) {
+    case SR22:
         sample_rate = 22050;
         return sample_rate;
         break;
-    case SR32 :
+    case SR32:
         sample_rate = 32000;
         return sample_rate;
         break;
-    case SR44 :
+    case SR44:
         sample_rate = 44100;
         return sample_rate;
         break;
-    case SR48 :
+    case SR48:
         sample_rate = 48000;
         return sample_rate;
         break;
-    case SR88 :
+    case SR88:
         sample_rate = 88200;
         return sample_rate;
         break;
-    case SR96 :
+    case SR96:
         sample_rate = 96000;
         return sample_rate;
         break;
-    case SR192 :
+    case SR192:
         sample_rate = 192000;
         return sample_rate;
         break;

--- a/src/AudioInterface.cpp
+++ b/src/AudioInterface.cpp
@@ -314,7 +314,6 @@ void AudioInterface::callback(QVarLengthArray<sample_t*>& in_buffer,
 #ifdef WAIR  // WAIR
     if (mNumNetRevChans)  // else not wair, so skip all this
     {
-        ///////////////////////////////////////////////////////////////////////////////
 #define AP
 #ifndef AP
         // straight to audio out
@@ -326,12 +325,11 @@ void AudioInterface::callback(QVarLengthArray<sample_t*>& in_buffer,
             sample_t* tmp_sample = mNetInBuffer[i];  //mNetInBuffer
             for (int j = 0; j < (int)n_frames; j++) { mix_sample[j] += tmp_sample[j]; }
         }  // nib6 to aob2
-           ///////////////////////////////////////////////////////////////////////////////
-#else  // AP                                                                            \
-       ///////////////////////////////////////////////////////////////////////////////  \
-       // output through all-pass cascade                                               \
-       // AP2 is 2 channel, mixes inputs to mono, then splits to two parallel AP chains \
-       // AP8 is 2 channel, two parallel AP chains
+#else  // AP
+
+        // output through all-pass cascade
+        // AP2 is 2 channel, mixes inputs to mono, then splits to two parallel AP chains
+        // AP8 is 2 channel, two parallel AP chains
         for (int i = 0; i < mNumInChans; i++) {
             std::memset(mAPInBuffer[i], 0, sizeof(sample_t) * n_frames);
         }
@@ -356,8 +354,7 @@ void AudioInterface::callback(QVarLengthArray<sample_t*>& in_buffer,
         }
         // add aib2 to aob2
 #endif  // ADD_DIRECT
-#endif  // AP \
-    ///////////////////////////////////////////////////////////////////////////////
+#endif  // AP
     }
 #endif  // endwhere
 

--- a/src/AudioInterface.h
+++ b/src/AudioInterface.h
@@ -38,12 +38,12 @@
 #ifndef __AUDIOINTERFACE_H__
 #define __AUDIOINTERFACE_H__
 
-#include "ProcessPlugin.h"
-#include "jacktrip_types.h"
-#include "AudioTester.h"
-
 #include <QVarLengthArray>
 #include <QVector>
+
+#include "AudioTester.h"
+#include "ProcessPlugin.h"
+#include "jacktrip_types.h"
 //#include "jacktrip_globals.h"
 
 // Forward declarations
@@ -51,31 +51,29 @@ class JackTrip;
 
 //using namespace JackTripNamespace;
 
-
 /** \brief Base Class that provides an interface with audio
  */
 class AudioInterface
 {
-public:
-
+   public:
     /// \brief Enum for Audio Resolution in bits
     enum audioBitResolutionT {
-        BIT8  = 1, ///< 8 bits
-        BIT16 = 2, ///< 16 bits (default)
-        BIT24 = 3, ///< 24 bits
-        BIT32 = 4  ///< 32 bits
+        BIT8  = 1,  ///< 8 bits
+        BIT16 = 2,  ///< 16 bits (default)
+        BIT24 = 3,  ///< 24 bits
+        BIT32 = 4   ///< 32 bits
     };
 
     /// \brief Sampling Rates supported by JACK
     enum samplingRateT {
-        SR22, ///<  22050 Hz
-        SR32, ///<  32000 Hz
-        SR44, ///<  44100 Hz
-        SR48, ///<  48000 Hz
-        SR88, ///<  88200 Hz
-        SR96, ///<  96000 Hz
-        SR192, ///< 192000 Hz
-        UNDEF ///< Undefined
+        SR22,   ///<  22050 Hz
+        SR32,   ///<  32000 Hz
+        SR44,   ///<  44100 Hz
+        SR48,   ///<  48000 Hz
+        SR88,   ///<  88200 Hz
+        SR96,   ///<  96000 Hz
+        SR192,  ///< 192000 Hz
+        UNDEF   ///< Undefined
     };
 
     /** \brief The class constructor
@@ -84,13 +82,12 @@ public:
    * \param NumOutChans Number of Output Channels
    * \param AudioBitResolution Audio Sample Resolutions in bits
    */
-    AudioInterface(JackTrip* jacktrip,
-                   int NumInChans, int NumOutChans,
-               #ifdef WAIR // wair
-                   int NumNetRevChans,
-               #endif // endwhere
-                   AudioInterface::audioBitResolutionT AudioBitResolution =
-            AudioInterface::BIT16);
+    AudioInterface(
+        JackTrip* jacktrip, int NumInChans, int NumOutChans,
+#ifdef WAIR  // wair
+        int NumNetRevChans,
+#endif  // endwhere
+        AudioInterface::audioBitResolutionT AudioBitResolution = AudioInterface::BIT16);
     /// \brief The class destructor
     virtual ~AudioInterface();
 
@@ -117,11 +114,10 @@ public:
     * is reponsible to check that each channel has n_frames samplers
     */
     virtual void broadcastCallback(QVarLengthArray<sample_t*>& mon_buffer,
-                          unsigned int n_frames);
+                                   unsigned int n_frames);
     virtual void callback(QVarLengthArray<sample_t*>& in_buffer,
-                          QVarLengthArray<sample_t*>& out_buffer,
-                          unsigned int n_frames);
-   /** \brief appendProcessPluginToNetwork(): Append a ProcessPlugin for outgoing audio. 
+                          QVarLengthArray<sample_t*>& out_buffer, unsigned int n_frames);
+    /** \brief appendProcessPluginToNetwork(): Append a ProcessPlugin for outgoing audio. 
    * The processing order equals order they were appended.
    * This processing is in the JackTrip client before sending to the network.
    * \param plugin a ProcessPlugin smart pointer. Create the object instance
@@ -129,7 +125,7 @@ public:
    * <tt>std::tr1::shared_ptr<ProcessPluginName> loopback(new ProcessPluginName);</tt>
    */
     virtual void appendProcessPluginToNetwork(ProcessPlugin* plugin);
-   /** \brief appendProcessPluginFromNetwork():
+    /** \brief appendProcessPluginFromNetwork():
    * Same as appendProcessPluginToNetwork() except that these plugins operate
    * on the audio received from the network (typically from a JackTrip server).
    * The complete processing chain then looks like this:
@@ -138,7 +134,7 @@ public:
    *               -> JackTrip client -> processPlugin from network -> JACK -> audio
    */
     virtual void appendProcessPluginFromNetwork(ProcessPlugin* plugin);
-   /** \brief initPlugins():
+    /** \brief initPlugins():
    * Initialize all ProcessPlugin modules.
    * The audio sampling rate (mSampleRate) must be set at this time.
    */
@@ -151,9 +147,9 @@ public:
    * appropriate size to hold the value. The caller is responsible to allocate
    * enough space to store the result.
    */
-    static void fromSampleToBitConversion(const sample_t* const input,
-                                          int8_t* output,
-                                          const AudioInterface::audioBitResolutionT targetBitResolution);
+    static void fromSampleToBitConversion(
+        const sample_t* const input, int8_t* output,
+        const AudioInterface::audioBitResolutionT targetBitResolution);
     /** \brief Convert a audioBitResolutionT bit resolution number into a
    * 32bit number (sample_t)
    *
@@ -161,21 +157,19 @@ public:
    * appropriate size to hold the value. The caller is responsible to allocate
    * enough space to store the result.
    */
-    static void fromBitToSampleConversion(const int8_t* const input,
-                                          sample_t* output,
-                                          const AudioInterface::audioBitResolutionT sourceBitResolution);
+    static void fromBitToSampleConversion(
+        const int8_t* const input, sample_t* output,
+        const AudioInterface::audioBitResolutionT sourceBitResolution);
 
     //--------------SETTERS---------------------------------------------
-    virtual void setNumInputChannels(int nchannels)
-    { mNumInChans = nchannels; }
-    virtual void setNumOutputChannels(int nchannels)
-    { mNumOutChans = nchannels; }
-    virtual void setSampleRate(uint32_t sample_rate)
-    { mSampleRate = sample_rate; }
-    virtual void setDeviceID(uint32_t device_id)
-    { mDeviceID = device_id; }
+    virtual void setNumInputChannels(int nchannels) { mNumInChans = nchannels; }
+    virtual void setNumOutputChannels(int nchannels) { mNumOutChans = nchannels; }
+    virtual void setSampleRate(uint32_t sample_rate) { mSampleRate = sample_rate; }
+    virtual void setDeviceID(uint32_t device_id) { mDeviceID = device_id; }
     virtual void setBufferSizeInSamples(uint32_t buf_size)
-    { mBufferSizeInSamples = buf_size; }
+    {
+        mBufferSizeInSamples = buf_size;
+    }
     /// \brief Set Client Name to something different that the default (JackTrip)
     virtual void setClientName(QString ClientName) = 0;
     virtual void setLoopBack(bool b) { mLoopBack = b; }
@@ -187,15 +181,12 @@ public:
     /// \brief Get Number of Input Channels
     virtual int getNumInputChannels() const { return mNumInChans; }
     /// \brief Get Number of Output Channels
-    virtual int getNumOutputChannels() const  { return mNumOutChans; }
-    virtual uint32_t getBufferSizeInSamples() const
-    { return mBufferSizeInSamples; }
-    virtual uint32_t getDeviceID() const
-    { return mDeviceID; }
+    virtual int getNumOutputChannels() const { return mNumOutChans; }
+    virtual uint32_t getBufferSizeInSamples() const { return mBufferSizeInSamples; }
+    virtual uint32_t getDeviceID() const { return mDeviceID; }
     virtual size_t getSizeInBytesPerChannel() const;
     /// \brief Get the Jack Server Sampling Rate, in samples/second
-    virtual uint32_t getSampleRate() const
-    { return mSampleRate; }
+    virtual uint32_t getSampleRate() const { return mSampleRate; }
     /// \brief Get the Jack Server Sampling Rate Enum Type samplingRateT
     /// \return  AudioInterface::samplingRateT enum type
     virtual samplingRateT getSampleRateType() const;
@@ -212,9 +203,7 @@ public:
     static int getSampleRateFromType(samplingRateT rate_type);
     //------------------------------------------------------------------
 
-
-private:
-
+   private:
     /// \brief Compute the process to receive packets
     void computeProcessFromNetwork(QVarLengthArray<sample_t*>& out_buffer,
                                    unsigned int n_frames);
@@ -222,32 +211,43 @@ private:
     void computeProcessToNetwork(QVarLengthArray<sample_t*>& in_buffer,
                                  unsigned int n_frames);
 
-    JackTrip* mJackTrip; ///< JackTrip Mediator Class pointer
-    int mNumInChans;///< Number of Input Channels
-    int mNumOutChans; ///<  Number of Output Channels
-#ifdef WAIR // wair
-    int mNumNetRevChans; ///<  Number of Network Audio Channels (net comb filters)
-    QVarLengthArray<sample_t*> mNetInBuffer; ///< Vector of Input buffers/channel read from net
-    QVarLengthArray<sample_t*> mAPInBuffer; ///< Vector of Input buffers/channel for AllPass input
-#endif // endwhere
-    QVarLengthArray<sample_t*> mInBufCopy; ///< needed in callback() to modify JACK audio input
-    int mAudioBitResolution; ///< Bit resolution in audio samples
-    AudioInterface::audioBitResolutionT mBitResolutionMode; ///< Bit resolution (audioBitResolutionT) mode
-    uint32_t mSampleRate; ///< Sampling Rate
-    uint32_t mDeviceID; ///< RTAudio DeviceID
-    uint32_t mBufferSizeInSamples; ///< Buffer size in samples
-    size_t mSizeInBytesPerChannel; ///< Size in bytes per audio channel
-    QVector<ProcessPlugin*> mProcessPluginsFromNetwork; ///< Vector of ProcessPlugin<EM>s</EM>
-    QVector<ProcessPlugin*> mProcessPluginsToNetwork; ///< Vector of ProcessPlugin<EM>s</EM>
-    QVarLengthArray<sample_t*> mInProcessBuffer;///< Vector of Input buffers/channel for ProcessPlugin
-    QVarLengthArray<sample_t*> mOutProcessBuffer;///< Vector of Output buffers/channel for ProcessPlugin
-    int8_t* mInputPacket; ///< Packet containing all the channels to read from the RingBuffer
-    int8_t* mOutputPacket;  ///< Packet containing all the channels to send to the RingBuffer
+    JackTrip* mJackTrip;  ///< JackTrip Mediator Class pointer
+    int mNumInChans;      ///< Number of Input Channels
+    int mNumOutChans;     ///<  Number of Output Channels
+#ifdef WAIR               // wair
+    int mNumNetRevChans;  ///<  Number of Network Audio Channels (net comb filters)
+    QVarLengthArray<sample_t*>
+        mNetInBuffer;  ///< Vector of Input buffers/channel read from net
+    QVarLengthArray<sample_t*>
+        mAPInBuffer;  ///< Vector of Input buffers/channel for AllPass input
+#endif                // endwhere
+    QVarLengthArray<sample_t*>
+        mInBufCopy;           ///< needed in callback() to modify JACK audio input
+    int mAudioBitResolution;  ///< Bit resolution in audio samples
+    AudioInterface::audioBitResolutionT
+        mBitResolutionMode;         ///< Bit resolution (audioBitResolutionT) mode
+    uint32_t mSampleRate;           ///< Sampling Rate
+    uint32_t mDeviceID;             ///< RTAudio DeviceID
+    uint32_t mBufferSizeInSamples;  ///< Buffer size in samples
+    size_t mSizeInBytesPerChannel;  ///< Size in bytes per audio channel
+    QVector<ProcessPlugin*>
+        mProcessPluginsFromNetwork;  ///< Vector of ProcessPlugin<EM>s</EM>
+    QVector<ProcessPlugin*>
+        mProcessPluginsToNetwork;  ///< Vector of ProcessPlugin<EM>s</EM>
+    QVarLengthArray<sample_t*>
+        mInProcessBuffer;  ///< Vector of Input buffers/channel for ProcessPlugin
+    QVarLengthArray<sample_t*>
+        mOutProcessBuffer;  ///< Vector of Output buffers/channel for ProcessPlugin
+    int8_t*
+        mInputPacket;  ///< Packet containing all the channels to read from the RingBuffer
+    int8_t*
+        mOutputPacket;  ///< Packet containing all the channels to send to the RingBuffer
     bool mLoopBack;
-    AudioTester* mAudioTesterP { nullptr };
-protected:
+    AudioTester* mAudioTesterP{nullptr};
+
+   protected:
     bool mProcessingAudio;  ///< Set when processing an audio callback buffer pair
     const uint32_t MAX_AUDIO_BUFFER_SIZE = 8192;
 };
 
-#endif // __AUDIOINTERFACE_H__
+#endif  // __AUDIOINTERFACE_H__

--- a/src/AudioTester.cpp
+++ b/src/AudioTester.cpp
@@ -37,159 +37,208 @@
  */
 
 #include "AudioTester.h"
+
 #include <assert.h>
 
 // Called 1st in Audiointerface.cpp
 void AudioTester::lookForReturnPulse(QVarLengthArray<sample_t*>& out_buffer,
-                                     unsigned int n_frames) {
-  if (not enabled) {
-    std::cerr << "*** AudioTester.h: lookForReturnPulse: NOT ENABLED\n";
-    return;
-  }
-  if (impulsePending) { // look for return impulse in channel sendChannel:
-    assert(sendChannel<out_buffer.size());
-    for (uint n=0; n<n_frames; n++) {
-      float amp = out_buffer[sendChannel][n];
-      if (amp > 0.5 * ampCellHeight) { // got something
-        int cellNum =  getImpulseCellNum(out_buffer[sendChannel][n]);
-        if (cellNum != pendingCell) { // not our impulse!
-          std::cerr <<
-            "*** AudioTester.h: computeProcessFromNetwork: Received pulse amplitude "
-                    << amp << " (cell " << cellNum << ") while looking for cell "
-                    << pendingCell << "\n";
+                                     unsigned int n_frames)
+{
+    if (not enabled) {
+        std::cerr << "*** AudioTester.h: lookForReturnPulse: NOT ENABLED\n";
+        return;
+    }
+    if (impulsePending) {  // look for return impulse in channel sendChannel:
+        assert(sendChannel < out_buffer.size());
+        for (uint n = 0; n < n_frames; n++) {
+            float amp = out_buffer[sendChannel][n];
+            if (amp > 0.5 * ampCellHeight) {  // got something
+                int cellNum = getImpulseCellNum(out_buffer[sendChannel][n]);
+                if (cellNum != pendingCell) {  // not our impulse!
+                    std::cerr << "*** AudioTester.h: computeProcessFromNetwork: Received "
+                                 "pulse amplitude "
+                              << amp << " (cell " << cellNum
+                              << ") while looking for cell " << pendingCell << "\n";
 
-          if (cellNum > pendingCell) { // we missed it
-            std::cerr << " - ABORTING CURRENT PULSE\n";
-            impulsePending = false;
-          } else { // somehow we got the previous pulse again - repeated packet or underrun-caused repetition (old buffer)
-            std::cerr << " - IGNORING FOUND PULSE WAITING FURTHER\n";
-          }
-        } else { // found our impulse:
-          int64_t elapsedSamples = -1;
-          if (n >= n_frames-1) {
-            // Impulse timestamp didn't make it so we skip this one.
-          } else {
-            float sampleCountWhenImpulseSent = - 32768.0f * out_buffer[sendChannel][n+1];
-            elapsedSamples = sampleCountSinceImpulse + n - int64_t(sampleCountWhenImpulseSent);
-            sampleCountSinceImpulse = 1; // reset sample counter between impulses
-            roundTripCount += 1.0;
-          }
-          // int64_t curTimeUS = timeMicroSec(); // time since launch in us
-          // int64_t impulseDelayUS = curTimeUS - ImpulseTimeUS;
-          // float impulseDelaySec = float(impulseDelayUS) * 1.0e-6;
-          // float impulseDelayBuffers = impulseDelaySec / (float(n_frames)/float(sampleRate));
-          // int64_t impulseDelayMS = (int64_t)round(double(impulseDelayUS)/1000.0);
-          if (elapsedSamples > 0) { // found impulse and reset, time to print buffer results:
-            double elapsedSamplesMS = 1000.0 * double(elapsedSamples)/double(sampleRate); // ms
-            extendLatencyHistogram(elapsedSamplesMS);
-            if (roundTripCount > 1.0) {
-              double prevSum = roundTripMean * (roundTripCount-1.0); // undo previous normalization
-              roundTripMean = (prevSum + elapsedSamplesMS) / roundTripCount; // add latest and renormalize
-              double prevSumSq = roundTripMeanSquare * (roundTripCount-1.0); // undo previous normalization
-              roundTripMeanSquare = (prevSumSq + elapsedSamplesMS*elapsedSamplesMS) / roundTripCount;
-            } else { // just getting started:
-              roundTripMean = elapsedSamplesMS;
-              roundTripMeanSquare = elapsedSamplesMS * elapsedSamplesMS;
-            }
-            if (roundTripCount == 1.0) {
-              printf("JackTrip Test Mode (option -x printIntervalInSeconds=%0.3f)\n",printIntervalSec);
-              printf("\tA test impulse-train is output on channel %d (from 0) with repeatedly ramping amplitude\n",
-                     sendChannel);
-              if (printIntervalSec == 0.0) {
-                printf("\tPrinting each audio buffer round-trip latency in ms followed by cumulative (mean and [standard deviation])");
-              } else {
-                printf("\tPrinting cumulative mean and [standard deviation] of audio round-trip latency in ms");
-                printf(" every %0.3f seconds", printIntervalSec);
-              }
-              printf(" after skipping first %d buffers:\n", bufferSkipStart);
-              // not printing this presently: printf("( * means buffer skipped due missing timestamp or lost impulse)\n");
-              lastPrintTimeUS = timeMicroSec();
-            }
-            //printf("%d (%d) ", elapsedSamplesMS, impulseDelayMS); // measured time is "buffer time" not sample time
-            int64_t curTimeUS = timeMicroSec(); // time since launch in us
-            double timeSinceLastPrintUS = double(curTimeUS - lastPrintTimeUS);
-            double stdDev = sqrt(std::max(0.0, (roundTripMeanSquare - (roundTripMean*roundTripMean))));
-            if (timeSinceLastPrintUS >= printIntervalSec * 1.0e6) {
-              if (printIntervalSec == 0.0) { printf("%0.1f (", elapsedSamplesMS); }
-              printf("%0.1f [%0.1f]", roundTripMean, stdDev);
-              if (printIntervalSec == 0.0) { printf(") "); } else { printf(" "); }
-              lastPrintTimeUS = curTimeUS;
-              if (printIntervalSec >= 1.0) { // print histogram
-                std::cout << "\n" << getLatencyHistogramString() << "\n";
-              }
-            }
-            std::cout << std::flush;
-          } else {
-            // not printing this presently: printf("* "); // we got the impulse but lost its timestamp in samples
-          }
-          impulsePending = false;
-        } // found our impulse
-          // remain pending until timeout, hoping to find our return pulse
-      } // got something
-    } // loop over samples
-    sampleCountSinceImpulse += n_frames; // gets reset to 1 when impulse is found, counts freely until then
-  } // ImpulsePending
+                    if (cellNum > pendingCell) {  // we missed it
+                        std::cerr << " - ABORTING CURRENT PULSE\n";
+                        impulsePending = false;
+                    } else {  // somehow we got the previous pulse again - repeated packet or underrun-caused repetition (old buffer)
+                        std::cerr << " - IGNORING FOUND PULSE WAITING FURTHER\n";
+                    }
+                } else {  // found our impulse:
+                    int64_t elapsedSamples = -1;
+                    if (n >= n_frames - 1) {
+                        // Impulse timestamp didn't make it so we skip this one.
+                    } else {
+                        float sampleCountWhenImpulseSent =
+                            -32768.0f * out_buffer[sendChannel][n + 1];
+                        elapsedSamples = sampleCountSinceImpulse + n
+                                         - int64_t(sampleCountWhenImpulseSent);
+                        sampleCountSinceImpulse =
+                            1;  // reset sample counter between impulses
+                        roundTripCount += 1.0;
+                    }
+                    // int64_t curTimeUS = timeMicroSec(); // time since launch in us
+                    // int64_t impulseDelayUS = curTimeUS - ImpulseTimeUS;
+                    // float impulseDelaySec = float(impulseDelayUS) * 1.0e-6;
+                    // float impulseDelayBuffers = impulseDelaySec / (float(n_frames)/float(sampleRate));
+                    // int64_t impulseDelayMS = (int64_t)round(double(impulseDelayUS)/1000.0);
+                    if (elapsedSamples
+                        > 0) {  // found impulse and reset, time to print buffer results:
+                        double elapsedSamplesMS =
+                            1000.0 * double(elapsedSamples) / double(sampleRate);  // ms
+                        extendLatencyHistogram(elapsedSamplesMS);
+                        if (roundTripCount > 1.0) {
+                            double prevSum =
+                                roundTripMean
+                                * (roundTripCount - 1.0);  // undo previous normalization
+                            roundTripMean =
+                                (prevSum + elapsedSamplesMS)
+                                / roundTripCount;  // add latest and renormalize
+                            double prevSumSq =
+                                roundTripMeanSquare
+                                * (roundTripCount - 1.0);  // undo previous normalization
+                            roundTripMeanSquare =
+                                (prevSumSq + elapsedSamplesMS * elapsedSamplesMS)
+                                / roundTripCount;
+                        } else {  // just getting started:
+                            roundTripMean       = elapsedSamplesMS;
+                            roundTripMeanSquare = elapsedSamplesMS * elapsedSamplesMS;
+                        }
+                        if (roundTripCount == 1.0) {
+                            printf(
+                                "JackTrip Test Mode (option -x "
+                                "printIntervalInSeconds=%0.3f)\n",
+                                printIntervalSec);
+                            printf(
+                                "\tA test impulse-train is output on channel %d (from 0) "
+                                "with repeatedly ramping amplitude\n",
+                                sendChannel);
+                            if (printIntervalSec == 0.0) {
+                                printf(
+                                    "\tPrinting each audio buffer round-trip latency in "
+                                    "ms followed by cumulative (mean and [standard "
+                                    "deviation])");
+                            } else {
+                                printf(
+                                    "\tPrinting cumulative mean and [standard deviation] "
+                                    "of audio round-trip latency in ms");
+                                printf(" every %0.3f seconds", printIntervalSec);
+                            }
+                            printf(" after skipping first %d buffers:\n",
+                                   bufferSkipStart);
+                            // not printing this presently: printf("( * means buffer skipped due missing timestamp or lost impulse)\n");
+                            lastPrintTimeUS = timeMicroSec();
+                        }
+                        //printf("%d (%d) ", elapsedSamplesMS, impulseDelayMS); // measured time is "buffer time" not sample time
+                        int64_t curTimeUS = timeMicroSec();  // time since launch in us
+                        double timeSinceLastPrintUS = double(curTimeUS - lastPrintTimeUS);
+                        double stdDev =
+                            sqrt(std::max(0.0, (roundTripMeanSquare
+                                                - (roundTripMean * roundTripMean))));
+                        if (timeSinceLastPrintUS >= printIntervalSec * 1.0e6) {
+                            if (printIntervalSec == 0.0) {
+                                printf("%0.1f (", elapsedSamplesMS);
+                            }
+                            printf("%0.1f [%0.1f]", roundTripMean, stdDev);
+                            if (printIntervalSec == 0.0) {
+                                printf(") ");
+                            } else {
+                                printf(" ");
+                            }
+                            lastPrintTimeUS = curTimeUS;
+                            if (printIntervalSec >= 1.0) {  // print histogram
+                                std::cout << "\n" << getLatencyHistogramString() << "\n";
+                            }
+                        }
+                        std::cout << std::flush;
+                    } else {
+                        // not printing this presently: printf("* "); // we got the impulse but lost its timestamp in samples
+                    }
+                    impulsePending = false;
+                }  // found our impulse
+                // remain pending until timeout, hoping to find our return pulse
+            }  // got something
+        }      // loop over samples
+        sampleCountSinceImpulse +=
+            n_frames;  // gets reset to 1 when impulse is found, counts freely until then
+    }                  // ImpulsePending
 }
 
 // Called 2nd in Audiointerface.cpp
 void AudioTester::writeImpulse(QVarLengthArray<sample_t*>& mInBufCopy,
-                               unsigned int n_frames) {
-  if (not enabled) {
-    std::cerr << "*** AudioTester.h: writeImpulse: NOT ENABLED\n";
-    return;
-  }
-  if (bufferSkip <= 0) { // send test signals (-x option)
-    bool sendImpulse;
-    if (impulsePending) {
-      sendImpulse = false; // unless:
-      const uint64_t timeOut = 500e3; // time out after waiting 500 ms
-      if (timeMicroSec() > (impulseTimeUS + timeOut)) {
-        sendImpulse = true;
-        std::cout << "\n*** Audio Latency Test (-x): TIMED OUT waiting for return impulse *** sending a new one\n";
-      }
-    } else { // time for the next repeating impulse:
-      sendImpulse = true;
+                               unsigned int n_frames)
+{
+    if (not enabled) {
+        std::cerr << "*** AudioTester.h: writeImpulse: NOT ENABLED\n";
+        return;
     }
-    if (sendImpulse) {
-      assert(sendChannel < mInBufCopy.size());
-      mInBufCopy[sendChannel][0] = getImpulseAmp();
-      for (uint n=1; n<n_frames; n++) {
-        mInBufCopy[sendChannel][n] = 0;
-      }
-      impulsePending = true;
-      impulseTimeUS = timeMicroSec();
-      impulseTimeSamples = sampleCountSinceImpulse; // timer in samples for current impulse loopback test
-      // Also send impulse time:
-      if (n_frames>1) { // always true?
-        mInBufCopy[sendChannel][1] = -float(impulseTimeSamples)/32768.0f; // survives if there is no digital processing at the server
-      } else {
-        std::cerr << "\n*** AudioTester.h: Timestamp cannot fit into a lenth " << n_frames << " buffer ***\n";
-      }
+    if (bufferSkip <= 0) {  // send test signals (-x option)
+        bool sendImpulse;
+        if (impulsePending) {
+            sendImpulse            = false;  // unless:
+            const uint64_t timeOut = 500e3;  // time out after waiting 500 ms
+            if (timeMicroSec() > (impulseTimeUS + timeOut)) {
+                sendImpulse = true;
+                std::cout << "\n*** Audio Latency Test (-x): TIMED OUT waiting for "
+                             "return impulse *** sending a new one\n";
+            }
+        } else {  // time for the next repeating impulse:
+            sendImpulse = true;
+        }
+        if (sendImpulse) {
+            assert(sendChannel < mInBufCopy.size());
+            mInBufCopy[sendChannel][0] = getImpulseAmp();
+            for (uint n = 1; n < n_frames; n++) { mInBufCopy[sendChannel][n] = 0; }
+            impulsePending = true;
+            impulseTimeUS  = timeMicroSec();
+            impulseTimeSamples =
+                sampleCountSinceImpulse;  // timer in samples for current impulse loopback test
+            // Also send impulse time:
+            if (n_frames > 1) {  // always true?
+                mInBufCopy[sendChannel][1] =
+                    -float(impulseTimeSamples)
+                    / 32768.0f;  // survives if there is no digital processing at the server
+            } else {
+                std::cerr << "\n*** AudioTester.h: Timestamp cannot fit into a lenth "
+                          << n_frames << " buffer ***\n";
+            }
+        } else {
+            mInBufCopy[sendChannel][0] =
+                0.0f;  // send zeros until a new impulse is needed
+            if (n_frames > 1) { mInBufCopy[sendChannel][1] = 0.0f; }
+        }
     } else {
-      mInBufCopy[sendChannel][0] = 0.0f; // send zeros until a new impulse is needed
-      if (n_frames>1) {
-        mInBufCopy[sendChannel][1] = 0.0f;
-      }
+        bufferSkip--;
     }
-  } else {
-    bufferSkip--;
-  }
 }
 
-void AudioTester::printHelp(char* command, [[maybe_unused]] char helpCase) {
-  std::cout << "HELP for \"" << command << " printIntervalSec\" // (end-of-line comments start with `//'):\n";
-  std::cout << "\n";
-  std::cout << "Print roundtrip audio delay statistics for the highest-numbered audio channel every printIntervalSec seconds,\n";
-  std::cout << "including an ASCII latency histogram if printIntervalSec is 1.0 or more.\n";
-  std::cout << "\n";
-  std::cout << "A test impulse is sent to the server in the last audio channel,\n";
-  std::cout << "  the number of samples until it returns is measured, and this repeats.\n";
-  std::cout << "The jacktrip server must provide audio loopback (e.g., -p4).\n";
-  std::cout << "The cumulative mean and standard-deviation (\"statistics\") are computed for the measured loopback times,\n";
-  std::cout << "  and printed every printIntervalSec seconds.\n";
-  std::cout << "If printIntervalSec is zero, the roundtrip-time and statistics in milliseconds are printed for each individual impulse.\n";
-  std::cout << "If printIntervalSec is positive, statistics are printed after each print interval, with no individual measurements.\n";
-  std::cout << "If printIntervalSec is 1.0 or larger, a cumulative histogram of all impulse roundtrip-times is printed as well.\n";
-  std::cout << "The first 100 audio buffers are skipped in order to measure only steady-state network-audio-delay performance.\n";
-  std::cout << "Lower audio channels are not affected, enabling latency measurement and display during normal operation.\n";
+void AudioTester::printHelp(char* command, [[maybe_unused]] char helpCase)
+{
+    std::cout << "HELP for \"" << command
+              << " printIntervalSec\" // (end-of-line comments start with `//'):\n";
+    std::cout << "\n";
+    std::cout << "Print roundtrip audio delay statistics for the highest-numbered audio "
+                 "channel every printIntervalSec seconds,\n";
+    std::cout
+        << "including an ASCII latency histogram if printIntervalSec is 1.0 or more.\n";
+    std::cout << "\n";
+    std::cout << "A test impulse is sent to the server in the last audio channel,\n";
+    std::cout
+        << "  the number of samples until it returns is measured, and this repeats.\n";
+    std::cout << "The jacktrip server must provide audio loopback (e.g., -p4).\n";
+    std::cout << "The cumulative mean and standard-deviation (\"statistics\") are "
+                 "computed for the measured loopback times,\n";
+    std::cout << "  and printed every printIntervalSec seconds.\n";
+    std::cout << "If printIntervalSec is zero, the roundtrip-time and statistics in "
+                 "milliseconds are printed for each individual impulse.\n";
+    std::cout << "If printIntervalSec is positive, statistics are printed after each "
+                 "print interval, with no individual measurements.\n";
+    std::cout << "If printIntervalSec is 1.0 or larger, a cumulative histogram of all "
+                 "impulse roundtrip-times is printed as well.\n";
+    std::cout << "The first 100 audio buffers are skipped in order to measure only "
+                 "steady-state network-audio-delay performance.\n";
+    std::cout << "Lower audio channels are not affected, enabling latency measurement "
+                 "and display during normal operation.\n";
 }

--- a/src/AudioTester.h
+++ b/src/AudioTester.h
@@ -38,183 +38,182 @@
 
 #pragma once
 
-#include "jacktrip_types.h" // sample_t
-
 #include <iostream>
-//#include <ctime>
-#include <chrono>
-#include <cstdint>
-#include <cmath>
-#include <string>
-#include <map>
 
+#include "jacktrip_types.h"  // sample_t
+//#include <ctime>
 #include <QVarLengthArray>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <map>
+#include <string>
 
 class AudioTester
 {
-  bool enabled { false };
-  float printIntervalSec { 1.0f };
-  int sendChannel { 0 };
+    bool enabled{false};
+    float printIntervalSec{1.0f};
+    int sendChannel{0};
 
-  bool impulsePending { false };
-  int64_t lastPrintTimeUS { 0 };
-  int64_t impulseTimeUS { 0 };
-  int64_t impulseTimeSamples { 0 };
-  uint64_t sampleCountSinceImpulse { 1 }; // 0 not used
-  double roundTripMean { 0.0 };
-  double roundTripMeanSquare { 0.0 };
-  double roundTripCount { 0.0 };
-  const int bufferSkipStart { 100 };
-  int bufferSkip { bufferSkipStart };
-  const float impulseAmplitude { 0.1f };
-  const int numAmpCells { 10 };
-  const float ampCellHeight { impulseAmplitude/numAmpCells };
+    bool impulsePending{false};
+    int64_t lastPrintTimeUS{0};
+    int64_t impulseTimeUS{0};
+    int64_t impulseTimeSamples{0};
+    uint64_t sampleCountSinceImpulse{1};  // 0 not used
+    double roundTripMean{0.0};
+    double roundTripMeanSquare{0.0};
+    double roundTripCount{0.0};
+    const int bufferSkipStart{100};
+    int bufferSkip{bufferSkipStart};
+    const float impulseAmplitude{0.1f};
+    const int numAmpCells{10};
+    const float ampCellHeight{impulseAmplitude / numAmpCells};
 
-  const double latencyHistogramCellWidth { 5.0 }; // latency range in ms covered one cell
-  const double latencyHistogramCellMin { 0.0 };
-  const double latencyHistogramCellMax { 19.0 };  // in cells, so 5x this is max latency in ms
-  const int latencyHistogramPrintCountMax { 72 }; // normalize when asterisks exceed this number
+    const double latencyHistogramCellWidth{5.0};  // latency range in ms covered one cell
+    const double latencyHistogramCellMin{0.0};
+    const double latencyHistogramCellMax{
+        19.0};  // in cells, so 5x this is max latency in ms
+    const int latencyHistogramPrintCountMax{
+        72};  // normalize when asterisks exceed this number
 
-  int pendingCell { 0 }; // 0 is not used
-  float sampleRate { 48000.0f };
+    int pendingCell{0};  // 0 is not used
+    float sampleRate{48000.0f};
 
-public:
-  AudioTester() {}
-  ~AudioTester() = default;
+   public:
+    AudioTester() {}
+    ~AudioTester() = default;
 
-  void lookForReturnPulse(QVarLengthArray<sample_t*>& out_buffer,
-                                       unsigned int n_frames);
+    void lookForReturnPulse(QVarLengthArray<sample_t*>& out_buffer,
+                            unsigned int n_frames);
 
-  void writeImpulse(QVarLengthArray<sample_t*>& mInBufCopy,
-                    unsigned int n_frames);
+    void writeImpulse(QVarLengthArray<sample_t*>& mInBufCopy, unsigned int n_frames);
 
-  bool getEnabled() { return enabled; }
-  void setEnabled(bool e) { enabled = e; }
-  void setPrintIntervalSec(float s) { printIntervalSec = s; }
-  void setSendChannel(int c) { sendChannel = c; }
-  int getSendChannel() { return sendChannel; }
-  int getPendingCell() { return pendingCell; }
-  void setPendingCell(int pc) { pendingCell = pc; }
-  void setSampleRate(float fs) { sampleRate = fs; }
-  int getBufferSkip() { return bufferSkip; } // used for debugging breakpoints
-  void printHelp(char* command, char helpCase);
+    bool getEnabled() { return enabled; }
+    void setEnabled(bool e) { enabled = e; }
+    void setPrintIntervalSec(float s) { printIntervalSec = s; }
+    void setSendChannel(int c) { sendChannel = c; }
+    int getSendChannel() { return sendChannel; }
+    int getPendingCell() { return pendingCell; }
+    void setPendingCell(int pc) { pendingCell = pc; }
+    void setSampleRate(float fs) { sampleRate = fs; }
+    int getBufferSkip() { return bufferSkip; }  // used for debugging breakpoints
+    void printHelp(char* command, char helpCase);
 
-private:
-
-  float getImpulseAmp() {
-    pendingCell += 1; // only called when no impulse is pending
-    if (pendingCell >= numAmpCells) {
-      pendingCell = 1; // wrap-around, not using zero
+   private:
+    float getImpulseAmp()
+    {
+        pendingCell += 1;  // only called when no impulse is pending
+        if (pendingCell >= numAmpCells) {
+            pendingCell = 1;  // wrap-around, not using zero
+        }
+        float imp = float(pendingCell) * (impulseAmplitude / float(numAmpCells));
+        return imp;
     }
-    float imp = float(pendingCell) * (impulseAmplitude/float(numAmpCells));
-    return imp;
-  }
 
-  int getImpulseCellNum(float amp) {
-    float ch = ampCellHeight;
-    float cell = amp / ch;
-    int iCell = int(std::floor(0.5f + cell));
-    if (iCell > numAmpCells - 1) {
-      std::cerr << "*** AudioTester.h: getImpulseCellNum("<<amp<<"): Return pulse amplitude is beyond maximum expected\n";
-      iCell = numAmpCells-1;
-    } else if (iCell < 0) {
-      std::cerr << "*** AudioTester.h: getImpulseCellNum("<<amp<<"): Return pulse amplitude is below minimum expected\n";
-      iCell = 0;
+    int getImpulseCellNum(float amp)
+    {
+        float ch   = ampCellHeight;
+        float cell = amp / ch;
+        int iCell  = int(std::floor(0.5f + cell));
+        if (iCell > numAmpCells - 1) {
+            std::cerr << "*** AudioTester.h: getImpulseCellNum(" << amp
+                      << "): Return pulse amplitude is beyond maximum expected\n";
+            iCell = numAmpCells - 1;
+        } else if (iCell < 0) {
+            std::cerr << "*** AudioTester.h: getImpulseCellNum(" << amp
+                      << "): Return pulse amplitude is below minimum expected\n";
+            iCell = 0;
+        }
+        return iCell;
     }
-    return iCell;
-  }
 
-  uint64_t timeMicroSec() {
+    uint64_t timeMicroSec()
+    {
 #if 1
-    using namespace std::chrono;
-    // return duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
-    return duration_cast<microseconds>(high_resolution_clock::now().time_since_epoch()).count();
+        using namespace std::chrono;
+        // return duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+        return duration_cast<microseconds>(
+                   high_resolution_clock::now().time_since_epoch())
+            .count();
 #else
-    clock_t tics_since_launch = std::clock();
-    double timeUS = double(tics_since_launch)/double(CLOCKS_PER_SEC);
-    return (uint64_t)timeUS;
+        clock_t tics_since_launch = std::clock();
+        double timeUS             = double(tics_since_launch) / double(CLOCKS_PER_SEC);
+        return (uint64_t)timeUS;
 #endif
-  }
-
-  std::map<int, int> latencyHistogram;
-
-  std::map<int, int> getLatencyHistogram() {
-    return latencyHistogram;
-  }
-
-  void extendLatencyHistogram(double latencyMS) {
-    int latencyCell = static_cast<int>(floor(std::max(latencyHistogramCellMin,
-                                                      std::min(latencyHistogramCellMax,
-                                                               std::floor(latencyMS / latencyHistogramCellWidth)))));
-    latencyHistogram[latencyCell] += 1;
-  }
-
-  int latencyHistogramCountMax() {
-    int lhMax = 0;
-    int histStart = latencyHistogramFirstNonzeroCellIndex();
-    int histLast = latencyHistogramLastNonzeroCellIndex();
-    for (int i = histStart; i <= histLast; ++i) {
-      int lhi = latencyHistogram[i];
-      if (lhi > lhMax) {
-        lhMax = lhi;
-      }
     }
-    return lhMax;
-  }
 
-  int latencyHistogramFirstNonzeroCellIndex() {
-    for (int i=latencyHistogramCellMin; i <= latencyHistogramCellMax; i++) {
-      if (latencyHistogram[i]>0) {
-        return i;
-      }
-    }
-    std::cerr << "*** AudioTester: LATENCY HISTOGRAM IS EMPTY!\n";
-    return -1;
-  }
+    std::map<int, int> latencyHistogram;
 
-  int latencyHistogramLastNonzeroCellIndex() {
-    for (int i=latencyHistogramCellMax; i>=latencyHistogramCellMin; i--) {
-      if (latencyHistogram[i]>0) {
-        return i;
-      }
-    }
-    std::cerr << "*** AudioTester: LATENCY HISTOGRAM IS EMPTY!\n";
-    return -1;
-  }
+    std::map<int, int> getLatencyHistogram() { return latencyHistogram; }
 
-  std::string getLatencyHistogramString() {
-    int histStart = latencyHistogramFirstNonzeroCellIndex();
-    int histLast = latencyHistogramLastNonzeroCellIndex();
-    std::string marker = "*";
-    double histScale = 1.0;
-    int lhcm = latencyHistogramCountMax();
-    int lhpcm = latencyHistogramPrintCountMax;
-    bool normalizing = lhpcm < lhcm;
-    if (normalizing) {
-      marker = "#";
-      histScale = double(lhpcm) / double(lhcm);
+    void extendLatencyHistogram(double latencyMS)
+    {
+        int latencyCell = static_cast<int>(
+            floor(std::max(latencyHistogramCellMin,
+                           std::min(latencyHistogramCellMax,
+                                    std::floor(latencyMS / latencyHistogramCellWidth)))));
+        latencyHistogram[latencyCell] += 1;
     }
-    std::string rows = "";
-    for (int i = histStart; i <= histLast; ++i) {
-      int hi = latencyHistogram[i];
-      int hin = int(std::round(histScale * double(hi)));
-      std::string istrm1 = std::to_string(int(latencyHistogramCellWidth * double(i)));
-      std::string istr = std::to_string(int(latencyHistogramCellWidth * double(i+1)));
-      // std::string histr = boost::format("%02d",hi);
-      std::string histr = std::to_string(hi);
-      while (histr.length()<3) {
-        histr = " " + histr;
-      }
-      std::string row = "["+istrm1+"-"+istr+"ms]="+histr+":";
-      for (int j=0; j<hin; j++) {
-        row += marker;
-      }
-      rows += row + "\n";
-    }
-    if (histLast == latencyHistogramCellMax) {
-      rows += " and above\n";
-    }
-    return rows;
-  }
 
+    int latencyHistogramCountMax()
+    {
+        int lhMax     = 0;
+        int histStart = latencyHistogramFirstNonzeroCellIndex();
+        int histLast  = latencyHistogramLastNonzeroCellIndex();
+        for (int i = histStart; i <= histLast; ++i) {
+            int lhi = latencyHistogram[i];
+            if (lhi > lhMax) { lhMax = lhi; }
+        }
+        return lhMax;
+    }
+
+    int latencyHistogramFirstNonzeroCellIndex()
+    {
+        for (int i = latencyHistogramCellMin; i <= latencyHistogramCellMax; i++) {
+            if (latencyHistogram[i] > 0) { return i; }
+        }
+        std::cerr << "*** AudioTester: LATENCY HISTOGRAM IS EMPTY!\n";
+        return -1;
+    }
+
+    int latencyHistogramLastNonzeroCellIndex()
+    {
+        for (int i = latencyHistogramCellMax; i >= latencyHistogramCellMin; i--) {
+            if (latencyHistogram[i] > 0) { return i; }
+        }
+        std::cerr << "*** AudioTester: LATENCY HISTOGRAM IS EMPTY!\n";
+        return -1;
+    }
+
+    std::string getLatencyHistogramString()
+    {
+        int histStart      = latencyHistogramFirstNonzeroCellIndex();
+        int histLast       = latencyHistogramLastNonzeroCellIndex();
+        std::string marker = "*";
+        double histScale   = 1.0;
+        int lhcm           = latencyHistogramCountMax();
+        int lhpcm          = latencyHistogramPrintCountMax;
+        bool normalizing   = lhpcm < lhcm;
+        if (normalizing) {
+            marker    = "#";
+            histScale = double(lhpcm) / double(lhcm);
+        }
+        std::string rows = "";
+        for (int i = histStart; i <= histLast; ++i) {
+            int hi  = latencyHistogram[i];
+            int hin = int(std::round(histScale * double(hi)));
+            std::string istrm1 =
+                std::to_string(int(latencyHistogramCellWidth * double(i)));
+            std::string istr =
+                std::to_string(int(latencyHistogramCellWidth * double(i + 1)));
+            // std::string histr = boost::format("%02d",hi);
+            std::string histr = std::to_string(hi);
+            while (histr.length() < 3) { histr = " " + histr; }
+            std::string row = "[" + istrm1 + "-" + istr + "ms]=" + histr + ":";
+            for (int j = 0; j < hin; j++) { row += marker; }
+            rows += row + "\n";
+        }
+        if (histLast == latencyHistogramCellMax) { rows += " and above\n"; }
+        return rows;
+    }
 };

--- a/src/Compressor.cpp
+++ b/src/Compressor.cpp
@@ -35,7 +35,6 @@
  * \date July 2008
  */
 
-
 #include "Compressor.h"
 
 #include <iostream>
@@ -43,15 +42,16 @@
 //*******************************************************************************
 void Compressor::compute(int nframes, float** inputs, float** outputs)
 {
-  if (not inited) {
-    std::cerr << "*** Compressor " << this << ": init never called! Doing it now.\n";
-    if (fSamplingFreq <= 0) {
-      fSamplingFreq = 48000;
-      std::cout << "Compressor " << this << ": *** HAD TO GUESS the sampling rate (chose 48000 Hz) ***\n";
+    if (not inited) {
+        std::cerr << "*** Compressor " << this << ": init never called! Doing it now.\n";
+        if (fSamplingFreq <= 0) {
+            fSamplingFreq = 48000;
+            std::cout << "Compressor " << this
+                      << ": *** HAD TO GUESS the sampling rate (chose 48000 Hz) ***\n";
+        }
+        init(fSamplingFreq);
     }
-    init(fSamplingFreq);
-  }
-  for ( int i = 0; i < mNumChannels; i++ ) {
-    compressorP[i]->compute(nframes, &inputs[i], &outputs[i]);
-  }
+    for (int i = 0; i < mNumChannels; i++) {
+        compressorP[i]->compute(nframes, &inputs[i], &outputs[i]);
+    }
 }

--- a/src/Compressor.h
+++ b/src/Compressor.h
@@ -35,114 +35,114 @@
  * \date August 2020
  */
 
-
 /** \brief Applies compressor_mono from the faustlibraries distribution, compressors.lib
  *
  */
 #ifndef __COMPRESSOR_H__
 #define __COMPRESSOR_H__
 
+#include <vector>
+
+#include "CompressorPresets.h"
 #include "ProcessPlugin.h"
 #include "compressordsp.h"
-#include "CompressorPresets.h"
-#include <vector>
 
 /** \brief A Compressor reduces the output dynamic range when the
  *         signal level exceeds the threshold.
  */
 class Compressor : public ProcessPlugin
 {
-public:
-  /// \brief The class constructor sets the number of audio channels and default parameters.
-  Compressor(int numchans, // xtor
-             bool verboseIn = false,
-             float ratioIn = 2.0f,
-             float thresholdDBIn = -24.0f,
-             float attackMSIn = 15.0f,
-             float releaseMSIn = 40.0f,
-             float makeUpGainDBIn = 2.0f)
-    : mNumChannels(numchans)
-    , ratio(ratioIn)
-    , thresholdDB(thresholdDBIn)
-    , attackMS(attackMSIn)
-    , releaseMS(releaseMSIn)
-    , makeUpGainDB(makeUpGainDBIn)
-  {
-    setVerbose(verboseIn);
-    // presets.push_back(std::make_unique<CompressorPreset>(ratio,thresholdDB,attackMS,releaseMS,makeUpGainDB));
-    for ( int i = 0; i < mNumChannels; i++ ) {
-      compressorP.push_back(new compressordsp);
-      compressorUIP.push_back(new APIUI); // #included in compressordsp.h
-      compressorP[i]->buildUserInterface(compressorUIP[i]);
-    }
-  }
-
-  Compressor(int numchans, // xtor
-             bool verboseIn = false,
-             CompressorPreset preset = CompressorPresets::voice) :
-    Compressor(numchans,verboseIn,
-               preset.ratio,
-               preset.thresholdDB,
-               preset.attackMS,
-               preset.releaseMS,
-               preset.makeUpGainDB)
-  {}
-  /// \brief The class destructor
-  virtual ~Compressor() {
-    for ( int i = 0; i < mNumChannels; i++ ) {
-      delete compressorP[i];
-      delete compressorUIP[i];
-    }
-    compressorP.clear();
-    compressorUIP.clear();
-  }
-
-  //  void setParamAllChannels(std::string& pName, float p) {
-  void setParamAllChannels(const char pName[], float p) {
-    for ( int i = 0; i < mNumChannels; i++ ) {
-      int ndx = compressorUIP[i]->getParamIndex(pName);
-      if (ndx >= 0) {
-        compressorUIP[i]->setParamValue(ndx, p);
-        if (verbose) {
-          std::cout << "Compressor.h: parameter " << pName << " set to " << p << " on audio channel " << i << "\n";
+   public:
+    /// \brief The class constructor sets the number of audio channels and default parameters.
+    Compressor(int numchans,  // xtor
+               bool verboseIn = false, float ratioIn = 2.0f, float thresholdDBIn = -24.0f,
+               float attackMSIn = 15.0f, float releaseMSIn = 40.0f,
+               float makeUpGainDBIn = 2.0f)
+        : mNumChannels(numchans)
+        , ratio(ratioIn)
+        , thresholdDB(thresholdDBIn)
+        , attackMS(attackMSIn)
+        , releaseMS(releaseMSIn)
+        , makeUpGainDB(makeUpGainDBIn)
+    {
+        setVerbose(verboseIn);
+        // presets.push_back(std::make_unique<CompressorPreset>(ratio,thresholdDB,attackMS,releaseMS,makeUpGainDB));
+        for (int i = 0; i < mNumChannels; i++) {
+            compressorP.push_back(new compressordsp);
+            compressorUIP.push_back(new APIUI);  // #included in compressordsp.h
+            compressorP[i]->buildUserInterface(compressorUIP[i]);
         }
-      } else {
-        std::cerr << "*** Compressor.h: Could not find parameter named " << pName << "\n";
-      }
     }
-  }
 
-  void init(int samplingRate) override {
-    ProcessPlugin::init(samplingRate);
-    if (samplingRate != fSamplingFreq) {
-      std::cerr << "Sampling rate not set by superclass!\n";
-      std::exit(1); }
-    fs = float(fSamplingFreq);
-    for ( int i = 0; i < mNumChannels; i++ ) {
-      compressorP[i]->init(fs); // compression filter parameters depend on sampling rate
+    Compressor(int numchans,  // xtor
+               bool verboseIn = false, CompressorPreset preset = CompressorPresets::voice)
+        : Compressor(numchans, verboseIn, preset.ratio, preset.thresholdDB,
+                     preset.attackMS, preset.releaseMS, preset.makeUpGainDB)
+    {
     }
-    setParamAllChannels("Ratio", ratio);
-    setParamAllChannels("Threshold", thresholdDB);
-    setParamAllChannels("Attack", attackMS);
-    setParamAllChannels("Release", releaseMS);
-    setParamAllChannels("MakeUpGain", makeUpGainDB);
-    inited = true;
-  }
+    /// \brief The class destructor
+    virtual ~Compressor()
+    {
+        for (int i = 0; i < mNumChannels; i++) {
+            delete compressorP[i];
+            delete compressorUIP[i];
+        }
+        compressorP.clear();
+        compressorUIP.clear();
+    }
 
-  int getNumInputs() override { return(mNumChannels); }
-  int getNumOutputs() override { return(mNumChannels); }
-  void compute(int nframes, float** inputs, float** outputs) override;
+    //  void setParamAllChannels(std::string& pName, float p) {
+    void setParamAllChannels(const char pName[], float p)
+    {
+        for (int i = 0; i < mNumChannels; i++) {
+            int ndx = compressorUIP[i]->getParamIndex(pName);
+            if (ndx >= 0) {
+                compressorUIP[i]->setParamValue(ndx, p);
+                if (verbose) {
+                    std::cout << "Compressor.h: parameter " << pName << " set to " << p
+                              << " on audio channel " << i << "\n";
+                }
+            } else {
+                std::cerr << "*** Compressor.h: Could not find parameter named " << pName
+                          << "\n";
+            }
+        }
+    }
 
-private:
-  float fs;
-  int mNumChannels;
-  std::vector<compressordsp*> compressorP;
-  std::vector<APIUI*> compressorUIP;
-  float ratio;
-  float thresholdDB;
-  float attackMS;
-  float releaseMS;
-  float makeUpGainDB;
+    void init(int samplingRate) override
+    {
+        ProcessPlugin::init(samplingRate);
+        if (samplingRate != fSamplingFreq) {
+            std::cerr << "Sampling rate not set by superclass!\n";
+            std::exit(1);
+        }
+        fs = float(fSamplingFreq);
+        for (int i = 0; i < mNumChannels; i++) {
+            compressorP[i]->init(
+                fs);  // compression filter parameters depend on sampling rate
+        }
+        setParamAllChannels("Ratio", ratio);
+        setParamAllChannels("Threshold", thresholdDB);
+        setParamAllChannels("Attack", attackMS);
+        setParamAllChannels("Release", releaseMS);
+        setParamAllChannels("MakeUpGain", makeUpGainDB);
+        inited = true;
+    }
+
+    int getNumInputs() override { return (mNumChannels); }
+    int getNumOutputs() override { return (mNumChannels); }
+    void compute(int nframes, float** inputs, float** outputs) override;
+
+   private:
+    float fs;
+    int mNumChannels;
+    std::vector<compressordsp*> compressorP;
+    std::vector<APIUI*> compressorUIP;
+    float ratio;
+    float thresholdDB;
+    float attackMS;
+    float releaseMS;
+    float makeUpGainDB;
 };
 
 #endif

--- a/src/CompressorPresets.h
+++ b/src/CompressorPresets.h
@@ -3,33 +3,30 @@
 #include <array>
 
 struct CompressorPreset {
-  float ratio;
-  float thresholdDB;
-  float attackMS;
-  float releaseMS;
-  float makeUpGainDB;
-  CompressorPreset(float r, float t, float a, float rel, float m)
-    : ratio(r)
-    , thresholdDB(t)
-    , attackMS(a)
-    , releaseMS(rel)
-    , makeUpGainDB(m)
-  {}
-  ~CompressorPreset() = default;
+    float ratio;
+    float thresholdDB;
+    float attackMS;
+    float releaseMS;
+    float makeUpGainDB;
+    CompressorPreset(float r, float t, float a, float rel, float m)
+        : ratio(r), thresholdDB(t), attackMS(a), releaseMS(rel), makeUpGainDB(m)
+    {
+    }
+    ~CompressorPreset() = default;
 };
 
 namespace CompressorPresets
 {
-  //                     name   ratio  thresh  attack  rel  mugain
-  const CompressorPreset voice { 2.0f, -24.0f, 15.0f, 40.0f, 2.0f };
-  const CompressorPreset horns { 3.0f, -10.0f, 100.0f, 250.0f, 2.0f };
-  const CompressorPreset snare { 5.0f, -4.0f, 5.0f, 150.0f, 3.0f };
-  const uint numPresets { 3 };
-  const std::array<CompressorPreset,numPresets> standardPresets { voice, horns, snare };
-  enum CompressorPresetNames { CPN_VOICE, CPN_BRASS, CPN_SNARE, CPN_NUMPRESETS };
-}
+//                     name   ratio  thresh  attack  rel  mugain
+const CompressorPreset voice{2.0f, -24.0f, 15.0f, 40.0f, 2.0f};
+const CompressorPreset horns{3.0f, -10.0f, 100.0f, 250.0f, 2.0f};
+const CompressorPreset snare{5.0f, -4.0f, 5.0f, 150.0f, 3.0f};
+const uint numPresets{3};
+const std::array<CompressorPreset, numPresets> standardPresets{voice, horns, snare};
+enum CompressorPresetNames { CPN_VOICE, CPN_BRASS, CPN_SNARE, CPN_NUMPRESETS };
+}  // namespace CompressorPresets
 
-#if 0 // not yet using this
+#if 0  // not yet using this
 // Dynamic extension of CompressorPresets:
 struct CompressorPresetList {
   std::vector<CompressorPreset*> presets;

--- a/src/CompressorPresets.h
+++ b/src/CompressorPresets.h
@@ -21,7 +21,7 @@ namespace CompressorPresets
 const CompressorPreset voice{2.0f, -24.0f, 15.0f, 40.0f, 2.0f};
 const CompressorPreset horns{3.0f, -10.0f, 100.0f, 250.0f, 2.0f};
 const CompressorPreset snare{5.0f, -4.0f, 5.0f, 150.0f, 3.0f};
-const uint numPresets{3};
+const unsigned int numPresets{3};
 const std::array<CompressorPreset, numPresets> standardPresets{voice, horns, snare};
 enum CompressorPresetNames { CPN_VOICE, CPN_BRASS, CPN_SNARE, CPN_NUMPRESETS };
 }  // namespace CompressorPresets

--- a/src/DataProtocol.cpp
+++ b/src/DataProtocol.cpp
@@ -36,26 +36,28 @@
  */
 
 #include "DataProtocol.h"
-#include "jacktrip_globals.h"
-#include "JackTrip.h"
 
-#include <iostream>
-#include <cstdlib>
-
-#include <QHostInfo>
 #include <QHostAddress>
+#include <QHostInfo>
+#include <cstdlib>
+#include <iostream>
 
-using std::cout; using std::endl;
+#include "JackTrip.h"
+#include "jacktrip_globals.h"
 
-
-//*******************************************************************************
-DataProtocol::DataProtocol(JackTrip* jacktrip,
-                           const runModeT runmode,
-                           int /*bind_port*/, int /*peer_port*/) :
-    mStopped(false), mHasPacketsToReceive(false), mRunMode(runmode), mJackTrip(jacktrip), mUseRtPriority(false)
-{}
-
+using std::cout;
+using std::endl;
 
 //*******************************************************************************
-DataProtocol::~DataProtocol()
-{}
+DataProtocol::DataProtocol(JackTrip* jacktrip, const runModeT runmode, int /*bind_port*/,
+                           int /*peer_port*/)
+    : mStopped(false)
+    , mHasPacketsToReceive(false)
+    , mRunMode(runmode)
+    , mJackTrip(jacktrip)
+    , mUseRtPriority(false)
+{
+}
+
+//*******************************************************************************
+DataProtocol::~DataProtocol() {}

--- a/src/DataProtocol.h
+++ b/src/DataProtocol.h
@@ -44,21 +44,19 @@
 #endif
 
 #ifndef __WIN_32__
-#include <netinet/in.h> //sockaddr_in{} and other Internet defns
-#include <arpa/inet.h> //inet(3) functions
+#include <arpa/inet.h>  //inet(3) functions
 #include <netdb.h>
+#include <netinet/in.h>  //sockaddr_in{} and other Internet defns
 //#include <tr1/memory> //for shared_ptr
 #endif
 
-#include <iostream>
-
-#include <QThread>
 #include <QHostAddress>
 #include <QMutex>
 #include <QMutexLocker>
+#include <QThread>
+#include <iostream>
 
-class JackTrip; // forward declaration
-
+class JackTrip;  // forward declaration
 
 /** \brief Base class that defines the transmission protocol.
  *
@@ -94,23 +92,21 @@ class DataProtocol : public QThread
 {
     Q_OBJECT;
 
-public:
-
+   public:
     //----------ENUMS------------------------------------------
     /// \brief Enum to define packet header types
     enum packetHeaderTypeT {
-        DEFAULT, ///< Default application header
-        JAMLINK, ///< Header to use with Jamlinks
-        EMPTY    ///< Empty Header
+        DEFAULT,  ///< Default application header
+        JAMLINK,  ///< Header to use with Jamlinks
+        EMPTY     ///< Empty Header
     };
 
     /// \brief Enum to define class modes, SENDER or RECEIVER
     enum runModeT {
-        SENDER, ///< Set class as a Sender (send packets)
-        RECEIVER ///< Set class as a Receiver (receives packets)
+        SENDER,   ///< Set class as a Sender (send packets)
+        RECEIVER  ///< Set class as a Receiver (receives packets)
     };
     //---------------------------------------------------------
-
 
     /** \brief The class constructor
    * \param jacktrip Pointer to the JackTrip class that connects all classes (mediator)
@@ -120,9 +116,8 @@ public:
    * \param bind_port Port number to bind for this socket (this is the receive or send port depending on the runmode)
    * \param peer_port Peer port number (this is the receive or send port depending on the runmode)
    */
-    DataProtocol(JackTrip* jacktrip,
-                 const runModeT runmode,
-                 int bind_port, int peer_port);
+    DataProtocol(JackTrip* jacktrip, const runModeT runmode, int bind_port,
+                 int peer_port);
 
     /// \brief The class destructor
     virtual ~DataProtocol();
@@ -135,7 +130,8 @@ public:
     virtual void run() = 0;
 
     /// \brief Stops the execution of the Thread
-    virtual void stop() {
+    virtual void stop()
+    {
         QMutexLocker lock(&mMutex);
         mStopped = true;
     }
@@ -143,12 +139,12 @@ public:
     /** \brief Sets the size of the audio part of the packets
    * \param size_bytes Size in bytes
    */
-    void setAudioPacketSize(const size_t size_bytes){ mAudioPacketSize = size_bytes; }
+    void setAudioPacketSize(const size_t size_bytes) { mAudioPacketSize = size_bytes; }
 
     /** \brief Get the size of the audio part of the packets
    * \return size_bytes Size in bytes
    */
-    size_t getAudioPacketSizeInBites() { return(mAudioPacketSize); }
+    size_t getAudioPacketSizeInBites() { return (mAudioPacketSize); }
 
     /** \brief Set the peer address
    * \param peerHostOrIP IPv4 number or host name
@@ -165,10 +161,10 @@ public:
     //virtual void getPeerAddressFromFirstPacket(QHostAddress& peerHostAddress,
     //				     uint16_t& port) = 0;
 
-#if defined (__WIN_32__)
-    virtual void setSocket(SOCKET &socket) = 0;
+#if defined(__WIN_32__)
+    virtual void setSocket(SOCKET& socket) = 0;
 #else
-    virtual void setSocket(int &socket) = 0;
+    virtual void setSocket(int& socket) = 0;
 #endif
 
     struct PktStat {
@@ -178,19 +174,21 @@ public:
         uint32_t revived;
         uint32_t statCount;
     };
-    virtual bool getStats(PktStat*) {return false;}
+    virtual bool getStats(PktStat*) { return false; }
 
-    virtual void setIssueSimulation(double /*loss*/, double /*jitter*/, double /*max_delay*/) {}
-    void setUseRtPriority(bool use) {mUseRtPriority = use;}
+    virtual void setIssueSimulation(double /*loss*/, double /*jitter*/,
+                                    double /*max_delay*/)
+    {
+    }
+    void setUseRtPriority(bool use) { mUseRtPriority = use; }
 
-signals:
+   signals:
 
     void signalError(const char* error_message);
     void signalReceivedConnectionFromPeer();
-    void signalCeaseTransmission(const QString &reason = "");
+    void signalCeaseTransmission(const QString& reason = "");
 
-protected:
-
+   protected:
     /** \brief Get the Run Mode of the object
    * \return SENDER or RECEIVER
    */
@@ -204,29 +202,25 @@ protected:
     volatile bool mHasPacketsToReceive;
     QMutex mMutex;
 
+   private:
+    int mLocalPort;           ///< Local Port number to Bind
+    int mPeerPort;            ///< Peer Port number to Bind
+    const runModeT mRunMode;  ///< Run mode, either SENDER or RECEIVER
 
-private:
-
-    int mLocalPort; ///< Local Port number to Bind
-    int mPeerPort; ///< Peer Port number to Bind
-    const runModeT mRunMode; ///< Run mode, either SENDER or RECEIVER
-
-    struct sockaddr_in mLocalIPv4Addr; ///< Local IPv4 Address struct
-    struct sockaddr_in mPeerIPv4Addr; ///< Peer IPv4 Address struct
+    struct sockaddr_in mLocalIPv4Addr;  ///< Local IPv4 Address struct
+    struct sockaddr_in mPeerIPv4Addr;   ///< Peer IPv4 Address struct
 
     /// Number of clients running to check for ports already used
     /// \note Unimplemented, try to find another way to check for used ports
     static int sClientsRunning;
 
-    size_t mAudioPacketSize; ///< Packet audio part size
-
+    size_t mAudioPacketSize;  ///< Packet audio part size
 
     /// \todo check a better way to access the header from the subclasses
-protected:
+   protected:
     //PacketHeader* mHeader; ///< Packet Header
-    JackTrip* mJackTrip; ///< JackTrip mediator class
+    JackTrip* mJackTrip;  ///< JackTrip mediator class
     bool mUseRtPriority;
-
 };
 
 #endif

--- a/src/Effects.h
+++ b/src/Effects.h
@@ -37,70 +37,76 @@
 
 #pragma once
 
-#include "ProcessPlugin.h"
-#include "Limiter.h"
+#include <assert.h>
+
+#include <vector>
+
 #include "Compressor.h"
 #include "CompressorPresets.h"
+#include "Limiter.h"
+#include "ProcessPlugin.h"
 #include "Reverb.h"
-#include <assert.h>
-#include <vector>
 
 class Effects
 {
-  int mNumIncomingChans;
-  int mNumOutgoingChans;
-  int gVerboseFlag = 0;
-public:
-  enum LIMITER_MODE {
-                     LIMITER_NONE,
-                     LIMITER_INCOMING, // from network
-                     LIMITER_OUTGOING, // to network
-                     LIMITER_BOTH
-  };
-private:
-  LIMITER_MODE mLimit; ///< audio limiter controls
-  unsigned int mNumClientsAssumed; ///< assumed number of clients (audio sources)
-  double limiterWarningAmplitude;
+    int mNumIncomingChans;
+    int mNumOutgoingChans;
+    int gVerboseFlag = 0;
 
-  enum InOrOut { IO_NEITHER, IO_IN, IO_OUT } io;
-  bool inCompressor = false;
-  bool outCompressor = false;
-  bool inZitarev = false;
-  bool outZitarev = false;
-  bool inFreeverb = false;
-  bool outFreeverb = false;
-  bool incomingEffectsAllocated = false;
-  bool outgoingEffectsAllocated = false;
-  Compressor* inCompressorP = nullptr;
-  Compressor* outCompressorP = nullptr;
-  CompressorPreset inCompressorPreset = CompressorPresets::voice; // ./CompressorPresets.h
-  CompressorPreset outCompressorPreset = CompressorPresets::voice;
-  Reverb* inZitarevP = nullptr;
-  Reverb* outZitarevP = nullptr;
-  Reverb* inFreeverbP = nullptr;
-  Reverb* outFreeverbP = nullptr;
-  int parenLevel = 0;
-  char lastEffect = '\0';
-  float zitarevInLevel = 1.0f; // "Level" = wetness from 0 to 1
-  float freeverbInLevel = 1.0f;
-  float zitarevOutLevel = 1.0f;
-  float freeverbOutLevel = 1.0f;
-  float mReverbLevel; // for backward compatibility: 0-1 Freeverb, 1-2 Zitarev
-  Limiter* inLimiterP = nullptr;
-  Limiter* outLimiterP = nullptr;
+   public:
+    enum LIMITER_MODE {
+        LIMITER_NONE,
+        LIMITER_INCOMING,  // from network
+        LIMITER_OUTGOING,  // to network
+        LIMITER_BOTH
+    };
 
-public:
+   private:
+    LIMITER_MODE mLimit;              ///< audio limiter controls
+    unsigned int mNumClientsAssumed;  ///< assumed number of clients (audio sources)
+    double limiterWarningAmplitude;
 
-  Effects(bool outGoingLimiterOn=true) :
-    mNumIncomingChans(2),
-    mNumOutgoingChans(2),
-    mLimit(outGoingLimiterOn ? LIMITER_OUTGOING : LIMITER_NONE),
-    mNumClientsAssumed(2),
-    limiterWarningAmplitude(0.0)
-  {}
+    enum InOrOut { IO_NEITHER, IO_IN, IO_OUT } io;
+    bool inCompressor             = false;
+    bool outCompressor            = false;
+    bool inZitarev                = false;
+    bool outZitarev               = false;
+    bool inFreeverb               = false;
+    bool outFreeverb              = false;
+    bool incomingEffectsAllocated = false;
+    bool outgoingEffectsAllocated = false;
+    Compressor* inCompressorP     = nullptr;
+    Compressor* outCompressorP    = nullptr;
+    CompressorPreset inCompressorPreset =
+        CompressorPresets::voice;  // ./CompressorPresets.h
+    CompressorPreset outCompressorPreset = CompressorPresets::voice;
+    Reverb* inZitarevP                   = nullptr;
+    Reverb* outZitarevP                  = nullptr;
+    Reverb* inFreeverbP                  = nullptr;
+    Reverb* outFreeverbP                 = nullptr;
+    int parenLevel                       = 0;
+    char lastEffect                      = '\0';
+    float zitarevInLevel                 = 1.0f;  // "Level" = wetness from 0 to 1
+    float freeverbInLevel                = 1.0f;
+    float zitarevOutLevel                = 1.0f;
+    float freeverbOutLevel               = 1.0f;
+    float mReverbLevel;  // for backward compatibility: 0-1 Freeverb, 1-2 Zitarev
+    Limiter* inLimiterP  = nullptr;
+    Limiter* outLimiterP = nullptr;
 
-  ~Effects() {
-    /*
+   public:
+    Effects(bool outGoingLimiterOn = true)
+        : mNumIncomingChans(2)
+        , mNumOutgoingChans(2)
+        , mLimit(outGoingLimiterOn ? LIMITER_OUTGOING : LIMITER_NONE)
+        , mNumClientsAssumed(2)
+        , limiterWarningAmplitude(0.0)
+    {
+    }
+
+    ~Effects()
+    {
+        /*
       Plugin ownership presently passes to JackTrip,
       and deletion occurs in AudioInterface.cpp. See
         delete mProcessPluginsFromNetwork[i];
@@ -115,457 +121,572 @@ public:
       but if everyone can compile C++11,
       let's switch to using std::unique_ptr.
     */
-  }
-
-  unsigned int getNumClientsAssumed() { return mNumClientsAssumed; }
-
-  LIMITER_MODE getLimit() { return mLimit; }
-  void setNoLimiters() { mLimit = LIMITER_NONE; }
-
-  ProcessPlugin* getInCompressor() { return inCompressorP; }
-  ProcessPlugin* getOutCompressor() { return outCompressorP; }
-  ProcessPlugin* getInZitarev() { return inZitarevP; }
-  ProcessPlugin* getOutZitarev() { return outZitarevP; }
-  ProcessPlugin* getInFreeverb() { return inFreeverbP; }
-  ProcessPlugin* getOutFreeverb() { return outFreeverbP; }
-  ProcessPlugin* getInLimiter() { return inLimiterP; }
-  ProcessPlugin* getOutLimiter() { return outLimiterP; }
-
-  bool getHaveEffect() {
-    return
-      inCompressor || outCompressor ||
-      inZitarev || outZitarev ||
-      inFreeverb || outFreeverb ;
-  }
-
-  bool getHaveLimiter() {
-    return mLimit != LIMITER_NONE;
-  }
-
-  void setVerboseFlag(int v) {
-    gVerboseFlag = v;
-  }
-
-  int getNumIncomingChans() {
-    return mNumIncomingChans;
-  }
-
-  int getOutgoingNumChans() {
-    return mNumOutgoingChans;
-  }
-
-  // call these next two after it is decided what effects we will be using for the duration:
-
-  std::vector<ProcessPlugin*> allocateIncomingEffects(int nIncomingChans) {
-    mNumIncomingChans = nIncomingChans;
-    if (incomingEffectsAllocated) {
-      std::cerr << "*** Effects.h: attempt to allocate incoming effects more than once\n";
-      std::exit(1);
     }
-    std::vector<ProcessPlugin*> incomingEffects;
-    if (inCompressor) {
-      assert(inCompressorP == nullptr);
-      inCompressorP = new Compressor(mNumIncomingChans, gVerboseFlag, inCompressorPreset);
-      if (gVerboseFlag) { std::cout << "Set up INCOMING COMPRESSOR\n"; }
-      incomingEffects.push_back(inCompressorP);
-    }
-    if (inZitarev) {
-      assert(inZitarevP == nullptr);
-      inZitarevP = new Reverb(mNumIncomingChans,mNumIncomingChans, 1.0 + zitarevInLevel);
-      if (gVerboseFlag) { std::cout << "Set up INCOMING REVERB (Zitarev)\n"; }
-      incomingEffects.push_back(inZitarevP);
-    }
-    if (inFreeverb) {
-      assert(inFreeverbP == nullptr);
-      inFreeverbP = new Reverb(mNumIncomingChans, mNumIncomingChans, freeverbInLevel);
-      if (gVerboseFlag) { std::cout << "Set up INCOMING REVERB (Freeverb)\n"; }
-      incomingEffects.push_back(inFreeverbP);
-    }
-    // LIMITER MUST GO LAST:
-    if ( mLimit == LIMITER_INCOMING || mLimit == LIMITER_BOTH) {
-      if (gVerboseFlag) {
-        std::cout << "Set up INCOMING LIMITER for " << mNumIncomingChans << " input channels\n";
-      }
-      assert(inLimiterP == nullptr);
-      inLimiterP = new Limiter(mNumIncomingChans, 1, gVerboseFlag); // mNumClientsAssumed not needed this direction
-      // Never needed in normal practice for incoming limiter: inLimiterP->setWarningAmplitude(limiterWarningAmplitude);
-      incomingEffects.push_back(inLimiterP);
-    }
-    incomingEffectsAllocated = true;
-    return incomingEffects;
-  }
 
-  std::vector<ProcessPlugin*> allocateOutgoingEffects(int nOutgoingChans) {
-    mNumOutgoingChans = nOutgoingChans;
-    if (outgoingEffectsAllocated) {
-      std::cerr << "*** Effects.h: attempt to allocate outgoing effects more than once\n";
-      std::exit(1);
+    unsigned int getNumClientsAssumed() { return mNumClientsAssumed; }
+
+    LIMITER_MODE getLimit() { return mLimit; }
+    void setNoLimiters() { mLimit = LIMITER_NONE; }
+
+    ProcessPlugin* getInCompressor() { return inCompressorP; }
+    ProcessPlugin* getOutCompressor() { return outCompressorP; }
+    ProcessPlugin* getInZitarev() { return inZitarevP; }
+    ProcessPlugin* getOutZitarev() { return outZitarevP; }
+    ProcessPlugin* getInFreeverb() { return inFreeverbP; }
+    ProcessPlugin* getOutFreeverb() { return outFreeverbP; }
+    ProcessPlugin* getInLimiter() { return inLimiterP; }
+    ProcessPlugin* getOutLimiter() { return outLimiterP; }
+
+    bool getHaveEffect()
+    {
+        return inCompressor || outCompressor || inZitarev || outZitarev || inFreeverb
+               || outFreeverb;
     }
-    std::vector<ProcessPlugin*> outgoingEffects;
-    if (outCompressor) {
-      assert(outCompressorP == nullptr);
-      outCompressorP = new Compressor(mNumOutgoingChans, gVerboseFlag, outCompressorPreset);
-      if (gVerboseFlag) { std::cout << "Set up OUTGOING COMPRESSOR\n"; }
-      outgoingEffects.push_back(outCompressorP);
-    }
-    if (outZitarev) {
-      assert(outZitarevP == nullptr);
-      outZitarevP = new Reverb(mNumOutgoingChans, mNumOutgoingChans, 1.0 + zitarevOutLevel);
-      if (gVerboseFlag) { std::cout << "Set up OUTGOING REVERB (Zitarev)\n"; }
-      outgoingEffects.push_back(outZitarevP);
-    }
-    if (outFreeverb) {
-      assert(outFreeverbP == nullptr);
-      outFreeverbP = new Reverb(mNumOutgoingChans, mNumOutgoingChans, freeverbOutLevel);
-      if (gVerboseFlag) { std::cout << "Set up OUTGOING REVERB (Freeverb)\n"; }
-      outgoingEffects.push_back(outFreeverbP);
-    }
-    // LIMITER MUST GO LAST:
-    if ( mLimit != LIMITER_NONE) {
-      if ( mLimit == LIMITER_OUTGOING || mLimit == LIMITER_BOTH) {
-        if (gVerboseFlag) {
-          std::cout << "Set up OUTGOING LIMITER for "
-                    << mNumOutgoingChans << " output channels and "
-                    << mNumClientsAssumed << " assumed client(s) ...\n";
+
+    bool getHaveLimiter() { return mLimit != LIMITER_NONE; }
+
+    void setVerboseFlag(int v) { gVerboseFlag = v; }
+
+    int getNumIncomingChans() { return mNumIncomingChans; }
+
+    int getOutgoingNumChans() { return mNumOutgoingChans; }
+
+    // call these next two after it is decided what effects we will be using for the duration:
+
+    std::vector<ProcessPlugin*> allocateIncomingEffects(int nIncomingChans)
+    {
+        mNumIncomingChans = nIncomingChans;
+        if (incomingEffectsAllocated) {
+            std::cerr
+                << "*** Effects.h: attempt to allocate incoming effects more than once\n";
+            std::exit(1);
         }
-        assert(outLimiterP == nullptr);
-        outLimiterP = new Limiter(mNumOutgoingChans,mNumClientsAssumed);
-        outLimiterP->setWarningAmplitude(limiterWarningAmplitude);
-        // do not have mSampleRate yet, so cannot call limiter->init(mSampleRate) here
-        outgoingEffects.push_back(outLimiterP);
-      }
-    }
-    outgoingEffectsAllocated = true;
-    return outgoingEffects;
-  }
-
-  void printHelp(char* command, char helpCase) {
-    std::cout << "HELP for `" << command << "' (end-of-line comments start with `//')\n";
-    std::cout << "\n";
-    std::cout << "Examples:\n";
-    std::cout << "\n";
-    if (helpCase == 0 || helpCase == 'f') { //
-      std::cout << command << " 0.3 // add a default outgoing compressor (for voice) and incoming reverb (freeverb) with wetness 0.3 (wetness from 0 to 1)\n";
-      std::cout << command << " 1.3 // add a default outgoing compressor (for voice) and incoming reverb (zitarev) with wetness 0.3 = 1.3-1 (i.e., 1+ to 2 is for zitarev)\n";
-      std::cout << "\n";
-      std::cout << command << " \"o:c i:f(0.3)\" // outgoing-compressor and incoming-freeverb example above using more general string argument\n";
-      std::cout << command << " \"o:c i:z(0.3)\" // outgoing-compressor and incoming-zitarev example above using more general string argument\n";
-      std::cout << command << " \"o:c(1)\" // outgoing compressor, using preset 1 (designed for voice - see below for details)\n";
-      std::cout << command << " \"o:c(2)\" // outgoing compressor, using preset 2 (for horns)\n";
-      std::cout << command << " \"o:c(3)\" // outgoing compressor, using preset 3 (for snare)\n";
-      std::cout << command << " \"o:c(c:compressionRatio t:thresholdDB a:attackTimeMS r:releaseTimeMS g:makeUpGainDB)\" // general compression parameter specification (all floats)\n";
-      std::cout << command << " \"o:c(c:2 t:-24 a:15 r:40 g:2)\"   // outgoing compressor, preset 1 details\n";
-      std::cout << command << " \"o:c(c:3 t:-10 a:100 r:250 g:2)\" // outgoing compressor, preset 2 details\n";
-      std::cout << command << " \"o:c(c:5 t:-4 a:5 r:150 g:3)\"    // outgoing compressor, preset 3 details\n";
-      std::cout << "  For these and more suggested compression settings, see http://www.anythingpeaceful.org/sonar/settings/comp.html\n";
-      std::cout << "\n";
-    }
-    if (helpCase == 0 || helpCase == 'O') { // limiter (-O option most likely)
-      std::cout << command << " i   // add limiter to INCOMING audio from network (only helpful for floats, i.e., -b32 used by server)\n";
-      std::cout << command << " o   // add limiter to OUTGOING audio to network (prevents your sound from harshly clipping going out)\n";
-      std::cout << command << " ow  // also warn and advise on levels when outgoing limiter compresses audio near clipping\n";
-      std::cout << command << " io  // add limiter to both INCOMING and OUTGOING audio\n";
-      std::cout << command << " iow // limiters both ways and compression warnings on outgoing direction only\n";
-      std::cout << "\n";
-    }
-    if (helpCase == 0 || helpCase == 'a') { // assumedNumClients (-a option)
-      std::cout << command << " 1 // assume 1 client - fine for loopback test, or if only one client plays at a time, or server uses -b32 and -Oi is used\n";
-      std::cout << command << " 2 // assume 2 clients possibly playing at the same time\n";
-      std::cout << command << " N // any integer N>0 can be used - the outgoing limiter will divide final amplitude by 1/sqrt(N) to reduce overages in server\n";
-      std::cout << "\n";
-    }
-  }
-
-  // ----------- Compressor stuff --------------
-
-  int setCompressorPresetIndexFrom1(unsigned long presetIndexFrom1, InOrOut io) {
-    int returnCode = 0;
-    if (presetIndexFrom1 <= 0 || presetIndexFrom1 > CompressorPresets::numPresets) {
-      std::cerr << "*** Effects.h: setCompressorPresetFrom1: Index " << presetIndexFrom1 << " out of range\n";
-      returnCode = 1;
-    } else {
-      CompressorPreset stdPreset = CompressorPresets::standardPresets[presetIndexFrom1-1];
-      if (io == IO_IN) {
-        inCompressorPreset = stdPreset;
-      } else if (io == IO_OUT) {
-        outCompressorPreset = stdPreset;
-      } else if (io != IO_NEITHER) {
-        std::cerr << "*** Effects.h: setCompressorPresetFrom1: Invalid InOrOut value " << io << "\n";
-        returnCode = 1;
-      }
-    }
-    return returnCode;
-  }
-
-  int parseCompresserArgs(char* args, InOrOut inOrOut) {
-    // args can be integerPresetNumberFrom1 or (all optional, any order):
-    // c:compressionRatio, a:attackTimeMS, r:releaseTimeMS, g:makeUpGain
-    int returnCode = 0;
-    if (not isalpha(args[0])) {
-      int presetIndexFrom1 = atoi(args);
-      setCompressorPresetIndexFrom1(presetIndexFrom1,inOrOut);
-    } else {
-      // args can be presetIndexFrom1, handled above, or (all optional, any order):
-      // c(c:compressionRatio, t:thresholdDB, a:attackTimeMS, r:releaseTimeMS, g:makeUpGainDB)
-      // See ./CompressorPresets.h for example settings.
-      if (gVerboseFlag) {
-        std::cout << "parseCompressorArgs = " << args << std::endl;
-      }
-      ulong argLen = strlen(args);
-      char lastParam = '\0';
-
-      CompressorPreset newPreset(CompressorPresets::voice); // Anything unset gets voice value (most gentle)
-
-      int nSkip = 0;
-      for (ulong i=0; i<argLen; i++) {
-        if (nSkip > 0) {
-          nSkip--;
-          continue;
+        std::vector<ProcessPlugin*> incomingEffects;
+        if (inCompressor) {
+            assert(inCompressorP == nullptr);
+            inCompressorP =
+                new Compressor(mNumIncomingChans, gVerboseFlag, inCompressorPreset);
+            if (gVerboseFlag) { std::cout << "Set up INCOMING COMPRESSOR\n"; }
+            incomingEffects.push_back(inCompressorP);
         }
-        char ch = args[i];
-        switch(ch) {
-        case ' ': break;
-        case '\t': break;
-        case 'c': case 't': case 'a': case 'r': case 'g':
-          lastParam = ch;
-          break;
-        case ':': break;
-        default: // must be a floating-point number at this point:
-          if (ch!='-' && isalpha(ch)) {
-            std::cerr << "*** Effects.h: parseCompressorArgs: " << ch << " not recognized in args = " << args << "\n";
-            returnCode = 2;
-          } else { // must have a digit or '-' or '.'
-            assert(ch=='-'||ch=='.'||isdigit(ch));
-            float paramValue = -1.0e10;
-            for (ulong j=i; j<argLen; j++) { // scan ahead for end of number
-              if (args[j] == ',' || args[j] == ' ' || j==argLen-1) { // comma or space required between parameters
-                char argsj = args[j];
-                if (j<argLen-1) { // there's more
-                  args[j] = '\0';
+        if (inZitarev) {
+            assert(inZitarevP == nullptr);
+            inZitarevP =
+                new Reverb(mNumIncomingChans, mNumIncomingChans, 1.0 + zitarevInLevel);
+            if (gVerboseFlag) { std::cout << "Set up INCOMING REVERB (Zitarev)\n"; }
+            incomingEffects.push_back(inZitarevP);
+        }
+        if (inFreeverb) {
+            assert(inFreeverbP == nullptr);
+            inFreeverbP =
+                new Reverb(mNumIncomingChans, mNumIncomingChans, freeverbInLevel);
+            if (gVerboseFlag) { std::cout << "Set up INCOMING REVERB (Freeverb)\n"; }
+            incomingEffects.push_back(inFreeverbP);
+        }
+        // LIMITER MUST GO LAST:
+        if (mLimit == LIMITER_INCOMING || mLimit == LIMITER_BOTH) {
+            if (gVerboseFlag) {
+                std::cout << "Set up INCOMING LIMITER for " << mNumIncomingChans
+                          << " input channels\n";
+            }
+            assert(inLimiterP == nullptr);
+            inLimiterP = new Limiter(
+                mNumIncomingChans, 1,
+                gVerboseFlag);  // mNumClientsAssumed not needed this direction
+            // Never needed in normal practice for incoming limiter: inLimiterP->setWarningAmplitude(limiterWarningAmplitude);
+            incomingEffects.push_back(inLimiterP);
+        }
+        incomingEffectsAllocated = true;
+        return incomingEffects;
+    }
+
+    std::vector<ProcessPlugin*> allocateOutgoingEffects(int nOutgoingChans)
+    {
+        mNumOutgoingChans = nOutgoingChans;
+        if (outgoingEffectsAllocated) {
+            std::cerr
+                << "*** Effects.h: attempt to allocate outgoing effects more than once\n";
+            std::exit(1);
+        }
+        std::vector<ProcessPlugin*> outgoingEffects;
+        if (outCompressor) {
+            assert(outCompressorP == nullptr);
+            outCompressorP =
+                new Compressor(mNumOutgoingChans, gVerboseFlag, outCompressorPreset);
+            if (gVerboseFlag) { std::cout << "Set up OUTGOING COMPRESSOR\n"; }
+            outgoingEffects.push_back(outCompressorP);
+        }
+        if (outZitarev) {
+            assert(outZitarevP == nullptr);
+            outZitarevP =
+                new Reverb(mNumOutgoingChans, mNumOutgoingChans, 1.0 + zitarevOutLevel);
+            if (gVerboseFlag) { std::cout << "Set up OUTGOING REVERB (Zitarev)\n"; }
+            outgoingEffects.push_back(outZitarevP);
+        }
+        if (outFreeverb) {
+            assert(outFreeverbP == nullptr);
+            outFreeverbP =
+                new Reverb(mNumOutgoingChans, mNumOutgoingChans, freeverbOutLevel);
+            if (gVerboseFlag) { std::cout << "Set up OUTGOING REVERB (Freeverb)\n"; }
+            outgoingEffects.push_back(outFreeverbP);
+        }
+        // LIMITER MUST GO LAST:
+        if (mLimit != LIMITER_NONE) {
+            if (mLimit == LIMITER_OUTGOING || mLimit == LIMITER_BOTH) {
+                if (gVerboseFlag) {
+                    std::cout << "Set up OUTGOING LIMITER for " << mNumOutgoingChans
+                              << " output channels and " << mNumClientsAssumed
+                              << " assumed client(s) ...\n";
                 }
-                paramValue = atof(&args[i]);
-                args[j] = argsj;
-                nSkip = j-i;
-                break;
-              }
+                assert(outLimiterP == nullptr);
+                outLimiterP = new Limiter(mNumOutgoingChans, mNumClientsAssumed);
+                outLimiterP->setWarningAmplitude(limiterWarningAmplitude);
+                // do not have mSampleRate yet, so cannot call limiter->init(mSampleRate) here
+                outgoingEffects.push_back(outLimiterP);
             }
-            if (paramValue == -1.0e10) {
-              std::cerr << "*** Effects.h: parseCompressorArgs: Could not find parameter for "
-                        << lastParam << " in args = " << args << "\n";
-              returnCode = 2;
-            } else {
-              switch (lastParam) {
-              case 'c':
-                newPreset.ratio = paramValue;
-                break;
-              case 't':
-                  newPreset.thresholdDB = paramValue;
-                break;
-              case 'a':
-                  newPreset.attackMS = paramValue;
-                break;
-              case 'r':
-                  newPreset.releaseMS = paramValue;
-                break;
-              case 'g':
-                  newPreset.makeUpGainDB = paramValue;
-                break;
-              default: // cannot happen:
-                std::cerr << "*** Effects.h: parseCompressorArgs: lastParam " << lastParam << " invalid\n";
-                returnCode = 3; // "reality failure"
-              } // switch(lastParam)
-            } // have valid parameter from atof
-          } // have valid non-alpha char for parameter
-        } // switch(ch)
-      } // for (ulong i=0; i<argLen; i++) {
-      if (inOrOut == IO_IN) {
-        inCompressorPreset = newPreset;
-      } else if (inOrOut == IO_OUT) {
-        outCompressorPreset = newPreset;
-      } else if (inOrOut != IO_NEITHER) {
-        std::cerr << "*** Effects.h: parseCompressorArgs: invalid InOrOut value " << inOrOut << "\n";
-        returnCode = 2;
-      }
-    } // long-form compressor args
-    return returnCode;
-  } // int parseCompresserArgs(char* args, InOrOut inOrOut)
+        }
+        outgoingEffectsAllocated = true;
+        return outgoingEffects;
+    }
 
-  // ============== General argument processing for all effects =================
+    void printHelp(char* command, char helpCase)
+    {
+        std::cout << "HELP for `" << command
+                  << "' (end-of-line comments start with `//')\n";
+        std::cout << "\n";
+        std::cout << "Examples:\n";
+        std::cout << "\n";
+        if (helpCase == 0 || helpCase == 'f') {  //
+            std::cout
+                << command
+                << " 0.3 // add a default outgoing compressor (for voice) and incoming "
+                   "reverb (freeverb) with wetness 0.3 (wetness from 0 to 1)\n";
+            std::cout << command
+                      << " 1.3 // add a default outgoing compressor (for voice) and "
+                         "incoming reverb (zitarev) with wetness 0.3 = 1.3-1 (i.e., 1+ "
+                         "to 2 is for zitarev)\n";
+            std::cout << "\n";
+            std::cout << command
+                      << " \"o:c i:f(0.3)\" // outgoing-compressor and incoming-freeverb "
+                         "example above using more general string argument\n";
+            std::cout << command
+                      << " \"o:c i:z(0.3)\" // outgoing-compressor and incoming-zitarev "
+                         "example above using more general string argument\n";
+            std::cout << command
+                      << " \"o:c(1)\" // outgoing compressor, using preset 1 (designed "
+                         "for voice - see below for details)\n";
+            std::cout
+                << command
+                << " \"o:c(2)\" // outgoing compressor, using preset 2 (for horns)\n";
+            std::cout
+                << command
+                << " \"o:c(3)\" // outgoing compressor, using preset 3 (for snare)\n";
+            std::cout << command
+                      << " \"o:c(c:compressionRatio t:thresholdDB a:attackTimeMS "
+                         "r:releaseTimeMS g:makeUpGainDB)\" // general compression "
+                         "parameter specification (all floats)\n";
+            std::cout << command
+                      << " \"o:c(c:2 t:-24 a:15 r:40 g:2)\"   // outgoing compressor, "
+                         "preset 1 details\n";
+            std::cout << command
+                      << " \"o:c(c:3 t:-10 a:100 r:250 g:2)\" // outgoing compressor, "
+                         "preset 2 details\n";
+            std::cout << command
+                      << " \"o:c(c:5 t:-4 a:5 r:150 g:3)\"    // outgoing compressor, "
+                         "preset 3 details\n";
+            std::cout << "  For these and more suggested compression settings, see "
+                         "http://www.anythingpeaceful.org/sonar/settings/comp.html\n";
+            std::cout << "\n";
+        }
+        if (helpCase == 0 || helpCase == 'O') {  // limiter (-O option most likely)
+            std::cout << command
+                      << " i   // add limiter to INCOMING audio from network (only "
+                         "helpful for floats, i.e., -b32 used by server)\n";
+            std::cout << command
+                      << " o   // add limiter to OUTGOING audio to network (prevents "
+                         "your sound from harshly clipping going out)\n";
+            std::cout << command
+                      << " ow  // also warn and advise on levels when outgoing limiter "
+                         "compresses audio near clipping\n";
+            std::cout << command
+                      << " io  // add limiter to both INCOMING and OUTGOING audio\n";
+            std::cout << command
+                      << " iow // limiters both ways and compression warnings on "
+                         "outgoing direction only\n";
+            std::cout << "\n";
+        }
+        if (helpCase == 0 || helpCase == 'a') {  // assumedNumClients (-a option)
+            std::cout << command
+                      << " 1 // assume 1 client - fine for loopback test, or if only one "
+                         "client plays at a time, or server uses -b32 and -Oi is used\n";
+            std::cout << command
+                      << " 2 // assume 2 clients possibly playing at the same time\n";
+            std::cout
+                << command
+                << " N // any integer N>0 can be used - the outgoing limiter will divide "
+                   "final amplitude by 1/sqrt(N) to reduce overages in server\n";
+            std::cout << "\n";
+        }
+    }
 
-  int parseEffectsOptArg(char* cmd, char* optarg) {
-    int returnCode = 0; // 0 means go, 1 means exit without error, higher => error exit
+    // ----------- Compressor stuff --------------
 
-    char c = optarg[0];
-    if (c == '-' || c==0) {
-      // happens when no -f argument specified
-      returnCode = 2;
-    } else if (not isalpha(c)) { // backward compatibility why not?, e.g., "-f 0.5"
-      // -f reverbLevelFloat
-      mReverbLevel = atof(optarg);
-      outCompressor = true;
-      inZitarev = mReverbLevel > 1.0;
-      inFreeverb = mReverbLevel <= 1.0;
-      if (inZitarev) {
-        zitarevInLevel = mReverbLevel - 1.0; // wetness from 0 to 1
-      }
-      if (inFreeverb) {
-        freeverbInLevel = mReverbLevel; // wetness from 0 to 1
-      }
-    } else { // long-form argument:
-      // -f "i:[c][f|z][(reverbLevel)]], o:[c][f|z][(rl)]"
-      // c can be c(integerPresetNumberFrom1) or (all optional, any order):
-      // c(c:compressionRatio, a:attackTimeMS, r:releaseTimeMS, g:makeUpGain)
-      if (gVerboseFlag) {
-        std::cout << cmd << " argument = " << optarg << std::endl;
-      }
-      ulong argLen = strlen(optarg);
-
-      for (ulong i=0; i<argLen; i++) {
-        if (optarg[i]!=')' && parenLevel>0) { continue; }
-        switch(optarg[i]) {
-        case ' ': break;
-        case ',': break;
-        case ';': break;
-        case '\t': break;
-        case 'h': printHelp(cmd,'f'); returnCode = 1; break;
-        case 'i': io=IO_IN; break;
-        case 'o': io=IO_OUT; break;
-        case ':': break;
-        case 'c': if (io==IO_IN) { inCompressor = true; } else if (io==IO_OUT) { outCompressor = true; }
-          else { std::cerr << "-f arg `" << optarg << "' malformed\n"; exit(1); }
-          lastEffect = 'c';
-          break;
-        case 'f': if (io==IO_IN) { inFreeverb = true; } else if (io==IO_OUT) { outFreeverb = true; }
-          else { std::cerr << "-f arg `" << optarg << "' malformed\n"; exit(1); }
-          lastEffect = 'f';
-          break;
-        case 'z': if (io==IO_IN) { inZitarev = true; } else if (io==IO_OUT) { outZitarev = true; }
-          else { std::cerr << "-f arg `" << optarg << "' malformed\n"; exit(1); }
-          lastEffect = 'z';
-          break;
-        case '(': parenLevel++;
-          for (ulong j=i+1; j<argLen; j++) {
-            if (optarg[j] == ')') {
-              optarg[j] = '\0';
-              switch(lastEffect) {
-              case 'c': {
-                returnCode += parseCompresserArgs(&optarg[i+1],io);
-                break; }
-              case 'z': {
-              float farg = atof(&optarg[i+1]);
-              if (io==IO_IN) {
-                  zitarevInLevel = farg;
-              } else if (io==IO_OUT) {
-                  zitarevOutLevel = farg;
-                } // else ignore the argument
-                break; }
-              case 'f': {
-                float farg = atof(&optarg[i+1]);
-                if (io==IO_IN) {
-                  freeverbInLevel = farg;
-                } else if (io==IO_OUT) {
-                  freeverbOutLevel = farg;
-                } // else ignore the argument
-                break; }
-              default: { // ignore
-                break; }
-              }
-              optarg[j] = ')';
-              break;
+    int setCompressorPresetIndexFrom1(unsigned long presetIndexFrom1, InOrOut io)
+    {
+        int returnCode = 0;
+        if (presetIndexFrom1 <= 0 || presetIndexFrom1 > CompressorPresets::numPresets) {
+            std::cerr << "*** Effects.h: setCompressorPresetFrom1: Index "
+                      << presetIndexFrom1 << " out of range\n";
+            returnCode = 1;
+        } else {
+            CompressorPreset stdPreset =
+                CompressorPresets::standardPresets[presetIndexFrom1 - 1];
+            if (io == IO_IN) {
+                inCompressorPreset = stdPreset;
+            } else if (io == IO_OUT) {
+                outCompressorPreset = stdPreset;
+            } else if (io != IO_NEITHER) {
+                std::cerr
+                    << "*** Effects.h: setCompressorPresetFrom1: Invalid InOrOut value "
+                    << io << "\n";
+                returnCode = 1;
             }
-          }
-          break;
-        case ')': parenLevel--;
-          break;
-        default:
-          break; // ignore
-        } // switch(optarg[i])
-      }
+        }
+        return returnCode;
     }
-    return returnCode;
-  }
 
-  int parseLimiterOptArg(char* cmd, char* optarg) {
-    int returnCode = 0;
-    lastEffect = 'O'; // OverflowLimiter
-    char ch = tolower(optarg[0]);
-    if (ch == '-' || ch == 0) {
-      std::cerr << cmd << " argument i, o, or io is REQUIRED\n";
-      returnCode = 2;
-    } else if (ch == 'h') {
-      printHelp(cmd,'O');
-      returnCode = 1;
-    } else {
-      bool haveIncoming = false;
-      bool haveOutgoing = false;
-      bool haveWarnings = false;
-      for (int i=0; i<strlen(optarg); i++) {
-        ch = tolower(optarg[i]);
-        switch(ch) {
-        case ' ': break;
-        case '\t': break;
-        case 'i':
-          haveIncoming = true;
-          break;
-        case 'o':
-          haveOutgoing = true;
-          break;
-        case 'w':
-          haveWarnings = true;
-          break;
-        case 'n':
-          haveIncoming = false;
-          haveOutgoing = false;
-          break;
-        default:
-          std::cerr << "*** Effects.h: parseLimiterOptArg: Unrecognized option " << ch << "\n";
-          returnCode = 2;
-        } // switch(ch)
-      } // process optarg char ch
-      mLimit = (haveIncoming && haveOutgoing ? LIMITER_BOTH
-                : (haveIncoming ? LIMITER_INCOMING
-                   : (haveOutgoing ? LIMITER_OUTGOING : LIMITER_NONE)));
-      if (haveWarnings) {
-        limiterWarningAmplitude = 0.5; // KEEP IN SYNC WITH LIMITER THRESHOLD/CEILING 'softClipLevel' in ../faust-src/limiterdsp.dsp
-        // the warning amplitude and limiter compression threshold can of course be brought as a parameters, e.g. w(0.5)
-      }
-      if (gVerboseFlag) {
-        if(haveIncoming) {
-          std::cout << "Set up INCOMING Overflow Limiter\n";
-        }
-        if(haveOutgoing) {
-          std::cout << "Set up OUTGOING Overflow Limiter\n";
-        }
-        if(haveWarnings) {
-          std::cout << "Enable DISTORTION WARNINGS in Overflow Limiters\n";
-        }
-        if(not haveIncoming and not haveOutgoing) {
-          std::cout << "Set up NO Overflow Limiters\n";
-        }
-      } // gVerboseFlag
-    } // optarg cases
-    return returnCode;
-  } // parseLimiterOptArg()
+    int parseCompresserArgs(char* args, InOrOut inOrOut)
+    {
+        // args can be integerPresetNumberFrom1 or (all optional, any order):
+        // c:compressionRatio, a:attackTimeMS, r:releaseTimeMS, g:makeUpGain
+        int returnCode = 0;
+        if (not isalpha(args[0])) {
+            int presetIndexFrom1 = atoi(args);
+            setCompressorPresetIndexFrom1(presetIndexFrom1, inOrOut);
+        } else {
+            // args can be presetIndexFrom1, handled above, or (all optional, any order):
+            // c(c:compressionRatio, t:thresholdDB, a:attackTimeMS, r:releaseTimeMS, g:makeUpGainDB)
+            // See ./CompressorPresets.h for example settings.
+            if (gVerboseFlag) {
+                std::cout << "parseCompressorArgs = " << args << std::endl;
+            }
+            ulong argLen   = strlen(args);
+            char lastParam = '\0';
 
-  int parseAssumedNumClientsOptArg(char* cmd, char* optarg) {
-    int returnCode = 0;
-    lastEffect = 'a'; // assumedNumClients
-    char ch = optarg[0];
-    if (ch == 'h') {
-      printHelp(cmd,'a');
-      returnCode = 1;
-    } else if (ch == '-' || isalpha(ch) || ch == 0) {
-      std::cerr << cmd << " argument help or integer > 0 is REQUIRED\n";
-      returnCode = 2;
-    } else {
-    mNumClientsAssumed = atoi(optarg);
-    if(mNumClientsAssumed < 1) {
-      std::cerr << "-p ERROR: Must have at least one assumed sound source: "
-                << atoi(optarg) << " is not supported." << std::endl;
-        returnCode = 2;
-      }
+            CompressorPreset newPreset(
+                CompressorPresets::
+                    voice);  // Anything unset gets voice value (most gentle)
+
+            int nSkip = 0;
+            for (ulong i = 0; i < argLen; i++) {
+                if (nSkip > 0) {
+                    nSkip--;
+                    continue;
+                }
+                char ch = args[i];
+                switch (ch) {
+                case ' ':
+                    break;
+                case '\t':
+                    break;
+                case 'c':
+                case 't':
+                case 'a':
+                case 'r':
+                case 'g':
+                    lastParam = ch;
+                    break;
+                case ':':
+                    break;
+                default:  // must be a floating-point number at this point:
+                    if (ch != '-' && isalpha(ch)) {
+                        std::cerr << "*** Effects.h: parseCompressorArgs: " << ch
+                                  << " not recognized in args = " << args << "\n";
+                        returnCode = 2;
+                    } else {  // must have a digit or '-' or '.'
+                        assert(ch == '-' || ch == '.' || isdigit(ch));
+                        float paramValue = -1.0e10;
+                        for (ulong j = i; j < argLen;
+                             j++) {  // scan ahead for end of number
+                            if (args[j] == ',' || args[j] == ' '
+                                || j
+                                       == argLen
+                                              - 1) {  // comma or space required between parameters
+                                char argsj = args[j];
+                                if (j < argLen - 1) {  // there's more
+                                    args[j] = '\0';
+                                }
+                                paramValue = atof(&args[i]);
+                                args[j]    = argsj;
+                                nSkip      = j - i;
+                                break;
+                            }
+                        }
+                        if (paramValue == -1.0e10) {
+                            std::cerr << "*** Effects.h: parseCompressorArgs: Could not "
+                                         "find parameter for "
+                                      << lastParam << " in args = " << args << "\n";
+                            returnCode = 2;
+                        } else {
+                            switch (lastParam) {
+                            case 'c':
+                                newPreset.ratio = paramValue;
+                                break;
+                            case 't':
+                                newPreset.thresholdDB = paramValue;
+                                break;
+                            case 'a':
+                                newPreset.attackMS = paramValue;
+                                break;
+                            case 'r':
+                                newPreset.releaseMS = paramValue;
+                                break;
+                            case 'g':
+                                newPreset.makeUpGainDB = paramValue;
+                                break;
+                            default:  // cannot happen:
+                                std::cerr
+                                    << "*** Effects.h: parseCompressorArgs: lastParam "
+                                    << lastParam << " invalid\n";
+                                returnCode = 3;  // "reality failure"
+                            }                    // switch(lastParam)
+                        }                        // have valid parameter from atof
+                    }  // have valid non-alpha char for parameter
+                }      // switch(ch)
+            }          // for (ulong i=0; i<argLen; i++) {
+            if (inOrOut == IO_IN) {
+                inCompressorPreset = newPreset;
+            } else if (inOrOut == IO_OUT) {
+                outCompressorPreset = newPreset;
+            } else if (inOrOut != IO_NEITHER) {
+                std::cerr << "*** Effects.h: parseCompressorArgs: invalid InOrOut value "
+                          << inOrOut << "\n";
+                returnCode = 2;
+            }
+        }  // long-form compressor args
+        return returnCode;
+    }  // int parseCompresserArgs(char* args, InOrOut inOrOut)
+
+    // ============== General argument processing for all effects =================
+
+    int parseEffectsOptArg(char* cmd, char* optarg)
+    {
+        int returnCode =
+            0;  // 0 means go, 1 means exit without error, higher => error exit
+
+        char c = optarg[0];
+        if (c == '-' || c == 0) {
+            // happens when no -f argument specified
+            returnCode = 2;
+        } else if (not isalpha(c)) {  // backward compatibility why not?, e.g., "-f 0.5"
+            // -f reverbLevelFloat
+            mReverbLevel  = atof(optarg);
+            outCompressor = true;
+            inZitarev     = mReverbLevel > 1.0;
+            inFreeverb    = mReverbLevel <= 1.0;
+            if (inZitarev) {
+                zitarevInLevel = mReverbLevel - 1.0;  // wetness from 0 to 1
+            }
+            if (inFreeverb) {
+                freeverbInLevel = mReverbLevel;  // wetness from 0 to 1
+            }
+        } else {  // long-form argument:
+            // -f "i:[c][f|z][(reverbLevel)]], o:[c][f|z][(rl)]"
+            // c can be c(integerPresetNumberFrom1) or (all optional, any order):
+            // c(c:compressionRatio, a:attackTimeMS, r:releaseTimeMS, g:makeUpGain)
+            if (gVerboseFlag) {
+                std::cout << cmd << " argument = " << optarg << std::endl;
+            }
+            ulong argLen = strlen(optarg);
+
+            for (ulong i = 0; i < argLen; i++) {
+                if (optarg[i] != ')' && parenLevel > 0) { continue; }
+                switch (optarg[i]) {
+                case ' ':
+                    break;
+                case ',':
+                    break;
+                case ';':
+                    break;
+                case '\t':
+                    break;
+                case 'h':
+                    printHelp(cmd, 'f');
+                    returnCode = 1;
+                    break;
+                case 'i':
+                    io = IO_IN;
+                    break;
+                case 'o':
+                    io = IO_OUT;
+                    break;
+                case ':':
+                    break;
+                case 'c':
+                    if (io == IO_IN) {
+                        inCompressor = true;
+                    } else if (io == IO_OUT) {
+                        outCompressor = true;
+                    } else {
+                        std::cerr << "-f arg `" << optarg << "' malformed\n";
+                        exit(1);
+                    }
+                    lastEffect = 'c';
+                    break;
+                case 'f':
+                    if (io == IO_IN) {
+                        inFreeverb = true;
+                    } else if (io == IO_OUT) {
+                        outFreeverb = true;
+                    } else {
+                        std::cerr << "-f arg `" << optarg << "' malformed\n";
+                        exit(1);
+                    }
+                    lastEffect = 'f';
+                    break;
+                case 'z':
+                    if (io == IO_IN) {
+                        inZitarev = true;
+                    } else if (io == IO_OUT) {
+                        outZitarev = true;
+                    } else {
+                        std::cerr << "-f arg `" << optarg << "' malformed\n";
+                        exit(1);
+                    }
+                    lastEffect = 'z';
+                    break;
+                case '(':
+                    parenLevel++;
+                    for (ulong j = i + 1; j < argLen; j++) {
+                        if (optarg[j] == ')') {
+                            optarg[j] = '\0';
+                            switch (lastEffect) {
+                            case 'c': {
+                                returnCode += parseCompresserArgs(&optarg[i + 1], io);
+                                break;
+                            }
+                            case 'z': {
+                                float farg = atof(&optarg[i + 1]);
+                                if (io == IO_IN) {
+                                    zitarevInLevel = farg;
+                                } else if (io == IO_OUT) {
+                                    zitarevOutLevel = farg;
+                                }  // else ignore the argument
+                                break;
+                            }
+                            case 'f': {
+                                float farg = atof(&optarg[i + 1]);
+                                if (io == IO_IN) {
+                                    freeverbInLevel = farg;
+                                } else if (io == IO_OUT) {
+                                    freeverbOutLevel = farg;
+                                }  // else ignore the argument
+                                break;
+                            }
+                            default: {  // ignore
+                                break;
+                            }
+                            }
+                            optarg[j] = ')';
+                            break;
+                        }
+                    }
+                    break;
+                case ')':
+                    parenLevel--;
+                    break;
+                default:
+                    break;  // ignore
+                }           // switch(optarg[i])
+            }
+        }
+        return returnCode;
     }
-    return returnCode;
-  }
 
+    int parseLimiterOptArg(char* cmd, char* optarg)
+    {
+        int returnCode = 0;
+        lastEffect     = 'O';  // OverflowLimiter
+        char ch        = tolower(optarg[0]);
+        if (ch == '-' || ch == 0) {
+            std::cerr << cmd << " argument i, o, or io is REQUIRED\n";
+            returnCode = 2;
+        } else if (ch == 'h') {
+            printHelp(cmd, 'O');
+            returnCode = 1;
+        } else {
+            bool haveIncoming = false;
+            bool haveOutgoing = false;
+            bool haveWarnings = false;
+            for (int i = 0; i < strlen(optarg); i++) {
+                ch = tolower(optarg[i]);
+                switch (ch) {
+                case ' ':
+                    break;
+                case '\t':
+                    break;
+                case 'i':
+                    haveIncoming = true;
+                    break;
+                case 'o':
+                    haveOutgoing = true;
+                    break;
+                case 'w':
+                    haveWarnings = true;
+                    break;
+                case 'n':
+                    haveIncoming = false;
+                    haveOutgoing = false;
+                    break;
+                default:
+                    std::cerr << "*** Effects.h: parseLimiterOptArg: Unrecognized option "
+                              << ch << "\n";
+                    returnCode = 2;
+                }  // switch(ch)
+            }      // process optarg char ch
+            mLimit =
+                (haveIncoming && haveOutgoing
+                     ? LIMITER_BOTH
+                     : (haveIncoming ? LIMITER_INCOMING
+                                     : (haveOutgoing ? LIMITER_OUTGOING : LIMITER_NONE)));
+            if (haveWarnings) {
+                limiterWarningAmplitude =
+                    0.5;  // KEEP IN SYNC WITH LIMITER THRESHOLD/CEILING 'softClipLevel' in ../faust-src/limiterdsp.dsp
+                // the warning amplitude and limiter compression threshold can of course be brought as a parameters, e.g. w(0.5)
+            }
+            if (gVerboseFlag) {
+                if (haveIncoming) { std::cout << "Set up INCOMING Overflow Limiter\n"; }
+                if (haveOutgoing) { std::cout << "Set up OUTGOING Overflow Limiter\n"; }
+                if (haveWarnings) {
+                    std::cout << "Enable DISTORTION WARNINGS in Overflow Limiters\n";
+                }
+                if (not haveIncoming and not haveOutgoing) {
+                    std::cout << "Set up NO Overflow Limiters\n";
+                }
+            }  // gVerboseFlag
+        }      // optarg cases
+        return returnCode;
+    }  // parseLimiterOptArg()
+
+    int parseAssumedNumClientsOptArg(char* cmd, char* optarg)
+    {
+        int returnCode = 0;
+        lastEffect     = 'a';  // assumedNumClients
+        char ch        = optarg[0];
+        if (ch == 'h') {
+            printHelp(cmd, 'a');
+            returnCode = 1;
+        } else if (ch == '-' || isalpha(ch) || ch == 0) {
+            std::cerr << cmd << " argument help or integer > 0 is REQUIRED\n";
+            returnCode = 2;
+        } else {
+            mNumClientsAssumed = atoi(optarg);
+            if (mNumClientsAssumed < 1) {
+                std::cerr << "-p ERROR: Must have at least one assumed sound source: "
+                          << atoi(optarg) << " is not supported." << std::endl;
+                returnCode = 2;
+            }
+        }
+        return returnCode;
+    }
 };

--- a/src/JMess.h
+++ b/src/JMess.h
@@ -25,7 +25,6 @@
   OTHER DEALINGS IN THE SOFTWARE.
 */
 
-
 /*
  * JMess.h
  */
@@ -33,20 +32,20 @@
 #ifndef __JMESS_H
 #define __JMESS_H
 
-#include <iostream>
-#include <string>
 #include <errno.h>
 
 #include <QIODevice>
 #include <QString>
 #include <QVector>
+#include <iostream>
+#include <string>
 //#include <QtXml>
 //#include <QXmlSimpleReader>
 //#include <QXmlInputSource>
 //#include <QXmlContentHandler>
-#include <QMutexLocker>
-
 #include <jack/jack.h>
+
+#include <QMutexLocker>
 
 using namespace std;
 
@@ -61,33 +60,33 @@ const int Indent = 2;
  * Has also an option to disconnect all the clients.
  */
 //-------------------------------------------------------------------------------
-class JMess {
+class JMess
+{
+   public:
+    JMess();
+    virtual ~JMess();
 
-public:
-  JMess();
-  virtual ~JMess();
+    void disconnectAll();
+    void writeOutput(QString xmlOutFile);
+    void connectPorts(QString xmlInFile);
+    void setConnectedPorts();
+    /// \brief Cross connect ports between net combs, -l LAIR mode
+    void connectSpawnedPorts(int nChans, int hubPatch);
+    void connectTUB(int nChans);
 
-  void disconnectAll();
-  void writeOutput(QString xmlOutFile);
-  void connectPorts(QString xmlInFile);
-  void setConnectedPorts();
-  /// \brief Cross connect ports between net combs, -l LAIR mode
-  void connectSpawnedPorts(int nChans, int hubPatch);
-  void connectTUB(int nChans);
+   private:
+    int parseXML(QString xmlInFile);
 
-private:
-  int parseXML(QString xmlInFile);
+    jack_client_t* mClient;  //Class client
+    jack_status_t mStatus;   //Class client status
 
-  jack_client_t *mClient; //Class client
-  jack_status_t mStatus; //Class client status
-
-  //Vectors of Connected Ports and Ports to connects
-  //This are a matrix (Nx2) of string like this:
-  //OuputPort1 InputPort1
-  // ...
-  //OuputPortN InputPortN
-  QVector<QVector<QString> > mConnectedPorts;
-  QVector<QVector<QString> > mPortsToConnect;
-  static QMutex sJMessMutex; ///< Mutex to make thread safe jack functions that are not
+    //Vectors of Connected Ports and Ports to connects
+    //This are a matrix (Nx2) of string like this:
+    //OuputPort1 InputPort1
+    // ...
+    //OuputPortN InputPortN
+    QVector<QVector<QString> > mConnectedPorts;
+    QVector<QVector<QString> > mPortsToConnect;
+    static QMutex sJMessMutex;  ///< Mutex to make thread safe jack functions that are not
 };
 #endif

--- a/src/JackAudioInterface.h
+++ b/src/JackAudioInterface.h
@@ -35,26 +35,23 @@
  * \date June 2008
  */
 
-
 #ifndef __JACKAUDIOINTERFACE_H__
 #define __JACKAUDIOINTERFACE_H__
 
 #include <iostream>
 //#include <tr1/memory> //for shared_ptr
-#include <functional> //for mem_fun_ref
 #include <jack/jack.h>
 
-#include <QVector>
-#include <QVarLengthArray>
 #include <QMutex>
+#include <QVarLengthArray>
+#include <QVector>
+#include <functional>  //for mem_fun_ref
 
-
-#include "jacktrip_types.h"
-#include "ProcessPlugin.h"
 #include "AudioInterface.h"
+#include "ProcessPlugin.h"
+#include "jacktrip_types.h"
 
 //class JackTrip; //forward declaration
-
 
 /** \brief Class that provides an interface with the Jack Audio Server
  *
@@ -63,8 +60,7 @@
  */
 class JackAudioInterface : public AudioInterface
 {
-public:
-
+   public:
     /** \brief The class constructor
    * \param jacktrip Pointer to the JackTrip class that connects all classes (mediator)
    * \param NumInChans Number of Input Channels
@@ -72,13 +68,13 @@ public:
    * \param AudioBitResolution Audio Sample Resolutions in bits
    * \param ClientName Client name in Jack
    */
-    JackAudioInterface(JackTrip* jacktrip,
-                       int NumInChans, int NumOutChans,
-                   #ifdef WAIR // wair
-                       int NumNetRevChans,
-                   #endif // endwhere
-                       AudioInterface::audioBitResolutionT AudioBitResolution = AudioInterface::BIT16,
-                       QString ClientName = "JackTrip");
+    JackAudioInterface(
+        JackTrip* jacktrip, int NumInChans, int NumOutChans,
+#ifdef WAIR  // wair
+        int NumNetRevChans,
+#endif  // endwhere
+        AudioInterface::audioBitResolutionT AudioBitResolution = AudioInterface::BIT16,
+        QString ClientName                                     = "JackTrip");
     /// \brief The class destructor
     virtual ~JackAudioInterface();
 
@@ -98,13 +94,18 @@ public:
 
     //--------------SETTERS---------------------------------------------
     /// \brief Set Client Name to something different that the default (JackTrip)
-    virtual void setClientName(QString ClientName)
-    { mClientName = ClientName; }
+    virtual void setClientName(QString ClientName) { mClientName = ClientName; }
     virtual void setSampleRate(uint32_t /*sample_rate*/)
-    { std::cout << "WARNING: Setting the Sample Rate in Jack mode has no effect." << std::endl; }
+    {
+        std::cout << "WARNING: Setting the Sample Rate in Jack mode has no effect."
+                  << std::endl;
+    }
     virtual void setBufferSizeInSamples(uint32_t /*buf_size*/)
-    { std::cout << "WARNING: Setting the Sample Rate in Jack mode has no effect." << std::endl; }
-    virtual void enableBroadcastOutput() {mBroadcast = true;}
+    {
+        std::cout << "WARNING: Setting the Sample Rate in Jack mode has no effect."
+                  << std::endl;
+    }
+    virtual void enableBroadcastOutput() { mBroadcast = true; }
     //------------------------------------------------------------------
 
     //--------------GETTERS---------------------------------------------
@@ -114,13 +115,14 @@ public:
     virtual uint32_t getBufferSizeInSamples() const;
     /// \brief Get the Jack Server Buffer Size, in bytes
     virtual uint32_t getBufferSizeInBytes() const
-    { return (getBufferSizeInSamples() * getAudioBitResolution() / 8); }
+    {
+        return (getBufferSizeInSamples() * getAudioBitResolution() / 8);
+    }
     /// \brief Get size of each audio per channel, in bytes
     virtual size_t getSizeInBytesPerChannel() const;
     //------------------------------------------------------------------
 
-private:
-
+   private:
     /** \brief Private method to setup a client of the Jack server.
    * \exception std::runtime_error Can't start Jack
    *
@@ -163,31 +165,34 @@ private:
    *                              this)</tt>
    */
     // reference : http://article.gmane.org/gmane.comp.audio.jackit/12873
-    static int wrapperProcessCallback(jack_nframes_t nframes, void *arg) ;
+    static int wrapperProcessCallback(jack_nframes_t nframes, void* arg);
 
-    int mNumInChans;///< Number of Input Channels
-    int mNumOutChans; ///<  Number of Output Channels
-#ifdef WAIR // WAIR
-    int mNumNetRevChans; ///<  Number of Network Audio Channels (network comb filters
-#endif // endwhere
-    int mNumFrames; ///< Buffer block size, in samples
+    int mNumInChans;   ///< Number of Input Channels
+    int mNumOutChans;  ///<  Number of Output Channels
+#ifdef WAIR            // WAIR
+    int mNumNetRevChans;  ///<  Number of Network Audio Channels (network comb filters
+#endif                    // endwhere
+    int mNumFrames;  ///< Buffer block size, in samples
     //int mAudioBitResolution; ///< Bit resolution in audio samples
-    AudioInterface::audioBitResolutionT mBitResolutionMode; ///< Bit resolution (audioBitResolutionT) mode
+    AudioInterface::audioBitResolutionT
+        mBitResolutionMode;  ///< Bit resolution (audioBitResolutionT) mode
 
-    jack_client_t* mClient; ///< Jack Client
-    QString mClientName; ///< Jack Client Name
-    QVarLengthArray<jack_port_t*> mInPorts; ///< Vector of Input Ports (Channels)
-    QVarLengthArray<jack_port_t*> mOutPorts; ///< Vector of Output Ports (Channels)
-    QVarLengthArray<jack_port_t*> mBroadcastPorts; ///< Vector of Output Ports (Channels)
-    QVarLengthArray<sample_t*> mInBuffer; ///< Vector of Input buffers/channel read from JACK
-    QVarLengthArray<sample_t*> mOutBuffer; ///< Vector of Output buffer/channel to write to JACK
-    QVarLengthArray<sample_t*> mBroadcastBuffer; ///< Vector of Output buffer/channel to write to JACK
+    jack_client_t* mClient;                         ///< Jack Client
+    QString mClientName;                            ///< Jack Client Name
+    QVarLengthArray<jack_port_t*> mInPorts;         ///< Vector of Input Ports (Channels)
+    QVarLengthArray<jack_port_t*> mOutPorts;        ///< Vector of Output Ports (Channels)
+    QVarLengthArray<jack_port_t*> mBroadcastPorts;  ///< Vector of Output Ports (Channels)
+    QVarLengthArray<sample_t*>
+        mInBuffer;  ///< Vector of Input buffers/channel read from JACK
+    QVarLengthArray<sample_t*>
+        mOutBuffer;  ///< Vector of Output buffer/channel to write to JACK
+    QVarLengthArray<sample_t*>
+        mBroadcastBuffer;  ///< Vector of Output buffer/channel to write to JACK
     bool mBroadcast;
-    size_t mSizeInBytesPerChannel; ///< Size in bytes per audio channel
-    QVector<ProcessPlugin*> mProcessPlugins; ///< Vector of ProcesPlugin<EM>s</EM>
-    JackTrip* mJackTrip; ///< JackTrip mediator class
-    static QMutex sJackMutex; ///< Mutex to make thread safe jack functions that are not
+    size_t mSizeInBytesPerChannel;            ///< Size in bytes per audio channel
+    QVector<ProcessPlugin*> mProcessPlugins;  ///< Vector of ProcesPlugin<EM>s</EM>
+    JackTrip* mJackTrip;                      ///< JackTrip mediator class
+    static QMutex sJackMutex;  ///< Mutex to make thread safe jack functions that are not
 };
-
 
 #endif

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -396,7 +396,7 @@ void JackTrip::startProcess(
     int ID
 #endif  // endwhere
 )
-{   //signal that catches ctrl c in rtaudio-asio mode
+{  //signal that catches ctrl c in rtaudio-asio mode
     /*#if defined (__WIN_32__)
     if (signal(SIGINT, sigint_handler) == SIG_ERR) {
         perror("signal");

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -36,26 +36,27 @@
  */
 
 #include "JackTrip.h"
-#include "UdpDataProtocol.h"
-#include "RingBufferWavetable.h"
-#include "JitterBuffer.h"
-#include "jacktrip_globals.h"
+
 #include "JackAudioInterface.h"
+#include "JitterBuffer.h"
+#include "RingBufferWavetable.h"
+#include "UdpDataProtocol.h"
+#include "jacktrip_globals.h"
 #ifdef __RT_AUDIO__
 #include "RtAudioInterface.h"
 #endif
 
-#include <iostream>
-#include <cstdlib>
-#include <stdexcept>
-
+#include <QDateTime>
 #include <QHostAddress>
 #include <QHostInfo>
 #include <QThread>
 #include <QTimer>
-#include <QDateTime>
+#include <cstdlib>
+#include <iostream>
+#include <stdexcept>
 
-using std::cout; using std::endl;
+using std::cout;
+using std::endl;
 
 //the following function has to remain outside the Jacktrip class definition
 //its purpose is to close the app when control c is hit by the user in rtaudio/asio4all mode
@@ -66,78 +67,77 @@ void sigint_handler(int sig)
 }
 #endif*/
 
-bool JackTrip::sSigInt = false;
+bool JackTrip::sSigInt      = false;
 bool JackTrip::sJackStopped = false;
 
 //*******************************************************************************
-JackTrip::JackTrip(jacktripModeT JacktripMode,
-                   dataProtocolT DataProtocolType,
+JackTrip::JackTrip(jacktripModeT JacktripMode, dataProtocolT DataProtocolType,
                    int NumChans,
-                   #ifdef WAIR // WAIR
+#ifdef WAIR  // WAIR
                    int NumNetRevChans,
-                   #endif // endwhere
-                   int BufferQueueLength,
-                   unsigned int redundancy,
+#endif  // endwhere
+                   int BufferQueueLength, unsigned int redundancy,
                    AudioInterface::audioBitResolutionT AudioBitResolution,
                    DataProtocol::packetHeaderTypeT PacketHeaderType,
-                   underrunModeT UnderRunMode,
-                   int receiver_bind_port, int sender_bind_port,
-                   int receiver_peer_port, int sender_peer_port, int tcp_peer_port) :
-    mJackTripMode(JacktripMode),
-    mDataProtocol(DataProtocolType),
-    mPacketHeaderType(PacketHeaderType),
-    mAudiointerfaceMode(JackTrip::JACK),
-    mNumChans(NumChans),
-    #ifdef WAIR // WAIR
-    mNumNetRevChans(NumNetRevChans),
-    #endif // endwhere
-    mBufferQueueLength(BufferQueueLength),
-    mBufferStrategy(1),
-    mBroadcastQueueLength(0),
-    mSampleRate(gDefaultSampleRate),
-    mDeviceID(gDefaultDeviceID),
-    mAudioBufferSize(gDefaultBufferSizeInSamples),
-    mAudioBitResolution(AudioBitResolution),
-    mLoopBack(false),
-    mDataProtocolSender(NULL),
-    mDataProtocolReceiver(NULL),
-    mAudioInterface(NULL),
-    mPacketHeader(NULL),
-    mUnderRunMode(UnderRunMode),
-    mStopOnTimeout(false),
-    mSendRingBuffer(NULL),
-    mReceiveRingBuffer(NULL),
-    mReceiverBindPort(receiver_bind_port),
-    mSenderPeerPort(sender_peer_port),
-    mSenderBindPort(sender_bind_port),
-    mReceiverPeerPort(receiver_peer_port),
-    mTcpServerPort(tcp_peer_port),
-    mRedundancy(redundancy),
-    mJackClientName(gJackDefaultClientName),
-    mConnectionMode(JackTrip::NORMAL),
-    mTimeoutTimer(this),
-    mSleepTime(100),
-    mElapsedTime(0),
-    mEndTime(0),
-    mTcpClient(this),
-    mUdpSockTemp(this),
-    mReceivedConnection(false),
-    mTcpConnectionError(false),
-    mStopped(false),
-    mHasShutdown(false),
-    mConnectDefaultAudioPorts(true),
-    mIOStatTimeout(0),
-    mIOStatLogStream(std::cout.rdbuf()),
-    mSimulatedLossRate(0.0),
-    mSimulatedJitterRate(0.0),
-    mSimulatedDelayRel(0.0),
-    mUseRtUdpPriority(false),
-    mAudioTesterP(nullptr)
+                   underrunModeT UnderRunMode, int receiver_bind_port,
+                   int sender_bind_port, int receiver_peer_port, int sender_peer_port,
+                   int tcp_peer_port)
+    : mJackTripMode(JacktripMode)
+    , mDataProtocol(DataProtocolType)
+    , mPacketHeaderType(PacketHeaderType)
+    , mAudiointerfaceMode(JackTrip::JACK)
+    , mNumChans(NumChans)
+    ,
+#ifdef WAIR  // WAIR
+    mNumNetRevChans(NumNetRevChans)
+    ,
+#endif  // endwhere
+    mBufferQueueLength(BufferQueueLength)
+    , mBufferStrategy(1)
+    , mBroadcastQueueLength(0)
+    , mSampleRate(gDefaultSampleRate)
+    , mDeviceID(gDefaultDeviceID)
+    , mAudioBufferSize(gDefaultBufferSizeInSamples)
+    , mAudioBitResolution(AudioBitResolution)
+    , mLoopBack(false)
+    , mDataProtocolSender(NULL)
+    , mDataProtocolReceiver(NULL)
+    , mAudioInterface(NULL)
+    , mPacketHeader(NULL)
+    , mUnderRunMode(UnderRunMode)
+    , mStopOnTimeout(false)
+    , mSendRingBuffer(NULL)
+    , mReceiveRingBuffer(NULL)
+    , mReceiverBindPort(receiver_bind_port)
+    , mSenderPeerPort(sender_peer_port)
+    , mSenderBindPort(sender_bind_port)
+    , mReceiverPeerPort(receiver_peer_port)
+    , mTcpServerPort(tcp_peer_port)
+    , mRedundancy(redundancy)
+    , mJackClientName(gJackDefaultClientName)
+    , mConnectionMode(JackTrip::NORMAL)
+    , mTimeoutTimer(this)
+    , mSleepTime(100)
+    , mElapsedTime(0)
+    , mEndTime(0)
+    , mTcpClient(this)
+    , mUdpSockTemp(this)
+    , mReceivedConnection(false)
+    , mTcpConnectionError(false)
+    , mStopped(false)
+    , mHasShutdown(false)
+    , mConnectDefaultAudioPorts(true)
+    , mIOStatTimeout(0)
+    , mIOStatLogStream(std::cout.rdbuf())
+    , mSimulatedLossRate(0.0)
+    , mSimulatedJitterRate(0.0)
+    , mSimulatedDelayRel(0.0)
+    , mUseRtUdpPriority(false)
+    , mAudioTesterP(nullptr)
 {
     createHeader(mPacketHeaderType);
     sJackStopped = false;
 }
-
 
 //*******************************************************************************
 JackTrip::~JackTrip()
@@ -151,16 +151,16 @@ JackTrip::~JackTrip()
     delete mReceiveRingBuffer;
 }
 
-
 //*******************************************************************************
 void JackTrip::setupAudio(
-        #ifdef WAIRTOHUB // WAIR
-        __attribute__((unused)) int ID
-        #endif // endwhere
-        )
+#ifdef WAIRTOHUB  // WAIR
+    __attribute__((unused)) int ID
+#endif  // endwhere
+)
 {
     // Check if mAudioInterface has already been created or not
-    if (mAudioInterface != NULL)  { // if it has been created, disconnet it from JACK and delete it
+    if (mAudioInterface
+        != NULL) {  // if it has been created, disconnet it from JACK and delete it
         cout << "WARINING: JackAudio interface was setup already:" << endl;
         cout << "It will be erased and setup again." << endl;
         cout << gPrintSeparator << endl;
@@ -168,53 +168,64 @@ void JackTrip::setupAudio(
     }
 
     // Create AudioInterface Client Object
-    if ( mAudiointerfaceMode == JackTrip::JACK ) {
+    if (mAudiointerfaceMode == JackTrip::JACK) {
 #ifndef __NO_JACK__
-        if (gVerboseFlag) std::cout << "  JackTrip:setupAudio before new JackAudioInterface" << std::endl;
+        if (gVerboseFlag)
+            std::cout << "  JackTrip:setupAudio before new JackAudioInterface"
+                      << std::endl;
         mAudioInterface = new JackAudioInterface(this, mNumChans, mNumChans,
-                                         #ifdef WAIR // wair
+#ifdef WAIR  // wair
                                                  mNumNetRevChans,
-                                         #endif // endwhere
+#endif  // endwhere
                                                  mAudioBitResolution);
 
-#ifdef WAIRTOHUB // WAIR
-        QString VARIABLE_AUDIO_NAME = WAIR_AUDIO_NAME; // legacy for WAIR
+#ifdef WAIRTOHUB  // WAIR
+        QString VARIABLE_AUDIO_NAME = WAIR_AUDIO_NAME;  // legacy for WAIR
         //Set our Jack client name if we're a hub server or a custom name hasn't been set
-        if (!mPeerAddress.isEmpty() && (mJackClientName.constData() == gJackDefaultClientName.constData())) {
+        if (!mPeerAddress.isEmpty()
+            && (mJackClientName.constData() == gJackDefaultClientName.constData())) {
             mJackClientName = QString(mPeerAddress).replace(":", "_");
         }
         //std::cout  << "WAIR ID " << ID << " jacktrip client name set to=" <<
         //              mJackClientName.toStdString() << std::endl;
 
-#endif // endwhere
+#endif  // endwhere
         mAudioInterface->setClientName(mJackClientName);
-        if (0 < mBroadcastQueueLength) {
-            mAudioInterface->enableBroadcastOutput();
-        }
+        if (0 < mBroadcastQueueLength) { mAudioInterface->enableBroadcastOutput(); }
 
-        if (gVerboseFlag) std::cout << "  JackTrip:setupAudio before mAudioInterface->setup" << std::endl;
+        if (gVerboseFlag)
+            std::cout << "  JackTrip:setupAudio before mAudioInterface->setup"
+                      << std::endl;
         mAudioInterface->setup();
-        if (gVerboseFlag) std::cout << "  JackTrip:setupAudio before mAudioInterface->getSampleRate" << std::endl;
+        if (gVerboseFlag)
+            std::cout << "  JackTrip:setupAudio before mAudioInterface->getSampleRate"
+                      << std::endl;
         mSampleRate = mAudioInterface->getSampleRate();
-        if (gVerboseFlag) std::cout << "  JackTrip:setupAudio before mAudioInterface->getDeviceID" << std::endl;
+        if (gVerboseFlag)
+            std::cout << "  JackTrip:setupAudio before mAudioInterface->getDeviceID"
+                      << std::endl;
         mDeviceID = mAudioInterface->getDeviceID();
-        if (gVerboseFlag) std::cout << "  JackTrip:setupAudio before mAudioInterface->getBufferSizeInSamples" << std::endl;
+        if (gVerboseFlag)
+            std::cout
+                << "  JackTrip:setupAudio before mAudioInterface->getBufferSizeInSamples"
+                << std::endl;
         mAudioBufferSize = mAudioInterface->getBufferSizeInSamples();
-#endif //__NON_JACK__
-#ifdef __NO_JACK__ /// \todo FIX THIS REPETITION OF CODE
+#endif  //__NON_JACK__
+#ifdef __NO_JACK__  /// \todo FIX THIS REPETITION OF CODE
 #ifdef __RT_AUDIO__
         cout << "Warning: using non jack version, RtAudio will be used instead" << endl;
-        mAudioInterface = new RtAudioInterface(this, mNumChans, mNumChans, mAudioBitResolution);
+        mAudioInterface =
+            new RtAudioInterface(this, mNumChans, mNumChans, mAudioBitResolution);
         mAudioInterface->setSampleRate(mSampleRate);
         mAudioInterface->setDeviceID(mDeviceID);
         mAudioInterface->setBufferSizeInSamples(mAudioBufferSize);
         mAudioInterface->setup();
 #endif
 #endif
-    }
-    else if ( mAudiointerfaceMode == JackTrip::RTAUDIO ) {
+    } else if (mAudiointerfaceMode == JackTrip::RTAUDIO) {
 #ifdef __RT_AUDIO__
-        mAudioInterface = new RtAudioInterface(this, mNumChans, mNumChans, mAudioBitResolution);
+        mAudioInterface =
+            new RtAudioInterface(this, mNumChans, mNumChans, mAudioBitResolution);
         mAudioInterface->setSampleRate(mSampleRate);
         mAudioInterface->setDeviceID(mDeviceID);
         mAudioInterface->setBufferSizeInSamples(mAudioBufferSize);
@@ -223,17 +234,18 @@ void JackTrip::setupAudio(
     }
 
     mAudioInterface->setLoopBack(mLoopBack);
-    if (mAudioTesterP) { // if we're a hub server, this will be a nullptr - MAJOR REFACTOR NEEDED, in my opinion
-      mAudioTesterP->setSampleRate(mSampleRate);
+    if (mAudioTesterP) {  // if we're a hub server, this will be a nullptr - MAJOR REFACTOR NEEDED, in my opinion
+        mAudioTesterP->setSampleRate(mSampleRate);
     }
     mAudioInterface->setAudioTesterP(mAudioTesterP);
 
     std::cout << "The Sampling Rate is: " << mSampleRate << std::endl;
     std::cout << gPrintSeparator << std::endl;
-    int AudioBufferSizeInBytes = mAudioBufferSize*sizeof(sample_t);
-    std::cout << "The Audio Buffer Size is: " << mAudioBufferSize << " samples" << std::endl;
-    std::cout << "                      or: " << AudioBufferSizeInBytes
-              << " bytes" << std::endl;
+    int AudioBufferSizeInBytes = mAudioBufferSize * sizeof(sample_t);
+    std::cout << "The Audio Buffer Size is: " << mAudioBufferSize << " samples"
+              << std::endl;
+    std::cout << "                      or: " << AudioBufferSizeInBytes << " bytes"
+              << std::endl;
     if (0 < mBroadcastQueueLength) {
         std::cout << gPrintSeparator << std::endl;
         cout << "Broadcast Output is enabled, delay = "
@@ -241,42 +253,44 @@ void JackTrip::setupAudio(
              << " (" << mBroadcastQueueLength * mAudioBufferSize << " samples)" << endl;
     }
     std::cout << gPrintSeparator << std::endl;
-    cout << "The Number of Channels is: " << mAudioInterface->getNumInputChannels() << endl;
+    cout << "The Number of Channels is: " << mAudioInterface->getNumInputChannels()
+         << endl;
     std::cout << gPrintSeparator << std::endl;
     QThread::usleep(100);
 }
-
 
 //*******************************************************************************
 void JackTrip::closeAudio()
 {
     //mAudioInterface->close();
-    if ( mAudioInterface != NULL ) {
+    if (mAudioInterface != NULL) {
         mAudioInterface->stopProcess();
         delete mAudioInterface;
         mAudioInterface = NULL;
     }
 }
 
-
 //*******************************************************************************
 void JackTrip::setupDataProtocol()
 {
-    double simulated_max_delay = mSimulatedDelayRel * getBufferSizeInSamples() / getSampleRate();
+    double simulated_max_delay =
+        mSimulatedDelayRel * getBufferSizeInSamples() / getSampleRate();
     // Create DataProtocol Objects
     switch (mDataProtocol) {
     case UDP:
         std::cout << "Using UDP Protocol" << std::endl;
         QThread::usleep(100);
-        mDataProtocolSender = new UdpDataProtocol(this, DataProtocol::SENDER,
-                                                  //mSenderPeerPort, mSenderBindPort,
-                                                  mSenderBindPort, mSenderPeerPort,
-                                                  mRedundancy);
-        mDataProtocolReceiver =  new UdpDataProtocol(this, DataProtocol::RECEIVER,
-                                                     mReceiverBindPort, mReceiverPeerPort,
-                                                     mRedundancy);
-        if (0.0 < mSimulatedLossRate || 0.0 < mSimulatedJitterRate || 0.0 < simulated_max_delay) {
-            mDataProtocolReceiver->setIssueSimulation(mSimulatedLossRate, mSimulatedJitterRate, simulated_max_delay);
+        mDataProtocolSender =
+            new UdpDataProtocol(this, DataProtocol::SENDER,
+                                //mSenderPeerPort, mSenderBindPort,
+                                mSenderBindPort, mSenderPeerPort, mRedundancy);
+        mDataProtocolReceiver =
+            new UdpDataProtocol(this, DataProtocol::RECEIVER, mReceiverBindPort,
+                                mReceiverPeerPort, mRedundancy);
+        if (0.0 < mSimulatedLossRate || 0.0 < mSimulatedJitterRate
+            || 0.0 < simulated_max_delay) {
+            mDataProtocolReceiver->setIssueSimulation(
+                mSimulatedLossRate, mSimulatedJitterRate, simulated_max_delay);
         }
         mDataProtocolSender->setUseRtPriority(mUseRtUdpPriority);
         mDataProtocolReceiver->setUseRtPriority(mUseRtUdpPriority);
@@ -305,7 +319,6 @@ void JackTrip::setupDataProtocol()
     mDataProtocolReceiver->setAudioPacketSize(getTotalAudioPacketSizeInBytes());
 }
 
-
 //*******************************************************************************
 void JackTrip::setupRingBuffers()
 {
@@ -313,19 +326,16 @@ void JackTrip::setupRingBuffers()
     /// \todo Make all this operations cleaner
     //int total_audio_packet_size = getTotalAudioPacketSizeInBytes();
     int slot_size = getRingBuffersSlotSize();
-    if (0 <=  mBufferStrategy) {
+    if (0 <= mBufferStrategy) {
         mUnderRunMode = ZEROS;
-    }
-    else if (0 > mBufferQueueLength) {
-      throw std::invalid_argument("Auto queue is not supported by RingBuffer");
+    } else if (0 > mBufferQueueLength) {
+        throw std::invalid_argument("Auto queue is not supported by RingBuffer");
     }
 
     switch (mUnderRunMode) {
     case WAVETABLE:
-        mSendRingBuffer = new RingBufferWavetable(slot_size,
-                                                  gDefaultOutputQueueLength);
-        mReceiveRingBuffer = new RingBufferWavetable(slot_size,
-                                                     mBufferQueueLength);
+        mSendRingBuffer = new RingBufferWavetable(slot_size, gDefaultOutputQueueLength);
+        mReceiveRingBuffer = new RingBufferWavetable(slot_size, mBufferQueueLength);
         /*
     mSendRingBuffer = new RingBufferWavetable(mAudioInterface->getSizeInBytesPerChannel() * mNumChans,
                 gDefaultOutputQueueLength);
@@ -334,20 +344,17 @@ void JackTrip::setupRingBuffers()
              */
         break;
     case ZEROS:
-        mSendRingBuffer = new RingBuffer(slot_size,
-                                         gDefaultOutputQueueLength);
+        mSendRingBuffer = new RingBuffer(slot_size, gDefaultOutputQueueLength);
         if (0 > mBufferStrategy) {
-            mReceiveRingBuffer = new RingBuffer(slot_size,
-                                                mBufferQueueLength);
-        }
-        else {
+            mReceiveRingBuffer = new RingBuffer(slot_size, mBufferQueueLength);
+        } else {
             cout << "Using JitterBuffer strategy " << mBufferStrategy << endl;
             if (0 > mBufferQueueLength) {
                 cout << "Using AutoQueue 1/" << -mBufferQueueLength << endl;
             }
-            mReceiveRingBuffer = new JitterBuffer(mAudioBufferSize, mBufferQueueLength,
-                                        mSampleRate, mBufferStrategy,
-                                        mBroadcastQueueLength, mNumChans, mAudioBitResolution);
+            mReceiveRingBuffer = new JitterBuffer(
+                mAudioBufferSize, mBufferQueueLength, mSampleRate, mBufferStrategy,
+                mBroadcastQueueLength, mNumChans, mAudioBitResolution);
         }
         /*
     mSendRingBuffer = new RingBuffer(mAudioInterface->getSizeInBytesPerChannel() * mNumChans,
@@ -362,41 +369,35 @@ void JackTrip::setupRingBuffers()
     }
 }
 
-
 //*******************************************************************************
-void JackTrip::setPeerAddress(QString PeerHostOrIP)
-{
-    mPeerAddress = PeerHostOrIP;
-}
-
+void JackTrip::setPeerAddress(QString PeerHostOrIP) { mPeerAddress = PeerHostOrIP; }
 
 //*******************************************************************************
 void JackTrip::appendProcessPluginToNetwork(ProcessPlugin* plugin)
 {
-  if (plugin) {
-    mProcessPluginsToNetwork.append(plugin); // ownership transferred
-    //mAudioInterface->appendProcessPluginToNetwork(plugin);
-  }
+    if (plugin) {
+        mProcessPluginsToNetwork.append(plugin);  // ownership transferred
+        //mAudioInterface->appendProcessPluginToNetwork(plugin);
+    }
 }
 
 //*******************************************************************************
 void JackTrip::appendProcessPluginFromNetwork(ProcessPlugin* plugin)
 {
-  if (plugin) {
-    mProcessPluginsFromNetwork.append(plugin); // ownership transferred
-    //mAudioInterface->appendProcessPluginFromNetwork(plugin);
-  }
+    if (plugin) {
+        mProcessPluginsFromNetwork.append(plugin);  // ownership transferred
+        //mAudioInterface->appendProcessPluginFromNetwork(plugin);
+    }
 }
-
 
 //*******************************************************************************
 void JackTrip::startProcess(
-        #ifdef WAIRTOHUB // WAIR
-        int ID
-        #endif // endwhere
-        )
-{ //signal that catches ctrl c in rtaudio-asio mode
-/*#if defined (__WIN_32__)
+#ifdef WAIRTOHUB  // WAIR
+    int ID
+#endif  // endwhere
+)
+{   //signal that catches ctrl c in rtaudio-asio mode
+    /*#if defined (__WIN_32__)
     if (signal(SIGINT, sigint_handler) == SIG_ERR) {
         perror("signal");
         exit(1);
@@ -406,73 +407,90 @@ void JackTrip::startProcess(
     // ------------------------------------------------------------------
     if (gVerboseFlag) std::cout << "step 1" << std::endl;
 
-    if (gVerboseFlag) std::cout << "  JackTrip:startProcess before checkIfPortIsBinded(mReceiverBindPort)" << std::endl;
+    if (gVerboseFlag)
+        std::cout
+            << "  JackTrip:startProcess before checkIfPortIsBinded(mReceiverBindPort)"
+            << std::endl;
 #if defined __WIN_32__
-    //cc fixed windows crash with this print statement!
-    //qDebug() << "before mJackTrip->startProcess" << mReceiverBindPort<< mSenderBindPort;
+        //cc fixed windows crash with this print statement!
+        //qDebug() << "before mJackTrip->startProcess" << mReceiverBindPort<< mSenderBindPort;
 #endif
     checkIfPortIsBinded(mReceiverBindPort);
-    if (gVerboseFlag) std::cout << "  JackTrip:startProcess before checkIfPortIsBinded(mSenderBindPort)" << std::endl;
+    if (gVerboseFlag)
+        std::cout << "  JackTrip:startProcess before checkIfPortIsBinded(mSenderBindPort)"
+                  << std::endl;
     checkIfPortIsBinded(mSenderBindPort);
     // Set all classes and parameters
     // ------------------------------
-    if (gVerboseFlag) std::cout << "  JackTrip:startProcess before setupAudio" << std::endl;
+    if (gVerboseFlag)
+        std::cout << "  JackTrip:startProcess before setupAudio" << std::endl;
     setupAudio(
-            #ifdef WAIRTOHUB // wair
-                ID
-            #endif // endwhere
-                );
+#ifdef WAIRTOHUB  // wair
+        ID
+#endif  // endwhere
+    );
     //cc redundant with instance creator  createHeader(mPacketHeaderType); next line fixme
     createHeader(mPacketHeaderType);
     setupDataProtocol();
     setupRingBuffers();
     // Connect Signals and Slots
     // -------------------------
-    QObject::connect(mPacketHeader, &PacketHeader::signalError,
-                     this, &JackTrip::slotStopProcessesDueToError, Qt::QueuedConnection);
+    QObject::connect(mPacketHeader, &PacketHeader::signalError, this,
+                     &JackTrip::slotStopProcessesDueToError, Qt::QueuedConnection);
     QObject::connect(mDataProtocolReceiver, SIGNAL(signalReceivedConnectionFromPeer()),
-                     this, SLOT(slotReceivedConnectionFromPeer()),
-                     Qt::QueuedConnection);
+                     this, SLOT(slotReceivedConnectionFromPeer()), Qt::QueuedConnection);
     //QObject::connect(this, SIGNAL(signalUdpTimeOut()),
     //                 this, SLOT(slotStopProcesses()), Qt::QueuedConnection);
-    QObject::connect((UdpDataProtocol *)mDataProtocolReceiver, &UdpDataProtocol::signalUdpWaitingTooLong, this,
+    QObject::connect((UdpDataProtocol*)mDataProtocolReceiver,
+                     &UdpDataProtocol::signalUdpWaitingTooLong, this,
                      &JackTrip::slotUdpWaitingTooLong, Qt::QueuedConnection);
-    QObject::connect(mDataProtocolSender, &DataProtocol::signalCeaseTransmission,
-                     this, &JackTrip::slotStopProcessesDueToError, Qt::QueuedConnection);
-    QObject::connect(mDataProtocolReceiver, &DataProtocol::signalCeaseTransmission,
-                     this, &JackTrip::slotStopProcessesDueToError, Qt::QueuedConnection);
+    QObject::connect(mDataProtocolSender, &DataProtocol::signalCeaseTransmission, this,
+                     &JackTrip::slotStopProcessesDueToError, Qt::QueuedConnection);
+    QObject::connect(mDataProtocolReceiver, &DataProtocol::signalCeaseTransmission, this,
+                     &JackTrip::slotStopProcessesDueToError, Qt::QueuedConnection);
 
     //QObject::connect(mDataProtocolSender, SIGNAL(signalError(const char*)),
     //                 this, SLOT(slotStopProcesses()), Qt::QueuedConnection);
-    QObject::connect(mDataProtocolReceiver, SIGNAL(signalError(const char*)),
-                     this, SLOT(slotStopProcesses()), Qt::QueuedConnection);
+    QObject::connect(mDataProtocolReceiver, SIGNAL(signalError(const char*)), this,
+                     SLOT(slotStopProcesses()), Qt::QueuedConnection);
 
     // Start the threads for the specific mode
     // ---------------------------------------
-    switch ( mJackTripMode )
-    {
-    case CLIENT :
+    switch (mJackTripMode) {
+    case CLIENT:
         if (gVerboseFlag) std::cout << "step 2c client only" << std::endl;
-        if (gVerboseFlag) std::cout << "  JackTrip:startProcess case CLIENT before clientStart" << std::endl;
+        if (gVerboseFlag)
+            std::cout << "  JackTrip:startProcess case CLIENT before clientStart"
+                      << std::endl;
         clientStart();
         break;
-    case SERVER :
+    case SERVER:
         if (gVerboseFlag) std::cout << "step 2s server only" << std::endl;
-        if (gVerboseFlag) std::cout << "  JackTrip:startProcess case SERVER before serverStart" << std::endl;
+        if (gVerboseFlag)
+            std::cout << "  JackTrip:startProcess case SERVER before serverStart"
+                      << std::endl;
         serverStart();
         break;
-    case CLIENTTOPINGSERVER :
+    case CLIENTTOPINGSERVER:
         if (gVerboseFlag) std::cout << "step 2C client only" << std::endl;
-        if (gVerboseFlag) std::cout << "  JackTrip:startProcess case CLIENTTOPINGSERVER before clientPingToServerStart" << std::endl;
-        if ( clientPingToServerStart() == -1 ) { // if error on server start (-1) we return inmediatly
+        if (gVerboseFlag)
+            std::cout << "  JackTrip:startProcess case CLIENTTOPINGSERVER before "
+                         "clientPingToServerStart"
+                      << std::endl;
+        if (clientPingToServerStart()
+            == -1) {  // if error on server start (-1) we return inmediatly
             stop("Peer Address has to be set if you run in CLIENTTOPINGSERVER mode");
             return;
         }
         break;
-    case SERVERPINGSERVER :
+    case SERVERPINGSERVER:
         if (gVerboseFlag) std::cout << "step 2S server only (same as 2s)" << std::endl;
-        if (gVerboseFlag) std::cout << "  JackTrip:startProcess case SERVERPINGSERVER before serverStart" << std::endl;
-        if ( serverStart(true) == -1 ) { // if error on server start (-1) we return inmediatly
+        if (gVerboseFlag)
+            std::cout
+                << "  JackTrip:startProcess case SERVERPINGSERVER before serverStart"
+                << std::endl;
+        if (serverStart(true)
+            == -1) {  // if error on server start (-1) we return inmediatly
             stop();
             return;
         }
@@ -486,7 +504,7 @@ void JackTrip::startProcess(
 void JackTrip::completeConnection()
 {
     // Have the threads share a single socket that operates at full duplex.
-#if defined (__WIN_32__)
+#if defined(__WIN_32__)
     SOCKET sock_fd = INVALID_SOCKET;
 #else
     int sock_fd = -1;
@@ -495,10 +513,14 @@ void JackTrip::completeConnection()
     mDataProtocolSender->setSocket(sock_fd);
 
     // Start Threads
-    if (gVerboseFlag) std::cout << "  JackTrip:startProcess before mDataProtocolReceiver->start" << std::endl;
+    if (gVerboseFlag)
+        std::cout << "  JackTrip:startProcess before mDataProtocolReceiver->start"
+                  << std::endl;
     mDataProtocolReceiver->start();
     QThread::msleep(1);
-    if (gVerboseFlag) std::cout << "  JackTrip:startProcess before mDataProtocolSender->start" << std::endl;
+    if (gVerboseFlag)
+        std::cout << "  JackTrip:startProcess before mDataProtocolSender->start"
+                  << std::endl;
     mDataProtocolSender->start();
     /*
      * changed order so that audio starts after receiver and sender
@@ -509,27 +531,29 @@ void JackTrip::completeConnection()
      */
     QThread::msleep(1);
     if (gVerboseFlag) std::cout << "step 5" << std::endl;
-    if (gVerboseFlag) std::cout << "  JackTrip:startProcess before mAudioInterface->startProcess" << std::endl;
+    if (gVerboseFlag)
+        std::cout << "  JackTrip:startProcess before mAudioInterface->startProcess"
+                  << std::endl;
     for (int i = 0; i < mProcessPluginsFromNetwork.size(); ++i) {
         mAudioInterface->appendProcessPluginFromNetwork(mProcessPluginsFromNetwork[i]);
     }
     for (int i = 0; i < mProcessPluginsToNetwork.size(); ++i) {
         mAudioInterface->appendProcessPluginToNetwork(mProcessPluginsToNetwork[i]);
     }
-    mAudioInterface->initPlugins();  // mSampleRate known now, which plugins require
-    mAudioInterface->startProcess(); // Tell JACK server we are ready for audio flow now
+    mAudioInterface->initPlugins();   // mSampleRate known now, which plugins require
+    mAudioInterface->startProcess();  // Tell JACK server we are ready for audio flow now
 
-    if (mConnectDefaultAudioPorts) {  mAudioInterface->connectDefaultPorts(); }
-    
+    if (mConnectDefaultAudioPorts) { mAudioInterface->connectDefaultPorts(); }
+
     //Start our IO stat timer
     if (mIOStatTimeout > 0) {
         cout << "STATS" << mIOStatTimeout << endl;
         if (!mIOStatStream.isNull()) {
-            mIOStatLogStream.rdbuf(((std::ostream *)mIOStatStream.data())->rdbuf());
+            mIOStatLogStream.rdbuf(((std::ostream*)mIOStatStream.data())->rdbuf());
         }
-        QTimer *timer = new QTimer(this);
+        QTimer* timer = new QTimer(this);
         connect(timer, SIGNAL(timeout()), this, SLOT(onStatTimer()));
-        timer->start(mIOStatTimeout*1000);
+        timer->start(mIOStatTimeout * 1000);
     }
 }
 
@@ -537,52 +561,33 @@ void JackTrip::completeConnection()
 void JackTrip::onStatTimer()
 {
     DataProtocol::PktStat pkt_stat;
-    if (!mDataProtocolReceiver->getStats(&pkt_stat)) {
-        return;
-    }
+    if (!mDataProtocolReceiver->getStats(&pkt_stat)) { return; }
     bool reset = (0 == pkt_stat.statCount);
     RingBuffer::IOStat recv_io_stat;
-    if (!mReceiveRingBuffer->getStats(&recv_io_stat, reset)) {
-        return;
-    }
+    if (!mReceiveRingBuffer->getStats(&recv_io_stat, reset)) { return; }
     RingBuffer::IOStat send_io_stat;
-    if (!mSendRingBuffer->getStats(&send_io_stat, reset)) {
-        return;
-    }
+    if (!mSendRingBuffer->getStats(&send_io_stat, reset)) { return; }
     QString now = QDateTime::currentDateTime().toString(Qt::ISODate);
 
     static QMutex mutex;
     QMutexLocker locker(&mutex);
-    if (mAudioTesterP && mAudioTesterP->getEnabled()) {
-      mIOStatLogStream << "\n";
-    }
-    mIOStatLogStream << now.toLocal8Bit().constData()
-      << " " << getPeerAddress().toLocal8Bit().constData()
-      << " send: "
-      << send_io_stat.underruns
-      << "/" << send_io_stat.overflows
-      << " recv: "
-      << recv_io_stat.underruns
-      << "/" << recv_io_stat.overflows
-      << " prot: "
-      << pkt_stat.lost
-      << "/" << pkt_stat.outOfOrder
-      << "/" << pkt_stat.revived
-      << " tot: "
-      << pkt_stat.tot
-      << " sync: "
-      << recv_io_stat.level
-      << "/" << recv_io_stat.buf_inc_underrun
-      << "/" << recv_io_stat.buf_inc_compensate
-      << "/" << recv_io_stat.buf_dec_overflows
-      << "/" << recv_io_stat.buf_dec_pktloss
-      << " skew: " << recv_io_stat.skew
-      << "/" << recv_io_stat.skew_raw
-      << " bcast: " << recv_io_stat.broadcast_skew
-      << "/" << recv_io_stat.broadcast_delta
-      << " autoq: " << 0.1*recv_io_stat.autoq_corr
-      << "/" << 0.1*recv_io_stat.autoq_rate
-      << endl;
+    if (mAudioTesterP && mAudioTesterP->getEnabled()) { mIOStatLogStream << "\n"; }
+    mIOStatLogStream << now.toLocal8Bit().constData() << " "
+                     << getPeerAddress().toLocal8Bit().constData()
+                     << " send: " << send_io_stat.underruns << "/"
+                     << send_io_stat.overflows << " recv: " << recv_io_stat.underruns
+                     << "/" << recv_io_stat.overflows << " prot: " << pkt_stat.lost << "/"
+                     << pkt_stat.outOfOrder << "/" << pkt_stat.revived
+                     << " tot: " << pkt_stat.tot << " sync: " << recv_io_stat.level << "/"
+                     << recv_io_stat.buf_inc_underrun << "/"
+                     << recv_io_stat.buf_inc_compensate << "/"
+                     << recv_io_stat.buf_dec_overflows << "/"
+                     << recv_io_stat.buf_dec_pktloss << " skew: " << recv_io_stat.skew
+                     << "/" << recv_io_stat.skew_raw
+                     << " bcast: " << recv_io_stat.broadcast_skew << "/"
+                     << recv_io_stat.broadcast_delta
+                     << " autoq: " << 0.1 * recv_io_stat.autoq_corr << "/"
+                     << 0.1 * recv_io_stat.autoq_rate << endl;
 }
 
 void JackTrip::receivedConnectionTCP()
@@ -624,10 +629,8 @@ void JackTrip::receivedConnectionTCP()
 
 void JackTrip::receivedDataTCP()
 {
-    if (mTcpClient.bytesAvailable() < (int)sizeof(uint16_t)) {
-        return;
-    }
-    
+    if (mTcpClient.bytesAvailable() < (int)sizeof(uint16_t)) { return; }
+
     // Read the size of the package
     // ----------------------------
     if (gVerboseFlag) cout << "Reading UDP port from Server..." << endl;
@@ -645,18 +648,19 @@ void JackTrip::receivedDataTCP()
 
     // Close the TCP Socket
     // --------------------
-    mTcpClient.close(); // Close the socket
+    mTcpClient.close();  // Close the socket
     //cout << "TCP Socket Closed!" << endl;
     if (gVerboseFlag) cout << "Connection Succesfull!" << endl;
 
     // Set with the received UDP port
     // ------------------------------
     setPeerPorts(udp_port);
-    mDataProtocolReceiver->setPeerAddress( mPeerAddress.toLatin1().data() );
-    mDataProtocolSender->setPeerAddress( mPeerAddress.toLatin1().data() );
+    mDataProtocolReceiver->setPeerAddress(mPeerAddress.toLatin1().data());
+    mDataProtocolSender->setPeerAddress(mPeerAddress.toLatin1().data());
     mDataProtocolSender->setPeerPort(udp_port);
     mDataProtocolReceiver->setPeerPort(udp_port);
-    cout << "Server Address set to: " << mPeerAddress.toStdString() << " Port: " << udp_port << std::endl;
+    cout << "Server Address set to: " << mPeerAddress.toStdString()
+         << " Port: " << udp_port << std::endl;
     cout << gPrintSeparator << endl;
     completeConnection();
 }
@@ -665,17 +669,17 @@ void JackTrip::receivedDataUDP()
 {
     //Stop our timer.
     mTimeoutTimer.stop();
-    
+
     QHostAddress peerHostAddress;
     uint16_t peer_port;
-    
+
     // IPv6 addition from fyfe
     // Get the datagram size to avoid problems with IPv6
     qint64 datagramSize = mUdpSockTemp.pendingDatagramSize();
     char buf[datagramSize];
     // set client address
     mUdpSockTemp.readDatagram(buf, datagramSize, &peerHostAddress, &peer_port);
-    mUdpSockTemp.close(); // close the socket
+    mUdpSockTemp.close();  // close the socket
 
     // Check for mapped IPv4->IPv6 addresses that look like ::ffff:x.x.x.x
     if (peerHostAddress.protocol() == QAbstractSocket::IPv6Protocol) {
@@ -684,20 +688,23 @@ void JackTrip::receivedDataUDP()
         // If the IPv4 address is mapped to IPv6, convert it to IPv4
         if (mappedIPv4) {
             QHostAddress ipv4Address = QHostAddress(address);
-            mPeerAddress = ipv4Address.toString();
+            mPeerAddress             = ipv4Address.toString();
         } else {
             mPeerAddress = peerHostAddress.toString();
         }
-    }
-    else {
+    } else {
         mPeerAddress = peerHostAddress.toString();
     }
 
     // Set the peer address to send packets (in the protocol sender)
-    if (gVerboseFlag) std::cout << "JackTrip:serverStart before mDataProtocolSender->setPeerAddress()" << std::endl;
-    mDataProtocolSender->setPeerAddress( mPeerAddress.toLatin1().constData() );
-    if (gVerboseFlag) std::cout << "JackTrip:serverStart before mDataProtocolReceiver->setPeerAddress()" << std::endl;
-    mDataProtocolReceiver->setPeerAddress( mPeerAddress.toLatin1().constData() );
+    if (gVerboseFlag)
+        std::cout << "JackTrip:serverStart before mDataProtocolSender->setPeerAddress()"
+                  << std::endl;
+    mDataProtocolSender->setPeerAddress(mPeerAddress.toLatin1().constData());
+    if (gVerboseFlag)
+        std::cout << "JackTrip:serverStart before mDataProtocolReceiver->setPeerAddress()"
+                  << std::endl;
+    mDataProtocolReceiver->setPeerAddress(mPeerAddress.toLatin1().constData());
     //     We reply to the same port the peer sent the packets from
     //     This way we can go through NAT
     //     Because of the NAT traversal scheme, the portn need to be
@@ -705,7 +712,9 @@ void JackTrip::receivedDataUDP()
     //     from Client to Server : src = 4474, dest = 4464
     //     from Server to Client : src = 4464, dest = 4474
     // no -- all are the same -- 4464
-    if (gVerboseFlag) std::cout << "JackTrip:serverStart before setting all peer_port instances to " << peer_port << std::endl;
+    if (gVerboseFlag)
+        std::cout << "JackTrip:serverStart before setting all peer_port instances to "
+                  << peer_port << std::endl;
     mDataProtocolSender->setPeerPort(peer_port);
     mDataProtocolReceiver->setPeerPort(peer_port);
     setPeerPorts(peer_port);
@@ -720,7 +729,7 @@ void JackTrip::udpTimerTick()
         mTimeoutTimer.stop();
         stop();
     }
-    
+
     if (gVerboseFlag) std::cout << mSleepTime << "ms  " << std::flush;
     mElapsedTime += mSleepTime;
     if (mEndTime > 0 && mElapsedTime >= mEndTime) {
@@ -739,7 +748,7 @@ void JackTrip::tcpTimerTick()
         mTimeoutTimer.stop();
         stop();
     }
-    
+
     mElapsedTime += mSleepTime;
     if (mEndTime > 0 && mElapsedTime >= mEndTime) {
         mTcpClient.close();
@@ -747,7 +756,6 @@ void JackTrip::tcpTimerTick()
         cout << "JackTrip Server Timed Out!" << endl;
         stop("Initial TCP Connection Timed Out");
     }
-    
 }
 
 //*******************************************************************************
@@ -755,12 +763,10 @@ void JackTrip::stop(QString errorMessage)
 {
     mStopped = true;
     //Make sure we're only run once
-    if (mHasShutdown) {
-        return;
-    }
+    if (mHasShutdown) { return; }
     mHasShutdown = true;
     std::cout << "Stopping JackTrip..." << std::endl;
-    
+
     // Stop The Sender
     mDataProtocolSender->stop();
     mDataProtocolSender->wait();
@@ -772,7 +778,7 @@ void JackTrip::stop(QString errorMessage)
     // Stop the audio processes
     //mAudioInterface->stopProcess();
     closeAudio();
-    
+
     cout << "JackTrip Processes STOPPED!" << endl;
     cout << gPrintSeparator << endl;
 
@@ -786,7 +792,6 @@ void JackTrip::stop(QString errorMessage)
     }
 }
 
-
 //*******************************************************************************
 void JackTrip::waitThreads()
 {
@@ -794,56 +799,57 @@ void JackTrip::waitThreads()
     mDataProtocolReceiver->wait();
 }
 
-
 //*******************************************************************************
 void JackTrip::clientStart()
 {
     // For the Client mode, the peer (or server) address has to be specified by the user
-    if ( mPeerAddress.isEmpty() ) {
-        throw std::invalid_argument("Peer Address has to be set if you run in CLIENT mode");
-    }
-    else {
-        mDataProtocolSender->setPeerAddress( mPeerAddress.toLatin1().data() );
-        mDataProtocolReceiver->setPeerAddress( mPeerAddress.toLatin1().data() );
+    if (mPeerAddress.isEmpty()) {
+        throw std::invalid_argument(
+            "Peer Address has to be set if you run in CLIENT mode");
+    } else {
+        mDataProtocolSender->setPeerAddress(mPeerAddress.toLatin1().data());
+        mDataProtocolReceiver->setPeerAddress(mPeerAddress.toLatin1().data());
         cout << "Peer Address set to: " << mPeerAddress.toStdString() << std::endl;
         cout << gPrintSeparator << endl;
         completeConnection();
     }
 }
 
-
 //*******************************************************************************
-int JackTrip::serverStart(bool timeout, int udpTimeout) // udpTimeout unused
+int JackTrip::serverStart(bool timeout, int udpTimeout)  // udpTimeout unused
 {
     // Set the peer address
-    if ( !mPeerAddress.isEmpty() ) {
-        if (gVerboseFlag) std::cout << "WARNING: SERVER mode: Peer Address was set but will be deleted." << endl;
+    if (!mPeerAddress.isEmpty()) {
+        if (gVerboseFlag)
+            std::cout << "WARNING: SERVER mode: Peer Address was set but will be deleted."
+                      << endl;
         //throw std::invalid_argument("Peer Address has to be set if you run in CLIENT mode");
         mPeerAddress.clear();
         //return;
     }
 
     // Get the client address when it connects
-    if (gVerboseFlag) std::cout << "JackTrip:serverStart before mUdpSockTemp.bind(Any)" << std::endl;
+    if (gVerboseFlag)
+        std::cout << "JackTrip:serverStart before mUdpSockTemp.bind(Any)" << std::endl;
     // Bind the socket
-    if ( !mUdpSockTemp.bind(QHostAddress::Any, mReceiverBindPort,
-                           QUdpSocket::DefaultForPlatform) )
-    {
-        std::cerr << "in JackTrip: Could not bind UDP socket. It may be already binded." << endl;
+    if (!mUdpSockTemp.bind(QHostAddress::Any, mReceiverBindPort,
+                           QUdpSocket::DefaultForPlatform)) {
+        std::cerr << "in JackTrip: Could not bind UDP socket. It may be already binded."
+                  << endl;
         throw std::runtime_error("Could not bind UDP socket. It may be already binded.");
     }
     connect(&mUdpSockTemp, &QUdpSocket::readyRead, this, &JackTrip::receivedDataUDP);
-    
+
     // Start timer and then wait for a signal to read datagrams.
     mElapsedTime = 0;
-    if (timeout) {
-        mEndTime = udpTimeout;
-    }
+    if (timeout) { mEndTime = udpTimeout; }
     mTimeoutTimer.setInterval(mSleepTime);
     connect(&mTimeoutTimer, &QTimer::timeout, this, &JackTrip::udpTimerTick);
     mTimeoutTimer.start();
-    
-    if (gVerboseFlag) std::cout << "JackTrip:serverStart before !UdpSockTemp.hasPendingDatagrams()" << std::endl;
+
+    if (gVerboseFlag)
+        std::cout << "JackTrip:serverStart before !UdpSockTemp.hasPendingDatagrams()"
+                  << std::endl;
     cout << "Waiting for Connection From a Client..." << endl;
     return 0;
     // Continued in the receivedDataUDP slot.
@@ -854,7 +860,6 @@ int JackTrip::serverStart(bool timeout, int udpTimeout) // udpTimeout unused
     //    UdpSockTemp.close(); // close the socket
 }
 
-
 //*******************************************************************************
 int JackTrip::clientPingToServerStart()
 {
@@ -864,8 +869,9 @@ int JackTrip::clientPingToServerStart()
     // Set Peer (server in this case) address
     // --------------------------------------
     // For the Client mode, the peer (or server) address has to be specified by the user
-    if ( mPeerAddress.isEmpty() ) {
-        throw std::invalid_argument("Peer Address has to be set if you run in CLIENTTOPINGSERVER mode");
+    if (mPeerAddress.isEmpty()) {
+        throw std::invalid_argument(
+            "Peer Address has to be set if you run in CLIENTTOPINGSERVER mode");
         return -1;
     }
 
@@ -885,13 +891,16 @@ int JackTrip::clientPingToServerStart()
     connect(&mTcpClient, &QTcpSocket::readyRead, this, &JackTrip::receivedDataTCP);
     connect(&mTcpClient, &QTcpSocket::connected, this, &JackTrip::receivedConnectionTCP);
     mElapsedTime = 0;
-    mEndTime = 5000; //Timeout after 5 seconds.
+    mEndTime     = 5000;  //Timeout after 5 seconds.
     mTimeoutTimer.setInterval(mSleepTime);
     connect(&mTimeoutTimer, &QTimer::timeout, this, &JackTrip::tcpTimerTick);
     mTimeoutTimer.start();
     mTcpClient.connectToHost(serverHostAddress, mTcpServerPort);
-    
-    if (gVerboseFlag) cout << "Connecting to TCP Server at " <<  serverHostAddress.toString().toLatin1().constData() << " port " << mTcpServerPort << "..." << endl;
+
+    if (gVerboseFlag)
+        cout << "Connecting to TCP Server at "
+             << serverHostAddress.toString().toLatin1().constData() << " port "
+             << mTcpServerPort << "..." << endl;
     return 0;
     // Continued in the receivedConnectionTCP slot.
 
@@ -946,7 +955,6 @@ int JackTrip::clientPingToServerStart()
   mDataProtocolReceiver->start();
   */
 }
-
 
 //*******************************************************************************
 /*
@@ -1004,27 +1012,25 @@ throw(std::runtime_error)
 }
 */
 
-
 //*******************************************************************************
 void JackTrip::createHeader(const DataProtocol::packetHeaderTypeT headertype)
 {
-    delete mPacketHeader; //Just in case it has already been allocated
+    delete mPacketHeader;  //Just in case it has already been allocated
     switch (headertype) {
-    case DataProtocol::DEFAULT :
+    case DataProtocol::DEFAULT:
         mPacketHeader = new DefaultHeader(this);
         break;
-    case DataProtocol::JAMLINK :
+    case DataProtocol::JAMLINK:
         mPacketHeader = new JamLinkHeader(this);
         break;
-    case DataProtocol::EMPTY :
+    case DataProtocol::EMPTY:
         mPacketHeader = new EmptyHeader(this);
         break;
-    default :
+    default:
         throw std::invalid_argument("Undefined Header Type");
         break;
     }
 }
-
 
 //*******************************************************************************
 void JackTrip::putHeaderInPacket(int8_t* full_packet, int8_t* audio_packet)
@@ -1039,17 +1045,14 @@ void JackTrip::putHeaderInPacket(int8_t* full_packet, int8_t* audio_packet)
     std::memcpy(audio_part, audio_packet, getTotalAudioPacketSizeInBytes());
 }
 
-
 //*******************************************************************************
 int JackTrip::getPacketSizeInBytes()
 {
     //return (mAudioInterface->getBufferSizeInBytes() + mPacketHeader->getHeaderSizeInBytes());
     //return (mAudioInterface->getSizeInBytesPerChannel() * mNumChans  +
     //mPacketHeader->getHeaderSizeInBytes());
-    return (getTotalAudioPacketSizeInBytes()  +
-            mPacketHeader->getHeaderSizeInBytes());
+    return (getTotalAudioPacketSizeInBytes() + mPacketHeader->getHeaderSizeInBytes());
 }
-
 
 //*******************************************************************************
 void JackTrip::parseAudioPacket(int8_t* full_packet, int8_t* audio_packet)
@@ -1067,19 +1070,17 @@ void JackTrip::checkPeerSettings(int8_t* full_packet)
     mPacketHeader->checkPeerSettings(full_packet);
 }
 
-
 //*******************************************************************************
 void JackTrip::checkIfPortIsBinded(int port)
 {
-    QUdpSocket UdpSockTemp;// Create socket to wait for client
+    QUdpSocket UdpSockTemp;  // Create socket to wait for client
     // Bind the socket
     //cc        if ( !UdpSockTemp.bind(QHostAddress::AnyIPv4, port, QUdpSocket::DontShareAddress) )
-    if ( !UdpSockTemp.bind(QHostAddress::Any, port,
-                           QUdpSocket::DontShareAddress) )
-    {
-        UdpSockTemp.close(); // close the socket
+    if (!UdpSockTemp.bind(QHostAddress::Any, port, QUdpSocket::DontShareAddress)) {
+        UdpSockTemp.close();  // close the socket
         throw std::runtime_error(
-                    "Could not bind UDP socket. It may already be binded by another process on your machine. Try using a different port number");
+            "Could not bind UDP socket. It may already be binded by another process on "
+            "your machine. Try using a different port number");
     }
-    UdpSockTemp.close(); // close the socket
+    UdpSockTemp.close();  // close the socket
 }

--- a/src/JackTrip.h
+++ b/src/JackTrip.h
@@ -39,25 +39,24 @@
 #define __JACKTRIP_H__
 
 //#include <tr1/memory> //for shared_ptr
-#include <stdexcept>
-
 #include <QObject>
+#include <QSharedPointer>
 #include <QString>
-#include <QUdpSocket>
 #include <QTcpSocket>
 #include <QTimer>
-#include <QSharedPointer>
+#include <QUdpSocket>
+#include <stdexcept>
 
-#include "DataProtocol.h"
 #include "AudioInterface.h"
+#include "DataProtocol.h"
 
 #ifndef __NO_JACK__
 #include "JackAudioInterface.h"
-#endif //__NO_JACK__
+#endif  //__NO_JACK__
 
+#include "AudioTester.h"
 #include "PacketHeader.h"
 #include "RingBuffer.h"
-#include "AudioTester.h"
 
 //#include <signal.h>
 /** \brief Main class to creates a SERVER (to listen) or a CLIENT (to connect
@@ -72,54 +71,52 @@ class JackTrip : public QObject
 {
     Q_OBJECT;
 
-public:
-
+   public:
     //----------ENUMS------------------------------------------
     /// \brief Enum for the data Protocol. At this time only UDP is implemented
     enum dataProtocolT {
-        UDP, ///< Use UDP (User Datagram Protocol)
-        TCP, ///< <B>NOT IMPLEMENTED</B>: Use TCP (Transmission Control Protocol)
-        SCTP ///< <B>NOT IMPLEMENTED</B>: Use SCTP (Stream Control Transmission Protocol)
+        UDP,  ///< Use UDP (User Datagram Protocol)
+        TCP,  ///< <B>NOT IMPLEMENTED</B>: Use TCP (Transmission Control Protocol)
+        SCTP  ///< <B>NOT IMPLEMENTED</B>: Use SCTP (Stream Control Transmission Protocol)
     };
 
     /// \brief Enum for the JackTrip mode
     enum jacktripModeT {
-        SERVER, ///< Run in P2P Server Mode
-        CLIENT,  ///< Run in P2P Client Mode
-        CLIENTTOPINGSERVER, ///< Client of the Ping Server Mode
-        SERVERPINGSERVER ///< Server of the MultiThreaded JackTrip
+        SERVER,              ///< Run in P2P Server Mode
+        CLIENT,              ///< Run in P2P Client Mode
+        CLIENTTOPINGSERVER,  ///< Client of the Ping Server Mode
+        SERVERPINGSERVER     ///< Server of the MultiThreaded JackTrip
     };
 
     /// \brief Enum for the JackTrip Underrun Mode, when packets
     enum underrunModeT {
-        WAVETABLE, ///< Loops on the last received packet
-        ZEROS  ///< Set new buffers to zero if there are no new ones
+        WAVETABLE,  ///< Loops on the last received packet
+        ZEROS       ///< Set new buffers to zero if there are no new ones
     };
 
     /// \brief Enum for Audio Interface Mode
     enum audiointerfaceModeT {
-        JACK, ///< Jack Mode
+        JACK,    ///< Jack Mode
         RTAUDIO  ///< RtAudio Mode
     };
 
     /// \brief Enum for Connection Mode (in packet header)
     enum connectionModeT {
-        NORMAL, ///< Normal Mode
+        NORMAL,   ///< Normal Mode
         KSTRONG,  ///< Karplus Strong
-        JAMTEST  ///< Karplus Strong
+        JAMTEST   ///< Karplus Strong
     };
 
     /// \brief Enum for Hub Server Audio Connection Mode (connections to hub server are automatically patched in Jack)
     enum hubConnectionModeT {
-        SERVERTOCLIENT, ///< Normal Mode, Sever to All Clients (but not client to any client)
-        CLIENTECHO,  ///< Client Echo (client self-to-self)
+        SERVERTOCLIENT,  ///< Normal Mode, Sever to All Clients (but not client to any client)
+        CLIENTECHO,      ///< Client Echo (client self-to-self)
         CLIENTFOFI,  ///< Client Fan Out to Clients and Fan In from Clients (but not self-to-self)
         RESERVEDMATRIX,  ///< Reserved for custom patch matrix (for TUB ensemble)
         FULLMIX,  ///< Client Fan Out to Clients and Fan In from Clients (including self-to-self)
         NOAUTO  ///< No automatic patching
     };
     //---------------------------------------------------------
-
 
     /** \brief The class Constructor with Default Parameters
    * \param JacktripMode JackTrip::CLIENT or JackTrip::SERVER
@@ -129,30 +126,28 @@ public:
    * \param AudioBitResolution Audio Sample Resolutions in bits
    * \param redundancy redundancy factor for network data
    */
-    JackTrip(jacktripModeT JacktripMode = CLIENT,
-             dataProtocolT DataProtocolType = UDP,
-             int NumChans = gDefaultNumInChannels,
-         #ifdef WAIR // wair
-             int NumNetRevChans = 0,
-         #endif // endwhere
-             int BufferQueueLength = gDefaultQueueLength,
-             unsigned int redundancy = gDefaultRedundancy,
-             AudioInterface::audioBitResolutionT AudioBitResolution =
-             AudioInterface::BIT16,
-             DataProtocol::packetHeaderTypeT PacketHeaderType =
-             DataProtocol::DEFAULT,
-             underrunModeT UnderRunMode = WAVETABLE,
-             int receiver_bind_port = gDefaultPort,
-             int sender_bind_port = gDefaultPort,
-             int receiver_peer_port = gDefaultPort,
-             int sender_peer_port = gDefaultPort,
-             int tcp_peer_port = gDefaultPort);
+    JackTrip(
+        jacktripModeT JacktripMode = CLIENT, dataProtocolT DataProtocolType = UDP,
+        int NumChans = gDefaultNumInChannels,
+#ifdef WAIR  // wair
+        int NumNetRevChans = 0,
+#endif  // endwhere
+        int BufferQueueLength                                  = gDefaultQueueLength,
+        unsigned int redundancy                                = gDefaultRedundancy,
+        AudioInterface::audioBitResolutionT AudioBitResolution = AudioInterface::BIT16,
+        DataProtocol::packetHeaderTypeT PacketHeaderType       = DataProtocol::DEFAULT,
+        underrunModeT UnderRunMode = WAVETABLE, int receiver_bind_port = gDefaultPort,
+        int sender_bind_port = gDefaultPort, int receiver_peer_port = gDefaultPort,
+        int sender_peer_port = gDefaultPort, int tcp_peer_port = gDefaultPort);
 
     /// \brief The class destructor
     virtual ~JackTrip();
-    
+
     static void sigIntHandler(__attribute__((unused)) int unused)
-    { std::cout << std::endl << "Shutting Down..." << std::endl; sSigInt = true; }
+    {
+        std::cout << std::endl << "Shutting Down..." << std::endl;
+        sSigInt = true;
+    }
     static bool sSigInt;
     static bool sJackStopped;
 
@@ -173,10 +168,10 @@ public:
 
     /// \brief Start the processing threads
     virtual void startProcess(
-        #ifdef WAIRTOHUB // wair
-            int ID
-        #endif // endwhere
-            );
+#ifdef WAIRTOHUB  // wair
+        int ID
+#endif  // endwhere
+    );
     virtual void completeConnection();
 
     /// \brief Stop the processing threads
@@ -196,10 +191,14 @@ public:
     //
     /// \brief Sets (override) JackTrip Mode after construction
     virtual void setJackTripMode(jacktripModeT JacktripMode)
-    { mJackTripMode = JacktripMode; }
+    {
+        mJackTripMode = JacktripMode;
+    }
     /// \brief Sets (override) DataProtocol Type after construction
     virtual void setDataProtocoType(dataProtocolT DataProtocolType)
-    { mDataProtocol = DataProtocolType; }
+    {
+        mDataProtocol = DataProtocolType;
+    }
     /// \brief Sets the Packet header type
     virtual void setPacketHeaderType(DataProtocol::packetHeaderTypeT PacketHeaderType)
     {
@@ -210,129 +209,145 @@ public:
     }
     /// \brief Sets (override) Buffer Queue Length Mode after construction
     virtual void setBufferQueueLength(int BufferQueueLength)
-    { mBufferQueueLength = BufferQueueLength; }
+    {
+        mBufferQueueLength = BufferQueueLength;
+    }
     virtual void setBufferStrategy(int BufferStrategy)
-    { mBufferStrategy = BufferStrategy; }
+    {
+        mBufferStrategy = BufferStrategy;
+    }
     /// \brief Sets (override) Audio Bit Resolution after construction
-    virtual void setAudioBitResolution(AudioInterface::audioBitResolutionT AudioBitResolution)
-    { mAudioBitResolution = AudioBitResolution; }
+    virtual void setAudioBitResolution(
+        AudioInterface::audioBitResolutionT AudioBitResolution)
+    {
+        mAudioBitResolution = AudioBitResolution;
+    }
     /// \brief Sets (override) Underrun Mode
     virtual void setUnderRunMode(underrunModeT UnderRunMode)
-    { mUnderRunMode = UnderRunMode; }
+    {
+        mUnderRunMode = UnderRunMode;
+    }
     /// \brief Sets whether to quit on timeout.
-    virtual void setStopOnTimeout(bool stopOnTimeout)
-    { mStopOnTimeout = stopOnTimeout; }
+    virtual void setStopOnTimeout(bool stopOnTimeout) { mStopOnTimeout = stopOnTimeout; }
     /// \brief Sets port numbers for the local and peer machine.
     /// Receive port is <tt>port</tt>
     virtual void setAllPorts(int port)
     {
         mReceiverBindPort = port;
-        mSenderPeerPort = port;
-        mSenderBindPort = port;
+        mSenderPeerPort   = port;
+        mSenderBindPort   = port;
         mReceiverPeerPort = port;
     }
     /// \brief Sets port numbers to bind in RECEIVER and SENDER sockets.
     void setBindPorts(int port)
     {
         mReceiverBindPort = port;
-        mSenderBindPort = port;
+        mSenderBindPort   = port;
     }
     /// \brief Sets port numbers for the peer (remote) machine.
     void setPeerPorts(int port)
     {
-        mSenderPeerPort = port;
+        mSenderPeerPort   = port;
         mReceiverPeerPort = port;
     }
     /// \brief Set Client Name to something different that the default (JackTrip)
-    virtual void setClientName(QString clientName)
-    { mJackClientName = clientName; }
+    virtual void setClientName(QString clientName) { mJackClientName = clientName; }
     virtual void setRemoteClientName(QString remoteClientName)
-    { mRemoteClientName = remoteClientName; }
+    {
+        mRemoteClientName = remoteClientName;
+    }
     /// \brief Set the number of audio channels
-    virtual void setNumChannels(int num_chans)
-    { mNumChans = num_chans; }
-    
+    virtual void setNumChannels(int num_chans) { mNumChans = num_chans; }
+
     virtual void setIOStatTimeout(int timeout) { mIOStatTimeout = timeout; }
-    virtual void setIOStatStream(QSharedPointer<std::ofstream> statStream) { mIOStatStream = statStream; }
+    virtual void setIOStatStream(QSharedPointer<std::ofstream> statStream)
+    {
+        mIOStatStream = statStream;
+    }
 
     /// Set to connect or not default audio ports (only implemented in Jack)
     virtual void setConnectDefaultAudioPorts(bool connect)
-    {mConnectDefaultAudioPorts = connect;}
+    {
+        mConnectDefaultAudioPorts = connect;
+    }
 
-    virtual int getReceiverBindPort() const
-    { return mReceiverBindPort; }
-    virtual int getSenderPeerPort() const
-    { return mSenderPeerPort; }
-    virtual int getSenderBindPort() const
-    { return mSenderBindPort; }
-    virtual int getReceiverPeerPort() const
-    { return mReceiverPeerPort; }
+    virtual int getReceiverBindPort() const { return mReceiverBindPort; }
+    virtual int getSenderPeerPort() const { return mSenderPeerPort; }
+    virtual int getSenderBindPort() const { return mSenderBindPort; }
+    virtual int getReceiverPeerPort() const { return mReceiverPeerPort; }
 
-    virtual DataProtocol* getDataProtocolSender() const
-    { return mDataProtocolSender; }
+    virtual DataProtocol* getDataProtocolSender() const { return mDataProtocolSender; }
     virtual DataProtocol* getDataProtocolReceiver() const
-    { return mDataProtocolReceiver; }
+    {
+        return mDataProtocolReceiver;
+    }
     virtual void setDataProtocolSender(DataProtocol* const DataProtocolSender)
-    { mDataProtocolSender = DataProtocolSender; }
+    {
+        mDataProtocolSender = DataProtocolSender;
+    }
     virtual void setDataProtocolReceiver(DataProtocol* const DataProtocolReceiver)
-    { mDataProtocolReceiver = DataProtocolReceiver; }
+    {
+        mDataProtocolReceiver = DataProtocolReceiver;
+    }
 
-    virtual RingBuffer* getSendRingBuffer() const
-    { return mSendRingBuffer; }
-    virtual RingBuffer* getReceiveRingBuffer() const
-    { return mReceiveRingBuffer; }
+    virtual RingBuffer* getSendRingBuffer() const { return mSendRingBuffer; }
+    virtual RingBuffer* getReceiveRingBuffer() const { return mReceiveRingBuffer; }
     virtual void setSendRingBuffer(RingBuffer* const SendRingBuffer)
-    { mSendRingBuffer = SendRingBuffer; }
+    {
+        mSendRingBuffer = SendRingBuffer;
+    }
     virtual void setReceiveRingBuffer(RingBuffer* const ReceiveRingBuffer)
-    { mReceiveRingBuffer = ReceiveRingBuffer; }
+    {
+        mReceiveRingBuffer = ReceiveRingBuffer;
+    }
 
     virtual void setPacketHeader(PacketHeader* const PacketHeader)
-    { mPacketHeader = PacketHeader; }
+    {
+        mPacketHeader = PacketHeader;
+    }
 
-    virtual int getRingBuffersSlotSize()
-    { return getTotalAudioPacketSizeInBytes(); }
+    virtual int getRingBuffersSlotSize() { return getTotalAudioPacketSizeInBytes(); }
 
     virtual void setAudiointerfaceMode(JackTrip::audiointerfaceModeT audiointerface_mode)
-    { mAudiointerfaceMode = audiointerface_mode; }
+    {
+        mAudiointerfaceMode = audiointerface_mode;
+    }
     virtual void setAudioInterface(AudioInterface* const AudioInterface)
-    { mAudioInterface = AudioInterface; }
-    virtual void setLoopBack(bool b)
-    { mLoopBack = b; }
+    {
+        mAudioInterface = AudioInterface;
+    }
+    virtual void setLoopBack(bool b) { mLoopBack = b; }
     virtual void setAudioTesterP(AudioTester* atp) { mAudioTesterP = atp; }
 
-    void setSampleRate(uint32_t sample_rate)
-    { mSampleRate = sample_rate; }
-    void setDeviceID(uint32_t device_id)
-    { mDeviceID = device_id; }
-    void setAudioBufferSizeInSamples(uint32_t buf_size)
-    { mAudioBufferSize = buf_size; }
+    void setSampleRate(uint32_t sample_rate) { mSampleRate = sample_rate; }
+    void setDeviceID(uint32_t device_id) { mDeviceID = device_id; }
+    void setAudioBufferSizeInSamples(uint32_t buf_size) { mAudioBufferSize = buf_size; }
 
-
-    JackTrip::connectionModeT getConnectionMode() const
-    { return mConnectionMode; }
+    JackTrip::connectionModeT getConnectionMode() const { return mConnectionMode; }
     void setConnectionMode(JackTrip::connectionModeT connection_mode)
-    { mConnectionMode = connection_mode; }
+    {
+        mConnectionMode = connection_mode;
+    }
 
     JackTrip::hubConnectionModeT getHubConnectionModeT() const
-    { return mHubConnectionModeT; }
+    {
+        return mHubConnectionModeT;
+    }
     void setHubConnectionModeT(JackTrip::hubConnectionModeT connection_mode)
-    { mHubConnectionModeT = connection_mode; }
+    {
+        mHubConnectionModeT = connection_mode;
+    }
 
-    JackTrip::jacktripModeT getJackTripMode() const
-    { return mJackTripMode; }
+    JackTrip::jacktripModeT getJackTripMode() const { return mJackTripMode; }
 
-    QString getPeerAddress() const
-    { return mPeerAddress; }
+    QString getPeerAddress() const { return mPeerAddress; }
 
-    bool receivedConnectionFromPeer()
-    { return mReceivedConnection; }
+    bool receivedConnectionFromPeer() { return mReceivedConnection; }
 
-    bool tcpConnectionError()
-    { return mTcpConnectionError; }
+    bool tcpConnectionError() { return mTcpConnectionError; }
 
     //@}
     //------------------------------------------------------------------------------------
-
 
     //------------------------------------------------------------------------------------
     /// \name Mediator Functions
@@ -343,98 +358,139 @@ public:
     virtual int getPacketSizeInBytes();
     void parseAudioPacket(int8_t* full_packet, int8_t* audio_packet);
     virtual void sendNetworkPacket(const int8_t* ptrToSlot)
-    { mSendRingBuffer->insertSlotNonBlocking(ptrToSlot, 0, 0); }
+    {
+        mSendRingBuffer->insertSlotNonBlocking(ptrToSlot, 0, 0);
+    }
     virtual void receiveBroadcastPacket(int8_t* ptrToReadSlot)
-    { mReceiveRingBuffer->readBroadcastSlot(ptrToReadSlot); }
+    {
+        mReceiveRingBuffer->readBroadcastSlot(ptrToReadSlot);
+    }
     virtual void receiveNetworkPacket(int8_t* ptrToReadSlot)
-    { mReceiveRingBuffer->readSlotNonBlocking(ptrToReadSlot); }
+    {
+        mReceiveRingBuffer->readSlotNonBlocking(ptrToReadSlot);
+    }
     virtual void readAudioBuffer(int8_t* ptrToReadSlot)
-    { mSendRingBuffer->readSlotBlocking(ptrToReadSlot); }
+    {
+        mSendRingBuffer->readSlotBlocking(ptrToReadSlot);
+    }
     virtual bool writeAudioBuffer(const int8_t* ptrToSlot, int len, int lostLen)
-    { return mReceiveRingBuffer->insertSlotNonBlocking(ptrToSlot, len, lostLen); }
+    {
+        return mReceiveRingBuffer->insertSlotNonBlocking(ptrToSlot, len, lostLen);
+    }
     uint32_t getBufferSizeInSamples() const
-    { return mAudioBufferSize; /*return mAudioInterface->getBufferSizeInSamples();*/ }
+    {
+        return mAudioBufferSize; /*return mAudioInterface->getBufferSizeInSamples();*/
+    }
     uint32_t getDeviceID() const
-    { return mDeviceID; /*return mAudioInterface->mDeviceID();*/ }
+    {
+        return mDeviceID; /*return mAudioInterface->mDeviceID();*/
+    }
 
     AudioInterface::samplingRateT getSampleRateType() const
-    { return mAudioInterface->getSampleRateType(); }
+    {
+        return mAudioInterface->getSampleRateType();
+    }
     int getSampleRate() const
-    { return mSampleRate; /*return mAudioInterface->getSampleRate();*/ }
+    {
+        return mSampleRate; /*return mAudioInterface->getSampleRate();*/
+    }
 
     uint8_t getAudioBitResolution() const
-    { return mAudioBitResolution*8; /*return mAudioInterface->getAudioBitResolution();*/ }
+    {
+        return mAudioBitResolution
+               * 8; /*return mAudioInterface->getAudioBitResolution();*/
+    }
     unsigned int getNumInputChannels() const
-    { return mNumChans; /*return mAudioInterface->getNumInputChannels();*/ }
+    {
+        return mNumChans; /*return mAudioInterface->getNumInputChannels();*/
+    }
     unsigned int getNumOutputChannels() const
-    { return mNumChans; /*return mAudioInterface->getNumOutputChannels();*/ }
+    {
+        return mNumChans; /*return mAudioInterface->getNumOutputChannels();*/
+    }
     unsigned int getNumChannels() const
     {
-        if (getNumInputChannels() == getNumOutputChannels())
-        { return getNumInputChannels(); }
-        else { return 0; }
+        if (getNumInputChannels() == getNumOutputChannels()) {
+            return getNumInputChannels();
+        } else {
+            return 0;
+        }
     }
     virtual void checkPeerSettings(int8_t* full_packet);
-    void increaseSequenceNumber()
-    { mPacketHeader->increaseSequenceNumber(); }
-    int getSequenceNumber() const
-    { return mPacketHeader->getSequenceNumber(); }
+    void increaseSequenceNumber() { mPacketHeader->increaseSequenceNumber(); }
+    int getSequenceNumber() const { return mPacketHeader->getSequenceNumber(); }
 
     uint64_t getPeerTimeStamp(int8_t* full_packet) const
-    { return mPacketHeader->getPeerTimeStamp(full_packet); }
+    {
+        return mPacketHeader->getPeerTimeStamp(full_packet);
+    }
 
     uint16_t getPeerSequenceNumber(int8_t* full_packet) const
-    { return mPacketHeader->getPeerSequenceNumber(full_packet); }
+    {
+        return mPacketHeader->getPeerSequenceNumber(full_packet);
+    }
 
     uint16_t getPeerBufferSize(int8_t* full_packet) const
-    { return mPacketHeader->getPeerBufferSize(full_packet); }
+    {
+        return mPacketHeader->getPeerBufferSize(full_packet);
+    }
 
     uint8_t getPeerSamplingRate(int8_t* full_packet) const
-    { return mPacketHeader->getPeerSamplingRate(full_packet); }
+    {
+        return mPacketHeader->getPeerSamplingRate(full_packet);
+    }
 
     uint8_t getPeerBitResolution(int8_t* full_packet) const
-    { return mPacketHeader->getPeerBitResolution(full_packet); }
+    {
+        return mPacketHeader->getPeerBitResolution(full_packet);
+    }
 
-    uint8_t  getPeerNumChannels(int8_t* full_packet) const
-    { return mPacketHeader->getPeerNumChannels(full_packet); }
+    uint8_t getPeerNumChannels(int8_t* full_packet) const
+    {
+        return mPacketHeader->getPeerNumChannels(full_packet);
+    }
 
-    uint8_t  getPeerConnectionMode(int8_t* full_packet) const
-    { return mPacketHeader->getPeerConnectionMode(full_packet); }
+    uint8_t getPeerConnectionMode(int8_t* full_packet) const
+    {
+        return mPacketHeader->getPeerConnectionMode(full_packet);
+    }
 
     size_t getSizeInBytesPerChannel() const
-    { return mAudioInterface->getSizeInBytesPerChannel(); }
-    int getHeaderSizeInBytes() const
-    { return mPacketHeader->getHeaderSizeInBytes(); }
+    {
+        return mAudioInterface->getSizeInBytesPerChannel();
+    }
+    int getHeaderSizeInBytes() const { return mPacketHeader->getHeaderSizeInBytes(); }
     virtual int getTotalAudioPacketSizeInBytes() const
     {
-#ifdef WAIR // WAIR
+#ifdef WAIR  // WAIR
         if (mNumNetRevChans)
             return mAudioInterface->getSizeInBytesPerChannel() * mNumNetRevChans;
-        else // not wair
-#endif // endwhere
+        else  // not wair
+#endif        // endwhere
             return mAudioInterface->getSizeInBytesPerChannel() * mNumChans;
     }
     //@}
     //------------------------------------------------------------------------------------
 
-    void printTextTest() {std::cout << "=== JackTrip PRINT ===" << std::endl;}
-    void printTextTest2() {std::cout << "=== JackTrip PRINT2 ===" << std::endl;}
+    void printTextTest() { std::cout << "=== JackTrip PRINT ===" << std::endl; }
+    void printTextTest2() { std::cout << "=== JackTrip PRINT2 ===" << std::endl; }
 
     void setNetIssuesSimulation(double loss, double jitter, double delay_rel)
     {
-        mSimulatedLossRate = loss;
+        mSimulatedLossRate   = loss;
         mSimulatedJitterRate = jitter;
-        mSimulatedDelayRel = delay_rel;
+        mSimulatedDelayRel   = delay_rel;
     }
-    void setBroadcast(int broadcast_queue) {mBroadcastQueueLength = broadcast_queue;}
-    void setUseRtUdpPriority(bool use) {mUseRtUdpPriority = use;}
+    void setBroadcast(int broadcast_queue) { mBroadcastQueueLength = broadcast_queue; }
+    void setUseRtUdpPriority(bool use) { mUseRtUdpPriority = use; }
 
-public slots:
+   public slots:
     /// \brief Slot to stop all the processes and threads
-    virtual void slotStopProcesses()
-    { this->stop(); }
-    virtual void slotStopProcessesDueToError(const QString &errorMessage)
-    { this->stop(errorMessage); }
+    virtual void slotStopProcesses() { this->stop(); }
+    virtual void slotStopProcessesDueToError(const QString& errorMessage)
+    {
+        this->stop(errorMessage);
+    }
 
     /** \brief This slot emits in turn the signal signalNoUdpPacketsForSeconds
    * when UDP has waited for more than 30 seconds.
@@ -443,49 +499,47 @@ public slots:
    */
     void slotUdpWaitingTooLongClientGoneProbably(int wait_msec)
     {
-        int wait_time = 10000; // msec
-        if ( !(wait_msec%wait_time) ) {
+        int wait_time = 10000;  // msec
+        if (!(wait_msec % wait_time)) {
             std::cerr << "UDP WAITED MORE THAN 10 seconds." << std::endl;
-            if (mStopOnTimeout) {
-                stop("No network data received for 10 seconds");
-            }
+            if (mStopOnTimeout) { stop("No network data received for 10 seconds"); }
             emit signalNoUdpPacketsForSeconds();
         }
     }
-    void slotUdpWaitingTooLong()
-    { emit signalUdpWaitingTooLong(); }
-    void slotPrintTest()
-    { std::cout << "=== TESTING ===" << std::endl; }
+    void slotUdpWaitingTooLong() { emit signalUdpWaitingTooLong(); }
+    void slotPrintTest() { std::cout << "=== TESTING ===" << std::endl; }
     void slotReceivedConnectionFromPeer()
-    { mReceivedConnection = true; emit signalReceivedConnectionFromPeer(); }
+    {
+        mReceivedConnection = true;
+        emit signalReceivedConnectionFromPeer();
+    }
     void onStatTimer();
-    
-private slots:
+
+   private slots:
     void receivedConnectionTCP();
     void receivedDataTCP();
     void receivedDataUDP();
     void udpTimerTick();
     void tcpTimerTick();
 
-signals:
+   signals:
     //void signalUdpTimeOut();
     /// \brief Signal emitted when all the processes and threads are stopped
     void signalProcessesStopped();
     /// \brief Signal emitted when no UDP Packets have been received for a while
     void signalNoUdpPacketsForSeconds();
     void signalTcpClientConnected();
-    void signalError(const QString &errorMessage);
+    void signalError(const QString& errorMessage);
     void signalReceivedConnectionFromPeer();
     void signalUdpWaitingTooLong();
 
-public:
-
+   public:
     /// \brief Set the AudioInteface object
     virtual void setupAudio(
-        #ifdef WAIRTOHUB // WAIR
-            int ID
-        #endif // endwhere
-            );
+#ifdef WAIRTOHUB  // WAIR
+        int ID
+#endif  // endwhere
+    );
     /// \brief Close the JackAudioInteface and disconnects it from JACK
     void closeAudio();
     /// \brief Set the DataProtocol objects
@@ -503,61 +557,63 @@ public:
     /// \return -1 on error, 0 on success
     virtual int clientPingToServerStart();
 
-private:
+   private:
     //void bindReceiveSocket(QUdpSocket& UdpSocket, int bind_port,
     //                       QHostAddress PeerHostAddress, int peer_port)
     //throw(std::runtime_error);
 
-
-    jacktripModeT mJackTripMode; ///< JackTrip::jacktripModeT
-    dataProtocolT mDataProtocol; ///< Data Protocol Tipe
-    DataProtocol::packetHeaderTypeT mPacketHeaderType; ///< Packet Header Type
+    jacktripModeT mJackTripMode;                        ///< JackTrip::jacktripModeT
+    dataProtocolT mDataProtocol;                        ///< Data Protocol Tipe
+    DataProtocol::packetHeaderTypeT mPacketHeaderType;  ///< Packet Header Type
     JackTrip::audiointerfaceModeT mAudiointerfaceMode;
 
-    int mNumChans; ///< Number of Channels (inputs = outputs)
-#ifdef WAIR // WAIR
-    int mNumNetRevChans; ///< Number of Network Audio Channels (net comb filters)
-#endif // endwhere
-    int mBufferQueueLength; ///< Audio Buffer from network queue length
+    int mNumChans;  ///< Number of Channels (inputs = outputs)
+#ifdef WAIR         // WAIR
+    int mNumNetRevChans;  ///< Number of Network Audio Channels (net comb filters)
+#endif                    // endwhere
+    int mBufferQueueLength;  ///< Audio Buffer from network queue length
     int mBufferStrategy;
     int mBroadcastQueueLength;
-    uint32_t mSampleRate; ///< Sample Rate
-    uint32_t mDeviceID; ///< RTAudio DeviceID
-    uint32_t mAudioBufferSize; ///< Audio buffer size to process on each callback
-    AudioInterface::audioBitResolutionT mAudioBitResolution; ///< Audio Bit Resolutions
+    uint32_t mSampleRate;       ///< Sample Rate
+    uint32_t mDeviceID;         ///< RTAudio DeviceID
+    uint32_t mAudioBufferSize;  ///< Audio buffer size to process on each callback
+    AudioInterface::audioBitResolutionT mAudioBitResolution;  ///< Audio Bit Resolutions
     bool mLoopBack;
-    QString mPeerAddress; ///< Peer Address to use in jacktripModeT::CLIENT Mode
+    QString mPeerAddress;  ///< Peer Address to use in jacktripModeT::CLIENT Mode
 
     /// Pointer to Abstract Type DataProtocol that sends packets
     DataProtocol* mDataProtocolSender;
     /// Pointer to Abstract Type DataProtocol that receives packets
     DataProtocol* mDataProtocolReceiver;
-    AudioInterface* mAudioInterface; ///< Interface to Jack Client
-    PacketHeader* mPacketHeader; ///< Pointer to Packet Header
-    underrunModeT mUnderRunMode; ///< underrunModeT Mode
-    bool mStopOnTimeout; ///< Stop on 10 second timeout
+    AudioInterface* mAudioInterface;  ///< Interface to Jack Client
+    PacketHeader* mPacketHeader;      ///< Pointer to Packet Header
+    underrunModeT mUnderRunMode;      ///< underrunModeT Mode
+    bool mStopOnTimeout;              ///< Stop on 10 second timeout
 
     /// Pointer for the Send RingBuffer
     RingBuffer* mSendRingBuffer;
     /// Pointer for the Receive RingBuffer
     RingBuffer* mReceiveRingBuffer;
 
-    int mReceiverBindPort; ///< Incoming (receiving) port for local machine
-    int mSenderPeerPort; ///< Incoming (receiving) port for peer machine
-    int mSenderBindPort; ///< Outgoing (sending) port for local machine
-    int mReceiverPeerPort; ///< Outgoing (sending) port for peer machine
+    int mReceiverBindPort;  ///< Incoming (receiving) port for local machine
+    int mSenderPeerPort;    ///< Incoming (receiving) port for peer machine
+    int mSenderBindPort;    ///< Outgoing (sending) port for local machine
+    int mReceiverPeerPort;  ///< Outgoing (sending) port for peer machine
     int mTcpServerPort;
 
-    unsigned int mRedundancy; ///< Redundancy factor in network data
-    QString mJackClientName; ///< JackAudio Client Name
-    QString mRemoteClientName; ///< Remote JackAudio Client Name for hub client mode
+    unsigned int mRedundancy;   ///< Redundancy factor in network data
+    QString mJackClientName;    ///< JackAudio Client Name
+    QString mRemoteClientName;  ///< Remote JackAudio Client Name for hub client mode
 
-    JackTrip::connectionModeT mConnectionMode; ///< Connection Mode
-    JackTrip::hubConnectionModeT mHubConnectionModeT; ///< Hub Server Jack Audio Patch Connection Mode
+    JackTrip::connectionModeT mConnectionMode;  ///< Connection Mode
+    JackTrip::hubConnectionModeT
+        mHubConnectionModeT;  ///< Hub Server Jack Audio Patch Connection Mode
 
-    QVector<ProcessPlugin*> mProcessPluginsFromNetwork; ///< Vector of ProcessPlugin<EM>s</EM>
-    QVector<ProcessPlugin*> mProcessPluginsToNetwork; ///< Vector of ProcessPlugin<EM>s</EM>
-    
+    QVector<ProcessPlugin*>
+        mProcessPluginsFromNetwork;  ///< Vector of ProcessPlugin<EM>s</EM>
+    QVector<ProcessPlugin*>
+        mProcessPluginsToNetwork;  ///< Vector of ProcessPlugin<EM>s</EM>
+
     QTimer mTimeoutTimer;
     int mSleepTime;
     int mElapsedTime;
@@ -565,12 +621,12 @@ private:
     QTcpSocket mTcpClient;
     QUdpSocket mUdpSockTemp;
 
-    volatile bool mReceivedConnection; ///< Bool of received connection from peer
+    volatile bool mReceivedConnection;  ///< Bool of received connection from peer
     volatile bool mTcpConnectionError;
     volatile bool mStopped;
     volatile bool mHasShutdown;
 
-    bool mConnectDefaultAudioPorts; ///< Connect or not default audio ports
+    bool mConnectDefaultAudioPorts;  ///< Connect or not default audio ports
     QSharedPointer<std::ofstream> mIOStatStream;
     int mIOStatTimeout;
     std::ostream mIOStatLogStream;

--- a/src/JackTripThread.cpp
+++ b/src/JackTripThread.cpp
@@ -35,15 +35,15 @@
  * \date September 2008
  */
 
-
 #include "JackTripThread.h"
+
+#include <cstdlib>
+#include <iostream>
+
 #include "NetKS.h"
 
-#include <iostream>
-#include <cstdlib>
-
-using std::cout; using std::endl;
-
+using std::cout;
+using std::endl;
 
 //*******************************************************************************
 void JackTripThread::run()
@@ -51,26 +51,19 @@ void JackTripThread::run()
     JackTrip jacktrip(mJackTripMode);
     jacktrip.setAllPorts(mPortNum);
 
-    if ( mJackTripMode == JackTrip::CLIENT )
-    {
-        jacktrip.setPeerAddress(mPeerAddress);
-    }
+    if (mJackTripMode == JackTrip::CLIENT) { jacktrip.setPeerAddress(mPeerAddress); }
 
     NetKS netks;
     jacktrip.appendProcessPluginFromNetwork(&netks);
     //netks.play();
-
 
     //QThread::sleep(1);
     //jacktrip.start();
     //netks.play();
     //jacktrip.wait();
 
-
     cout << "******** AFTER JACKTRIPTHREAD START **************" << endl;
     //QThread::sleep(9999999);
-
-
 
     /*
   jack_client_t* mClient;
@@ -97,6 +90,4 @@ void JackTripThread::run()
     fprintf (stderr, "unique name `%s' assigned\n", client_name);
   }
   */
-
-
 }

--- a/src/JackTripThread.h
+++ b/src/JackTripThread.h
@@ -46,19 +46,18 @@
  */
 class JackTripThread : public QThread
 {
-public:
+   public:
     JackTripThread(JackTrip::jacktripModeT JacktripMode) : mJackTripMode(JacktripMode) {}
-    virtual ~JackTripThread(){}
+    virtual ~JackTripThread() {}
     void run();
 
     void setPort(int port_num) { mPortNum = port_num; }
     void setPeerAddress(const char* PeerHostOrIP) { mPeerAddress = PeerHostOrIP; }
 
-private:
-    JackTrip::jacktripModeT mJackTripMode; ///< JackTrip::jacktripModeT
+   private:
+    JackTrip::jacktripModeT mJackTripMode;  ///< JackTrip::jacktripModeT
     int mPortNum;
-    const char* mPeerAddress; ///< Peer Address to use in jacktripModeT::CLIENT Mode
+    const char* mPeerAddress;  ///< Peer Address to use in jacktripModeT::CLIENT Mode
 };
 
-
-#endif //__JACKTRIPTHREAD_H__
+#endif  //__JACKTRIPTHREAD_H__

--- a/src/JackTripWorker.cpp
+++ b/src/JackTripWorker.cpp
@@ -35,55 +35,57 @@
  * \date September 2008
  */
 
-#include <iostream>
+#include "JackTripWorker.h"
+
 #include <unistd.h>
 
-#include <QTimer>
 #include <QMutexLocker>
+#include <QTimer>
 #include <QWaitCondition>
+#include <iostream>
 
-#include "JackTripWorker.h"
 #include "JackTrip.h"
 #include "UdpHubListener.h"
 //#include "NetKS.h"
 #include "LoopBack.h"
 #include "Settings.h"
-#ifdef WAIR // wair
+#ifdef WAIR  // wair
 #include "dcblock2gain.dsp.h"
-#endif // endwhere
+#endif  // endwhere
 #ifdef __JAMTEST__
 #include "JamTest.h"
 #endif
 
-using std::cout; using std::endl;
+using std::cout;
+using std::endl;
 
 //*******************************************************************************
-JackTripWorker::JackTripWorker(UdpHubListener* udphublistener, int BufferQueueLength, JackTrip::underrunModeT UnderRunMode, QString clientName) :
-    mUdpHubListener(udphublistener),
-    m_connectDefaultAudioPorts(false),
-    mBufferQueueLength(BufferQueueLength),
-    mUnderRunMode(UnderRunMode),
-    mClientName(clientName),
-    mSpawning(false),
-    mID(0),
-    mNumChans(1),
-    mIOStatTimeout(0)
-  #ifdef WAIR // wair
-  ,mNumNetRevChans(0),
-    mWAIR(false)
-  #endif // endwhere
+JackTripWorker::JackTripWorker(UdpHubListener* udphublistener, int BufferQueueLength,
+                               JackTrip::underrunModeT UnderRunMode, QString clientName)
+    : mUdpHubListener(udphublistener)
+    , m_connectDefaultAudioPorts(false)
+    , mBufferQueueLength(BufferQueueLength)
+    , mUnderRunMode(UnderRunMode)
+    , mClientName(clientName)
+    , mSpawning(false)
+    , mID(0)
+    , mNumChans(1)
+    , mIOStatTimeout(0)
+#ifdef WAIR  // wair
+    , mNumNetRevChans(0)
+    , mWAIR(false)
+#endif  // endwhere
 {
-    setAutoDelete(false); // stick around after calling run()
+    setAutoDelete(false);  // stick around after calling run()
     //mNetks = new NetKS;
     //mNetks->play();
-    mBufferStrategy = 1;
-    mBroadcastQueue = 0;
-    mSimulatedLossRate = 0.0;
+    mBufferStrategy      = 1;
+    mBroadcastQueue      = 0;
+    mSimulatedLossRate   = 0.0;
     mSimulatedJitterRate = 0.0;
-    mSimulatedDelayRel = 0.0;
-    mUseRtUdpPriority = false;
+    mSimulatedDelayRel   = 0.0;
+    mUseRtUdpPriority    = false;
 }
-
 
 //*******************************************************************************
 JackTripWorker::~JackTripWorker()
@@ -91,29 +93,24 @@ JackTripWorker::~JackTripWorker()
     //delete mUdpHubListener;
 }
 
-
 //*******************************************************************************
-void JackTripWorker::setJackTrip(int id,
-                                 QString client_address,
-                                 uint16_t server_port,
-                                 uint16_t client_port,
-                                 int num_channels,
+void JackTripWorker::setJackTrip(int id, QString client_address, uint16_t server_port,
+                                 uint16_t client_port, int num_channels,
                                  bool connectDefaultAudioPorts)
 {
-    { //Start Spawning, so lock mSpawning
+    {  //Start Spawning, so lock mSpawning
         QMutexLocker locker(&mMutex);
         mSpawning = true;
     }
     mID = id;
     // Set the jacktrip address and ports
     //mClientAddress.setAddress(client_address);
-    mClientAddress = client_address;
-    mServerPort = server_port;
-    mClientPort = client_port;
-    mNumChans = num_channels;
+    mClientAddress             = client_address;
+    mServerPort                = server_port;
+    mClientPort                = client_port;
+    mNumChans                  = num_channels;
     m_connectDefaultAudioPorts = connectDefaultAudioPorts;
 }
-
 
 //*******************************************************************************
 void JackTripWorker::run()
@@ -123,67 +120,74 @@ void JackTripWorker::run()
     This is not supported, exceptions thrown in worker threads must be
     caught before control returns to Qt Concurrent.'*/
 
-    { QMutexLocker locker(&mMutex); mSpawning = true; }
+    {
+        QMutexLocker locker(&mMutex);
+        mSpawning = true;
+    }
 
     //QHostAddress ClientAddress;
 
     // Try catching any exceptions that come from JackTrip
-    try
-    {
+    try {
         // Local event loop. this is necesary because QRunnables don't have their own as QThreads
         QEventLoop event_loop;
 
         // Create and setup JackTrip Object
         //JackTrip jacktrip(JackTrip::SERVER, JackTrip::UDP, mNumChans, 2);
-        if (gVerboseFlag) cout << "---> JackTripWorker: Creating jacktrip objects..." << endl;
+        if (gVerboseFlag)
+            cout << "---> JackTripWorker: Creating jacktrip objects..." << endl;
 
-#ifdef WAIR // WAIR
-        // forces    BufferQueueLength to 2
-        // need to parse numNetChans from incoming header
-        // but force to 16 for now
+#ifdef WAIR  // WAIR
+            // forces    BufferQueueLength to 2
+            // need to parse numNetChans from incoming header
+            // but force to 16 for now
 #define FORCEBUFFERQ 2
-        if (mUdpHubListener->isWAIR()) { // invoked with -Sw
-            mWAIR = true;
+        if (mUdpHubListener->isWAIR()) {  // invoked with -Sw
+            mWAIR           = true;
             mNumNetRevChans = NUMNETREVCHANSbecauseNOTINRECEIVEDheader;
-        } else {};
-#endif // endwhere
+        } else {
+        };
+#endif  // endwhere
 
 #ifndef __JAMTEST__
-#ifdef WAIR // WAIR
+#ifdef WAIR  // WAIR
         //        bool tmp = mJTWorkers->at(id)->isWAIR();
         //        qDebug() << "is WAIR?" <<  tmp ;
-        qDebug() << "mNumNetRevChans" <<  mNumNetRevChans ;
+        qDebug() << "mNumNetRevChans" << mNumNetRevChans;
 
         JackTrip jacktrip(JackTrip::SERVERPINGSERVER, JackTrip::UDP, mNumChans,
                           mNumNetRevChans, FORCEBUFFERQ);
-        JackTrip * mJackTrip = &jacktrip;
-#else // endwhere
-        JackTrip jacktrip(JackTrip::SERVERPINGSERVER, JackTrip::UDP, mNumChans, mBufferQueueLength);
-#endif // not wair
+        JackTrip* mJackTrip = &jacktrip;
+#else  // endwhere
+        JackTrip jacktrip(JackTrip::SERVERPINGSERVER, JackTrip::UDP, mNumChans,
+                          mBufferQueueLength);
+#endif  // not wair
 
-#ifdef WAIR // WAIR
+#ifdef WAIR  // WAIR
         // Add Plugins
-        if ( mWAIR ) {
+        if (mWAIR) {
             cout << "Running in WAIR Mode..." << endl;
             cout << gPrintSeparator << std::endl;
-            switch ( mNumNetRevChans )
-            {
-            case 16 : // freeverb
-                mJackTrip->appendProcessPluginFromNetwork(new dcblock2gain(mNumChans)); // plugin slot 0
+            switch (mNumNetRevChans) {
+            case 16:  // freeverb
+                mJackTrip->appendProcessPluginFromNetwork(
+                    new dcblock2gain(mNumChans));  // plugin slot 0
                 ///////////////
                 //            mJackTrip->appendProcessPlugin(new comb16server(mNumNetChans));
                 // -S LAIR no AP  mJackTrip->appendProcessPlugin(new AP8(mNumChans));
                 break;
             default:
-                throw std::invalid_argument("Settings: mNumNetChans doesn't correspond to Faust plugin");
+                throw std::invalid_argument(
+                    "Settings: mNumNetChans doesn't correspond to Faust plugin");
                 break;
             }
         }
-#endif // endwhere
-#endif // ifndef __JAMTEST__
+#endif  // endwhere
+#endif  // ifndef __JAMTEST__
 
 #ifdef __JAMTEST__
-        JamTest jacktrip(JackTrip::SERVERPINGSERVER); // ########### JamTest #################
+        JamTest jacktrip(
+            JackTrip::SERVERPINGSERVER);  // ########### JamTest #################
         //JackTrip jacktrip(JackTrip::SERVERPINGSERVER, JackTrip::UDP, mNumChans, 2);
 #endif
 
@@ -195,24 +199,24 @@ void JackTripWorker::run()
             jacktrip.setIOStatTimeout(mIOStatTimeout);
             jacktrip.setIOStatStream(mIOStatStream);
         }
-        
-        if (!mClientName.isEmpty()) {
-            jacktrip.setClientName(mClientName);
-        }
+
+        if (!mClientName.isEmpty()) { jacktrip.setClientName(mClientName); }
 
         // Connect signals and slots
         // -------------------------
-        if (gVerboseFlag) cout << "---> JackTripWorker: Connecting signals and slots..." << endl;
+        if (gVerboseFlag)
+            cout << "---> JackTripWorker: Connecting signals and slots..." << endl;
         // Connection to terminate JackTrip when packets haven't arrive for
         // a certain amount of time
-        QObject::connect(&jacktrip, SIGNAL(signalNoUdpPacketsForSeconds()),
-                         &jacktrip, SLOT(slotStopProcesses()), Qt::QueuedConnection);
+        QObject::connect(&jacktrip, SIGNAL(signalNoUdpPacketsForSeconds()), &jacktrip,
+                         SLOT(slotStopProcesses()), Qt::QueuedConnection);
         // Connection to terminate the local eventloop when jacktrip is done
-        QObject::connect(&jacktrip, SIGNAL(signalProcessesStopped()),
-                         &event_loop, SLOT(quit()), Qt::QueuedConnection);
-        QObject::connect(&jacktrip, &JackTrip::signalError, &event_loop, &QEventLoop::quit, Qt::QueuedConnection);
-        QObject::connect(this, SIGNAL(signalRemoveThread()),
-                         &jacktrip, SLOT(slotStopProcesses()), Qt::QueuedConnection);
+        QObject::connect(&jacktrip, SIGNAL(signalProcessesStopped()), &event_loop,
+                         SLOT(quit()), Qt::QueuedConnection);
+        QObject::connect(&jacktrip, &JackTrip::signalError, &event_loop,
+                         &QEventLoop::quit, Qt::QueuedConnection);
+        QObject::connect(this, SIGNAL(signalRemoveThread()), &jacktrip,
+                         SLOT(slotStopProcesses()), Qt::QueuedConnection);
 
         //ClientAddress.setAddress(mClientAddress);
         // If I don't type this line, I get a bus error in the next line.
@@ -223,48 +227,59 @@ void JackTripWorker::run()
         jacktrip.setBindPorts(mServerPort);
         //jacktrip.setPeerPorts(mClientPort);
         jacktrip.setBufferStrategy(mBufferStrategy);
-        jacktrip.setNetIssuesSimulation(mSimulatedLossRate,
-            mSimulatedJitterRate, mSimulatedDelayRel);
+        jacktrip.setNetIssuesSimulation(mSimulatedLossRate, mSimulatedJitterRate,
+                                        mSimulatedDelayRel);
         jacktrip.setBroadcast(mBroadcastQueue);
         jacktrip.setUseRtUdpPriority(mUseRtUdpPriority);
 
-        if (gVerboseFlag) cout << "---> JackTripWorker: setJackTripFromClientHeader..." << endl;
+        if (gVerboseFlag)
+            cout << "---> JackTripWorker: setJackTripFromClientHeader..." << endl;
         int PeerConnectionMode = setJackTripFromClientHeader(jacktrip);
-        if ( PeerConnectionMode == -1 ) {
+        if (PeerConnectionMode == -1) {
             mUdpHubListener->releaseThread(mID);
-            { QMutexLocker locker(&mMutex); mSpawning = false; }
+            {
+                QMutexLocker locker(&mMutex);
+                mSpawning = false;
+            }
             return;
         }
 
         // Start Threads and event loop
         if (gVerboseFlag) cout << "---> JackTripWorker: startProcess..." << endl;
         jacktrip.startProcess(
-            #ifdef WAIRTOHUB // wair
-                    mID
-            #endif // endwhere
-                    );
+#ifdef WAIRTOHUB  // wair
+            mID
+#endif  // endwhere
+        );
         // if (gVerboseFlag) cout << "---> JackTripWorker: start..." << endl;
         // jacktrip.start(); // ########### JamTest Only #################
 
         // Thread is already spawning, so release the lock
-        { QMutexLocker locker(&mMutex); mSpawning = false; }
+        {
+            QMutexLocker locker(&mMutex);
+            mSpawning = false;
+        }
 
-        event_loop.exec(); // Excecution will block here until exit() the QEventLoop
+        event_loop.exec();  // Excecution will block here until exit() the QEventLoop
         //--------------------------------------------------------------------------
-        
-        { QMutexLocker locker(&mMutex); mSpawning = true; }
+
+        {
+            QMutexLocker locker(&mMutex);
+            mSpawning = true;
+        }
 
         // wait for jacktrip to be done before exiting the Worker Thread
         //jacktrip.wait();
 
-    }
-    catch ( const std::exception & e )
-    {
+    } catch (const std::exception& e) {
         std::cerr << "Couldn't send thread to the Pool" << endl;
         std::cerr << e.what() << endl;
         std::cerr << gPrintSeparator << endl;
         mUdpHubListener->releaseThread(mID);
-        { QMutexLocker locker(&mMutex); mSpawning = false; }
+        {
+            QMutexLocker locker(&mMutex);
+            mSpawning = false;
+        }
         return;
     }
 
@@ -282,33 +297,33 @@ void JackTripWorker::run()
     }
 }
 
-
 //*******************************************************************************
 // returns -1 on error
 int JackTripWorker::setJackTripFromClientHeader(JackTrip& jacktrip)
 {
     //QHostAddress peerHostAddress;
     //uint16_t peer_port;
-    QUdpSocket UdpSockTemp;// Create socket to wait for client
+    QUdpSocket UdpSockTemp;  // Create socket to wait for client
 
     // Bind the socket
-    if ( !UdpSockTemp.bind(QHostAddress::Any, mServerPort,
-                           QUdpSocket::DefaultForPlatform) )
-    {
-        std::cerr << "in JackTripWorker: Could not bind UDP socket. It may be already binded." << endl;
+    if (!UdpSockTemp.bind(QHostAddress::Any, mServerPort,
+                          QUdpSocket::DefaultForPlatform)) {
+        std::cerr
+            << "in JackTripWorker: Could not bind UDP socket. It may be already binded."
+            << endl;
         throw std::runtime_error("Could not bind UDP socket. It may be already binded.");
     }
 
     // Listen to client
-    QWaitCondition sleep; // time is in milliseconds
+    QWaitCondition sleep;  // time is in milliseconds
     QMutex mutex;
-    int sleepTime = 100; // ms
-    int udpTimeout = gTimeOutMultiThreadedServer; // gTimeOutMultiThreadedServer mseconds
+    int sleepTime  = 100;                          // ms
+    int udpTimeout = gTimeOutMultiThreadedServer;  // gTimeOutMultiThreadedServer mseconds
     int elapsedTime = 0;
     {
         QMutexLocker lock(&mutex);
-        while ( (!UdpSockTemp.hasPendingDatagrams()) && (elapsedTime <= udpTimeout) ) {
-            sleep.wait(&mutex,sleepTime);
+        while ((!UdpSockTemp.hasPendingDatagrams()) && (elapsedTime <= udpTimeout)) {
+            sleep.wait(&mutex, sleepTime);
             elapsedTime += sleepTime;
             if (gVerboseFlag) cout << "---------> ELAPSED TIME: " << elapsedTime << endl;
         }
@@ -322,25 +337,30 @@ int JackTripWorker::setJackTripFromClientHeader(JackTrip& jacktrip)
     int packet_size = UdpSockTemp.pendingDatagramSize();
     char packet[packet_size];
     UdpSockTemp.readDatagram(packet, packet_size);
-    UdpSockTemp.close(); // close the socket
+    UdpSockTemp.close();  // close the socket
     int8_t* full_packet = reinterpret_cast<int8_t*>(packet);
 
-    int PeerBufferSize = jacktrip.getPeerBufferSize(full_packet);
-    int PeerSamplingRate = jacktrip.getPeerSamplingRate(full_packet);
-    int PeerBitResolution = jacktrip.getPeerBitResolution(full_packet);
-    int PeerNumChannels = jacktrip.getPeerNumChannels(full_packet);
+    int PeerBufferSize     = jacktrip.getPeerBufferSize(full_packet);
+    int PeerSamplingRate   = jacktrip.getPeerSamplingRate(full_packet);
+    int PeerBitResolution  = jacktrip.getPeerBitResolution(full_packet);
+    int PeerNumChannels    = jacktrip.getPeerNumChannels(full_packet);
     int PeerConnectionMode = jacktrip.getPeerConnectionMode(full_packet);
 
-    if (gVerboseFlag) cout << "--->JackTripWorker: getPeerBufferSize = " << PeerBufferSize << endl;
-    if (gVerboseFlag) cout << "--->JackTripWorker: getPeerSamplingRate = " << PeerSamplingRate << endl;
-    if (gVerboseFlag) cout << "--->JackTripWorker: getPeerBitResolution = " << PeerBitResolution << endl;
+    if (gVerboseFlag)
+        cout << "--->JackTripWorker: getPeerBufferSize = " << PeerBufferSize << endl;
+    if (gVerboseFlag)
+        cout << "--->JackTripWorker: getPeerSamplingRate = " << PeerSamplingRate << endl;
+    if (gVerboseFlag)
+        cout << "--->JackTripWorker: getPeerBitResolution = " << PeerBitResolution
+             << endl;
     cout << "--->JackTripWorker: PeerNumChannels = " << PeerNumChannels << endl;
-    if (gVerboseFlag) cout << "--->JackTripWorker: getPeerConnectionMode = " << PeerConnectionMode << endl;
+    if (gVerboseFlag)
+        cout << "--->JackTripWorker: getPeerConnectionMode = " << PeerConnectionMode
+             << endl;
 
     jacktrip.setNumChannels(PeerNumChannels);
     return PeerConnectionMode;
 }
-
 
 //*******************************************************************************
 bool JackTripWorker::isSpawning()
@@ -348,7 +368,6 @@ bool JackTripWorker::isSpawning()
     QMutexLocker locker(&mMutex);
     return mSpawning;
 }
-
 
 //*******************************************************************************
 void JackTripWorker::stopThread()

--- a/src/JackTripWorker.h
+++ b/src/JackTripWorker.h
@@ -38,20 +38,18 @@
 #ifndef __JACKTRIPWORKER_H__
 #define __JACKTRIPWORKER_H__
 
-#include <iostream>
-
-#include <QThreadPool>
-#include <QObject>
 #include <QEventLoop>
 #include <QHostAddress>
 #include <QMutex>
+#include <QObject>
+#include <QThreadPool>
+#include <iostream>
 
 #include "JackTrip.h"
 #include "jacktrip_globals.h"
 
 //class JackTrip; // forward declaration
-class UdpHubListener; // forward declaration
-
+class UdpHubListener;  // forward declaration
 
 /** \brief Prototype of the worker class that will be cloned through sending threads to the
  * Thread Pool
@@ -64,13 +62,18 @@ class UdpHubListener; // forward declaration
  */
 // Note that it is not possible to start run() as an event loop. That has to be implemented
 // inside a QThread
-class JackTripWorker : public QObject, public QRunnable
+class JackTripWorker
+    : public QObject
+    , public QRunnable
 {
-    Q_OBJECT; // QRunnable is not a QObject, so I have to inherit from QObject as well
+    Q_OBJECT;  // QRunnable is not a QObject, so I have to inherit from QObject as well
 
-public:
+   public:
     /// \brief The class constructor
-    JackTripWorker(UdpHubListener* udphublistener, int BufferQueueLength = gDefaultQueueLength, JackTrip::underrunModeT UnderRunMode = JackTrip::WAVETABLE, QString clientName = "");
+    JackTripWorker(UdpHubListener* udphublistener,
+                   int BufferQueueLength                = gDefaultQueueLength,
+                   JackTrip::underrunModeT UnderRunMode = JackTrip::WAVETABLE,
+                   QString clientName                   = "");
     /// \brief The class destructor
     virtual ~JackTripWorker();
 
@@ -83,54 +86,48 @@ public:
     /// \brief Sets the JackTripWorker properties
     /// \param id ID number
     /// \param address
-    void setJackTrip(int id,
-                     QString client_address,
-                     uint16_t server_port,
-                     uint16_t client_port,
-                     int num_channels,
-                     bool connectDefaultAudioPorts
-                     );
+    void setJackTrip(int id, QString client_address, uint16_t server_port,
+                     uint16_t client_port, int num_channels,
+                     bool connectDefaultAudioPorts);
     /// Stop and remove thread from pool
     void stopThread();
-    int getID()
-    {
-        return mID;
-    }
+    int getID() { return mID; }
 
     void setBufferStrategy(int BufferStrategy) { mBufferStrategy = BufferStrategy; }
     void setNetIssuesSimulation(double loss, double jitter, double delay_rel)
     {
-        mSimulatedLossRate = loss;
+        mSimulatedLossRate   = loss;
         mSimulatedJitterRate = jitter;
-        mSimulatedDelayRel = delay_rel;
+        mSimulatedDelayRel   = delay_rel;
     }
-    void setBroadcast(int broadcast_queue) {mBroadcastQueue = broadcast_queue;}
-    void setUseRtUdpPriority(bool use) {mUseRtUdpPriority = use;}
-    
+    void setBroadcast(int broadcast_queue) { mBroadcastQueue = broadcast_queue; }
+    void setUseRtUdpPriority(bool use) { mUseRtUdpPriority = use; }
+
     void setIOStatTimeout(int timeout) { mIOStatTimeout = timeout; }
-    void setIOStatStream(QSharedPointer<std::ofstream> statStream) { mIOStatStream = statStream; }
-    
-private slots:
-    void slotTest()
-    { std::cout << "--- JackTripWorker TEST SLOT ---" << std::endl; }
+    void setIOStatStream(QSharedPointer<std::ofstream> statStream)
+    {
+        mIOStatStream = statStream;
+    }
 
+   private slots:
+    void slotTest() { std::cout << "--- JackTripWorker TEST SLOT ---" << std::endl; }
 
-signals:
+   signals:
     void signalRemoveThread();
 
-private:
+   private:
     int setJackTripFromClientHeader(JackTrip& jacktrip);
     JackTrip::connectionModeT getConnectionModeFromHeader();
 
-    UdpHubListener* mUdpHubListener; ///< Hub Listener Socket
+    UdpHubListener* mUdpHubListener;  ///< Hub Listener Socket
     //QHostAddress mClientAddress; ///< Client Address
     QString mClientAddress;
-    uint16_t mServerPort; ///< Server Ephemeral Incomming Port to use with Client
+    uint16_t mServerPort;  ///< Server Ephemeral Incomming Port to use with Client
     bool m_connectDefaultAudioPorts;
 
     /// Client Outgoing Port. By convention, the receving port will be <tt>mClientPort -1</tt>
     uint16_t mClientPort;
-    
+
     int mBufferQueueLength;
     JackTrip::underrunModeT mUnderRunMode;
     QString mClientName;
@@ -138,10 +135,10 @@ private:
     /// Thread spawning internal lock.
     /// If true, the prototype is working on creating (spawning) a new thread
     volatile bool mSpawning;
-    QMutex mMutex; ///< Mutex to protect mSpawning
+    QMutex mMutex;  ///< Mutex to protect mSpawning
 
-    int mID; ///< ID thread number
-    int mNumChans; ///< Number of Channels
+    int mID;        ///< ID thread number
+    int mNumChans;  ///< Number of Channels
 
     int mBufferStrategy;
     int mBroadcastQueue;
@@ -149,14 +146,13 @@ private:
     double mSimulatedJitterRate;
     double mSimulatedDelayRel;
     bool mUseRtUdpPriority;
-    
+
     int mIOStatTimeout;
     QSharedPointer<std::ofstream> mIOStatStream;
-#ifdef WAIR // wair
-    int mNumNetRevChans; ///< Number of Net Channels = net combs
+#ifdef WAIR  // wair
+    int mNumNetRevChans;  ///< Number of Net Channels = net combs
     bool mWAIR;
-#endif // endwhere
+#endif  // endwhere
 };
 
-
-#endif //__JACKTRIPWORKER_H__
+#endif  //__JACKTRIPWORKER_H__

--- a/src/JackTripWorkerMessages.h
+++ b/src/JackTripWorkerMessages.h
@@ -40,36 +40,36 @@
 
 #include <QObject>
 #include <QTimer>
-
 #include <iostream>
 
 class JackTripWorkerMessages : public QObject
 {
     Q_OBJECT;
 
-public:
-    JackTripWorkerMessages() {};
-    virtual ~JackTripWorkerMessages() {};
+   public:
+    JackTripWorkerMessages(){};
+    virtual ~JackTripWorkerMessages(){};
 
     void play()
     {
-        std::cout << "********** PALYING ***********************************" << std::endl;
-        QTimer *timer = new QTimer(this);
-        QObject::connect(timer, SIGNAL(timeout()), this, SLOT(slotTest()), Qt::QueuedConnection);
+        std::cout << "********** PALYING ***********************************"
+                  << std::endl;
+        QTimer* timer = new QTimer(this);
+        QObject::connect(timer, SIGNAL(timeout()), this, SLOT(slotTest()),
+                         Qt::QueuedConnection);
         timer->start(300);
     }
 
-public slots:
+   public slots:
     void slotTest()
     {
         std::cout << "---JackTripWorkerMessages slotTest()---" << std::endl;
     }
 
-signals:
+   signals:
     void signalTest();
     /// Signal to stop the event loop inside the JackTripWorker Thread
     void signalStopEventLoop();
-
 };
 
-#endif //__JACKTRIPWORKERMESSAGES_H__
+#endif  //__JACKTRIPWORKERMESSAGES_H__

--- a/src/JitterBuffer.cpp
+++ b/src/JitterBuffer.cpp
@@ -35,154 +35,143 @@
  * \date June 2020
  */
 
-
 #include "JitterBuffer.h"
 
-#include <iostream>
-#include <cstring>
-#include <cstdlib>
-#include <stdexcept>
 #include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <stdexcept>
 
-using std::cout; using std::endl;
-
+using std::cout;
+using std::endl;
 
 //*******************************************************************************
 JitterBuffer::JitterBuffer(int buf_samples, int qlen, int sample_rate, int strategy,
-                                          int bcast_qlen, int channels, int bit_res) :
-    RingBuffer(0, 0)
+                           int bcast_qlen, int channels, int bit_res)
+    : RingBuffer(0, 0)
 {
-    int total_size = sample_rate * channels * bit_res * 2; // 2 secs of audio
-    int slot_size = buf_samples * channels * bit_res;
-    mSlotSize = slot_size;
-    mInSlotSize = slot_size;
+    int total_size = sample_rate * channels * bit_res * 2;  // 2 secs of audio
+    int slot_size  = buf_samples * channels * bit_res;
+    mSlotSize      = slot_size;
+    mInSlotSize    = slot_size;
     if (0 < qlen) {
         mMaxLatency = qlen * slot_size;
-        mAutoQueue = 0;
-    }
-    else {
+        mAutoQueue  = 0;
+    } else {
         // AutoQueue
-        mMaxLatency = 3*slot_size;
-        mAutoQueue = 1;
+        mMaxLatency = 3 * slot_size;
+        mAutoQueue  = 1;
     }
-    mTotalSize = total_size;
+    mTotalSize        = total_size;
     mBroadcastLatency = bcast_qlen * mSlotSize;
-    mNumChannels = channels;
-    mAudioBitRes = bit_res;
-    mMinStepSize = channels * bit_res;
-    mFPP = buf_samples;
-    mSampleRate = sample_rate;
-    mActive = false;
+    mNumChannels      = channels;
+    mAudioBitRes      = bit_res;
+    mMinStepSize      = channels * bit_res;
+    mFPP              = buf_samples;
+    mSampleRate       = sample_rate;
+    mActive           = false;
 
     // Defaults for zero strategy
     mUnderrunIncTolerance = -10 * mSlotSize;
-    mCorrIncTolerance = 100*mMaxLatency;     // should be greater than mUnderrunIncTolerance
-    mOverflowDecTolerance = 100*mMaxLatency;
-    mWritePosition = mMaxLatency;
-    mStatUnit = mSlotSize;
-    mLevelDownRate = std::min(256, mFPP) / (5.0*sample_rate) * mSlotSize;
-    mOverflowDropStep = mMaxLatency / 2;
-    mLevelCur = mMaxLatency;
-    mLevel = mLevelCur;
-    mMinLevelThreshold = 1.9 * mSlotSize;
-    mBroadcastPosition = 0;
+    mCorrIncTolerance =
+        100 * mMaxLatency;  // should be greater than mUnderrunIncTolerance
+    mOverflowDecTolerance  = 100 * mMaxLatency;
+    mWritePosition         = mMaxLatency;
+    mStatUnit              = mSlotSize;
+    mLevelDownRate         = std::min(256, mFPP) / (5.0 * sample_rate) * mSlotSize;
+    mOverflowDropStep      = mMaxLatency / 2;
+    mLevelCur              = mMaxLatency;
+    mLevel                 = mLevelCur;
+    mMinLevelThreshold     = 1.9 * mSlotSize;
+    mBroadcastPosition     = 0;
     mBroadcastPositionCorr = 0.0;
-    mLastCorrCounter = 0;
-    mLastCorrDirection = 0;
+    mLastCorrCounter       = 0;
+    mLastCorrDirection     = 0;
 
     switch (strategy) {
-      case 1:
+    case 1:
         mOverflowDropStep = mSlotSize;
         break;
-      case 2:
+    case 2:
         mUnderrunIncTolerance = 1.1 * mSlotSize;
-        mCorrIncTolerance = 1.9 * mSlotSize;     // should be greater than mUnderrunIncTolerance
-        mOverflowDecTolerance = 0.1*mSlotSize;
-        mOverflowDropStep = mSlotSize;
+        mCorrIncTolerance =
+            1.9 * mSlotSize;  // should be greater than mUnderrunIncTolerance
+        mOverflowDecTolerance = 0.1 * mSlotSize;
+        mOverflowDropStep     = mSlotSize;
         break;
     }
 
     mRingBuffer = new int8_t[mTotalSize];
     std::memset(mRingBuffer, 0, mTotalSize);
 
-    mAutoQueueCorr = 2*mSlotSize;
+    mAutoQueueCorr = 2 * mSlotSize;
     if (0 > qlen) {
-        mAutoQFactor = 1.0/-qlen;
+        mAutoQFactor = 1.0 / -qlen;
+    } else {
+        mAutoQFactor = 1.0 / 500;
     }
-    else {
-        mAutoQFactor = 1.0/500;
-    }
-    mAutoQRate = mSlotSize * 0.5;
-    mAutoQRateMin = mSlotSize * 0.0005;
-    mAutoQRateDecay = 1.0 - std::min(mFPP*1.2e-6, 0.0005);
+    mAutoQRate      = mSlotSize * 0.5;
+    mAutoQRateMin   = mSlotSize * 0.0005;
+    mAutoQRateDecay = 1.0 - std::min(mFPP * 1.2e-6, 0.0005);
 }
 
 //*******************************************************************************
 bool JitterBuffer::insertSlotNonBlocking(const int8_t* ptrToSlot, int len, int lostLen)
 {
-    if (0 == len) {
-        len = mSlotSize;
-    }
+    if (0 == len) { len = mSlotSize; }
     QMutexLocker locker(&mMutex);
     mInSlotSize = len;
-    if (!mActive) {
-        mActive = true;
-    }
-    if (mMaxLatency < len + mSlotSize) {
-        mMaxLatency = len + mSlotSize;
-    }
-    if (0 < lostLen) {
-        processPacketLoss(lostLen);
-    }
+    if (!mActive) { mActive = true; }
+    if (mMaxLatency < len + mSlotSize) { mMaxLatency = len + mSlotSize; }
+    if (0 < lostLen) { processPacketLoss(lostLen); }
     mSkewRaw += mReadsNew - len;
     mReadsNew = 0;
     mUnderruns += mUnderrunsNew;
     mUnderrunsNew = 0;
-    mLevel = mSlotSize*std::ceil(mLevelCur/mSlotSize);
+    mLevel        = mSlotSize * std::ceil(mLevelCur / mSlotSize);
 
     // Update positions if necessary
     int32_t available = mWritePosition - mReadPosition;
 
     int delta = 0;
-    if (available < -10*mMaxLatency) {
+    if (available < -10 * mMaxLatency) {
         delta = available;
         mBufIncUnderrun += -delta;
         mLevelCur = len;
         //cout << "reset" << endl;
-    }
-    else if (available + len > mMaxLatency) {
+    } else if (available + len > mMaxLatency) {
         delta = mOverflowDropStep;
         mOverflows += delta;
         mBufDecOverflow += delta;
         mLevelCur = mMaxLatency;
-    }
-    else if (0 > available &&
-          mLevelCur < std::max(mInSlotSize + mMinLevelThreshold,
-              mMaxLatency - mUnderrunIncTolerance - 2*mSlotSize*lastCorrFactor())) {
+    } else if (0 > available
+               && mLevelCur < std::max(mInSlotSize + mMinLevelThreshold,
+                                       mMaxLatency - mUnderrunIncTolerance
+                                           - 2 * mSlotSize * lastCorrFactor())) {
         delta = -std::min(-available, mSlotSize);
         mBufIncUnderrun += -delta;
-    }
-    else if (mLevelCur < mMaxLatency - mCorrIncTolerance - 6*mSlotSize*lastCorrFactor()) {
+    } else if (mLevelCur
+               < mMaxLatency - mCorrIncTolerance - 6 * mSlotSize * lastCorrFactor()) {
         delta = -mSlotSize;
         mUnderruns += -delta;
         mBufIncCompensate += -delta;
     }
 
     if (0 != delta) {
-      mReadPosition += delta;
-      mLastCorrCounter = 0;
-      mLastCorrDirection = 0 < delta ? 1 : -1;
-    }
-    else {
-      ++mLastCorrCounter;
+        mReadPosition += delta;
+        mLastCorrCounter   = 0;
+        mLastCorrDirection = 0 < delta ? 1 : -1;
+    } else {
+        ++mLastCorrCounter;
     }
 
     int wpos = mWritePosition % mTotalSize;
-    int n = std::min(mTotalSize - wpos, len);
-    std::memcpy(mRingBuffer+wpos, ptrToSlot, n);
+    int n    = std::min(mTotalSize - wpos, len);
+    std::memcpy(mRingBuffer + wpos, ptrToSlot, n);
     if (n < len) {
         //cout << "split write: " << len << "-" << n << endl;
-        std::memcpy(mRingBuffer, ptrToSlot+n, len-n);
+        std::memcpy(mRingBuffer, ptrToSlot + n, len - n);
     }
     mWritePosition += len;
 
@@ -201,45 +190,42 @@ void JitterBuffer::readSlotNonBlocking(int8_t* ptrToReadSlot)
     mReadsNew += len;
     int32_t available = mWritePosition - mReadPosition;
     if (available < mLevelCur) {
-        mLevelCur = std::max((double)available, mLevelCur-mLevelDownRate);
-    }
-    else {
+        mLevelCur = std::max((double)available, mLevelCur - mLevelDownRate);
+    } else {
         mLevelCur = available;
     }
 
     // auto queue correction
     if (0 > available + mAutoQueueCorr - mLevelCur) {
         mAutoQueueCorr += mAutoQRate;
-    }
-    else if (mInSlotSize + mSlotSize < mAutoQueueCorr) {
+    } else if (mInSlotSize + mSlotSize < mAutoQueueCorr) {
         mAutoQueueCorr -= mAutoQRate * mAutoQFactor;
     }
-    if (mAutoQRate > mAutoQRateMin) {
-        mAutoQRate *= mAutoQRateDecay;
-    }
+    if (mAutoQRate > mAutoQRateMin) { mAutoQRate *= mAutoQRateDecay; }
     if (0 != mAutoQueue) {
         int PPS = mSampleRate / mFPP;
-        if (2*PPS == mAutoQueue++ % (4*PPS)) {
-            double k = 1.0 + 1e-5/mAutoQFactor;
-            if (12*PPS > mAutoQueue ||
-                    std::abs(mAutoQueueCorr*k - mMaxLatency + mSlotSize/2) > 0.6*mSlotSize) {
-                mMaxLatency = mSlotSize * std::ceil(mAutoQueueCorr*k/mSlotSize);
+        if (2 * PPS == mAutoQueue++ % (4 * PPS)) {
+            double k = 1.0 + 1e-5 / mAutoQFactor;
+            if (12 * PPS > mAutoQueue
+                || std::abs(mAutoQueueCorr * k - mMaxLatency + mSlotSize / 2)
+                       > 0.6 * mSlotSize) {
+                mMaxLatency = mSlotSize * std::ceil(mAutoQueueCorr * k / mSlotSize);
                 cout << "AutoQueue: " << mMaxLatency / mSlotSize << endl;
             }
         }
     }
 
     int read_len = qBound(0, available, len);
-    int rpos = mReadPosition % mTotalSize;
-    int n = std::min(mTotalSize - rpos, read_len);
-    std::memcpy(ptrToReadSlot, mRingBuffer+rpos, n);
+    int rpos     = mReadPosition % mTotalSize;
+    int n        = std::min(mTotalSize - rpos, read_len);
+    std::memcpy(ptrToReadSlot, mRingBuffer + rpos, n);
     if (n < read_len) {
         //cout << "split read: " << read_len << "-" << n << endl;
-        std::memcpy(ptrToReadSlot+n, mRingBuffer, read_len-n);
+        std::memcpy(ptrToReadSlot + n, mRingBuffer, read_len - n);
     }
     if (read_len < len) {
-        std::memset(ptrToReadSlot+read_len, 0, len-read_len);
-        mUnderrunsNew += len-read_len;
+        std::memset(ptrToReadSlot + read_len, 0, len - read_len);
+        mUnderrunsNew += len - read_len;
     }
     mReadPosition += len;
 }
@@ -256,59 +242,55 @@ void JitterBuffer::readBroadcastSlot(int8_t* ptrToReadSlot)
     // latency correction
     int32_t d = mReadPosition - mBroadcastLatency - mBroadcastPosition - len;
     if (std::abs(d) > mBroadcastLatency / 2) {
-        mBroadcastPosition = mReadPosition - mBroadcastLatency - len;
+        mBroadcastPosition     = mReadPosition - mBroadcastLatency - len;
         mBroadcastPositionCorr = 0.0;
         mBroadcastSkew += d / mMinStepSize;
-    }
-    else {
+    } else {
         mBroadcastPositionCorr += 0.0003 * d;
         int delta = mBroadcastPositionCorr / mMinStepSize;
         if (0 != delta) {
             mBroadcastPositionCorr -= delta * mMinStepSize;
-            if (2 == mAudioBitRes && (int32_t)(mWritePosition - mBroadcastPosition) > len) {
+            if (2 == mAudioBitRes
+                && (int32_t)(mWritePosition - mBroadcastPosition) > len) {
                 // interpolate
                 len += delta * mMinStepSize;
-            }
-            else {
+            } else {
                 // skip
                 mBroadcastPosition += delta * mMinStepSize;
             }
             mBroadcastSkew += delta;
         }
     }
-    mBroadcastDelta = d / mMinStepSize;
+    mBroadcastDelta   = d / mMinStepSize;
     int32_t available = mWritePosition - mBroadcastPosition;
-    int read_len = qBound(0, available, len);
+    int read_len      = qBound(0, available, len);
     if (len == mSlotSize) {
         int rpos = mBroadcastPosition % mTotalSize;
-        int n = std::min(mTotalSize - rpos, read_len);
-        std::memcpy(ptrToReadSlot, mRingBuffer+rpos, n);
+        int n    = std::min(mTotalSize - rpos, read_len);
+        std::memcpy(ptrToReadSlot, mRingBuffer + rpos, n);
         if (n < read_len) {
             //cout << "split read: " << read_len << "-" << n << endl;
-            std::memcpy(ptrToReadSlot+n, mRingBuffer, read_len-n);
+            std::memcpy(ptrToReadSlot + n, mRingBuffer, read_len - n);
         }
-        if (read_len < len) {
-            std::memset(ptrToReadSlot+read_len, 0, len-read_len);
-        }
-    }
-    else {
+        if (read_len < len) { std::memset(ptrToReadSlot + read_len, 0, len - read_len); }
+    } else {
         // interpolation len => mSlotSize
         double K = 1.0 * len / mSlotSize;
-        for (int c=0; c < mMinStepSize; c+=sizeof(int16_t)) {
-            for (int j=0; j < mSlotSize/mMinStepSize; ++j) {
-                int j1 = std::floor(j*K);
-                double a = j*K - j1;
-                int rpos = (mBroadcastPosition + j1*mMinStepSize + c) % mTotalSize;
+        for (int c = 0; c < mMinStepSize; c += sizeof(int16_t)) {
+            for (int j = 0; j < mSlotSize / mMinStepSize; ++j) {
+                int j1     = std::floor(j * K);
+                double a   = j * K - j1;
+                int rpos   = (mBroadcastPosition + j1 * mMinStepSize + c) % mTotalSize;
                 int16_t v1 = *(int16_t*)(mRingBuffer + rpos);
-                rpos = (rpos + mMinStepSize) % mTotalSize;
+                rpos       = (rpos + mMinStepSize) % mTotalSize;
                 int16_t v2 = *(int16_t*)(mRingBuffer + rpos);
-                *(int16_t*)(ptrToReadSlot + j*mMinStepSize + c) = std::round((1-a)*v1 + a*v2);
+                *(int16_t*)(ptrToReadSlot + j * mMinStepSize + c) =
+                    std::round((1 - a) * v1 + a * v2);
             }
         }
     }
     mBroadcastPosition += len;
 }
-
 
 //*******************************************************************************
 void JitterBuffer::processPacketLoss(int lostLen)
@@ -320,33 +302,32 @@ void JitterBuffer::processPacketLoss(int lostLen)
     if (0 < delta) {
         lostLen -= delta;
         mBufDecPktLoss += delta;
-        mLevelCur = mMaxLatency;
-        mLastCorrCounter = 0;
+        mLevelCur          = mMaxLatency;
+        mLastCorrCounter   = 0;
         mLastCorrDirection = 1;
-    }
-    else if (mSlotSize < available + lostLen && (
-            mOverflowDecTolerance > mMaxLatency   // for strategies 0,1
-            || (0 < mLastCorrDirection && mLevelCur >
-                    mMaxLatency - mOverflowDecTolerance*(1.1 - lastCorrFactor()))
-            )) {
+    } else if (mSlotSize < available + lostLen
+               && (mOverflowDecTolerance > mMaxLatency  // for strategies 0,1
+                   || (0 < mLastCorrDirection
+                       && mLevelCur > mMaxLatency
+                                          - mOverflowDecTolerance
+                                                * (1.1 - lastCorrFactor())))) {
         delta = std::min(lostLen, mSlotSize);
         lostLen -= delta;
         mBufDecPktLoss += delta;
         mLevelCur -= delta;
-        mLastCorrCounter = 0;
+        mLastCorrCounter   = 0;
         mLastCorrDirection = 1;
     }
     if (lostLen >= mTotalSize) {
         std::memset(mRingBuffer, 0, mTotalSize);
         mUnderruns += std::max(0, lostLen - std::max(0, -available));
-    }
-    else if (0 < lostLen) {
+    } else if (0 < lostLen) {
         int wpos = mWritePosition % mTotalSize;
-        int n = std::min(mTotalSize - wpos, lostLen);
-        std::memset(mRingBuffer+wpos, 0, n);
+        int n    = std::min(mTotalSize - wpos, lostLen);
+        std::memset(mRingBuffer + wpos, 0, n);
         if (n < lostLen) {
             //cout << "split write: " << lostLen << "-" << n << endl;
-            std::memset(mRingBuffer, 0, lostLen-n);
+            std::memset(mRingBuffer, 0, lostLen - n);
         }
         mUnderruns += std::max(0, lostLen - std::max(0, -available));
     }
@@ -358,32 +339,32 @@ bool JitterBuffer::getStats(RingBuffer::IOStat* stat, bool reset)
 {
     QMutexLocker locker(&mMutex);
     if (reset) {
-        mUnderruns = 0;
-        mOverflows = 0;
-        mSkew0 = mLevel;
-        mSkewRaw = 0;
-        mBufDecOverflow = 0;
-        mBufDecPktLoss = 0;
-        mBufIncUnderrun = 0;
+        mUnderruns        = 0;
+        mOverflows        = 0;
+        mSkew0            = mLevel;
+        mSkewRaw          = 0;
+        mBufDecOverflow   = 0;
+        mBufDecPktLoss    = 0;
+        mBufIncUnderrun   = 0;
         mBufIncCompensate = 0;
-        mBroadcastSkew = 0;
+        mBroadcastSkew    = 0;
     }
     stat->underruns = mUnderruns / mStatUnit;
     stat->overflows = mOverflows / mStatUnit;
-    stat->skew = (int32_t)((mSkew0 - mLevel + mBufIncUnderrun + mBufIncCompensate
-                        - mBufDecOverflow - mBufDecPktLoss)) / mStatUnit;
+    stat->skew      = (int32_t)((mSkew0 - mLevel + mBufIncUnderrun + mBufIncCompensate
+                            - mBufDecOverflow - mBufDecPktLoss))
+                 / mStatUnit;
     stat->skew_raw = mSkewRaw / mStatUnit;
-    stat->level = mLevel / mStatUnit;
+    stat->level    = mLevel / mStatUnit;
 
-    stat->buf_dec_overflows = mBufDecOverflow / mStatUnit;
-    stat->buf_dec_pktloss = mBufDecPktLoss / mStatUnit;
-    stat->buf_inc_underrun = mBufIncUnderrun / mStatUnit;
+    stat->buf_dec_overflows  = mBufDecOverflow / mStatUnit;
+    stat->buf_dec_pktloss    = mBufDecPktLoss / mStatUnit;
+    stat->buf_inc_underrun   = mBufIncUnderrun / mStatUnit;
     stat->buf_inc_compensate = mBufIncCompensate / mStatUnit;
-    stat->broadcast_skew = mBroadcastSkew;
-    stat->broadcast_delta = mBroadcastDelta;
+    stat->broadcast_skew     = mBroadcastSkew;
+    stat->broadcast_delta    = mBroadcastDelta;
 
     stat->autoq_corr = mAutoQueueCorr / mStatUnit * 10;
     stat->autoq_rate = mAutoQRate / mStatUnit * 1000;
     return true;
 }
-

--- a/src/JitterBuffer.h
+++ b/src/JitterBuffer.h
@@ -42,9 +42,9 @@
 
 class JitterBuffer : public RingBuffer
 {
-public:
-    JitterBuffer(int buf_samples, int qlen, int sample_rate, int strategy,
-                                int bcast_qlen, int channels, int bit_res);
+   public:
+    JitterBuffer(int buf_samples, int qlen, int sample_rate, int strategy, int bcast_qlen,
+                 int channels, int bit_res);
     virtual ~JitterBuffer() {}
 
     virtual bool insertSlotNonBlocking(const int8_t* ptrToSlot, int len, int lostLen);
@@ -53,10 +53,10 @@ public:
 
     virtual bool getStats(IOStat* stat, bool reset);
 
-protected:
+   protected:
     void processPacketLoss(int lostLen);
 
-protected:
+   protected:
     int mMaxLatency;
     int mNumChannels;
     int mAudioBitRes;
@@ -67,18 +67,18 @@ protected:
     bool mActive;
     uint32_t mBroadcastLatency;
     uint32_t mBroadcastPosition;
-    double  mBroadcastPositionCorr;
+    double mBroadcastPositionCorr;
 
     double mUnderrunIncTolerance;
     double mCorrIncTolerance;
     double mOverflowDecTolerance;
-    int    mOverflowDropStep;
+    int mOverflowDropStep;
     uint32_t mLastCorrCounter;
-    int    mLastCorrDirection;
+    int mLastCorrDirection;
     double mMinLevelThreshold;
-    double lastCorrFactor() const {return 500.0 / std::max(500U, mLastCorrCounter);}
+    double lastCorrFactor() const { return 500.0 / std::max(500U, mLastCorrCounter); }
 
-    int    mAutoQueue;
+    int mAutoQueue;
     double mAutoQueueCorr;
     double mAutoQFactor;
     double mAutoQRate;
@@ -86,5 +86,4 @@ protected:
     double mAutoQRateDecay;
 };
 
-
-#endif //__JITTERBUFFER_H__
+#endif  //__JITTERBUFFER_H__

--- a/src/Limiter.cpp
+++ b/src/Limiter.cpp
@@ -37,35 +37,38 @@
  */
 
 #include "Limiter.h"
-#include "jacktrip_types.h"
 
 #include <iostream>
+
+#include "jacktrip_types.h"
 
 //*******************************************************************************
 void Limiter::compute(int nframes, float** inputs, float** outputs)
 {
-  if (not inited) {
-    std::cerr << "*** Limiter " << this << ": init never called! Doing it now.\n";
-    if (fSamplingFreq <= 0) {
-      fSamplingFreq = 48000;
-      std::cout << "Limiter " << this << ": *** HAD TO GUESS the sampling rate (chose 48000 Hz) ***\n";
+    if (not inited) {
+        std::cerr << "*** Limiter " << this << ": init never called! Doing it now.\n";
+        if (fSamplingFreq <= 0) {
+            fSamplingFreq = 48000;
+            std::cout << "Limiter " << this
+                      << ": *** HAD TO GUESS the sampling rate (chose 48000 Hz) ***\n";
+        }
+        init(fSamplingFreq);
     }
-    init(fSamplingFreq);
-  }
 #ifdef SINE_TEST
-  float sineTestOut[nframes];
-  float* faustSigs[1] { sineTestOut };
+    float sineTestOut[nframes];
+    float* faustSigs[1]{sineTestOut};
 #endif
-  for ( int i = 0; i < mNumChannels; i++ ) {
-    if (warningAmp > 0.0) {
-      checkAmplitudes(nframes, inputs[i]); // we presently do one check across all channels
-    }
-    limiterP[i]->compute(nframes, &inputs[i], &outputs[i]);
+    for (int i = 0; i < mNumChannels; i++) {
+        if (warningAmp > 0.0) {
+            checkAmplitudes(nframes,
+                            inputs[i]);  // we presently do one check across all channels
+        }
+        limiterP[i]->compute(nframes, &inputs[i], &outputs[i]);
 #ifdef SINE_TEST
-    limiterTestP[i]->compute(nframes, faustSigs, faustSigs);
-    for ( int n = 0; n < nframes; n++ ) {
-      outputs[i][n] = outputs[i][n] + sineTestOut[n];
-    }
+        limiterTestP[i]->compute(nframes, faustSigs, faustSigs);
+        for (int n = 0; n < nframes; n++) {
+            outputs[i][n] = outputs[i][n] + sineTestOut[n];
+        }
 #endif
-  }
+    }
 }

--- a/src/Limiter.h
+++ b/src/Limiter.h
@@ -48,132 +48,156 @@
 #include "limitertest.h"
 #endif
 
-#include "ProcessPlugin.h"
-#include "limiterdsp.h"
 #include <vector>
+
+#include "ProcessPlugin.h"
 #include "assert.h"
+#include "limiterdsp.h"
 
 /** \brief The Limiter class confines the output dynamic range to a
  *  "dynamic range lane" determined by the assumed number of clients.
  */
 class Limiter : public ProcessPlugin
 {
-public:
-  /// \brief The class constructor sets the number of channels to limit
-  Limiter(int numchans, int numclients, bool verboseFlag = false) // xtor
-    : mNumChannels(numchans), mNumClients(numclients)
-    , warningAmp(0.0), warnCount(0), peakMagnitude(0.0), nextWarning(1)
-  {
-    setVerbose(verboseFlag);
-    for ( int i = 0; i < mNumChannels; i++ ) {
-      limiterP.push_back(new limiterdsp);
-      limiterUIP.push_back(new APIUI); // #included in limiterdsp.h
-      limiterP[i]->buildUserInterface(limiterUIP[i]);
+   public:
+    /// \brief The class constructor sets the number of channels to limit
+    Limiter(int numchans, int numclients, bool verboseFlag = false)  // xtor
+        : mNumChannels(numchans)
+        , mNumClients(numclients)
+        , warningAmp(0.0)
+        , warnCount(0)
+        , peakMagnitude(0.0)
+        , nextWarning(1)
+    {
+        setVerbose(verboseFlag);
+        for (int i = 0; i < mNumChannels; i++) {
+            limiterP.push_back(new limiterdsp);
+            limiterUIP.push_back(new APIUI);  // #included in limiterdsp.h
+            limiterP[i]->buildUserInterface(limiterUIP[i]);
 #ifdef SINE_TEST
-      limiterTestP.push_back(new limitertest);
-      limiterTestUIP.push_back(new APIUI); // #included in limitertest.h
-      limiterTestP[i]->buildUserInterface(limiterTestUIP[i]);
+            limiterTestP.push_back(new limitertest);
+            limiterTestUIP.push_back(new APIUI);  // #included in limitertest.h
+            limiterTestP[i]->buildUserInterface(limiterTestUIP[i]);
 #endif
+        }
+        //    std::cout << "Limiter: constructed for "
+        // << mNumChannels << " channels and "
+        // << mNumClients << " assumed clients\n";
     }
-    //    std::cout << "Limiter: constructed for "
-    // << mNumChannels << " channels and "
-    // << mNumClients << " assumed clients\n";
-  }
 
-  /// \brief The class destructor
-  virtual ~Limiter() {
-    for ( int i = 0; i < mNumChannels; i++ ) {
-      delete limiterP[i];
-      delete limiterUIP[i];
+    /// \brief The class destructor
+    virtual ~Limiter()
+    {
+        for (int i = 0; i < mNumChannels; i++) {
+            delete limiterP[i];
+            delete limiterUIP[i];
+        }
+        limiterP.clear();
+        limiterUIP.clear();
     }
-    limiterP.clear();
-    limiterUIP.clear();
-  }
 
-  void init(int samplingRate) override {
-    ProcessPlugin::init(samplingRate);
-    if (samplingRate != fSamplingFreq) {
-      std::cerr << "Sampling rate not set by superclass!\n";
-      std::exit(1); }
-    fs = float(fSamplingFreq);
-    for ( int i = 0; i < mNumChannels; i++ ) {
-      limiterP[i]->init(fs); // compression filter parameters depend on sampling rate
-      int ndx = limiterUIP[i]->getParamIndex("NumClientsAssumed");
-      limiterUIP[i]->setParamValue(ndx, mNumClients);
+    void init(int samplingRate) override
+    {
+        ProcessPlugin::init(samplingRate);
+        if (samplingRate != fSamplingFreq) {
+            std::cerr << "Sampling rate not set by superclass!\n";
+            std::exit(1);
+        }
+        fs = float(fSamplingFreq);
+        for (int i = 0; i < mNumChannels; i++) {
+            limiterP[i]->init(
+                fs);  // compression filter parameters depend on sampling rate
+            int ndx = limiterUIP[i]->getParamIndex("NumClientsAssumed");
+            limiterUIP[i]->setParamValue(ndx, mNumClients);
 #ifdef SINE_TEST
-      limiterTestP[i]->init(fs); // oscillator parameters depend on sampling rate
-      ndx = limiterTestUIP[i]->getParamIndex("Amp");
-      limiterTestUIP[i]->setParamValue(ndx, 0.2);
-      ndx = limiterTestUIP[i]->getParamIndex("Freq");
-      float sineFreq = 110.0 * pow(1.5,double(i)) * (mNumClients>1?1.25:1.0); // Maj 7 chord for stereo in & out
-      limiterTestUIP[i]->setParamValue(ndx, sineFreq);
+            limiterTestP[i]->init(fs);  // oscillator parameters depend on sampling rate
+            ndx = limiterTestUIP[i]->getParamIndex("Amp");
+            limiterTestUIP[i]->setParamValue(ndx, 0.2);
+            ndx = limiterTestUIP[i]->getParamIndex("Freq");
+            float sineFreq =
+                110.0 * pow(1.5, double(i))
+                * (mNumClients > 1 ? 1.25 : 1.0);  // Maj 7 chord for stereo in & out
+            limiterTestUIP[i]->setParamValue(ndx, sineFreq);
 #endif
+        }
+        inited = true;
     }
-    inited = true;
-  }
-  int getNumInputs() override { return(mNumChannels); }
-  int getNumOutputs() override { return(mNumChannels); }
-  void compute(int nframes, float** inputs, float** outputs) override;
+    int getNumInputs() override { return (mNumChannels); }
+    int getNumOutputs() override { return (mNumChannels); }
+    void compute(int nframes, float** inputs, float** outputs) override;
 
-  void setWarningAmplitude(double wa) { // setting to 0 turns off warnings
-    warningAmp = std::max(0.0,std::min(1.0,wa));
-  }
+    void setWarningAmplitude(double wa)
+    {  // setting to 0 turns off warnings
+        warningAmp = std::max(0.0, std::min(1.0, wa));
+    }
 
- private:
+   private:
+    void checkAmplitudes(int nframes, float* buf)
+    {
+        const int maxWarningInterval{10000};  // this could become an option
+        assert(warningAmp > 0.0);
+        assert(mNumClients > 0);
+        for (int i = 0; i < nframes; i++) {
+            double tmp_sample = double(buf[i]);
+            double limiterAmp =
+                fabs(tmp_sample)
+                / sqrt(double(
+                    mNumClients));  // KEEP IN SYNC with gain in ../faust-src/limiterdsp.dsp
+            if (limiterAmp >= warningAmp) {
+                warnCount++;
+                peakMagnitude = std::max(peakMagnitude, limiterAmp);
+                if (warnCount == nextWarning) {
+                    double peakMagnitudeDB = 20.0 * std::log10(peakMagnitude);
+                    double warningAmpDB    = 20.0 * std::log10(warningAmp);
+                    if (warnCount == 1) {
+                        if (warningAmp == 1.0) {
+                            std::cerr << "*** Limiter.cpp: Audio HARD-CLIPPED!\n";
+                            fprintf(stderr,
+                                    "\tReduce your audio input level(s) by %0.1f dB to "
+                                    "avoid this.\n",
+                                    peakMagnitudeDB);
+                        } else {
+                            fprintf(stderr,
+                                    "*** Limiter.cpp: Amplitude levels must stay below "
+                                    "%0.1f dBFS to avoid compression.\n",
+                                    warningAmpDB);
+                            fprintf(
+                                stderr,
+                                "\tReduce input level(s) by %0.1f dB to achieve this.\n",
+                                peakMagnitudeDB - warningAmpDB);
+                        }
+                    } else {
+                        fprintf(stderr,
+                                "\tReduce audio input level(s) by %0.1f dB to avoid "
+                                "limiter compression distortion.\n",
+                                peakMagnitudeDB - warningAmpDB);
+                    }
+                    peakMagnitude = 0.0;  // reset for next group measurement
+                    if (nextWarning
+                        < maxWarningInterval) {  // don't let it stop reporting for too long
+                        nextWarning *= 10;
+                    } else {
+                        warnCount = 0;
+                    }
+                }  // warnCount==nextWarning
+            }      // above warningAmp
+        }          // loop over frames
+    }              // checkAmplitudes()
 
-  void checkAmplitudes(int nframes, float* buf) {
-    const int maxWarningInterval { 10000 }; // this could become an option
-    assert(warningAmp > 0.0);
-    assert(mNumClients > 0);
-    for (int i=0; i<nframes; i++) {
-      double tmp_sample = double(buf[i]);
-      double limiterAmp = fabs(tmp_sample)/sqrt(double(mNumClients)); // KEEP IN SYNC with gain in ../faust-src/limiterdsp.dsp
-      if (limiterAmp >= warningAmp) {
-        warnCount++;
-        peakMagnitude = std::max(peakMagnitude,limiterAmp);
-        if (warnCount==nextWarning) {
-          double peakMagnitudeDB = 20.0 * std::log10(peakMagnitude);
-          double warningAmpDB = 20.0 * std::log10(warningAmp);
-          if (warnCount==1) {
-            if (warningAmp == 1.0) {
-              std::cerr << "*** Limiter.cpp: Audio HARD-CLIPPED!\n";
-              fprintf(stderr, "\tReduce your audio input level(s) by %0.1f dB to avoid this.\n", peakMagnitudeDB);
-            } else {
-              fprintf(stderr,
-                      "*** Limiter.cpp: Amplitude levels must stay below %0.1f dBFS to avoid compression.\n",
-                      warningAmpDB);
-              fprintf(stderr, "\tReduce input level(s) by %0.1f dB to achieve this.\n",
-                      peakMagnitudeDB-warningAmpDB);
-            }
-          } else {
-            fprintf(stderr, "\tReduce audio input level(s) by %0.1f dB to avoid limiter compression distortion.\n",
-                    peakMagnitudeDB-warningAmpDB);
-          }
-          peakMagnitude = 0.0; // reset for next group measurement
-          if (nextWarning < maxWarningInterval) { // don't let it stop reporting for too long
-            nextWarning *= 10;
-          } else {
-            warnCount=0;
-          }
-        } // warnCount==nextWarning
-      } // above warningAmp
-    } // loop over frames
-  } // checkAmplitudes()
-
-private:
-  float fs;
-  int mNumChannels;
-  int mNumClients;
-  std::vector<limiterdsp*> limiterP;
-  std::vector<APIUI*> limiterUIP;
+   private:
+    float fs;
+    int mNumChannels;
+    int mNumClients;
+    std::vector<limiterdsp*> limiterP;
+    std::vector<APIUI*> limiterUIP;
 #ifdef SINE_TEST
-  std::vector<limitertest*> limiterTestP;
-  std::vector<APIUI*> limiterTestUIP;
+    std::vector<limitertest*> limiterTestP;
+    std::vector<APIUI*> limiterTestUIP;
 #endif
-  double warningAmp;
-  uint32_t warnCount;
-  double peakMagnitude;
-  uint32_t nextWarning;
+    double warningAmp;
+    uint32_t warnCount;
+    double peakMagnitude;
+    uint32_t nextWarning;
 };
 
 #endif

--- a/src/LoopBack.cpp
+++ b/src/LoopBack.cpp
@@ -35,21 +35,21 @@
  * \date July 2008
  */
 
-
 #include "LoopBack.h"
-#include "jacktrip_types.h"
 
-#include <cstring> // for memcpy
+#include <cstring>  // for memcpy
 #include <iostream>
 
-using std::cout; using std::endl;
-//using namespace JackTripNamespace;
+#include "jacktrip_types.h"
 
+using std::cout;
+using std::endl;
+//using namespace JackTripNamespace;
 
 //*******************************************************************************
 void LoopBack::compute(int nframes, float** inputs, float** outputs)
 {
-    for ( int i = 0; i < getNumInputs(); i++ ) {
+    for (int i = 0; i < getNumInputs(); i++) {
         // Everything that comes out, copy back to inputs
         //memcpy(inputs[i], outputs[i], sizeof(sample_t) * nframes);
         memcpy(outputs[i], inputs[i], sizeof(sample_t) * nframes);

--- a/src/LoopBack.h
+++ b/src/LoopBack.h
@@ -35,7 +35,6 @@
  * \date July 2008
  */
 
-
 /** \brief Connect Inputs to Outputs
  *
  */
@@ -43,7 +42,6 @@
 #define __LOOPBACK_H__
 
 #include "ProcessPlugin.h"
-
 
 /** \brief This Class just copy audio from its inputs to its outputs.
  *
@@ -53,17 +51,17 @@
  */
 class LoopBack : public ProcessPlugin
 {
-public:
+   public:
     /// \brief The class constructor sets the number of channels to connect as loopback
     LoopBack(int numchans) { mNumChannels = numchans; };
     /// \brief The class destructor
-    virtual ~LoopBack() {};
+    virtual ~LoopBack(){};
 
-    virtual int getNumInputs() { return(mNumChannels); };
-    virtual int getNumOutputs() { return(mNumChannels); };
+    virtual int getNumInputs() { return (mNumChannels); };
+    virtual int getNumOutputs() { return (mNumChannels); };
     virtual void compute(int nframes, float** inputs, float** outputs);
 
-private:
+   private:
     int mNumChannels;
 };
 

--- a/src/NetKS.h
+++ b/src/NetKS.h
@@ -53,8 +53,7 @@ class NetKS : public ProcessPlugin
 {
     Q_OBJECT;
 
-
-public:
+   public:
     /*
   void play()
   {
@@ -65,7 +64,7 @@ public:
   }
   */
 
-private slots:
+   private slots:
 
     /// \brief Stlot to excite (play) the string
     void exciteString()
@@ -73,31 +72,35 @@ private slots:
         std::cout << "========= EXTICING STRING ===========" << std::endl;
         fbutton0 = 1.0;
         //std::cout << fbutton0 << std::endl;
-        QThread::usleep(280000); /// \todo Define this number based on the sampling rate and buffer size
+        QThread::usleep(
+            280000);  /// \todo Define this number based on the sampling rate and buffer size
         fbutton0 = 0.0;
         //std::cout << fbutton0 << std::endl;
     }
 
     //=========== FROM FAUST ===================================================
-private:
+   private:
     float fbutton0;
     float fVec0[2];
     float fRec0[2];
-    int   iRec1[2];
+    int iRec1[2];
     float fVec1[2];
-public:
+
+   public:
     virtual int getNumInputs() { return 1; }
     virtual int getNumOutputs() { return 1; }
     static void classInit(int /*samplingFreq*/) {}
-    virtual void instanceInit(int samplingFreq) {
+    virtual void instanceInit(int samplingFreq)
+    {
         fSamplingFreq = samplingFreq;
-        fbutton0 = 0.0;
-        for (int i=0; i<2; i++) fVec0[i] = 0;
-        for (int i=0; i<2; i++) fRec0[i] = 0;
-        for (int i=0; i<2; i++) iRec1[i] = 0;
-        for (int i=0; i<2; i++) fVec1[i] = 0;
+        fbutton0      = 0.0;
+        for (int i = 0; i < 2; i++) fVec0[i] = 0;
+        for (int i = 0; i < 2; i++) fRec0[i] = 0;
+        for (int i = 0; i < 2; i++) iRec1[i] = 0;
+        for (int i = 0; i < 2; i++) fVec1[i] = 0;
     }
-    virtual void init(int samplingFreq) {
+    virtual void init(int samplingFreq)
+    {
         classInit(samplingFreq);
         instanceInit(samplingFreq);
     }
@@ -108,18 +111,20 @@ public:
                 interface->closeBox();
         }
   */
-    virtual void compute (int count, float** input, float** output) {
-        float* input0 = input[0];
+    virtual void compute(int count, float** input, float** output)
+    {
+        float* input0  = input[0];
         float* output0 = output[0];
-        float fSlow0 = fbutton0;
-        for (int i=0; i<count; i++) {
-            fVec0[0] = fSlow0;
-            fRec0[0] = ((((fSlow0 - fVec0[1]) > 0.000000f) + fRec0[1]) - (3.333333e-03f * (fRec0[1] > 0.000000f)));
-            iRec1[0] = (12345 + (1103515245 * iRec1[1]));
+        float fSlow0   = fbutton0;
+        for (int i = 0; i < count; i++) {
+            fVec0[0]     = fSlow0;
+            fRec0[0]     = ((((fSlow0 - fVec0[1]) > 0.000000f) + fRec0[1])
+                        - (3.333333e-03f * (fRec0[1] > 0.000000f)));
+            iRec1[0]     = (12345 + (1103515245 * iRec1[1]));
             float fTemp0 = ((4.190951e-10f * iRec1[0]) * (fRec0[0] > 0.000000f));
             float fTemp1 = input0[i];
-            fVec1[0] = (fTemp1 + fTemp0);
-            output0[i] = (0.500000f * ((fTemp0 + fTemp1) + fVec1[1]));
+            fVec1[0]     = (fTemp1 + fTemp0);
+            output0[i]   = (0.500000f * ((fTemp0 + fTemp1) + fVec1[1]));
             // post processing
             fVec1[1] = fVec1[0];
             iRec1[1] = iRec1[0];
@@ -129,8 +134,6 @@ public:
     }
 
     //============================================================================
-
 };
 
-
-#endif // __NETKS_H__
+#endif  // __NETKS_H__

--- a/src/PacketHeader.cpp
+++ b/src/PacketHeader.cpp
@@ -36,15 +36,17 @@
  */
 
 #include "PacketHeader.h"
-#include "JackTrip.h"
 
 #include <sys/time.h>
+
 #include <cstdlib>
 #include <iostream>
 #include <stdexcept>
 
-using std::cout; using std::endl;
+#include "JackTrip.h"
 
+using std::cout;
+using std::endl;
 
 // below is the gettimeofday definition for windows: this function is not defined in sys/time.h as it is in unix
 // for more info check: http://www.halcode.com/archives/2008/08/26/retrieving-system-time-gettimeofday/
@@ -57,9 +59,9 @@ inline int gettimeofday(struct timeval* p, void* tz /* IGNORED */)
         long long ns100; /*time since 1 Jan 1601 in 100ns units */
         FILETIME ft;
     } now;
-    GetSystemTimeAsFileTime( &(now.ft) );
-    p->tv_usec=(long)((now.ns100 / 10LL) % 1000000LL );
-    p->tv_sec= (long)((now.ns100-(116444736000000000LL))/10000000LL);
+    GetSystemTimeAsFileTime(&(now.ft));
+    p->tv_usec = (long)((now.ns100 / 10LL) % 1000000LL);
+    p->tv_sec  = (long)((now.ns100 - (116444736000000000LL)) / 10000000LL);
     return 0;
 }
 #else
@@ -68,59 +70,51 @@ int gettimeofday(struct timeval* p, void* tz /* IGNORED */);
 #endif
 #endif
 
-
 //#######################################################################
 //####################### PacketHeader ##################################
 //#######################################################################
 //***********************************************************************
-PacketHeader::PacketHeader(JackTrip* jacktrip) :
-    mSeqNumber(0), mJackTrip(jacktrip)
-{}
-
+PacketHeader::PacketHeader(JackTrip* jacktrip) : mSeqNumber(0), mJackTrip(jacktrip) {}
 
 //***********************************************************************
 uint64_t PacketHeader::usecTime()
 {
     struct timeval tv;
-    gettimeofday (&tv, NULL);
-    return ( (tv.tv_sec * 1000000)  + // seconds
-             (tv.tv_usec) );  // plus the microseconds. Type suseconds_t, range [-1, 1000000]
+    gettimeofday(&tv, NULL);
+    return (
+        (tv.tv_sec * 1000000) +  // seconds
+        (tv.tv_usec));  // plus the microseconds. Type suseconds_t, range [-1, 1000000]
 }
-
-
-
 
 //#######################################################################
 //####################### DefaultHeader #################################
 //#######################################################################
 //***********************************************************************
-DefaultHeader::DefaultHeader(JackTrip* jacktrip) :
-    PacketHeader(jacktrip), mJackTrip(jacktrip)
+DefaultHeader::DefaultHeader(JackTrip* jacktrip)
+    : PacketHeader(jacktrip), mJackTrip(jacktrip)
 {
-    mHeader.TimeStamp = 0;
-    mHeader.SeqNumber = 0;
-    mHeader.BufferSize = 0;
-    mHeader.SamplingRate = 0;
+    mHeader.TimeStamp     = 0;
+    mHeader.SeqNumber     = 0;
+    mHeader.BufferSize    = 0;
+    mHeader.SamplingRate  = 0;
     mHeader.BitResolution = 0;
     //mHeader.NumInChannels = 0;
     //mHeader.NumOutChannels = 0;
-    mHeader.NumChannels = 0;
+    mHeader.NumChannels    = 0;
     mHeader.ConnectionMode = 0;
 }
-
 
 //***********************************************************************
 void DefaultHeader::fillHeaderCommonFromAudio()
 {
-    mHeader.TimeStamp = PacketHeader::usecTime();
-    mHeader.BufferSize = mJackTrip->getBufferSizeInSamples();
-    mHeader.SamplingRate = mJackTrip->getSampleRateType ();
-    mHeader.BitResolution = mJackTrip->getAudioBitResolution();
-    mHeader.NumChannels = mJackTrip->getNumChannels();
+    mHeader.TimeStamp      = PacketHeader::usecTime();
+    mHeader.BufferSize     = mJackTrip->getBufferSizeInSamples();
+    mHeader.SamplingRate   = mJackTrip->getSampleRateType();
+    mHeader.BitResolution  = mJackTrip->getAudioBitResolution();
+    mHeader.NumChannels    = mJackTrip->getNumChannels();
     mHeader.ConnectionMode = static_cast<int>(mJackTrip->getConnectionMode());
     //printHeader();
 }
-
 
 //***********************************************************************
 void DefaultHeader::checkPeerSettings(int8_t* full_packet)
@@ -128,12 +122,12 @@ void DefaultHeader::checkPeerSettings(int8_t* full_packet)
     bool error = false;
 
     DefaultHeaderStruct* peer_header;
-    peer_header =  reinterpret_cast<DefaultHeaderStruct*>(full_packet);
+    peer_header = reinterpret_cast<DefaultHeaderStruct*>(full_packet);
 
     // Check Buffer Size
-    if ( peer_header->BufferSize != mHeader.BufferSize )
-    {
-        std::cerr << "WARNING: Peer Buffer Size is  : " << peer_header->BufferSize << endl;
+    if (peer_header->BufferSize != mHeader.BufferSize) {
+        std::cerr << "WARNING: Peer Buffer Size is  : " << peer_header->BufferSize
+                  << endl;
         std::cerr << "         Local Buffer Size is : " << mHeader.BufferSize << endl;
         //std::cerr << "Make sure both machines use same buffer size" << endl;
         //std::cerr << gPrintSeparator << endl;
@@ -141,22 +135,23 @@ void DefaultHeader::checkPeerSettings(int8_t* full_packet)
     }
 
     // Check Sampling Rate
-    if ( peer_header->SamplingRate != mHeader.SamplingRate )
-    {
-        std::cerr << "ERROR: Peer Sampling Rate is   : " <<
-                     AudioInterface::getSampleRateFromType
-                     ( static_cast<AudioInterface::samplingRateT>(peer_header->SamplingRate) ) << endl;
-        std::cerr << "       Local Sampling Rate is  : " <<
-                     AudioInterface::getSampleRateFromType
-                     ( static_cast<AudioInterface::samplingRateT>(mHeader.SamplingRate) ) << endl;
+    if (peer_header->SamplingRate != mHeader.SamplingRate) {
+        std::cerr << "ERROR: Peer Sampling Rate is   : "
+                  << AudioInterface::getSampleRateFromType(
+                         static_cast<AudioInterface::samplingRateT>(
+                             peer_header->SamplingRate))
+                  << endl;
+        std::cerr << "       Local Sampling Rate is  : "
+                  << AudioInterface::getSampleRateFromType(
+                         static_cast<AudioInterface::samplingRateT>(mHeader.SamplingRate))
+                  << endl;
         std::cerr << "Make sure both machines use the same Sampling Rate" << endl;
         std::cerr << gPrintSeparator << endl;
         error = true;
     }
 
     // Check Audio Bit Resolution
-    if ( peer_header->BitResolution != mHeader.BitResolution )
-    {
+    if (peer_header->BitResolution != mHeader.BitResolution) {
         std::cerr << "ERROR: Peer Audio Bit Resolution is  : "
                   << static_cast<int>(peer_header->BitResolution) << endl;
         std::cerr << "       Local Audio Bit Resolution is : "
@@ -167,8 +162,7 @@ void DefaultHeader::checkPeerSettings(int8_t* full_packet)
     }
 
     // Exit program if error
-    if (error)
-    {
+    if (error) {
         //std::cerr << "Exiting program..." << endl;
         //std::exit(1);
         //throw std::logic_error("Local and Peer Settings don't match");
@@ -177,154 +171,145 @@ void DefaultHeader::checkPeerSettings(int8_t* full_packet)
     /// \todo Check number of channels and other parameters
 }
 
-
 //***********************************************************************
 void DefaultHeader::printHeader() const
 {
     cout << "Default Packet Header:" << endl;
-    cout << "Buffer Size               = " << static_cast<int>(mHeader.BufferSize) << endl;
+    cout << "Buffer Size               = " << static_cast<int>(mHeader.BufferSize)
+         << endl;
     // Get the sample rate in Hz form the AudioInterface::samplingRateT
-    int sample_rate =
-            AudioInterface::getSampleRateFromType
-            ( static_cast<AudioInterface::samplingRateT>(mHeader.SamplingRate) );
+    int sample_rate = AudioInterface::getSampleRateFromType(
+        static_cast<AudioInterface::samplingRateT>(mHeader.SamplingRate));
     cout << "Sampling Rate             = " << sample_rate << endl;
-    cout << "Audio Bit Resolutions     = " << static_cast<int>(mHeader.BitResolution) << endl;
+    cout << "Audio Bit Resolutions     = " << static_cast<int>(mHeader.BitResolution)
+         << endl;
     //cout << "Number of Input Channels  = " << static_cast<int>(mHeader.NumInChannels) << endl;
     //cout << "Number of Output Channels = " << static_cast<int>(mHeader.NumOutChannels) << endl;
-    cout << "Number of Channels        = " << static_cast<int>(mHeader.NumChannels) << endl;
+    cout << "Number of Channels        = " << static_cast<int>(mHeader.NumChannels)
+         << endl;
     cout << "Sequence Number           = " << static_cast<int>(mHeader.SeqNumber) << endl;
     cout << "Time Stamp                = " << mHeader.TimeStamp << endl;
-    cout << "Connection Mode           = " << static_cast<int>(mHeader.ConnectionMode) << endl;
+    cout << "Connection Mode           = " << static_cast<int>(mHeader.ConnectionMode)
+         << endl;
     cout << gPrintSeparator << endl;
     //cout << sizeof(mHeader) << endl;
 }
-
-
 
 //***********************************************************************
 uint64_t DefaultHeader::getPeerTimeStamp(int8_t* full_packet) const
 {
     DefaultHeaderStruct* peer_header;
-    peer_header =  reinterpret_cast<DefaultHeaderStruct*>(full_packet);
+    peer_header = reinterpret_cast<DefaultHeaderStruct*>(full_packet);
     return peer_header->TimeStamp;
 }
-
 
 //***********************************************************************
 uint16_t DefaultHeader::getPeerSequenceNumber(int8_t* full_packet) const
 {
     DefaultHeaderStruct* peer_header;
-    peer_header =  reinterpret_cast<DefaultHeaderStruct*>(full_packet);
+    peer_header = reinterpret_cast<DefaultHeaderStruct*>(full_packet);
     return peer_header->SeqNumber;
 }
-
 
 //***********************************************************************
 uint16_t DefaultHeader::getPeerBufferSize(int8_t* full_packet) const
 {
     DefaultHeaderStruct* peer_header;
-    peer_header =  reinterpret_cast<DefaultHeaderStruct*>(full_packet);
+    peer_header = reinterpret_cast<DefaultHeaderStruct*>(full_packet);
     return peer_header->BufferSize;
 }
 
-
 //***********************************************************************
-uint8_t  DefaultHeader::getPeerSamplingRate(int8_t* full_packet) const
+uint8_t DefaultHeader::getPeerSamplingRate(int8_t* full_packet) const
 {
     DefaultHeaderStruct* peer_header;
-    peer_header =  reinterpret_cast<DefaultHeaderStruct*>(full_packet);
+    peer_header = reinterpret_cast<DefaultHeaderStruct*>(full_packet);
     return peer_header->SamplingRate;
 }
-
 
 //***********************************************************************
 uint8_t DefaultHeader::getPeerBitResolution(int8_t* full_packet) const
 {
     DefaultHeaderStruct* peer_header;
-    peer_header =  reinterpret_cast<DefaultHeaderStruct*>(full_packet);
+    peer_header = reinterpret_cast<DefaultHeaderStruct*>(full_packet);
     return peer_header->BitResolution;
 }
-
 
 //***********************************************************************
 uint8_t DefaultHeader::getPeerNumChannels(int8_t* full_packet) const
 {
     DefaultHeaderStruct* peer_header;
-    peer_header =  reinterpret_cast<DefaultHeaderStruct*>(full_packet);
+    peer_header = reinterpret_cast<DefaultHeaderStruct*>(full_packet);
     return peer_header->NumChannels;
 }
-
 
 //***********************************************************************
 uint8_t DefaultHeader::getPeerConnectionMode(int8_t* full_packet) const
 {
     DefaultHeaderStruct* peer_header;
-    peer_header =  reinterpret_cast<DefaultHeaderStruct*>(full_packet);
+    peer_header = reinterpret_cast<DefaultHeaderStruct*>(full_packet);
     return static_cast<uint8_t>(peer_header->ConnectionMode);
 }
-
-
-
-
-
 
 //#######################################################################
 //####################### JamLinkHeader #################################
 //#######################################################################
 //***********************************************************************
-JamLinkHeader::JamLinkHeader(JackTrip* jacktrip) :
-    PacketHeader(jacktrip), mJackTrip(jacktrip)
+JamLinkHeader::JamLinkHeader(JackTrip* jacktrip)
+    : PacketHeader(jacktrip), mJackTrip(jacktrip)
 {
-    mHeader.Common = 0;
+    mHeader.Common    = 0;
     mHeader.SeqNumber = 0;
     mHeader.TimeStamp = 0;
 }
-
 
 //***********************************************************************
 void JamLinkHeader::fillHeaderCommonFromAudio()
 {
     // Check number of channels
     int num_inchannels = mJackTrip->getNumInputChannels();
-    if ( num_inchannels != 1 ) {
+    if (num_inchannels != 1) {
         //std::cerr << "ERROR: JamLink only support ONE channel. Run JackTrip using only one channel"
         //	      << endl;
         //std::exit(1);
         //std::cerr << "WARINING: JamLink only support ONE channel. Run JackTrip using only one channel" << endl;
         //throw std::logic_error("JamLink only support ONE channel. Run JackTrip using only one channel");
-        emit signalError("JamLink only support ONE channel. Run JackTrip using only one channel");
-
+        emit signalError(
+            "JamLink only support ONE channel. Run JackTrip using only one channel");
     }
 
     // Sampling Rate
     int rate_type = mJackTrip->getSampleRateType();
-    if ( rate_type != AudioInterface::SR48 ) {
+    if (rate_type != AudioInterface::SR48) {
         //std::cerr << "WARINING: JamLink only support 48kHz for communication with JackTrip at the moment." << endl;
         //throw std::logic_error("ERROR: JamLink only support 48kHz for communication with JackTrip at the moment.");
-        emit signalError("ERROR: JamLink only support 48kHz for communication with JackTrip at the moment.");
+        emit signalError(
+            "ERROR: JamLink only support 48kHz for communication with JackTrip at the "
+            "moment.");
     }
 
     // Check Buffer Size
     int buf_size = mJackTrip->getBufferSizeInSamples();
-    if ( buf_size != 64 ) {
+    if (buf_size != 64) {
         //std::cerr << "WARINING: JamLink only support 64 buffer size for communication with JackTrip at the moment." << endl;
         //throw std::logic_error("ERROR: JamLink only support 64 buffer size for communication with JackTrip at the moment.");
-        emit signalError("ERROR: JamLink only support 64 buffer size for communication with JackTrip at the moment.");
+        emit signalError(
+            "ERROR: JamLink only support 64 buffer size for communication with JackTrip "
+            "at the moment.");
     }
 
     mHeader.Common = (ETX_MONO | ETX_16BIT | ETX_XTND) + 64;
-    switch (rate_type)
-    {
-    case AudioInterface::SR48 :
+    switch (rate_type) {
+    case AudioInterface::SR48:
         mHeader.Common = (mHeader.Common | ETX_48KHZ);
         break;
-    case AudioInterface::SR44 :
+    case AudioInterface::SR44:
         mHeader.Common = (mHeader.Common | ETX_44KHZ);
         break;
-    case AudioInterface::SR32 :
+    case AudioInterface::SR32:
         mHeader.Common = (mHeader.Common | ETX_32KHZ);
         break;
-    case AudioInterface::SR22 :
+    case AudioInterface::SR22:
         mHeader.Common = (mHeader.Common | ETX_22KHZ);
         break;
     default:
@@ -336,15 +321,10 @@ void JamLinkHeader::fillHeaderCommonFromAudio()
     }
 }
 
-
-
-
-
-
 //#######################################################################
 //####################### EmptyHeader #################################
 //#######################################################################
 //***********************************************************************
-EmptyHeader::EmptyHeader(JackTrip* jacktrip) :
-    PacketHeader(jacktrip), mJackTrip(jacktrip)
-{}
+EmptyHeader::EmptyHeader(JackTrip* jacktrip) : PacketHeader(jacktrip), mJackTrip(jacktrip)
+{
+}

--- a/src/PacketHeader.h
+++ b/src/PacketHeader.h
@@ -40,33 +40,32 @@
 
 #include <iostream>
 //#include <tr1/memory> // for shared_ptr
-#include <cstring>
-
 #include <QObject>
 #include <QString>
+#include <cstring>
 
-#include "jacktrip_types.h"
 #include "jacktrip_globals.h"
-class JackTrip; // Forward Declaration
-
+#include "jacktrip_types.h"
+class JackTrip;  // Forward Declaration
 
 /// \brief Abstract Header Struct, Header Stucts should subclass it
-struct HeaderStruct{};
+struct HeaderStruct {
+};
 
 /// \brief Default Header Struct
-struct DefaultHeaderStruct : public HeaderStruct
-{
-public:
+struct DefaultHeaderStruct : public HeaderStruct {
+   public:
     // watch out for alignment...
-    uint64_t TimeStamp; ///< Time Stamp
-    uint16_t SeqNumber; ///< Sequence Number
-    uint16_t BufferSize; ///< Buffer Size in Samples
-    uint8_t  SamplingRate; ///< Sampling Rate in JackAudioInterface::samplingRateT
-    uint8_t BitResolution; ///< Audio Bit Resolution
+    uint64_t TimeStamp;     ///< Time Stamp
+    uint16_t SeqNumber;     ///< Sequence Number
+    uint16_t BufferSize;    ///< Buffer Size in Samples
+    uint8_t SamplingRate;   ///< Sampling Rate in JackAudioInterface::samplingRateT
+    uint8_t BitResolution;  ///< Audio Bit Resolution
     //uint8_t  NumInChannels; ///< Number of Input Channels
     //uint8_t  NumOutChannels; ///<  Number of Output Channels
-    uint8_t  NumChannels; ///< Number of Channels, we assume input and outputs are the same
-    uint8_t  ConnectionMode;
+    uint8_t
+        NumChannels;  ///< Number of Channels, we assume input and outputs are the same
+    uint8_t ConnectionMode;
 };
 
 //---------------------------------------------------------
@@ -80,33 +79,30 @@ public:
 /*         4-22 Khz, 5-16 Khz, 6-11 Khz, 7-8 Khz                        */
 /* B8-0: Samples in packet                                              */
 /************************************************************************/
-const unsigned short ETX_RSVD = (0<<15);
-const unsigned short ETX_XTND = (1<<14);
-const unsigned short ETX_STEREO = (1<<13);
-const unsigned short ETX_MONO = (0<<13);
-const unsigned short ETX_16BIT = (0<<12);
+const unsigned short ETX_RSVD   = (0 << 15);
+const unsigned short ETX_XTND   = (1 << 14);
+const unsigned short ETX_STEREO = (1 << 13);
+const unsigned short ETX_MONO   = (0 << 13);
+const unsigned short ETX_16BIT  = (0 << 12);
 //inline unsigned short ETX_RATE_MASK(const unsigned short a) { a&(0x7<<9); }
-const unsigned short ETX_48KHZ = (0<<9);
-const unsigned short ETX_44KHZ = (1<<9);
-const unsigned short ETX_32KHZ = (2<<9);
-const unsigned short ETX_24KHZ = (3<<9);
-const unsigned short ETX_22KHZ = (4<<9);
-const unsigned short ETX_16KHZ = (5<<9);
-const unsigned short ETX_11KHZ = (6<<9);
-const unsigned short ETX_8KHZ  = (7<<9);
+const unsigned short ETX_48KHZ = (0 << 9);
+const unsigned short ETX_44KHZ = (1 << 9);
+const unsigned short ETX_32KHZ = (2 << 9);
+const unsigned short ETX_24KHZ = (3 << 9);
+const unsigned short ETX_22KHZ = (4 << 9);
+const unsigned short ETX_16KHZ = (5 << 9);
+const unsigned short ETX_11KHZ = (6 << 9);
+const unsigned short ETX_8KHZ  = (7 << 9);
 // able to express up to 512 SPP
 //inline unsigned short  ETX_SPP(const unsigned short a) { (a&0x01FF); }
 
 /// \brief JamLink Header Struct
-struct JamLinkHeaderStuct : public HeaderStruct
-{
+struct JamLinkHeaderStuct : public HeaderStruct {
     // watch out for alignment -- need to be on 4 byte chunks
-    uint16_t Common; ///< Common part of the header, 16 bit
-    uint16_t SeqNumber; ///< Sequence Number
-    uint32_t TimeStamp; ///< Time Stamp
+    uint16_t Common;     ///< Common part of the header, 16 bit
+    uint16_t SeqNumber;  ///< Sequence Number
+    uint32_t TimeStamp;  ///< Time Stamp
 };
-
-
 
 //#######################################################################
 //####################### PacketHeader ##################################
@@ -118,7 +114,7 @@ class PacketHeader : public QObject
 {
     Q_OBJECT;
 
-public:
+   public:
     /// \brief The class Constructor
     PacketHeader(JackTrip* jacktrip);
     /// \brief The class Destructor
@@ -132,49 +128,42 @@ public:
     virtual void fillHeaderCommonFromAudio() = 0;
     /// \brief Parse the packet header and take appropriate measures (like change settings, or
     /// quit the program if peer settings don't match)
-    virtual void parseHeader() = 0;
+    virtual void parseHeader()                          = 0;
     virtual void checkPeerSettings(int8_t* full_packet) = 0;
 
-    virtual uint64_t getPeerTimeStamp(int8_t* full_packet) const = 0;
+    virtual uint64_t getPeerTimeStamp(int8_t* full_packet) const      = 0;
     virtual uint16_t getPeerSequenceNumber(int8_t* full_packet) const = 0;
-    virtual uint16_t getPeerBufferSize(int8_t* full_packet) const = 0;
-    virtual uint8_t  getPeerSamplingRate(int8_t* full_packet) const = 0;
-    virtual uint8_t getPeerBitResolution(int8_t* full_packet) const = 0;
-    virtual uint8_t  getPeerNumChannels(int8_t* full_packet) const = 0;
-    virtual uint8_t  getPeerConnectionMode(int8_t* full_packet) const = 0;
+    virtual uint16_t getPeerBufferSize(int8_t* full_packet) const     = 0;
+    virtual uint8_t getPeerSamplingRate(int8_t* full_packet) const    = 0;
+    virtual uint8_t getPeerBitResolution(int8_t* full_packet) const   = 0;
+    virtual uint8_t getPeerNumChannels(int8_t* full_packet) const     = 0;
+    virtual uint8_t getPeerConnectionMode(int8_t* full_packet) const  = 0;
 
     /// \brief Increase sequence number for counter, a 16bit number
-    virtual void increaseSequenceNumber()
-    { mSeqNumber++; }
+    virtual void increaseSequenceNumber() { mSeqNumber++; }
     /// \brief Returns the current sequence number
     /// \return 16bit Sequence number
-    virtual uint16_t getSequenceNumber() const
-    { return mSeqNumber; }
+    virtual uint16_t getSequenceNumber() const { return mSeqNumber; }
     /// \brief Get the header size in bytes
     virtual int getHeaderSizeInBytes() const = 0;
     virtual void putHeaderInPacketBaseClass(int8_t* full_packet,
                                             const HeaderStruct& header_struct)
     {
         std::memcpy(full_packet, reinterpret_cast<const void*>(&header_struct),
-                    getHeaderSizeInBytes() );
+                    getHeaderSizeInBytes());
     }
     /// \brief Put the header in buffer pointed by full_packet
     /// \param full_packet Pointer to full packet (audio+header). Size must be
     /// sizeof(header part) + sizeof(audio part)
     virtual void putHeaderInPacket(int8_t* full_packet) = 0;
 
+   signals:
+    void signalError(const QString& error_message);
 
-signals:
-    void signalError(const QString &error_message);
-
-
-private:
+   private:
     uint16_t mSeqNumber;
-    JackTrip* mJackTrip; ///< JackTrip mediator class
+    JackTrip* mJackTrip;  ///< JackTrip mediator class
 };
-
-
-
 
 //#######################################################################
 //####################### DefaultHeader #################################
@@ -183,44 +172,36 @@ private:
  */
 class DefaultHeader : public PacketHeader
 {
-public:
-
+   public:
     DefaultHeader(JackTrip* jacktrip);
     virtual ~DefaultHeader() {}
 
     virtual void fillHeaderCommonFromAudio();
     virtual void parseHeader() {}
     virtual void checkPeerSettings(int8_t* full_packet);
-    virtual void increaseSequenceNumber()
-    { mHeader.SeqNumber++; }
-    virtual uint16_t getSequenceNumber() const
-    { return mHeader.SeqNumber; }
+    virtual void increaseSequenceNumber() { mHeader.SeqNumber++; }
+    virtual uint16_t getSequenceNumber() const { return mHeader.SeqNumber; }
     virtual int getHeaderSizeInBytes() const { return sizeof(mHeader); }
     virtual void putHeaderInPacket(int8_t* full_packet)
-    { putHeaderInPacketBaseClass(full_packet, mHeader); }
+    {
+        putHeaderInPacketBaseClass(full_packet, mHeader);
+    }
     void printHeader() const;
-    uint8_t getConnectionMode() const
-    { return mHeader.ConnectionMode; }
-    uint8_t getNumChannels() const
-    { return mHeader.NumChannels; }
-
+    uint8_t getConnectionMode() const { return mHeader.ConnectionMode; }
+    uint8_t getNumChannels() const { return mHeader.NumChannels; }
 
     virtual uint64_t getPeerTimeStamp(int8_t* full_packet) const;
     virtual uint16_t getPeerSequenceNumber(int8_t* full_packet) const;
     virtual uint16_t getPeerBufferSize(int8_t* full_packet) const;
-    virtual uint8_t  getPeerSamplingRate(int8_t* full_packet) const;
+    virtual uint8_t getPeerSamplingRate(int8_t* full_packet) const;
     virtual uint8_t getPeerBitResolution(int8_t* full_packet) const;
-    virtual uint8_t  getPeerNumChannels(int8_t* full_packet) const;
-    virtual uint8_t  getPeerConnectionMode(int8_t* full_packet) const;
+    virtual uint8_t getPeerNumChannels(int8_t* full_packet) const;
+    virtual uint8_t getPeerConnectionMode(int8_t* full_packet) const;
 
-
-private:
-    DefaultHeaderStruct mHeader;///< Default Header Struct
-    JackTrip* mJackTrip; ///< JackTrip mediator class
+   private:
+    DefaultHeaderStruct mHeader;  ///< Default Header Struct
+    JackTrip* mJackTrip;          ///< JackTrip mediator class
 };
-
-
-
 
 //#######################################################################
 //####################### JamLinkHeader #################################
@@ -230,8 +211,7 @@ private:
  */
 class JamLinkHeader : public PacketHeader
 {
-public:
-
+   public:
     JamLinkHeader(JackTrip* jacktrip);
     virtual ~JamLinkHeader() {}
 
@@ -242,22 +222,22 @@ public:
     virtual uint64_t getPeerTimeStamp(int8_t* /*full_packet*/) const { return 0; }
     virtual uint16_t getPeerSequenceNumber(int8_t* /*full_packet*/) const { return 0; }
     virtual uint16_t getPeerBufferSize(int8_t* /*full_packet*/) const { return 0; }
-    virtual uint8_t  getPeerSamplingRate(int8_t* /*full_packet*/) const { return 0; }
+    virtual uint8_t getPeerSamplingRate(int8_t* /*full_packet*/) const { return 0; }
     virtual uint8_t getPeerBitResolution(int8_t* /*full_packet*/) const { return 0; }
-    virtual uint8_t  getPeerNumChannels(int8_t* /*full_packet*/) const { return 0; }
-    virtual uint8_t  getPeerConnectionMode(int8_t* /*full_packet*/) const { return 0; }
+    virtual uint8_t getPeerNumChannels(int8_t* /*full_packet*/) const { return 0; }
+    virtual uint8_t getPeerConnectionMode(int8_t* /*full_packet*/) const { return 0; }
 
     virtual void increaseSequenceNumber() {}
     virtual int getHeaderSizeInBytes() const { return sizeof(mHeader); }
     virtual void putHeaderInPacket(int8_t* full_packet)
-    { putHeaderInPacketBaseClass(full_packet, mHeader); }
+    {
+        putHeaderInPacketBaseClass(full_packet, mHeader);
+    }
 
-private:
-    JamLinkHeaderStuct mHeader; ///< JamLink Header Struct
-    JackTrip* mJackTrip; ///< JackTrip mediator class
+   private:
+    JamLinkHeaderStuct mHeader;  ///< JamLink Header Struct
+    JackTrip* mJackTrip;         ///< JackTrip mediator class
 };
-
-
 
 //#######################################################################
 //####################### EmptyHeader #################################
@@ -267,8 +247,7 @@ private:
  */
 class EmptyHeader : public PacketHeader
 {
-public:
-
+   public:
     EmptyHeader(JackTrip* jacktrip);
     virtual ~EmptyHeader() {}
 
@@ -281,16 +260,15 @@ public:
     virtual uint64_t getPeerTimeStamp(int8_t* /*full_packet*/) const { return 0; }
     virtual uint16_t getPeerSequenceNumber(int8_t* /*full_packet*/) const { return 0; }
     virtual uint16_t getPeerBufferSize(int8_t* /*full_packet*/) const { return 0; }
-    virtual uint8_t  getPeerSamplingRate(int8_t* /*full_packet*/) const { return 0; }
+    virtual uint8_t getPeerSamplingRate(int8_t* /*full_packet*/) const { return 0; }
     virtual uint8_t getPeerBitResolution(int8_t* /*full_packet*/) const { return 0; }
-    virtual uint8_t  getPeerNumChannels(int8_t* /*full_packet*/) const { return 0; }
-    virtual uint8_t  getPeerConnectionMode(int8_t* /*full_packet*/) const { return 0; }
+    virtual uint8_t getPeerNumChannels(int8_t* /*full_packet*/) const { return 0; }
+    virtual uint8_t getPeerConnectionMode(int8_t* /*full_packet*/) const { return 0; }
 
     virtual void putHeaderInPacket(int8_t* /*full_packet*/) {}
 
-private:
-    JackTrip* mJackTrip; ///< JackTrip mediator class
+   private:
+    JackTrip* mJackTrip;  ///< JackTrip mediator class
 };
 
-
-#endif //__PACKETHEADER_H__
+#endif  //__PACKETHEADER_H__

--- a/src/ProcessPlugin.h
+++ b/src/ProcessPlugin.h
@@ -39,6 +39,7 @@
 #define __PROCESSPLUGIN_H__
 
 #include <jack/jack.h>
+
 #include <QThread>
 
 /** \brief Interface for the process plugins to add to the JACK callback process in
@@ -51,12 +52,11 @@
  */
 class ProcessPlugin : public QThread
 {
-public:
-
+   public:
     /// \brief The Class Constructor
-    ProcessPlugin() {};
+    ProcessPlugin(){};
     /// \brief The Class Destructor
-    virtual ~ProcessPlugin() {};
+    virtual ~ProcessPlugin(){};
 
     /// \brief Return Number of Input Channels
     virtual int getNumInputs() = 0;
@@ -65,22 +65,25 @@ public:
 
     //virtual void buildUserInterface(UI* interface) = 0;
 
-    virtual char* getName() {
-      char* pluginName { const_cast<char*>(typeid(*this).name()) }; // get name of DERIVED class
-      while (isdigit(*pluginName)) { pluginName++; }
-      return pluginName;
+    virtual char* getName()
+    {
+        char* pluginName{
+            const_cast<char*>(typeid(*this).name())};  // get name of DERIVED class
+        while (isdigit(*pluginName)) { pluginName++; }
+        return pluginName;
     }
 
     /** \brief Do proper Initialization of members and class instances. By default this
    * initializes the Sampling Frequency. If a class instance depends on the
    * sampling frequency, it should be initialize here.
    */
-    virtual void init(int samplingRate) {
-      fSamplingFreq = samplingRate;
-      if (verbose) {
-        char* derivedClassName = getName();
-        printf("%s: init(%d)\n",derivedClassName,samplingRate);
-      }
+    virtual void init(int samplingRate)
+    {
+        fSamplingFreq = samplingRate;
+        if (verbose) {
+            char* derivedClassName = getName();
+            printf("%s: init(%d)\n", derivedClassName, samplingRate);
+        }
     }
     virtual bool getInited() { return inited; }
     virtual void setVerbose(bool v) { verbose = v; }
@@ -88,9 +91,9 @@ public:
     /// \brief Compute process
     virtual void compute(int nframes, float** inputs, float** outputs) = 0;
 
-protected:
-    int fSamplingFreq; ///< Faust Data member, Sampling Rate
-    bool inited = false;
+   protected:
+    int fSamplingFreq;  ///< Faust Data member, Sampling Rate
+    bool inited  = false;
     bool verbose = false;
 };
 

--- a/src/Reverb.cpp
+++ b/src/Reverb.cpp
@@ -35,36 +35,37 @@
  * \date August 2020
  */
 
-
 #include "Reverb.h"
-#include "jacktrip_types.h"
 
 #include <iostream>
+
+#include "jacktrip_types.h"
 
 //*******************************************************************************
 void Reverb::compute(int nframes, float** inputs, float** outputs)
 {
-  if (not inited) {
-    std::cerr << "*** Reverb " << this << ": init never called! Doing it now.\n";
-    if (fSamplingFreq <= 0) {
-      fSamplingFreq = 48000;
-      std::cout << "Reverb " << this << ": *** HAD TO GUESS the sampling rate (chose 48000 Hz) ***\n";
+    if (not inited) {
+        std::cerr << "*** Reverb " << this << ": init never called! Doing it now.\n";
+        if (fSamplingFreq <= 0) {
+            fSamplingFreq = 48000;
+            std::cout << "Reverb " << this
+                      << ": *** HAD TO GUESS the sampling rate (chose 48000 Hz) ***\n";
+        }
+        init(fSamplingFreq);
     }
-    init(fSamplingFreq);
-  }
-  if (mReverbLevel <= 1.0) {
-    if (mNumInChannels == 1) {
-      freeverbMonoP->compute(nframes, inputs, outputs);
+    if (mReverbLevel <= 1.0) {
+        if (mNumInChannels == 1) {
+            freeverbMonoP->compute(nframes, inputs, outputs);
+        } else {
+            assert(mNumInChannels == 2);
+            freeverbStereoP->compute(nframes, inputs, outputs);
+        }
     } else {
-      assert(mNumInChannels == 2);
-      freeverbStereoP->compute(nframes, inputs, outputs);
+        if (mNumInChannels == 1) {
+            zitarevMonoP->compute(nframes, inputs, outputs);
+        } else {
+            assert(mNumInChannels == 2);
+            zitarevStereoP->compute(nframes, inputs, outputs);
+        }
     }
-  } else {
-    if (mNumInChannels == 1) {
-      zitarevMonoP->compute(nframes, inputs, outputs);
-    } else {
-      assert(mNumInChannels == 2);
-      zitarevStereoP->compute(nframes, inputs, outputs);
-    }
-  }
 }

--- a/src/RingBuffer.cpp
+++ b/src/RingBuffer.cpp
@@ -35,37 +35,37 @@
  * \date July 2008
  */
 
-
 #include "RingBuffer.h"
 
-#include <iostream>
-#include <cstring>
-#include <cstdlib>
-#include <stdexcept>
 #include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <stdexcept>
+
 #include "JackTrip.h"
 
-using std::cout; using std::endl;
-
+using std::cout;
+using std::endl;
 
 //*******************************************************************************
-RingBuffer::RingBuffer(int SlotSize, int NumSlots) :
-    mSlotSize(SlotSize),
-    mNumSlots(NumSlots),
-    mTotalSize(mSlotSize*mNumSlots),
-    mReadPosition(0),
-    mWritePosition(0),
-    mFullSlots(0),
-    mRingBuffer(NULL),
-    mLastReadSlot(NULL)
+RingBuffer::RingBuffer(int SlotSize, int NumSlots)
+    : mSlotSize(SlotSize)
+    , mNumSlots(NumSlots)
+    , mTotalSize(mSlotSize * mNumSlots)
+    , mReadPosition(0)
+    , mWritePosition(0)
+    , mFullSlots(0)
+    , mRingBuffer(NULL)
+    , mLastReadSlot(NULL)
 {
     if (0 < mTotalSize) {
-        mRingBuffer = new int8_t[mTotalSize];
+        mRingBuffer   = new int8_t[mTotalSize];
         mLastReadSlot = new int8_t[mSlotSize];
         //QMutexLocker locker(&mMutex); // lock the mutex
 
         // Verify if there's enough space to for the buffers
-        if ( (mRingBuffer == NULL) || (mLastReadSlot == NULL) ) {
+        if ((mRingBuffer == NULL) || (mLastReadSlot == NULL)) {
             //std::cerr << "ERROR: RingBuffer out of memory!" << endl;
             //std::cerr << "Exiting program..." << endl;
             //std::exit(1);
@@ -78,50 +78,48 @@ RingBuffer::RingBuffer(int SlotSize, int NumSlots) :
         mRingBuffer[i] = 0;    // Initialize all elements to zero.
       }
       */
-        std::memset(mRingBuffer, 0, mTotalSize); // set buffer to 0
+        std::memset(mRingBuffer, 0, mTotalSize);  // set buffer to 0
         /*
       for (int i=0; i<mSlotSize; i++) {
         mLastReadSlot[i] = 0;    // Initialize all elements to zero.
       }
       */
-        std::memset(mLastReadSlot, 0, mSlotSize); // set buffer to 0
-        mWritePosition = ( (NumSlots/2) * SlotSize ) % mTotalSize;
+        std::memset(mLastReadSlot, 0, mSlotSize);  // set buffer to 0
+        mWritePosition = ((NumSlots / 2) * SlotSize) % mTotalSize;
     }
 
     // Advance write position to half of the RingBuffer
     // Udpate Full Slots accordingly
-    mFullSlots = (NumSlots/2);
-    mLevelDownRate = 0.01;
-    mStatUnit = 1;
-    mUnderruns = 0;
-    mOverflows = 0;
-    mSkew0 = 0;
-    mSkewRaw = 0;
-    mLevelCur = mFullSlots;
-    mLevel = mLevelCur;
-    mBufDecOverflow = 0;
-    mBufDecPktLoss = 0;
-    mBufIncUnderrun = 0;
+    mFullSlots        = (NumSlots / 2);
+    mLevelDownRate    = 0.01;
+    mStatUnit         = 1;
+    mUnderruns        = 0;
+    mOverflows        = 0;
+    mSkew0            = 0;
+    mSkewRaw          = 0;
+    mLevelCur         = mFullSlots;
+    mLevel            = mLevelCur;
+    mBufDecOverflow   = 0;
+    mBufDecPktLoss    = 0;
+    mBufIncUnderrun   = 0;
     mBufIncCompensate = 0;
-    mBroadcastSkew = 0;
-    mBroadcastDelta = 0;
+    mBroadcastSkew    = 0;
+    mBroadcastDelta   = 0;
 }
-
 
 //*******************************************************************************
 RingBuffer::~RingBuffer()
 {
-    delete[] mRingBuffer; // Free memory
-    mRingBuffer = NULL; // Clear to prevent using invalid memory reference
+    delete[] mRingBuffer;  // Free memory
+    mRingBuffer = NULL;    // Clear to prevent using invalid memory reference
     delete[] mLastReadSlot;
     mLastReadSlot = NULL;
 }
 
-
 //*******************************************************************************
 void RingBuffer::insertSlotBlocking(const int8_t* ptrToSlot)
 {
-    QMutexLocker locker(&mMutex); // lock the mutex
+    QMutexLocker locker(&mMutex);  // lock the mutex
     updateReadStats();
 
     // Check if there is space available to write a slot
@@ -132,19 +130,18 @@ void RingBuffer::insertSlotBlocking(const int8_t* ptrToSlot)
     }
 
     // Copy mSlotSize bytes to mRingBuffer
-    std::memcpy(mRingBuffer+mWritePosition, ptrToSlot, mSlotSize);
+    std::memcpy(mRingBuffer + mWritePosition, ptrToSlot, mSlotSize);
     // Update write position
-    mWritePosition = (mWritePosition+mSlotSize) % mTotalSize;
-    mFullSlots++; //update full slots
+    mWritePosition = (mWritePosition + mSlotSize) % mTotalSize;
+    mFullSlots++;  //update full slots
     // Wake threads waitng for bufferIsNotFull condition
     mBufferIsNotEmpty.wakeAll();
 }
 
-
 //*******************************************************************************
 void RingBuffer::readSlotBlocking(int8_t* ptrToReadSlot)
 {
-    QMutexLocker locker(&mMutex); // lock the mutex
+    QMutexLocker locker(&mMutex);  // lock the mutex
     ++mReadsNew;
 
     // Check if there are slots available to read
@@ -152,22 +149,19 @@ void RingBuffer::readSlotBlocking(int8_t* ptrToReadSlot)
     while (mFullSlots == 0) {
         //std::cerr << "READ UNDER-RUN BLOCKING before" << endl;
         mBufferIsNotEmpty.wait(&mMutex, 200);
-        if (JackTrip::sJackStopped) {
-            return;
-        }
+        if (JackTrip::sJackStopped) { return; }
     }
 
     // Copy mSlotSize bytes to ReadSlot
-    std::memcpy(ptrToReadSlot, mRingBuffer+mReadPosition, mSlotSize);
+    std::memcpy(ptrToReadSlot, mRingBuffer + mReadPosition, mSlotSize);
     // Always save memory of the last read slot
-    std::memcpy(mLastReadSlot, mRingBuffer+mReadPosition, mSlotSize);
+    std::memcpy(mLastReadSlot, mRingBuffer + mReadPosition, mSlotSize);
     // Update write position
-    mReadPosition = (mReadPosition+mSlotSize) % mTotalSize;
-    mFullSlots--; //update full slots
+    mReadPosition = (mReadPosition + mSlotSize) % mTotalSize;
+    mFullSlots--;  //update full slots
     // Wake threads waitng for bufferIsNotFull condition
     mBufferIsNotFull.wakeAll();
 }
-
 
 //*******************************************************************************
 bool RingBuffer::insertSlotNonBlocking(const int8_t* ptrToSlot, int len, int lostLen)
@@ -176,7 +170,7 @@ bool RingBuffer::insertSlotNonBlocking(const int8_t* ptrToSlot, int len, int los
         // RingBuffer does not suppport mixed buf sizes
         return false;
     }
-    QMutexLocker locker(&mMutex); // lock the mutex
+    QMutexLocker locker(&mMutex);  // lock the mutex
     if (0 < lostLen) {
         int lostCount = lostLen / mSlotSize;
         mBufDecPktLoss += lostCount;
@@ -197,25 +191,23 @@ bool RingBuffer::insertSlotNonBlocking(const int8_t* ptrToSlot, int len, int los
     }
 
     // Copy mSlotSize bytes to mRingBuffer
-    std::memcpy(mRingBuffer+mWritePosition, ptrToSlot, mSlotSize);
+    std::memcpy(mRingBuffer + mWritePosition, ptrToSlot, mSlotSize);
     // Update write position
-    mWritePosition = (mWritePosition+mSlotSize) % mTotalSize;
-    mFullSlots++; //update full slots
+    mWritePosition = (mWritePosition + mSlotSize) % mTotalSize;
+    mFullSlots++;  //update full slots
     // Wake threads waitng for bufferIsNotFull condition
     mBufferIsNotEmpty.wakeAll();
     return true;
 }
 
-
 //*******************************************************************************
 void RingBuffer::readSlotNonBlocking(int8_t* ptrToReadSlot)
 {
-    QMutexLocker locker(&mMutex); // lock the mutex
+    QMutexLocker locker(&mMutex);  // lock the mutex
     ++mReadsNew;
     if (mFullSlots < mLevelCur) {
-        mLevelCur = std::max((double)mFullSlots, mLevelCur-mLevelDownRate);
-    }
-    else {
+        mLevelCur = std::max((double)mFullSlots, mLevelCur - mLevelDownRate);
+    } else {
         mLevelCur = mFullSlots;
     }
 
@@ -231,16 +223,15 @@ void RingBuffer::readSlotNonBlocking(int8_t* ptrToReadSlot)
     }
 
     // Copy mSlotSize bytes to ReadSlot
-    std::memcpy(ptrToReadSlot, mRingBuffer+mReadPosition, mSlotSize);
+    std::memcpy(ptrToReadSlot, mRingBuffer + mReadPosition, mSlotSize);
     // Always save memory of the last read slot
-    std::memcpy(mLastReadSlot, mRingBuffer+mReadPosition, mSlotSize);
+    std::memcpy(mLastReadSlot, mRingBuffer + mReadPosition, mSlotSize);
     // Update write position
-    mReadPosition = (mReadPosition+mSlotSize) % mTotalSize;
-    mFullSlots--; //update full slots
+    mReadPosition = (mReadPosition + mSlotSize) % mTotalSize;
+    mFullSlots--;  //update full slots
     // Wake threads waitng for bufferIsNotFull condition
     mBufferIsNotFull.wakeAll();
 }
-
 
 //*******************************************************************************
 // Not supported in RingBuffer
@@ -249,22 +240,17 @@ void RingBuffer::readBroadcastSlot(int8_t* ptrToReadSlot)
     std::memset(ptrToReadSlot, 0, mSlotSize);
 }
 
-
 //*******************************************************************************
 void RingBuffer::setUnderrunReadSlot(int8_t* ptrToReadSlot)
 {
     std::memset(ptrToReadSlot, 0, mSlotSize);
 }
 
-
 //*******************************************************************************
 void RingBuffer::setMemoryInReadSlotWithLastReadSlot(int8_t* ptrToReadSlot)
 {
     std::memcpy(ptrToReadSlot, mLastReadSlot, mSlotSize);
 }
-
-
-
 
 //*******************************************************************************
 // Under-run happens when there's nothing to read.
@@ -279,21 +265,19 @@ void RingBuffer::underrunReset()
     ++mUnderrunsNew;
 }
 
-
 //*******************************************************************************
 // Over-flow happens when there's no space to write more slots.
 void RingBuffer::overflowReset()
 {
     // Advance the read pointer 1/2 the ring buffer
     //mReadPosition = ( mWritePosition + ( (mNumSlots/2) * mSlotSize ) ) % mTotalSize;
-    int d = mNumSlots / 2;
-    mReadPosition = ( mReadPosition + ( d * mSlotSize ) ) % mTotalSize;
+    int d         = mNumSlots / 2;
+    mReadPosition = (mReadPosition + (d * mSlotSize)) % mTotalSize;
     mFullSlots -= d;
     mOverflows += d + 1;
     mBufDecOverflow += d + 1;
     mLevelCur -= d;
 }
-
 
 //*******************************************************************************
 void RingBuffer::debugDump() const
@@ -301,7 +285,7 @@ void RingBuffer::debugDump() const
     cout << "mTotalSize = " << mTotalSize << endl;
     cout << "mReadPosition = " << mReadPosition << endl;
     cout << "mWritePosition = " << mWritePosition << endl;
-    cout <<  "mFullSlots = " << mFullSlots << endl;
+    cout << "mFullSlots = " << mFullSlots << endl;
 }
 
 //*******************************************************************************
@@ -309,29 +293,30 @@ bool RingBuffer::getStats(RingBuffer::IOStat* stat, bool reset)
 {
     QMutexLocker locker(&mMutex);
     if (reset) {
-        mUnderruns = 0;
-        mOverflows = 0;
-        mSkew0 = mLevel;
-        mSkewRaw = 0;
-        mBufDecOverflow = 0;
-        mBufDecPktLoss = 0;
-        mBufIncUnderrun = 0;
+        mUnderruns        = 0;
+        mOverflows        = 0;
+        mSkew0            = mLevel;
+        mSkewRaw          = 0;
+        mBufDecOverflow   = 0;
+        mBufDecPktLoss    = 0;
+        mBufIncUnderrun   = 0;
         mBufIncCompensate = 0;
-        mBroadcastSkew = 0;
+        mBroadcastSkew    = 0;
     }
     stat->underruns = mUnderruns / mStatUnit;
     stat->overflows = mOverflows / mStatUnit;
-    stat->skew = (int32_t)((mSkew0 - mLevel + mBufIncUnderrun + mBufIncCompensate
-                        - mBufDecOverflow - mBufDecPktLoss)) / mStatUnit;
+    stat->skew      = (int32_t)((mSkew0 - mLevel + mBufIncUnderrun + mBufIncCompensate
+                            - mBufDecOverflow - mBufDecPktLoss))
+                 / mStatUnit;
     stat->skew_raw = mSkewRaw / mStatUnit;
-    stat->level = mLevel / mStatUnit;
+    stat->level    = mLevel / mStatUnit;
 
-    stat->buf_dec_overflows = mBufDecOverflow / mStatUnit;
-    stat->buf_dec_pktloss = mBufDecPktLoss / mStatUnit;
-    stat->buf_inc_underrun = mBufIncUnderrun / mStatUnit;
+    stat->buf_dec_overflows  = mBufDecOverflow / mStatUnit;
+    stat->buf_dec_pktloss    = mBufDecPktLoss / mStatUnit;
+    stat->buf_inc_underrun   = mBufIncUnderrun / mStatUnit;
     stat->buf_inc_compensate = mBufIncCompensate / mStatUnit;
-    stat->broadcast_skew = mBroadcastSkew;
-    stat->broadcast_delta = mBroadcastDelta;
+    stat->broadcast_skew     = mBroadcastSkew;
+    stat->broadcast_delta    = mBroadcastDelta;
 
     stat->autoq_corr = 0;
     stat->autoq_rate = 0;
@@ -347,5 +332,5 @@ void RingBuffer::updateReadStats()
     mUnderruns += mUnderrunsNew;
     mBufIncUnderrun += mUnderrunsNew;
     mUnderrunsNew = 0;
-    mLevel = std::ceil(mLevelCur);
+    mLevel        = std::ceil(mLevelCur);
 }

--- a/src/RingBuffer.h
+++ b/src/RingBuffer.h
@@ -38,16 +38,14 @@
 #ifndef __RINGBUFFER_H__
 #define __RINGBUFFER_H__
 
-#include <QWaitCondition>
 #include <QMutex>
 #include <QMutexLocker>
+#include <QWaitCondition>
+#include <atomic>
 
 #include "jacktrip_types.h"
 
-#include <atomic>
-
 //using namespace JackTripNamespace;
-
 
 /** \brief Provides a ring-buffer (or circular-buffer) that can be written to and read from
  * asynchronously (blocking) or synchronously (non-blocking).
@@ -58,8 +56,7 @@
  */
 class RingBuffer
 {
-public:
-
+   public:
     /** \brief The class constructor
    * \param SlotSize Size of one slot in bytes
    * \param NumSlots Number of slots
@@ -121,8 +118,7 @@ public:
     };
     virtual bool getStats(IOStat* stat, bool reset);
 
-protected:
-
+   protected:
     /** \brief Sets the memory in the Read Slot when uderrun occurs. By default,
    * this sets it to 0. Override this method in a subclass for a different behavior.
    * \param ptrToReadSlot Pointer to read slot from the RingBuffer
@@ -145,28 +141,28 @@ protected:
     void debugDump() const;
     void updateReadStats();
 
-    /*const*/ int mSlotSize; ///< The size of one slot in byes
-    /*const*/ int mNumSlots; ///< Number of Slots
-    /*const*/ int mTotalSize; ///< Total size of the mRingBuffer = mSlotSize*mNumSlotss
-    uint32_t mReadPosition; ///< Read Positions in the RingBuffer (Tail)
-    uint32_t mWritePosition; ///< Write Position in the RingBuffer (Head)
-    int mFullSlots; ///< Number of used (full) slots, in slot-size
-    int8_t* mRingBuffer; ///< 8-bit array of data (1-byte)
-    int8_t* mLastReadSlot; ///< Last slot read
+    /*const*/ int mSlotSize;   ///< The size of one slot in byes
+    /*const*/ int mNumSlots;   ///< Number of Slots
+    /*const*/ int mTotalSize;  ///< Total size of the mRingBuffer = mSlotSize*mNumSlotss
+    uint32_t mReadPosition;    ///< Read Positions in the RingBuffer (Tail)
+    uint32_t mWritePosition;   ///< Write Position in the RingBuffer (Head)
+    int mFullSlots;            ///< Number of used (full) slots, in slot-size
+    int8_t* mRingBuffer;       ///< 8-bit array of data (1-byte)
+    int8_t* mLastReadSlot;     ///< Last slot read
 
     // Thread Synchronization Private Members
-    QMutex mMutex; ///< Mutex to protect read and write operations
-    QWaitCondition mBufferIsNotFull; ///< Buffer not full condition to monitor threads
-    QWaitCondition mBufferIsNotEmpty; ///< Buffer not empty condition to monitor threads
+    QMutex mMutex;                     ///< Mutex to protect read and write operations
+    QWaitCondition mBufferIsNotFull;   ///< Buffer not full condition to monitor threads
+    QWaitCondition mBufferIsNotEmpty;  ///< Buffer not empty condition to monitor threads
 
     // IO stat
     int mStatUnit;
     uint32_t mUnderruns;
     uint32_t mOverflows;
-    int32_t  mSkewRaw;
-    double   mLevelCur;
-    double   mLevelDownRate;
-    int32_t  mLevel;
+    int32_t mSkewRaw;
+    double mLevelCur;
+    double mLevelDownRate;
+    int32_t mLevel;
 
     uint32_t mBufDecOverflow;
     uint32_t mBufDecPktLoss;
@@ -176,7 +172,7 @@ protected:
     // temp counters for reads
     uint32_t mReadsNew;
     uint32_t mUnderrunsNew;
-    int32_t  mSkew0;
+    int32_t mSkew0;
 
     // broadcast counters
     int32_t mBroadcastSkew;

--- a/src/RingBufferWavetable.h
+++ b/src/RingBufferWavetable.h
@@ -38,13 +38,12 @@
 #ifndef __RINGBUFFERWAVETABLE_H__
 #define __RINGBUFFERWAVETABLE_H__
 
-
 /** \brief Same as RingBuffer, except that it uses the Wavetable mode for
  * lost or late packets.
  */
 class RingBufferWavetable : public RingBuffer
 {
-public:
+   public:
     /** \brief The class constructor
    * \param SlotSize Size of one slot in bytes
    * \param NumSlots Number of slots
@@ -55,7 +54,7 @@ public:
    */
     virtual ~RingBufferWavetable() {}
 
-protected:
+   protected:
     /** \brief Sets the memory in the Read Slot when uderrun occurs. This loops as a
    * wavetable in the last received packet.
    * \param ptrToReadSlot Pointer to read slot from the RingBuffer
@@ -64,8 +63,6 @@ protected:
     {
         setMemoryInReadSlotWithLastReadSlot(ptrToReadSlot);
     }
-
 };
 
-
-#endif //__RINGBUFFERWAVETABLE_H__
+#endif  //__RINGBUFFERWAVETABLE_H__

--- a/src/RtAudioInterface.h
+++ b/src/RtAudioInterface.h
@@ -42,22 +42,20 @@
 
 #include "AudioInterface.h"
 #include "jacktrip_globals.h"
-class JackTrip; // Forward declaration
+class JackTrip;  // Forward declaration
 
 /// \brief Base Class that provides an interface with RtAudio
 class RtAudioInterface : public AudioInterface
 {
-public:
-
+   public:
     /** \brief The class constructor
    * \param jacktrip Pointer to the JackTrip class that connects all classes (mediator)
    * \param NumInChans Number of Input Channels
    * \param NumOutChans Number of Output Channels
    * \param AudioBitResolution Audio Sample Resolutions in bits
    */
-    RtAudioInterface(JackTrip* jacktrip,
-                     int NumInChans = gDefaultNumInChannels,
-                     int NumOutChans = gDefaultNumOutChannels,
+    RtAudioInterface(JackTrip* jacktrip, int NumInChans = gDefaultNumInChannels,
+                     int NumOutChans                        = gDefaultNumOutChannels,
                      audioBitResolutionT AudioBitResolution = BIT16);
     /// \brief The class destructor
     virtual ~RtAudioInterface();
@@ -78,20 +76,22 @@ public:
     //--------------GETTERS---------------------------------------------
     //------------------------------------------------------------------
 
-
-private:
-    int RtAudioCallback(void *outputBuffer, void *inputBuffer, unsigned int nFrames,
+   private:
+    int RtAudioCallback(void* outputBuffer, void* inputBuffer, unsigned int nFrames,
                         double streamTime, RtAudioStreamStatus status);
-    static int wrapperRtAudioCallback(void *outputBuffer, void *inputBuffer, unsigned int nFrames,
-                                      double streamTime, RtAudioStreamStatus status, void *userData);
+    static int wrapperRtAudioCallback(void* outputBuffer, void* inputBuffer,
+                                      unsigned int nFrames, double streamTime,
+                                      RtAudioStreamStatus status, void* userData);
     void printDeviceInfo(unsigned int deviceId);
 
-    JackTrip* mJackTrip; ///< JackTrip Mediator Class pointer
-    int mNumInChans;///< Number of Input Channels
-    int mNumOutChans; ///<  Number of Output Channels
-    QVarLengthArray<float*> mInBuffer; ///< Vector of Input buffers/channel read from JACK
-    QVarLengthArray<float*> mOutBuffer; ///< Vector of Output buffer/channel to write to JACK
-    RtAudio* mRtAudio; ///< RtAudio class
+    JackTrip* mJackTrip;  ///< JackTrip Mediator Class pointer
+    int mNumInChans;      ///< Number of Input Channels
+    int mNumOutChans;     ///<  Number of Output Channels
+    QVarLengthArray<float*>
+        mInBuffer;  ///< Vector of Input buffers/channel read from JACK
+    QVarLengthArray<float*>
+        mOutBuffer;     ///< Vector of Output buffer/channel to write to JACK
+    RtAudio* mRtAudio;  ///< RtAudio class
 };
 
-#endif // __RTAUDIOINTERFACE_H__
+#endif  // __RTAUDIOINTERFACE_H__

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -36,74 +36,82 @@
  */
 
 #include "Settings.h"
+
 #include "LoopBack.h"
 //#include "NetKS.h"
 #include "Effects.h"
 
-#ifdef WAIR // wair
-#include "ap8x2.dsp.h"
+#ifdef WAIR  // wair
 #include "Stk16.dsp.h"
-#endif // endwhere
+#include "ap8x2.dsp.h"
+#endif  // endwhere
 
 //#include "JackTripWorker.h"
-#include "jacktrip_globals.h"
-
-#include <iostream>
-#include <getopt.h> // for command line parsing
-#include <cstdlib>
 #include <assert.h>
 #include <ctype.h>
+#include <getopt.h>  // for command line parsing
+
+#include <cstdlib>
+#include <iostream>
+
+#include "jacktrip_globals.h"
 
 //#include "ThreadPoolTest.h"
 
-using std::cout; using std::endl;
+using std::cout;
+using std::endl;
 
 int gVerboseFlag = 0;
 
 enum JTLongOptIDS {
-  OPT_BUFSTRATEGY = 1001,
-  OPT_SIMLOSS,
-  OPT_SIMJITTER,
-  OPT_BROADCAST,
-  OPT_RTUDPPRIORITY,
+    OPT_BUFSTRATEGY = 1001,
+    OPT_SIMLOSS,
+    OPT_SIMJITTER,
+    OPT_BROADCAST,
+    OPT_RTUDPPRIORITY,
 };
 
 //*******************************************************************************
-Settings::Settings() :
-    mJackTripMode(JackTrip::SERVER),
-    mDataProtocol(JackTrip::UDP),
-    mNumChans(2),
-    mBufferQueueLength(gDefaultQueueLength),
-    mAudioBitResolution(AudioInterface::BIT16),
-    mBindPortNum(gDefaultPort), mPeerPortNum(gDefaultPort),
-    mServerUdpPortNum(0),
-    mUnderrunMode(JackTrip::WAVETABLE),
-    mStopOnTimeout(false),
-    mBufferStrategy(1),
-    mLoopBack(false),
-    #ifdef WAIR // WAIR
-    mNumNetRevChans(0),
-    mWAIR(false),
-    #endif // endwhere
-    mJamLink(false),
-    mEmptyHeader(false),
-    mJackTripServer(false),
-    mLocalAddress(gDefaultLocalAddress),
-    mRedundancy(1),
-    mUseJack(true),
-    mChanfeDefaultSR(false),
-    mChanfeDefaultID(0),
-    mChanfeDefaultBS(false),
-    mHubConnectionMode(JackTrip::SERVERTOCLIENT),
-    mConnectDefaultAudioPorts(true),
-    mIOStatTimeout(0),
-    mEffects(false), // outgoing limiter OFF by default
-    mSimulatedLossRate(0.0),
-    mSimulatedJitterRate(0.0),
-    mSimulatedDelayRel(0.0),
-    mBroadcastQueue(0),
-    mUseRtUdpPriority(false)
-{}
+Settings::Settings()
+    : mJackTripMode(JackTrip::SERVER)
+    , mDataProtocol(JackTrip::UDP)
+    , mNumChans(2)
+    , mBufferQueueLength(gDefaultQueueLength)
+    , mAudioBitResolution(AudioInterface::BIT16)
+    , mBindPortNum(gDefaultPort)
+    , mPeerPortNum(gDefaultPort)
+    , mServerUdpPortNum(0)
+    , mUnderrunMode(JackTrip::WAVETABLE)
+    , mStopOnTimeout(false)
+    , mBufferStrategy(1)
+    , mLoopBack(false)
+    ,
+#ifdef WAIR  // WAIR
+    mNumNetRevChans(0)
+    , mWAIR(false)
+    ,
+#endif  // endwhere
+    mJamLink(false)
+    , mEmptyHeader(false)
+    , mJackTripServer(false)
+    , mLocalAddress(gDefaultLocalAddress)
+    , mRedundancy(1)
+    , mUseJack(true)
+    , mChanfeDefaultSR(false)
+    , mChanfeDefaultID(0)
+    , mChanfeDefaultBS(false)
+    , mHubConnectionMode(JackTrip::SERVERTOCLIENT)
+    , mConnectDefaultAudioPorts(true)
+    , mIOStatTimeout(0)
+    , mEffects(false)
+    ,  // outgoing limiter OFF by default
+    mSimulatedLossRate(0.0)
+    , mSimulatedJitterRate(0.0)
+    , mSimulatedDelayRel(0.0)
+    , mBroadcastQueue(0)
+    , mUseRtUdpPriority(false)
+{
+}
 
 //*******************************************************************************
 Settings::~Settings() = default;
@@ -112,9 +120,9 @@ Settings::~Settings() = default;
 void Settings::parseInput(int argc, char** argv)
 {
     // Always use decimal point for floating point numbers
-    setlocale( LC_NUMERIC, "C" );
+    setlocale(LC_NUMERIC, "C");
     // If no command arguments are given, print instructions
-    if(argc == 1) {
+    if (argc == 1) {
         printUsage();
         std::exit(0);
     }
@@ -125,122 +133,144 @@ void Settings::parseInput(int argc, char** argv)
     //----------------------------------------------------------------------------
     static struct option longopts[] = {
         // These options don't set a flag.
-        { "numchannels", required_argument, NULL, 'n' }, // Number of input and output channels
-#ifdef WAIR // WAIR
-        { "wair", no_argument, NULL, 'w' }, // Run in LAIR mode, sets numnetrevchannels
-        { "addcombfilterlength", required_argument, NULL, 'N' }, // added comb filter length
-        { "combfilterfeedback", required_argument, NULL, 'H' }, // comb filter feedback
-#endif // endwhere
-        { "server", no_argument, NULL, 's' }, // Run in P2P server mode
-        { "client", required_argument, NULL, 'c' }, // Run in P2P client mode, set server IP address
-        { "localaddress", required_argument, NULL, 'L' }, // set local address e.g., 127.0.0.2 for second instance on same host
-        { "jacktripserver", no_argument, NULL, 'S' }, // Run in JamLink mode
-        { "pingtoserver", required_argument, NULL, 'C' }, // Run in ping to server mode, set server IP address
-        { "portoffset", required_argument, NULL, 'o' }, // Port Offset from 4464
-        { "bindport", required_argument, NULL, 'B' }, // Port Offset from 4464
-        { "peerport", required_argument, NULL, 'P' }, // Port Offset from 4464
-        { "udpbaseport", required_argument, NULL, 'U' }, // Server udp base port (defaults to 61002)
-        { "queue", required_argument, NULL, 'q' }, // Queue Length
-        { "redundancy", required_argument, NULL, 'r' }, // Redundancy
-        { "bitres", required_argument, NULL, 'b' }, // Audio Bit Resolution
-        { "zerounderrun", no_argument, NULL, 'z' }, // Use Underrun to Zeros Mode
-        { "timeout", no_argument, NULL, 't' }, // Quit after 10 second network timeout
-        { "loopback", no_argument, NULL, 'l' }, // Run in loopback mode
-        { "jamlink", no_argument, NULL, 'j' }, // Run in JamLink mode
-        { "emptyheader", no_argument, NULL, 'e' }, // Run in JamLink mode
-        { "clientname", required_argument, NULL, 'J' }, // Run in JamLink mode
-        { "remotename", required_argument, NULL, 'K' }, // Client name on hub server
-        { "rtaudio", no_argument, NULL, 'R' }, // Run in JamLink mode
-        { "srate", required_argument, NULL, 'T' }, // Set Sample Rate
-        { "deviceid", required_argument, NULL, 'd' }, // Set RTAudio device id to use
-        { "bufsize", required_argument, NULL, 'F' }, // Set buffer Size
-        { "nojackportsconnect" , no_argument, NULL,  'D'}, // Don't connect default Audio Ports
-        { "version", no_argument, NULL, 'v' }, // Version Number
-        { "verbose", no_argument, NULL, 'V' }, // Verbose mode
-        { "hubpatch", required_argument, NULL, 'p' }, // Set hubConnectionMode for auto patch in Jack
-        { "iostat", required_argument, NULL, 'I' }, // Set IO stat timeout
-        { "iostatlog", required_argument, NULL, 'G' }, // Set IO stat log file
-        { "effects", required_argument, NULL, 'f' }, // Turn on outgoing compressor and incoming reverb, reverbLevel arg
-        { "overflowlimiting", required_argument, NULL, 'O' }, // Turn On limiter, cases 'i', 'o', 'io'
-        { "assumednumclients", required_argument, NULL, 'a' }, // assumed number of clients (sound sources) (otherwise 2)
-        { "bufstrategy", required_argument, NULL, OPT_BUFSTRATEGY }, // Set bufstrategy
-        { "simloss", required_argument, NULL, OPT_SIMLOSS },
-        { "simjitter", required_argument, NULL, OPT_SIMJITTER },
-        { "broadcast", required_argument, NULL, OPT_BROADCAST },
-        { "udprt", no_argument, NULL, OPT_RTUDPPRIORITY },
-        { "help", no_argument, NULL, 'h' }, // Print Help
-        { "examine-audio-delay", required_argument, NULL, 'x' }, // test mode - measure audio round-trip latency statistics
-        { NULL, 0, NULL, 0 }
-    };
+        {"numchannels", required_argument, NULL,
+         'n'},  // Number of input and output channels
+#ifdef WAIR     // WAIR
+        {"wair", no_argument, NULL, 'w'},  // Run in LAIR mode, sets numnetrevchannels
+        {"addcombfilterlength", required_argument, NULL,
+         'N'},                                                 // added comb filter length
+        {"combfilterfeedback", required_argument, NULL, 'H'},  // comb filter feedback
+#endif  // endwhere
+        {"server", no_argument, NULL, 's'},  // Run in P2P server mode
+        {"client", required_argument, NULL,
+         'c'},  // Run in P2P client mode, set server IP address
+        {"localaddress", required_argument, NULL,
+         'L'},  // set local address e.g., 127.0.0.2 for second instance on same host
+        {"jacktripserver", no_argument, NULL, 'S'},  // Run in JamLink mode
+        {"pingtoserver", required_argument, NULL,
+         'C'},  // Run in ping to server mode, set server IP address
+        {"portoffset", required_argument, NULL, 'o'},  // Port Offset from 4464
+        {"bindport", required_argument, NULL, 'B'},    // Port Offset from 4464
+        {"peerport", required_argument, NULL, 'P'},    // Port Offset from 4464
+        {"udpbaseport", required_argument, NULL,
+         'U'},  // Server udp base port (defaults to 61002)
+        {"queue", required_argument, NULL, 'q'},       // Queue Length
+        {"redundancy", required_argument, NULL, 'r'},  // Redundancy
+        {"bitres", required_argument, NULL, 'b'},      // Audio Bit Resolution
+        {"zerounderrun", no_argument, NULL, 'z'},      // Use Underrun to Zeros Mode
+        {"timeout", no_argument, NULL, 't'},      // Quit after 10 second network timeout
+        {"loopback", no_argument, NULL, 'l'},     // Run in loopback mode
+        {"jamlink", no_argument, NULL, 'j'},      // Run in JamLink mode
+        {"emptyheader", no_argument, NULL, 'e'},  // Run in JamLink mode
+        {"clientname", required_argument, NULL, 'J'},  // Run in JamLink mode
+        {"remotename", required_argument, NULL, 'K'},  // Client name on hub server
+        {"rtaudio", no_argument, NULL, 'R'},           // Run in JamLink mode
+        {"srate", required_argument, NULL, 'T'},       // Set Sample Rate
+        {"deviceid", required_argument, NULL, 'd'},    // Set RTAudio device id to use
+        {"bufsize", required_argument, NULL, 'F'},     // Set buffer Size
+        {"nojackportsconnect", no_argument, NULL,
+         'D'},                                // Don't connect default Audio Ports
+        {"version", no_argument, NULL, 'v'},  // Version Number
+        {"verbose", no_argument, NULL, 'V'},  // Verbose mode
+        {"hubpatch", required_argument, NULL,
+         'p'},  // Set hubConnectionMode for auto patch in Jack
+        {"iostat", required_argument, NULL, 'I'},     // Set IO stat timeout
+        {"iostatlog", required_argument, NULL, 'G'},  // Set IO stat log file
+        {"effects", required_argument, NULL,
+         'f'},  // Turn on outgoing compressor and incoming reverb, reverbLevel arg
+        {"overflowlimiting", required_argument, NULL,
+         'O'},  // Turn On limiter, cases 'i', 'o', 'io'
+        {"assumednumclients", required_argument, NULL,
+         'a'},  // assumed number of clients (sound sources) (otherwise 2)
+        {"bufstrategy", required_argument, NULL, OPT_BUFSTRATEGY},  // Set bufstrategy
+        {"simloss", required_argument, NULL, OPT_SIMLOSS},
+        {"simjitter", required_argument, NULL, OPT_SIMJITTER},
+        {"broadcast", required_argument, NULL, OPT_BROADCAST},
+        {"udprt", no_argument, NULL, OPT_RTUDPPRIORITY},
+        {"help", no_argument, NULL, 'h'},  // Print Help
+        {"examine-audio-delay", required_argument, NULL,
+         'x'},  // test mode - measure audio round-trip latency statistics
+        {NULL, 0, NULL, 0}};
 
     // Parse Command Line Arguments
     //----------------------------------------------------------------------------
     /// \todo Specify mandatory arguments
     int ch;
-    while ((ch = getopt_long(argc, argv,
-                             "n:N:H:sc:SC:o:B:P:U:q:r:b:ztlwjeJ:K:RTd:F:p:DvVhI:G:f:O:a:x:", longopts, NULL)) != -1)
+    while ((ch = getopt_long(
+                argc, argv,
+                "n:N:H:sc:SC:o:B:P:U:q:r:b:ztlwjeJ:K:RTd:F:p:DvVhI:G:f:O:a:x:", longopts,
+                NULL))
+           != -1)
         switch (ch) {
-
-        case 'n': // Number of input and output channels
+        case 'n':  // Number of input and output channels
             //-------------------------------------------------------
             mNumChans = atoi(optarg);
             break;
-        case 'U': // UDP Bind Port
+        case 'U':  // UDP Bind Port
             mServerUdpPortNum = atoi(optarg);
             break;
 #ifdef WAIR
         case 'w':
             //-------------------------------------------------------
             mWAIR = true;
-            mNumNetRevChans = gDefaultNumNetRevChannels; // fixed amount sets number of network channels and comb filters for WAIR
+            mNumNetRevChans =
+                gDefaultNumNetRevChannels;  // fixed amount sets number of network channels and comb filters for WAIR
             break;
         case 'N':
             //-------------------------------------------------------
-            mClientAddCombLen = atoi(optarg); // cmd line comb length adjustment
+            mClientAddCombLen = atoi(optarg);  // cmd line comb length adjustment
             break;
-        case 'H': // comb feedback adjustment
+        case 'H':  // comb feedback adjustment
             //-------------------------------------------------------
-            mClientRoomSize = atof(optarg); // cmd line comb feedback adjustment
+            mClientRoomSize = atof(optarg);  // cmd line comb feedback adjustment
             break;
-#endif // endwhere
-        case 's': // Run in P2P server mode
+#endif  // endwhere
+        case 's':  // Run in P2P server mode
             //-------------------------------------------------------
             mJackTripMode = JackTrip::SERVER;
             break;
-        case 'S': // Run in Hub server mode
+        case 'S':  // Run in Hub server mode
             //-------------------------------------------------------
             mJackTripServer = true;
             break;
-        case 'c': // P2P client mode
+        case 'c':  // P2P client mode
             //-------------------------------------------------------
             mJackTripMode = JackTrip::CLIENT;
-            mPeerAddress = optarg;
+            mPeerAddress  = optarg;
             break;
-        case 'L': // set optional local host address
+        case 'L':  // set optional local host address
             //-------------------------------------------------------
             mLocalAddress = optarg;
             break;
-        case 'C': // Ping to server
+        case 'C':  // Ping to server
             //-------------------------------------------------------
             mJackTripMode = JackTrip::CLIENTTOPINGSERVER;
-            mPeerAddress = optarg;
+            mPeerAddress  = optarg;
             break;
-        case 'o': // Port Offset
+        case 'o':  // Port Offset
             //-------------------------------------------------------
             mBindPortNum += atoi(optarg);
             mPeerPortNum += atoi(optarg);
-            if (gVerboseFlag) std::cout << "SETTINGS: argument parsed for TCP Bind Port: " << mBindPortNum << std::endl;
-            if (gVerboseFlag) std::cout << "SETTINGS: argument parsed for TCP Peer Port: " << mPeerPortNum << std::endl;
+            if (gVerboseFlag)
+                std::cout << "SETTINGS: argument parsed for TCP Bind Port: "
+                          << mBindPortNum << std::endl;
+            if (gVerboseFlag)
+                std::cout << "SETTINGS: argument parsed for TCP Peer Port: "
+                          << mPeerPortNum << std::endl;
             break;
-        case 'B': // Bind Port
+        case 'B':  // Bind Port
             //-------------------------------------------------------
             mBindPortNum = atoi(optarg);
-            if (gVerboseFlag) std::cout << "SETTINGS: argument parsed for TCP Bind Port: " << mBindPortNum << std::endl;
+            if (gVerboseFlag)
+                std::cout << "SETTINGS: argument parsed for TCP Bind Port: "
+                          << mBindPortNum << std::endl;
             break;
-        case 'P': // Peer Port
+        case 'P':  // Peer Port
             //-------------------------------------------------------
             mPeerPortNum = atoi(optarg);
-            if (gVerboseFlag) std::cout << "SETTINGS: argument parsed for TCP Peer Port: " << mPeerPortNum << std::endl;
+            if (gVerboseFlag)
+                std::cout << "SETTINGS: argument parsed for TCP Peer Port: "
+                          << mPeerPortNum << std::endl;
             break;
         case 'b':
             //-------------------------------------------------------
@@ -254,79 +284,79 @@ void Settings::parseInput(int argc, char** argv)
                 mAudioBitResolution = AudioInterface::BIT32;
             } else {
                 printUsage();
-                std::cerr << "--bitres ERROR: Bit resolution: "
-                          << atoi(optarg) << " is not supported." << endl;
+                std::cerr << "--bitres ERROR: Bit resolution: " << atoi(optarg)
+                          << " is not supported." << endl;
                 std::exit(1);
             }
             break;
         case 'q':
             //-------------------------------------------------------
             if (0 == strncmp(optarg, "auto", 4)) {
-              mBufferQueueLength = -atoi(optarg+4);
-              if (0 == mBufferQueueLength) {
-                mBufferQueueLength = -500;
-              }
-            }
-            else if ( atoi(optarg) <= 0 ) {
+                mBufferQueueLength = -atoi(optarg + 4);
+                if (0 == mBufferQueueLength) { mBufferQueueLength = -500; }
+            } else if (atoi(optarg) <= 0) {
                 printUsage();
-                std::cerr << "--queue ERROR: The queue has to be equal or greater than 2" << endl;
-                std::exit(1); }
-            else {
+                std::cerr << "--queue ERROR: The queue has to be equal or greater than 2"
+                          << endl;
+                std::exit(1);
+            } else {
                 mBufferQueueLength = atoi(optarg);
             }
             break;
         case 'r':
             //-------------------------------------------------------
-            if ( atoi(optarg) <= 0 ) {
+            if (atoi(optarg) <= 0) {
                 printUsage();
-                std::cerr << "--redundancy ERROR: The redundancy has to be a positive integer" << endl;
-                std::exit(1); }
-            else {
+                std::cerr
+                    << "--redundancy ERROR: The redundancy has to be a positive integer"
+                    << endl;
+                std::exit(1);
+            } else {
                 mRedundancy = atoi(optarg);
             }
             break;
-        case 'z': // underrun to zero
+        case 'z':  // underrun to zero
             //-------------------------------------------------------
             mUnderrunMode = JackTrip::ZEROS;
             break;
-        case 't': // quit on timeout
+        case 't':  // quit on timeout
             mStopOnTimeout = true;
             break;
-        case 'l': // loopback
+        case 'l':  // loopback
             //-------------------------------------------------------
             mLoopBack = true;
             break;
-        case 'e': // jamlink
+        case 'e':  // jamlink
             //-------------------------------------------------------
             mEmptyHeader = true;
             break;
-        case 'j': // jamlink
+        case 'j':  // jamlink
             //-------------------------------------------------------
             mJamLink = true;
             break;
-        case 'J': // Set client Name
+        case 'J':  // Set client Name
             //-------------------------------------------------------
             mClientName = optarg;
             break;
-        case 'K': // Set Remote client Name
+        case 'K':  // Set Remote client Name
             //-------------------------------------------------------
             mRemoteClientName = optarg;
             break;
-        case 'R': // RtAudio
+        case 'R':  // RtAudio
             //-------------------------------------------------------
             mUseJack = false;
             break;
-        case 'T': // Sampling Rate
+        case 'T':  // Sampling Rate
             //-------------------------------------------------------
             mChanfeDefaultSR = true;
-            mSampleRate = atoi(optarg);
+            mSampleRate      = atoi(optarg);
             break;
-        case 'd': // RTAudio device id
+        case 'd':  // RTAudio device id
             //-------------------------------------------------------
             mChanfeDefaultID = true;
-            mDeviceID = atoi(optarg);
+            mDeviceID        = atoi(optarg);
             break;
-        case 'F': // Buffer Size
+        case 'F':  // Buffer Size
             //-------------------------------------------------------
             mChanfeDefaultBS = true;
             mAudioBufferSize = atoi(optarg);
@@ -351,26 +381,26 @@ void Settings::parseInput(int argc, char** argv)
             break;
         case 'p':
             //-------------------------------------------------------
-            if ( atoi(optarg) == 0 ) {
+            if (atoi(optarg) == 0) {
                 mHubConnectionMode = JackTrip::SERVERTOCLIENT;
-            } else if ( atoi(optarg) == 1 ) {
+            } else if (atoi(optarg) == 1) {
                 mHubConnectionMode = JackTrip::CLIENTECHO;
-            } else if ( atoi(optarg) == 2 ) {
+            } else if (atoi(optarg) == 2) {
                 mHubConnectionMode = JackTrip::CLIENTFOFI;
-            } else if ( atoi(optarg) == 3 ) {
+            } else if (atoi(optarg) == 3) {
                 mHubConnectionMode = JackTrip::RESERVEDMATRIX;
-            } else if ( atoi(optarg) == 4 ) {
+            } else if (atoi(optarg) == 4) {
                 mHubConnectionMode = JackTrip::FULLMIX;
-            } else if ( atoi(optarg) == 5 ) {
+            } else if (atoi(optarg) == 5) {
                 mHubConnectionMode = JackTrip::NOAUTO;
             } else {
                 printUsage();
-                std::cerr << "-p ERROR: Wrong HubConnectionMode: "
-                          << atoi(optarg) << " is not supported." << endl;
+                std::cerr << "-p ERROR: Wrong HubConnectionMode: " << atoi(optarg)
+                          << " is not supported." << endl;
                 std::exit(1);
             }
             break;
-        case 'I': // IO Stat timeout
+        case 'I':  // IO Stat timeout
             //-------------------------------------------------------
             mIOStatTimeout = atoi(optarg);
             if (0 > mIOStatTimeout) {
@@ -379,17 +409,17 @@ void Settings::parseInput(int argc, char** argv)
                 std::exit(1);
             }
             break;
-        case 'G': // IO Stat log file
+        case 'G':  // IO Stat log file
             //-------------------------------------------------------
             mIOStatStream.reset(new std::ofstream(optarg));
             if (!mIOStatStream->is_open()) {
                 printUsage();
-                std::cerr << "--iostatlog FAILED to open " << optarg
-                          << " for writing." << endl;
+                std::cerr << "--iostatlog FAILED to open " << optarg << " for writing."
+                          << endl;
                 std::exit(1);
             }
             break;
-        case OPT_BUFSTRATEGY: // Buf strategy
+        case OPT_BUFSTRATEGY:  // Buf strategy
             mBufferStrategy = atoi(optarg);
             if (-1 > mBufferStrategy || 2 < mBufferStrategy) {
                 std::cerr << "Unsupported buffer strategy " << optarg << endl;
@@ -397,23 +427,22 @@ void Settings::parseInput(int argc, char** argv)
                 std::exit(1);
             }
             break;
-        case OPT_SIMLOSS: // Simulate packet loss
+        case OPT_SIMLOSS:  // Simulate packet loss
             mSimulatedLossRate = atof(optarg);
             break;
-        case OPT_SIMJITTER: // Simulate jitter
+        case OPT_SIMJITTER:  // Simulate jitter
             char* endp;
             mSimulatedJitterRate = strtod(optarg, &endp);
             if (0 == *endp) {
                 mSimulatedDelayRel = 1.0;
-            }
-            else {
-                mSimulatedDelayRel = atof(endp+1);
+            } else {
+                mSimulatedDelayRel = atof(endp + 1);
             }
             break;
-        case OPT_BROADCAST: // Broadcast output
+        case OPT_BROADCAST:  // Broadcast output
             mBroadcastQueue = atoi(optarg);
             break;
-        case OPT_RTUDPPRIORITY: // Use RT priority for UDPDataProtocol thread
+        case OPT_RTUDPPRIORITY:  // Use RT priority for UDPDataProtocol thread
             mUseRtUdpPriority = true;
             break;
         case 'h':
@@ -421,97 +450,106 @@ void Settings::parseInput(int argc, char** argv)
             printUsage();
             std::exit(0);
             break;
-        case 'O': { // Overflow limiter (i, o, or io)
-          //-------------------------------------------------------
-          char cmd[] { "--overflowlimiting (-O)" };
-          if (gVerboseFlag) {
-            printf("%s argument = %s\n",cmd,optarg);
-          }
-          int returnCode = mEffects.parseLimiterOptArg(cmd,optarg);
-          if (returnCode > 1) {
-            mEffects.printHelp(cmd,ch);
-            std::cerr << cmd << " required argument `" << optarg << "' is malformed\n";
-            std::exit(1);
-          } else if (returnCode == 1) {
-            std::exit(0); // benign but not continuing such as "help"
-          }
-          break; }
-        case 'a': { // assumed number of clients (applies to outgoing limiter)
-          //-------------------------------------------------------
-          char cmd[] { "--assumednumclients (-a)" };
-          if (gVerboseFlag) {
-            printf("%s argument = %s\n",cmd,optarg);
-          }
-          int returnCode = mEffects.parseAssumedNumClientsOptArg(cmd,optarg);
-          if (returnCode > 1) {
-            mEffects.printHelp(cmd,ch);
-            std::cerr << cmd << " required argument `" << optarg << "' is malformed\n";
-            std::exit(1);
-          } else if (returnCode == 1) {
-            std::exit(0); // help printed
-          }
-          break; }
-        case 'f': { // --effects (-f) effectsSpecArg
-          //-------------------------------------------------------
-          char cmd[] { "--effects (-f)" };
-          int returnCode = mEffects.parseEffectsOptArg(cmd,optarg);
-          if (returnCode > 1) {
-            mEffects.printHelp(cmd,ch);
-            std::cerr << cmd << " required argument `" << optarg << "' is malformed\n";
-            std::exit(1);
-          } else if (returnCode == 1) {
-            std::exit(0); // something benign but non-continuing like "help"
-          }
-          break; }
-        case 'x': { // examine connection (test mode)
-          //-------------------------------------------------------
-          char cmd[] { "--examine-audio-delay (-x)" };
-          if (tolower(optarg[0])=='h') {
-            mAudioTester.printHelp(cmd,ch);
-            std::exit(0);
-          }
-          mAudioTester.setEnabled(true);
-          if (optarg == 0 || optarg[0] == '-' || optarg[0] == 0) { // happens when no -f argument specified
-            printUsage();
-            std::cerr << cmd << " ERROR: Print-interval argument REQUIRED (set to 0.0 to see every delay)\n";
-            std::exit(1);
-          }
-          mAudioTester.setPrintIntervalSec(atof(optarg));
-          break; }
+        case 'O': {  // Overflow limiter (i, o, or io)
+            //-------------------------------------------------------
+            char cmd[]{"--overflowlimiting (-O)"};
+            if (gVerboseFlag) { printf("%s argument = %s\n", cmd, optarg); }
+            int returnCode = mEffects.parseLimiterOptArg(cmd, optarg);
+            if (returnCode > 1) {
+                mEffects.printHelp(cmd, ch);
+                std::cerr << cmd << " required argument `" << optarg
+                          << "' is malformed\n";
+                std::exit(1);
+            } else if (returnCode == 1) {
+                std::exit(0);  // benign but not continuing such as "help"
+            }
+            break;
+        }
+        case 'a': {  // assumed number of clients (applies to outgoing limiter)
+            //-------------------------------------------------------
+            char cmd[]{"--assumednumclients (-a)"};
+            if (gVerboseFlag) { printf("%s argument = %s\n", cmd, optarg); }
+            int returnCode = mEffects.parseAssumedNumClientsOptArg(cmd, optarg);
+            if (returnCode > 1) {
+                mEffects.printHelp(cmd, ch);
+                std::cerr << cmd << " required argument `" << optarg
+                          << "' is malformed\n";
+                std::exit(1);
+            } else if (returnCode == 1) {
+                std::exit(0);  // help printed
+            }
+            break;
+        }
+        case 'f': {  // --effects (-f) effectsSpecArg
+            //-------------------------------------------------------
+            char cmd[]{"--effects (-f)"};
+            int returnCode = mEffects.parseEffectsOptArg(cmd, optarg);
+            if (returnCode > 1) {
+                mEffects.printHelp(cmd, ch);
+                std::cerr << cmd << " required argument `" << optarg
+                          << "' is malformed\n";
+                std::exit(1);
+            } else if (returnCode == 1) {
+                std::exit(0);  // something benign but non-continuing like "help"
+            }
+            break;
+        }
+        case 'x': {  // examine connection (test mode)
+            //-------------------------------------------------------
+            char cmd[]{"--examine-audio-delay (-x)"};
+            if (tolower(optarg[0]) == 'h') {
+                mAudioTester.printHelp(cmd, ch);
+                std::exit(0);
+            }
+            mAudioTester.setEnabled(true);
+            if (optarg == 0 || optarg[0] == '-'
+                || optarg[0] == 0) {  // happens when no -f argument specified
+                printUsage();
+                std::cerr << cmd
+                          << " ERROR: Print-interval argument REQUIRED (set to 0.0 to "
+                             "see every delay)\n";
+                std::exit(1);
+            }
+            mAudioTester.setPrintIntervalSec(atof(optarg));
+            break;
+        }
         case ':': {
-          printUsage();
-          printf("*** Missing option argument *** see above for usage\n\n");
-          break; }
+            printUsage();
+            printf("*** Missing option argument *** see above for usage\n\n");
+            break;
+        }
         case '?': {
-          printUsage();
-          printf("*** Unknown, missing, or ambiguous option argument *** see above for usage\n\n");
-          std::exit(1);
-          break; }
+            printUsage();
+            printf(
+                "*** Unknown, missing, or ambiguous option argument *** see above for "
+                "usage\n\n");
+            std::exit(1);
+            break;
+        }
         default: {
             //-------------------------------------------------------
             printUsage();
-            printf("*** Unrecognized option -%c *** see above for usage\n",ch);
+            printf("*** Unrecognized option -%c *** see above for usage\n", ch);
             std::exit(1);
-            break; }
+            break;
+        }
         }
 
     // Warn user if undefined options where entered
     //----------------------------------------------------------------------------
     if (optind < argc) {
-      if (strcmp(argv[optind],"help")!=0) {
-        cout << gPrintSeparator << endl;
-        cout << "*** Unexpected command-line argument(s): ";
-        for( ; optind < argc; optind++) {
-          cout << argv[optind] << " ";
+        if (strcmp(argv[optind], "help") != 0) {
+            cout << gPrintSeparator << endl;
+            cout << "*** Unexpected command-line argument(s): ";
+            for (; optind < argc; optind++) { cout << argv[optind] << " "; }
+            cout << endl << gPrintSeparator << endl;
         }
-        cout << endl << gPrintSeparator << endl;
-      }
-      printUsage();
-      std::exit(1);
+        printUsage();
+        std::exit(1);
     }
 
-    assert(mNumChans>0);
-    mAudioTester.setSendChannel(mNumChans-1); // use last channel for latency testing
+    assert(mNumChans > 0);
+    mAudioTester.setSendChannel(mNumChans - 1);  // use last channel for latency testing
     // Originally, testing only in the last channel was adopted
     // because channel 0 ("left") was a clap track on CCRMA loopback
     // servers.  Now, however, we also do it in order to easily keep
@@ -520,29 +558,35 @@ void Settings::parseInput(int argc, char** argv)
 
     // Exit if options are incompatible
     //----------------------------------------------------------------------------
-    bool haveSomeServerMode = not ((mJackTripMode == JackTrip::CLIENT) || (mJackTripMode == JackTrip::CLIENTTOPINGSERVER));
+    bool haveSomeServerMode = not((mJackTripMode == JackTrip::CLIENT)
+                                  || (mJackTripMode == JackTrip::CLIENTTOPINGSERVER));
     if (mEffects.getHaveEffect() && haveSomeServerMode) {
-      std::cerr << "*** --effects (-f) ERROR: Effects not yet supported server modes (-S and -s).\n\n";
-      std::exit(1);
+        std::cerr << "*** --effects (-f) ERROR: Effects not yet supported server modes "
+                     "(-S and -s).\n\n";
+        std::exit(1);
     }
     if (mEffects.getHaveLimiter() && haveSomeServerMode) {
-      if (mEffects.getLimit() != Effects::LIMITER_MODE::LIMITER_OUTGOING) { // default case
-        std::cerr << "*** --overflowlimiting (-O) ERROR: Limiters not yet supported server modes (-S and -s).\n\n";
-      }
-      mEffects.setNoLimiters();
-      // don't exit since an outgoing limiter should be the default (could exit for incoming case):
-      // std::exit(1);
+        if (mEffects.getLimit()
+            != Effects::LIMITER_MODE::LIMITER_OUTGOING) {  // default case
+            std::cerr << "*** --overflowlimiting (-O) ERROR: Limiters not yet supported "
+                         "server modes (-S and -s).\n\n";
+        }
+        mEffects.setNoLimiters();
+        // don't exit since an outgoing limiter should be the default (could exit for incoming case):
+        // std::exit(1);
     }
     if (mAudioTester.getEnabled() && haveSomeServerMode) {
-      std::cerr << "*** --examine-audio-delay (-x) ERROR: Audio latency measurement not supported in server modes (-S and -s)\n\n";
-      std::exit(1);
+        std::cerr << "*** --examine-audio-delay (-x) ERROR: Audio latency measurement "
+                     "not supported in server modes (-S and -s)\n\n";
+        std::exit(1);
     }
-    if (mAudioTester.getEnabled()
-        && (mAudioBitResolution != AudioInterface::BIT16)
-        && (mAudioBitResolution != AudioInterface::BIT32) ) { // BIT32 not tested but should be ok
-      // BIT24 should work also, but there's a comment saying it's broken right now, so exclude it
-      std::cerr << "*** --examine-audio-delay (-x) ERROR: Only --bitres (-b) 16 and 32 presently supported for audio latency measurement.\n\n";
-      std::exit(1);
+    if (mAudioTester.getEnabled() && (mAudioBitResolution != AudioInterface::BIT16)
+        && (mAudioBitResolution
+            != AudioInterface::BIT32)) {  // BIT32 not tested but should be ok
+        // BIT24 should work also, but there's a comment saying it's broken right now, so exclude it
+        std::cerr << "*** --examine-audio-delay (-x) ERROR: Only --bitres (-b) 16 and 32 "
+                     "presently supported for audio latency measurement.\n\n";
+        std::exit(1);
     }
 }
 
@@ -566,79 +610,143 @@ void Settings::printUsage()
     cout << " -C, --pingtoserver <peer_name_or_IP>     Run in Hub Client Mode" << endl;
     cout << endl;
     cout << "OPTIONAL ARGUMENTS: " << endl;
-    cout << " -n, --numchannels #                      Number of Input and Output Channels (default: "
+    cout << " -n, --numchannels #                      Number of Input and Output "
+            "Channels (default: "
          << 2 << ")" << endl;
-#ifdef WAIR // WAIR
+#ifdef WAIR  // WAIR
     cout << " -w, --wair                               Run in WAIR Mode" << endl;
-    cout << " -N, --addcombfilterlength #              comb length adjustment for WAIR (default "
+    cout << " -N, --addcombfilterlength #              comb length adjustment for WAIR "
+            "(default "
          << gDefaultAddCombFilterLength << ")" << endl;
-    cout << " -H, --combfilterfeedback # (roomSize)    comb feedback adjustment for WAIR (default "
+    cout << " -H, --combfilterfeedback # (roomSize)    comb feedback adjustment for WAIR "
+            "(default "
          << gDefaultCombFilterFeedback << ")" << endl;
-#endif // endwhere
-    cout << " -q, --queue       # (2 or more)          Queue Buffer Length, in Packet Size (default: "
+#endif  // endwhere
+    cout << " -q, --queue       # (2 or more)          Queue Buffer Length, in Packet "
+            "Size (default: "
          << gDefaultQueueLength << ")" << endl;
-    cout << " -r, --redundancy  # (1 or more)          Packet Redundancy to avoid glitches with packet losses (default: 1)"
+    cout << " -r, --redundancy  # (1 or more)          Packet Redundancy to avoid "
+            "glitches with packet losses (default: 1)"
          << endl;
-    cout << " -o, --portoffset  #                      Receiving bind port and peer port offset from default " << gDefaultPort << endl;
-    cout << " -B, --bindport        #                  Set only the bind port number (default: " << gDefaultPort << ")" << endl;
-    cout << " -P, --peerport        #                  Set only the peer port number (default: " << gDefaultPort << ")" << endl;
-    cout << " -U, --udpbaseport                        Set only the server udp base port number (default: 61002)" << endl;
-    cout << " -b, --bitres      # (8, 16, 24, 32)      Audio Bit Rate Resolutions (default: 16, 32 uses floating-point)" << endl;
-    cout << " -p, --hubpatch    # (0, 1, 2, 3, 4, 5)   Hub auto audio patch, only has effect if running HUB SERVER mode, 0=server-to-clients, 1=client loopback, 2=client fan out/in but not loopback, 3=reserved for TUB, 4=full mix, 5=no auto patching (default: 0)" << endl;
-    cout << " -z, --zerounderrun                       Set buffer to zeros when underrun occurs (default: wavetable)" << endl;
-    cout << " -t, --timeout                            Quit after 10 seconds of no network activity" << endl;
+    cout << " -o, --portoffset  #                      Receiving bind port and peer port "
+            "offset from default "
+         << gDefaultPort << endl;
+    cout << " -B, --bindport        #                  Set only the bind port number "
+            "(default: "
+         << gDefaultPort << ")" << endl;
+    cout << " -P, --peerport        #                  Set only the peer port number "
+            "(default: "
+         << gDefaultPort << ")" << endl;
+    cout << " -U, --udpbaseport                        Set only the server udp base port "
+            "number (default: 61002)"
+         << endl;
+    cout << " -b, --bitres      # (8, 16, 24, 32)      Audio Bit Rate Resolutions "
+            "(default: 16, 32 uses floating-point)"
+         << endl;
+    cout << " -p, --hubpatch    # (0, 1, 2, 3, 4, 5)   Hub auto audio patch, only has "
+            "effect if running HUB SERVER mode, 0=server-to-clients, 1=client loopback, "
+            "2=client fan out/in but not loopback, 3=reserved for TUB, 4=full mix, 5=no "
+            "auto patching (default: 0)"
+         << endl;
+    cout << " -z, --zerounderrun                       Set buffer to zeros when underrun "
+            "occurs (default: wavetable)"
+         << endl;
+    cout << " -t, --timeout                            Quit after 10 seconds of no "
+            "network activity"
+         << endl;
     cout << " -l, --loopback                           Run in Loop-Back Mode" << endl;
-    cout << " -j, --jamlink                            Run in JamLink Mode (Connect to a JamLink Box)" << endl;
-    cout << " -J, --clientname                         Change default client name (default: JackTrip)" << endl;
-    cout << " -K, --remotename                         Change default remote client name when connecting to a hub server (the default is derived from this computer's external facing IP address)" << endl;
-    cout << " -L, --localaddress                       Change default local host IP address (default: 127.0.0.1)" << endl;
-    cout << " -D, --nojackportsconnect                 Don't connect default audio ports in jack" << endl;
-    cout << " --bufstrategy     # (0, 1, 2)            Use alternative jitter buffer" << endl;
-    cout << " --broadcast <broadcast_queue>            Turn on broadcast output ports with extra queue (requires new jitter buffer)" << endl;
-    cout << " --udprt                                  Use RT thread priority for network I/O" << endl;
+    cout << " -j, --jamlink                            Run in JamLink Mode (Connect to a "
+            "JamLink Box)"
+         << endl;
+    cout << " -J, --clientname                         Change default client name "
+            "(default: JackTrip)"
+         << endl;
+    cout << " -K, --remotename                         Change default remote client name "
+            "when connecting to a hub server (the default is derived from this "
+            "computer's external facing IP address)"
+         << endl;
+    cout << " -L, --localaddress                       Change default local host IP "
+            "address (default: 127.0.0.1)"
+         << endl;
+    cout << " -D, --nojackportsconnect                 Don't connect default audio ports "
+            "in jack"
+         << endl;
+    cout << " --bufstrategy     # (0, 1, 2)            Use alternative jitter buffer"
+         << endl;
+    cout << " --broadcast <broadcast_queue>            Turn on broadcast output ports "
+            "with extra queue (requires new jitter buffer)"
+         << endl;
+    cout << " --udprt                                  Use RT thread priority for "
+            "network I/O"
+         << endl;
     cout << endl;
     cout << "OPTIONAL SIGNAL PROCESSING: " << endl;
-    cout << " -f, --effects # | paramString | help     Turn on incoming and/or outgoing compressor and/or reverb in Client - see `-f help' for details" << endl;
+    cout << " -f, --effects # | paramString | help     Turn on incoming and/or outgoing "
+            "compressor and/or reverb in Client - see `-f help' for details"
+         << endl;
     cout << " -O, --overflowlimiting i|o[w]|io[w]|n|help" << endl;
-    cout << "                                          Use audio limiter(s) in Client, i=incoming from network, o=outgoing to network, io=both, n=no limiters, w=warn if limiting (default=n). Say -O help for more." << endl;
-    cout << " -a, --assumednumclients help|# (1,2,...) Assumed number of Clients (sources) mixing at Hub Server (otherwise 2 assumed by -O)" << endl;
+    cout << "                                          Use audio limiter(s) in Client, "
+            "i=incoming from network, o=outgoing to network, io=both, n=no limiters, "
+            "w=warn if limiting (default=n). Say -O help for more."
+         << endl;
+    cout << " -a, --assumednumclients help|# (1,2,...) Assumed number of Clients "
+            "(sources) mixing at Hub Server (otherwise 2 assumed by -O)"
+         << endl;
     cout << endl;
     cout << "ARGUMENTS TO USE JACKTRIP WITHOUT JACK:" << endl;
-    cout << " -R, --rtaudio                            Use system's default sound system instead of Jack" << endl;
-    cout << " -T, --srate         #                    Set the sampling rate, works on --rtaudio mode only (default: 48000)" << endl;
-    cout << " -F, --bufsize       #                    Set the buffer size, works on --rtaudio mode only (default: 128)" << endl;
-    cout << " -d, --deviceid      #                    The rtaudio device id --rtaudio mode only (default: 0)" << endl;
+    cout << " -R, --rtaudio                            Use system's default sound system "
+            "instead of Jack"
+         << endl;
+    cout << " -T, --srate         #                    Set the sampling rate, works on "
+            "--rtaudio mode only (default: 48000)"
+         << endl;
+    cout << " -F, --bufsize       #                    Set the buffer size, works on "
+            "--rtaudio mode only (default: 128)"
+         << endl;
+    cout << " -d, --deviceid      #                    The rtaudio device id --rtaudio "
+            "mode only (default: 0)"
+         << endl;
     cout << endl;
     cout << "ARGUMENTS TO DISPLAY IO STATISTICS:" << endl;
-    cout << " -I, --iostat <time_in_secs>              Turn on IO stat reporting with specified interval (in seconds)" << endl;
-    cout << " -G, --iostatlog <log_file>               Save stat log into a file (default: print in stdout)" << endl;
+    cout << " -I, --iostat <time_in_secs>              Turn on IO stat reporting with "
+            "specified interval (in seconds)"
+         << endl;
+    cout << " -G, --iostatlog <log_file>               Save stat log into a file "
+            "(default: print in stdout)"
+         << endl;
     cout << " -x, --examine-audio-delay <print_interval_in_secs> | help\n";
-    cout << "                                          Print round-trip audio delay statistics. See `-x help' for details." << endl;
+    cout << "                                          Print round-trip audio delay "
+            "statistics. See `-x help' for details."
+         << endl;
     cout << endl;
     cout << "ARGUMENTS TO SIMULATE NETWORK ISSUES:" << endl;
     cout << " --simloss <rate>                         Simulate packet loss" << endl;
-    cout << " --simjitter <rate>,<d>                   Simulate jitter, d is max delay in packets" << endl;
+    cout << " --simjitter <rate>,<d>                   Simulate jitter, d is max delay "
+            "in packets"
+         << endl;
     cout << endl;
     cout << "HELP ARGUMENTS: " << endl;
     cout << " -v, --version                            Prints Version Number" << endl;
-    cout << " -V, --verbose                            Verbose mode, prints debug messages" << endl;
+    cout
+        << " -V, --verbose                            Verbose mode, prints debug messages"
+        << endl;
     cout << " -h, --help                               Prints this Help" << endl;
     cout << "" << endl;
 }
 
-
 //*******************************************************************************
-UdpHubListener *Settings::getConfiguredHubServer()
+UdpHubListener* Settings::getConfiguredHubServer()
 {
     if ((mBindPortNum < gBindPortLow) || (mBindPortNum > gBindPortHigh))
-        std::cout << "BindPort: "<< mBindPortNum << " outside range"  << std::endl;
+        std::cout << "BindPort: " << mBindPortNum << " outside range" << std::endl;
 
-    if (gVerboseFlag) std::cout << "JackTrip HUB SERVER TCP Bind Port: " << mBindPortNum << std::endl;
-    UdpHubListener *udpHub = new UdpHubListener(mBindPortNum, mServerUdpPortNum);
+    if (gVerboseFlag)
+        std::cout << "JackTrip HUB SERVER TCP Bind Port: " << mBindPortNum << std::endl;
+    UdpHubListener* udpHub = new UdpHubListener(mBindPortNum, mServerUdpPortNum);
     //udpHub->setSettings(this);
-#ifdef WAIR // WAIR
+#ifdef WAIR  // WAIR
     udpHub->setWAIR(mWAIR);
-#endif // endwhere
+#endif  // endwhere
     udpHub->setHubPatch(mHubConnectionMode);
     if (mHubConnectionMode == JackTrip::NOAUTO) {
         udpHub->setConnectDefaultAudioPorts(false);
@@ -646,7 +754,7 @@ UdpHubListener *Settings::getConfiguredHubServer()
         udpHub->setConnectDefaultAudioPorts(mConnectDefaultAudioPorts);
     }
     // Set buffers to zero when underrun
-    if ( mUnderrunMode == JackTrip::ZEROS ) {
+    if (mUnderrunMode == JackTrip::ZEROS) {
         cout << "Setting buffers to zero when underrun..." << endl;
         cout << gPrintSeparator << std::endl;
         udpHub->setUnderRunMode(mUnderrunMode);
@@ -654,11 +762,11 @@ UdpHubListener *Settings::getConfiguredHubServer()
     udpHub->setBufferQueueLength(mBufferQueueLength);
 
     udpHub->setBufferStrategy(mBufferStrategy);
-    udpHub->setNetIssuesSimulation(mSimulatedLossRate,
-        mSimulatedJitterRate, mSimulatedDelayRel);
+    udpHub->setNetIssuesSimulation(mSimulatedLossRate, mSimulatedJitterRate,
+                                   mSimulatedDelayRel);
     udpHub->setBroadcast(mBroadcastQueue);
     udpHub->setUseRtUdpPriority(mUseRtUdpPriority);
-    
+
     if (mIOStatTimeout > 0) {
         udpHub->setIOStatTimeout(mIOStatTimeout);
         udpHub->setIOStatStream(mIOStatStream);
@@ -666,32 +774,32 @@ UdpHubListener *Settings::getConfiguredHubServer()
     return udpHub;
 }
 
-JackTrip *Settings::getConfiguredJackTrip()
+JackTrip* Settings::getConfiguredJackTrip()
 {
-#ifdef WAIR // WAIR
-    if (gVerboseFlag) std::cout << "Settings:startJackTrip mNumNetRevChans = " << mNumNetRevChans << std::endl;
-#endif // endwhere
-    if (gVerboseFlag) std::cout << "Settings:startJackTrip before new JackTrip" << std::endl;
-    JackTrip *jackTrip = new JackTrip(mJackTripMode, mDataProtocol, mNumChans,
-#ifdef WAIR // wair
-                                      mNumNetRevChans,
-#endif // endwhere
-                                      mBufferQueueLength, mRedundancy, mAudioBitResolution,
-                                      /*DataProtocol::packetHeaderTypeT PacketHeaderType = */DataProtocol::DEFAULT,
-                                      /*underrunModeT UnderRunMode = */ mUnderrunMode,
-                                      /* int receiver_bind_port = */ mBindPortNum,
-                                      /*int sender_bind_port = */ mBindPortNum,
-                                      /*int receiver_peer_port = */ mPeerPortNum,
-                                      /* int sender_peer_port = */ mPeerPortNum,
-                                      mPeerPortNum
-                                      );
+#ifdef WAIR  // WAIR
+    if (gVerboseFlag)
+        std::cout << "Settings:startJackTrip mNumNetRevChans = " << mNumNetRevChans
+                  << std::endl;
+#endif  // endwhere
+    if (gVerboseFlag)
+        std::cout << "Settings:startJackTrip before new JackTrip" << std::endl;
+    JackTrip* jackTrip = new JackTrip(
+        mJackTripMode, mDataProtocol, mNumChans,
+#ifdef WAIR  // wair
+        mNumNetRevChans,
+#endif  // endwhere
+        mBufferQueueLength, mRedundancy, mAudioBitResolution,
+        /*DataProtocol::packetHeaderTypeT PacketHeaderType = */ DataProtocol::DEFAULT,
+        /*underrunModeT UnderRunMode = */ mUnderrunMode,
+        /* int receiver_bind_port = */ mBindPortNum,
+        /*int sender_bind_port = */ mBindPortNum,
+        /*int receiver_peer_port = */ mPeerPortNum,
+        /* int sender_peer_port = */ mPeerPortNum, mPeerPortNum);
     // Set connect or not default audio ports. Only work for jack
     jackTrip->setConnectDefaultAudioPorts(mConnectDefaultAudioPorts);
 
     // Change client name if different from default
-    if (!mClientName.isEmpty()) {
-        jackTrip->setClientName(mClientName);
-    }
+    if (!mClientName.isEmpty()) { jackTrip->setClientName(mClientName); }
 
     if (!mRemoteClientName.isEmpty() && (mJackTripMode == JackTrip::CLIENTTOPINGSERVER)) {
         jackTrip->setRemoteClientName(mRemoteClientName);
@@ -706,8 +814,10 @@ JackTrip *Settings::getConfiguredJackTrip()
     jackTrip->setStopOnTimeout(mStopOnTimeout);
 
     // Set peer address in server mode
-    if (mJackTripMode == JackTrip::CLIENT || mJackTripMode == JackTrip::CLIENTTOPINGSERVER) {
-        jackTrip->setPeerAddress(mPeerAddress); }
+    if (mJackTripMode == JackTrip::CLIENT
+        || mJackTripMode == JackTrip::CLIENTTOPINGSERVER) {
+        jackTrip->setPeerAddress(mPeerAddress);
+    }
 
     //        if(mLocalAddress!=QString()) // default
     //            mJackTrip->setLocalAddress(QHostAddress(mLocalAddress.toLatin1().data()));
@@ -722,7 +832,7 @@ JackTrip *Settings::getConfiguredJackTrip()
     jackTrip->setPeerPorts(mPeerPortNum);*/
 
     // Set in JamLink Mode
-    if ( mJamLink ) {
+    if (mJamLink) {
         cout << "Running in JamLink Mode..." << endl;
         cout << gPrintSeparator << std::endl;
         jackTrip->setPacketHeaderType(DataProtocol::JAMLINK);
@@ -737,28 +847,20 @@ JackTrip *Settings::getConfiguredJackTrip()
 
     // Set RtAudio
 #ifdef __RT_AUDIO__
-    if (!mUseJack) {
-        mJackTrip->setAudiointerfaceMode(JackTrip::RTAUDIO);
-    }
+    if (!mUseJack) { mJackTrip->setAudiointerfaceMode(JackTrip::RTAUDIO); }
 #endif
 
     // Chanfe default Sampling Rate
-    if (mChanfeDefaultSR) {
-        jackTrip->setSampleRate(mSampleRate);
-    }
+    if (mChanfeDefaultSR) { jackTrip->setSampleRate(mSampleRate); }
 
     // Chanfe defualt device ID
-    if (mChanfeDefaultID) {
-        jackTrip->setDeviceID(mDeviceID);
-    }
+    if (mChanfeDefaultID) { jackTrip->setDeviceID(mDeviceID); }
 
     // Chanfe default Buffer Size
-    if (mChanfeDefaultBS) {
-        jackTrip->setAudioBufferSizeInSamples(mAudioBufferSize);
-    }
+    if (mChanfeDefaultBS) { jackTrip->setAudioBufferSizeInSamples(mAudioBufferSize); }
     jackTrip->setBufferStrategy(mBufferStrategy);
-    jackTrip->setNetIssuesSimulation(mSimulatedLossRate,
-        mSimulatedJitterRate, mSimulatedDelayRel);
+    jackTrip->setNetIssuesSimulation(mSimulatedLossRate, mSimulatedJitterRate,
+                                     mSimulatedDelayRel);
     jackTrip->setBroadcast(mBroadcastQueue);
     jackTrip->setUseRtUdpPriority(mUseRtUdpPriority);
 
@@ -769,10 +871,10 @@ JackTrip *Settings::getConfiguredJackTrip()
         //std::tr1::shared_ptr<LoopBack> loopback(new LoopBack(mNumChans));
         //mJackTrip->appendProcessPlugin(loopback.get());
 
-#if 0 // previous technique:
+#if 0  // previous technique:
         LoopBack* loopback = new LoopBack(mNumChans);
         jackTrip->appendProcessPlugin(loopback);
-#else // simpler method ( see AudioInterface.cpp callback() ):
+#else  // simpler method ( see AudioInterface.cpp callback() ):
         jackTrip->setLoopBack(true);
 #endif
 
@@ -794,42 +896,41 @@ JackTrip *Settings::getConfiguredJackTrip()
     jackTrip->setAudioTesterP(&mAudioTester);
 
     // Allocate audio effects in client, if any:
-    int nReservedChans = mAudioTester.getEnabled() ? 1 : 0; // no fx allowed on tester channel
-    std::vector<ProcessPlugin*> outgoingEffects = mEffects.allocateOutgoingEffects(mNumChans-nReservedChans);
-    for (auto p : outgoingEffects) {
-      jackTrip->appendProcessPluginToNetwork( p );
-    }
-    std::vector<ProcessPlugin*> incomingEffects = mEffects.allocateIncomingEffects(mNumChans-nReservedChans);
-    for (auto p : incomingEffects) {
-      jackTrip->appendProcessPluginFromNetwork( p );
-    }
+    int nReservedChans =
+        mAudioTester.getEnabled() ? 1 : 0;  // no fx allowed on tester channel
+    std::vector<ProcessPlugin*> outgoingEffects =
+        mEffects.allocateOutgoingEffects(mNumChans - nReservedChans);
+    for (auto p : outgoingEffects) { jackTrip->appendProcessPluginToNetwork(p); }
+    std::vector<ProcessPlugin*> incomingEffects =
+        mEffects.allocateIncomingEffects(mNumChans - nReservedChans);
+    for (auto p : incomingEffects) { jackTrip->appendProcessPluginFromNetwork(p); }
 
-#ifdef WAIR // WAIR
-    if ( mWAIR ) {
+#ifdef WAIR  // WAIR
+    if (mWAIR) {
         cout << "Running in WAIR Mode..." << endl;
         cout << gPrintSeparator << std::endl;
-        switch ( mNumNetRevChans )
-        {
-        case 16 :
-        {
-            jackTrip->appendProcessPluginFromNetwork(new ap8x2(mNumChans)); // plugin slot 0
+        switch (mNumNetRevChans) {
+        case 16: {
+            jackTrip->appendProcessPluginFromNetwork(
+                new ap8x2(mNumChans));  // plugin slot 0
             /////////////////////////////////////////////////////////
             Stk16* plugin = new Stk16(mNumNetRevChans);
             plugin->Stk16::initCombClient(mClientAddCombLen, mClientRoomSize);
-            jackTrip->appendProcessPluginFromNetwork(plugin); // plugin slot 1
-        }
-            break;
+            jackTrip->appendProcessPluginFromNetwork(plugin);  // plugin slot 1
+        } break;
         default:
-            throw std::invalid_argument("Settings: mNumNetRevChans doesn't correspond to Faust plugin");
+            throw std::invalid_argument(
+                "Settings: mNumNetRevChans doesn't correspond to Faust plugin");
             break;
         }
-            break;
-        default:
-            throw std::invalid_argument("Settings: mNumNetRevChans doesn't correspond to Faust plugin");
-            break;
-        }
+        break;
+    default:
+        throw std::invalid_argument(
+            "Settings: mNumNetRevChans doesn't correspond to Faust plugin");
+        break;
     }
-#endif // endwhere
+}
+#endif  // endwhere
 
-    return jackTrip;
+return jackTrip;
 }

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -35,7 +35,6 @@
  * \date July 2008
  */
 
-
 #ifndef __SETTINGS_H__
 #define __SETTINGS_H__
 
@@ -47,13 +46,12 @@
 
 #ifndef __NO_JACK__
 #include "JackAudioInterface.h"
-#endif //__NO_JACK__
+#endif  //__NO_JACK__
 
+#include "AudioTester.h"
+#include "Effects.h"
 #include "JackTrip.h"
 #include "UdpHubListener.h"
-
-#include "Effects.h"
-#include "AudioTester.h"
 
 /** \brief Class to set usage options and parse settings from input
  */
@@ -61,15 +59,15 @@ class Settings : public QObject
 {
     Q_OBJECT;
 
-public:
+   public:
     Settings();
     virtual ~Settings();
 
     /// \brief Parses command line input
     void parseInput(int argc, char** argv);
 
-    UdpHubListener *getConfiguredHubServer();
-    JackTrip *getConfiguredJackTrip();
+    UdpHubListener* getConfiguredHubServer();
+    JackTrip* getConfiguredJackTrip();
 
     /// \brief Prints usage help
     void printUsage();
@@ -77,44 +75,44 @@ public:
     bool getLoopBack() { return mLoopBack; }
     bool isHubServer() { return mJackTripServer; }
 
-private:
-    JackTrip::jacktripModeT mJackTripMode; ///< JackTrip::jacktripModeT
-    JackTrip::dataProtocolT mDataProtocol; ///< Data Protocol
-    int mNumChans; ///< Number of Channels (inputs = outputs)
-    int mBufferQueueLength; ///< Audio Buffer from network queue length
+   private:
+    JackTrip::jacktripModeT mJackTripMode;  ///< JackTrip::jacktripModeT
+    JackTrip::dataProtocolT mDataProtocol;  ///< Data Protocol
+    int mNumChans;                          ///< Number of Channels (inputs = outputs)
+    int mBufferQueueLength;                 ///< Audio Buffer from network queue length
     AudioInterface::audioBitResolutionT mAudioBitResolution;
-    QString mPeerAddress; ///< Peer Address to use in jacktripModeT::CLIENT Mode
-    int mBindPortNum; ///< Bind Port Number
-    int mPeerPortNum; ///< Peer Port Number
+    QString mPeerAddress;  ///< Peer Address to use in jacktripModeT::CLIENT Mode
+    int mBindPortNum;      ///< Bind Port Number
+    int mPeerPortNum;      ///< Peer Port Number
     int mServerUdpPortNum;
-    QString mClientName; ///< JackClient Name
+    QString mClientName;  ///< JackClient Name
     QString mRemoteClientName;
-    JackTrip::underrunModeT mUnderrunMode; ///< Underrun mode
-    bool mStopOnTimeout; /// < Stop jacktrip after 10 second network timeout
+    JackTrip::underrunModeT mUnderrunMode;  ///< Underrun mode
+    bool mStopOnTimeout;  /// < Stop jacktrip after 10 second network timeout
     int mBufferStrategy;
 
-#ifdef WAIR // wair
-    int mNumNetRevChans; ///< Number of Network Audio Channels (net comb filters)
-    int mClientAddCombLen; ///< cmd line adjustment of net comb
-    double mClientRoomSize; ///< freeverb room size
-    bool mWAIR; ///< WAIR mode
-#endif // endwhere
+#ifdef WAIR  // wair
+    int mNumNetRevChans;     ///< Number of Network Audio Channels (net comb filters)
+    int mClientAddCombLen;   ///< cmd line adjustment of net comb
+    double mClientRoomSize;  ///< freeverb room size
+    bool mWAIR;              ///< WAIR mode
+#endif                       // endwhere
 
-    bool mLoopBack; ///< Loop-back mode
-    bool mJamLink; ///< JamLink mode
-    bool mEmptyHeader; ///< EmptyHeader mode
-    bool mJackTripServer; ///< JackTrip Server mode
-    QString mLocalAddress; ///< Local Address
-    unsigned int mRedundancy; ///< Redundancy factor for data in the network
-    bool mUseJack; ///< Use or not JackAduio
-    bool mChanfeDefaultSR; ///< Change Default Sampling Rate
-    bool mChanfeDefaultID; ///< Change Default device ID
-    bool mChanfeDefaultBS; ///< Change Default Buffer Size
+    bool mLoopBack;            ///< Loop-back mode
+    bool mJamLink;             ///< JamLink mode
+    bool mEmptyHeader;         ///< EmptyHeader mode
+    bool mJackTripServer;      ///< JackTrip Server mode
+    QString mLocalAddress;     ///< Local Address
+    unsigned int mRedundancy;  ///< Redundancy factor for data in the network
+    bool mUseJack;             ///< Use or not JackAduio
+    bool mChanfeDefaultSR;     ///< Change Default Sampling Rate
+    bool mChanfeDefaultID;     ///< Change Default device ID
+    bool mChanfeDefaultBS;     ///< Change Default Buffer Size
     unsigned int mSampleRate;
     unsigned int mDeviceID;
     unsigned int mAudioBufferSize;
     unsigned int mHubConnectionMode;
-    bool mConnectDefaultAudioPorts; ///< Connect or not jack audio ports
+    bool mConnectDefaultAudioPorts;  ///< Connect or not jack audio ports
     int mIOStatTimeout;
     QSharedPointer<std::ofstream> mIOStatStream;
     Effects mEffects;

--- a/src/TestRingBuffer.h
+++ b/src/TestRingBuffer.h
@@ -1,20 +1,20 @@
 #ifndef __TESTRINGBUFFER__
 #define __TESTRINGBUFFER__
 
-#include "RingBuffer.h"
 #include <QThread>
 #include <iostream>
 
-static RingBuffer rb(2,100);
+#include "RingBuffer.h"
+
+static RingBuffer rb(2, 100);
 
 class TestRingBufferWrite : public QThread
 {
-public:
-
+   public:
     void run()
     {
         int8_t* writeSlot;
-        writeSlot = new int8_t[2];
+        writeSlot    = new int8_t[2];
         writeSlot[0] = *"a";
         writeSlot[1] = *"b";
         while (true) {
@@ -23,14 +23,11 @@ public:
             //std::cout << "writing AFTER" << std::endl;
         }
     }
-
 };
-
 
 class TestRingBufferRead : public QThread
 {
-public:
-
+   public:
     void run()
     {
         int8_t* readSlot;

--- a/src/ThreadPoolTest.h
+++ b/src/ThreadPoolTest.h
@@ -7,27 +7,24 @@
 #ifndef __THREADPOOLTEST_H__
 #define __THREADPOOLTEST_H__
 
-#include <QThreadPool>
 #include <QEventLoop>
-#include <QThread>
 #include <QObject>
-
+#include <QThread>
+#include <QThreadPool>
 #include <iostream>
 
-#include "NetKS.h"
 #include "JackTripWorkerMessages.h"
+#include "NetKS.h"
 
-
-class ThreadPoolTest : public QObject, public QRunnable
-        //class ThreadPoolTest : public QThread
+class ThreadPoolTest
+    : public QObject
+    , public QRunnable
+//class ThreadPoolTest : public QThread
 {
     Q_OBJECT;
 
-public:
-    ThreadPoolTest()
-    {
-        setAutoDelete(false);
-    }
+   public:
+    ThreadPoolTest() { setAutoDelete(false); }
 
     void run()
     {
@@ -63,15 +60,14 @@ public:
         emit stopELoop();
     }
 
-signals:
+   signals:
     void stopELoop();
 
-private slots:
+   private slots:
     void fromServer()
     {
         std::cout << "--------------- SIGNAL RECEIVED ---------------" << std::endl;
     }
-
 };
 
-#endif //__THREADPOOLTEST_H__
+#endif  //__THREADPOOLTEST_H__

--- a/src/UdpDataProtocol.cpp
+++ b/src/UdpDataProtocol.cpp
@@ -36,28 +36,29 @@
  */
 
 #include "UdpDataProtocol.h"
-#include "jacktrip_globals.h"
-#include "JackTrip.h"
 
 #include <QHostInfo>
-
+#include <cerrno>
+#include <cstdlib>
 #include <cstring>
 #include <iostream>
-#include <cstdlib>
-#include <cerrno>
 #include <stdexcept>
+
+#include "JackTrip.h"
+#include "jacktrip_globals.h"
 #ifdef __WIN_32__
 //#include <winsock.h>
-#include <winsock2.h> //cc need SD_SEND
-#include <ws2tcpip.h> // for IPv6
+#include <winsock2.h>  //cc need SD_SEND
+#include <ws2tcpip.h>  // for IPv6
 #endif
-#if defined (__LINUX__) || (__MAC_OSX__)
-#include <sys/socket.h> // for POSIX Sockets
-#include <unistd.h>
+#if defined(__LINUX__) || (__MAC_OSX__)
 #include <sys/fcntl.h>
+#include <sys/socket.h>  // for POSIX Sockets
+#include <unistd.h>
 #endif
 
-using std::cout; using std::endl;
+using std::cout;
+using std::endl;
 
 // NOTE: It's better not to use
 // using namespace std;
@@ -69,31 +70,33 @@ QMutex UdpDataProtocol::sUdpMutex;
 //*******************************************************************************
 UdpDataProtocol::UdpDataProtocol(JackTrip* jacktrip, const runModeT runmode,
                                  int bind_port, int peer_port,
-                                 unsigned int udp_redundancy_factor) :
-    DataProtocol(jacktrip, runmode, bind_port, peer_port),
-    mBindPort(bind_port), mPeerPort(peer_port),
-    mRunMode(runmode),
-    mAudioPacket(NULL), mFullPacket(NULL),
-    mUdpRedundancyFactor(udp_redundancy_factor),
-    mControlPacketSize(63),
-    mStopSignalSent(false)
+                                 unsigned int udp_redundancy_factor)
+    : DataProtocol(jacktrip, runmode, bind_port, peer_port)
+    , mBindPort(bind_port)
+    , mPeerPort(peer_port)
+    , mRunMode(runmode)
+    , mAudioPacket(NULL)
+    , mFullPacket(NULL)
+    , mUdpRedundancyFactor(udp_redundancy_factor)
+    , mControlPacketSize(63)
+    , mStopSignalSent(false)
 {
     mStopped = false;
-    mIPv6 = false;
+    mIPv6    = false;
     std::memset(&mPeerAddr, 0, sizeof(mPeerAddr));
     std::memset(&mPeerAddr6, 0, sizeof(mPeerAddr6));
-    mPeerAddr.sin_port = htons(mPeerPort);
+    mPeerAddr.sin_port   = htons(mPeerPort);
     mPeerAddr6.sin6_port = htons(mPeerPort);
-    
+
     if (mRunMode == RECEIVER) {
-        QObject::connect(this, SIGNAL(signalWaitingTooLong(int)),
-                         jacktrip, SLOT(slotUdpWaitingTooLongClientGoneProbably(int)), Qt::QueuedConnection);
+        QObject::connect(this, SIGNAL(signalWaitingTooLong(int)), jacktrip,
+                         SLOT(slotUdpWaitingTooLongClientGoneProbably(int)),
+                         Qt::QueuedConnection);
     }
-    mSimulatedLossRate = 0.0;
-    mSimulatedJitterRate = 0.0;
+    mSimulatedLossRate       = 0.0;
+    mSimulatedJitterRate     = 0.0;
     mSimulatedJitterMaxDelay = 0.0;
 }
-
 
 //*******************************************************************************
 UdpDataProtocol::~UdpDataProtocol()
@@ -110,12 +113,11 @@ UdpDataProtocol::~UdpDataProtocol()
     wait();
 }
 
-
 //*******************************************************************************
 void UdpDataProtocol::setPeerAddress(const char* peerHostOrIP)
 {
     // Get DNS Address
-#if defined (__LINUX__) || (__MAC_OSX__)
+#if defined(__LINUX__) || (__MAC_OSX__)
     //Don't make the following code conditional on windows
     //(Addresses a weird timing bug when in hub client mode)
     if (!mPeerAddress.setAddress(peerHostOrIP)) {
@@ -127,21 +129,21 @@ void UdpDataProtocol::setPeerAddress(const char* peerHostOrIP)
         }
         //cout << "UdpDataProtocol::setPeerAddress IP Address Number: "
         //    << mPeerAddress.toString().toStdString() << endl;
-#if defined (__LINUX__) || (__MAC_OSX__)
+#if defined(__LINUX__) || (__MAC_OSX__)
     }
 #endif
 
     // check if the ip address is valid
-    if ( mPeerAddress.protocol() == QAbstractSocket::IPv6Protocol ) {
+    if (mPeerAddress.protocol() == QAbstractSocket::IPv6Protocol) {
         mIPv6 = true;
-    } else  if ( mPeerAddress.protocol() != QAbstractSocket::IPv4Protocol ) {
+    } else if (mPeerAddress.protocol() != QAbstractSocket::IPv4Protocol) {
         QString error_message = "Incorrect presentation format address\n'";
         error_message.append(peerHostOrIP);
         error_message.append("' is not a valid IP address or Host Name");
         //std::cerr << "ERROR: Incorrect presentation format address" << endl;
         //std::cerr << "'" << peerHostOrIP <<"' does not seem to be a valid IP address" << endl;
         //throw std::invalid_argument("Incorrect presentation format address");
-        throw std::invalid_argument( error_message.toStdString());
+        throw std::invalid_argument(error_message.toStdString());
     }
     /*
     else {
@@ -164,32 +166,33 @@ void UdpDataProtocol::setPeerAddress(const char* peerHostOrIP)
     }
 }
 
-#if defined (__WIN_32__)
-void UdpDataProtocol::setSocket(SOCKET &socket)
+#if defined(__WIN_32__)
+void UdpDataProtocol::setSocket(SOCKET& socket)
 #else
-void UdpDataProtocol::setSocket(int &socket)
+void UdpDataProtocol::setSocket(int& socket)
 #endif
 {
     //If we haven't been passed a valid socket, then we should bind one.
-#if defined (__WIN_32__)
+#if defined(__WIN_32__)
     if (socket == INVALID_SOCKET) {
 #else
     if (socket == -1) {
 #endif
         try {
-            if (gVerboseFlag) std::cout << "    UdpDataProtocol:run" << mRunMode << " before bindSocket" << std::endl;
-            socket = bindSocket(); // Bind Socket
-        } catch ( const std::exception & e ) {
-            emit signalError( e.what() );
+            if (gVerboseFlag)
+                std::cout << "    UdpDataProtocol:run" << mRunMode << " before bindSocket"
+                          << std::endl;
+            socket = bindSocket();  // Bind Socket
+        } catch (const std::exception& e) {
+            emit signalError(e.what());
             return;
         }
     }
     mSocket = socket;
 }
 
-
 //*******************************************************************************
-#if defined (__WIN_32__)
+#if defined(__WIN_32__)
 SOCKET UdpDataProtocol::bindSocket()
 #else
 int UdpDataProtocol::bindSocket()
@@ -202,10 +205,10 @@ int UdpDataProtocol::bindSocket()
     WSADATA wsaData;
     int err;
 
-    wVersionRequested = MAKEWORD( 2, 2 );
+    wVersionRequested = MAKEWORD(2, 2);
 
-    err = WSAStartup( wVersionRequested, &wsaData );
-    if ( err != 0 ) {
+    err = WSAStartup(wVersionRequested, &wsaData);
+    if (err != 0) {
         // Tell the user that we couldn't find a useable
         // winsock.dll.
 
@@ -214,18 +217,17 @@ int UdpDataProtocol::bindSocket()
 
     // Confirm that the Windows Sockets DLL supports 1.1. or higher
 
-    if ( LOBYTE( wsaData.wVersion ) != 2 ||
-         HIBYTE( wsaData.wVersion ) != 2 ) {
+    if (LOBYTE(wsaData.wVersion) != 2 || HIBYTE(wsaData.wVersion) != 2) {
         // Tell the user that we couldn't find a useable
         // winsock.dll.
-        WSACleanup( );
+        WSACleanup();
         return INVALID_SOCKET;
     }
 
     SOCKET sock_fd;
 #endif
 
-#if defined ( __LINUX__ ) || (__MAC_OSX__)
+#if defined(__LINUX__) || (__MAC_OSX__)
     int sock_fd;
 #endif
 
@@ -238,40 +240,43 @@ int UdpDataProtocol::bindSocket()
         sock_fd = socket(AF_INET6, SOCK_DGRAM, 0);
         std::memset(&local_addr6, 0, sizeof(local_addr6));
         local_addr6.sin6_family = AF_INET6;
-        local_addr6.sin6_addr = in6addr_any;
-        local_addr6.sin6_port = htons(mBindPort);
+        local_addr6.sin6_addr   = in6addr_any;
+        local_addr6.sin6_port   = htons(mBindPort);
     } else {
         sock_fd = socket(AF_INET, SOCK_DGRAM, 0);
 
         //::bzero(&local_addr, sizeof(local_addr));
-        std::memset(&local_addr, 0, sizeof(local_addr)); // set buffer to 0
-        local_addr.sin_family = AF_INET; //AF_INET: IPv4 Protocol
-        local_addr.sin_addr.s_addr = htonl(INADDR_ANY); //INADDR_ANY: let the kernel decide the active address
-        local_addr.sin_port = htons(mBindPort); //set local port
+        std::memset(&local_addr, 0, sizeof(local_addr));  // set buffer to 0
+        local_addr.sin_family = AF_INET;                  //AF_INET: IPv4 Protocol
+        local_addr.sin_addr.s_addr =
+            htonl(INADDR_ANY);  //INADDR_ANY: let the kernel decide the active address
+        local_addr.sin_port = htons(mBindPort);  //set local port
     }
 
     // Set socket to be reusable, this is platform dependent
     int one = 1;
-#if defined ( __LINUX__ )
+#if defined(__LINUX__)
     ::setsockopt(sock_fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
 #endif
-#if defined ( __MAC_OSX__ )
+#if defined(__MAC_OSX__)
     // This option is not avialable on Linux, and without it MAC OS X
     // has problems rebinding a socket
     ::setsockopt(sock_fd, SOL_SOCKET, SO_REUSEPORT, &one, sizeof(one));
 #endif
-#if defined (__WIN_32__)
+#if defined(__WIN_32__)
     //make address/port reusable
     setsockopt(sock_fd, SOL_SOCKET, SO_REUSEADDR, (char*)&one, sizeof(one));
 #endif
 
     // Bind the Socket
     if (mIPv6) {
-        if ( (::bind(sock_fd, (struct sockaddr *) &local_addr6, sizeof(local_addr6))) < 0 )
-        { throw std::runtime_error("ERROR: UDP Socket Bind Error"); }
+        if ((::bind(sock_fd, (struct sockaddr*)&local_addr6, sizeof(local_addr6))) < 0) {
+            throw std::runtime_error("ERROR: UDP Socket Bind Error");
+        }
     } else {
-        if ( (::bind(sock_fd, (struct sockaddr *) &local_addr, sizeof(local_addr))) < 0 )
-        { throw std::runtime_error("ERROR: UDP Socket Bind Error"); }
+        if ((::bind(sock_fd, (struct sockaddr*)&local_addr, sizeof(local_addr))) < 0) {
+            throw std::runtime_error("ERROR: UDP Socket Bind Error");
+        }
     }
 
     // To be able to use the two UDP sockets bound to the same port number,
@@ -287,9 +292,10 @@ int UdpDataProtocol::bindSocket()
         // Connect only if we're using IPv4.
         // (Connecting presents an issue when a host has multiple IP addresses and the peer decides to send from
         // a different address. While this generally won't be a problem for IPv4, it will for IPv6.)
-        if ( (::connect(sock_fd, (struct sockaddr *) &mPeerAddr, sizeof(mPeerAddr))) < 0)
-        { throw std::runtime_error("ERROR: Could not connect UDP socket"); }
-#if defined (__LINUX__) || (__MAC_OSX__)
+        if ((::connect(sock_fd, (struct sockaddr*)&mPeerAddr, sizeof(mPeerAddr))) < 0) {
+            throw std::runtime_error("ERROR: Could not connect UDP socket");
+        }
+#if defined(__LINUX__) || (__MAC_OSX__)
         //if ( (::shutdown(sock_fd,SHUT_WR)) < 0)
         //{ throw std::runtime_error("ERROR: Could shutdown SHUT_WR UDP socket"); }
 #endif
@@ -328,14 +334,11 @@ int UdpDataProtocol::bindSocket()
     // ----------------------------------------------------------------------------
 }
 
-
 //*******************************************************************************
 int UdpDataProtocol::receivePacket(char* buf, const size_t n)
 {
     // Block until There's something to read
-    while ( !datagramAvailable() && !mStopped ) {
-        QThread::usleep(100);
-    }
+    while (!datagramAvailable() && !mStopped) { QThread::usleep(100); }
     int n_bytes = ::recv(mSocket, buf, n, 0);
     if (n_bytes == mControlPacketSize) {
         //Control signal (currently just check for exit packet);
@@ -343,24 +346,23 @@ int UdpDataProtocol::receivePacket(char* buf, const size_t n)
         for (int i = 0; i < mControlPacketSize; i++) {
             if (buf[i] != char(0xff)) {
                 exit = false;
-                i = mControlPacketSize;
+                i    = mControlPacketSize;
             }
         }
         if (exit && !mStopSignalSent) {
             mStopSignalSent = true;
             emit signalCeaseTransmission("Peer Stopped");
-            std::cout << "Peer Stopped" <<std::endl;
+            std::cout << "Peer Stopped" << std::endl;
         }
         return 0;
     }
     return n_bytes;
 }
 
-
 //*******************************************************************************
 int UdpDataProtocol::sendPacket(const char* buf, const size_t n)
 {
-/*#if defined (__WIN_32__)
+    /*#if defined (__WIN_32__)
     //Alternative windows specific code that uses winsock equivalents of the bsd socket functions.
     DWORD n_bytes;
     WSABUF buffer;
@@ -380,50 +382,48 @@ int UdpDataProtocol::sendPacket(const char* buf, const size_t n)
 #else*/
     int n_bytes;
     if (mIPv6) {
-        n_bytes = ::sendto(mSocket, buf, n, 0, (struct sockaddr *) &mPeerAddr6, sizeof(mPeerAddr6));
+        n_bytes = ::sendto(mSocket, buf, n, 0, (struct sockaddr*)&mPeerAddr6,
+                           sizeof(mPeerAddr6));
     } else {
         n_bytes = ::send(mSocket, buf, n, 0);
     }
     return n_bytes;
-//#endif
+    //#endif
 }
-
 
 //*******************************************************************************
 void UdpDataProtocol::getPeerAddressFromFirstPacket(QHostAddress& peerHostAddress,
                                                     uint16_t& port)
 {
-    while ( !datagramAvailable() ) {
-        msleep(100);
-    }
+    while (!datagramAvailable()) { msleep(100); }
     char buf[1];
-    
+
     struct sockaddr_storage addr;
     std::memset(&addr, 0, sizeof(addr));
     socklen_t sa_len = sizeof(addr);
-    ::recvfrom(mSocket, buf, 1, 0, (struct sockaddr*) &addr, &sa_len);
-    peerHostAddress.setAddress((struct sockaddr*) &addr);
+    ::recvfrom(mSocket, buf, 1, 0, (struct sockaddr*)&addr, &sa_len);
+    peerHostAddress.setAddress((struct sockaddr*)&addr);
     if (mIPv6) {
-        port = ((struct sockaddr_in6*) &addr)->sin6_port;
+        port = ((struct sockaddr_in6*)&addr)->sin6_port;
     } else {
-        port = ((struct sockaddr_in*) &addr)->sin_port;
+        port = ((struct sockaddr_in*)&addr)->sin_port;
     }
 }
-
 
 //*******************************************************************************
 void UdpDataProtocol::run()
 {
-    if (gVerboseFlag) switch ( mRunMode )
-    {
-    case RECEIVER : {
-        std::cout << "step 3" << std::endl;
-        break; }
+    if (gVerboseFlag) switch (mRunMode) {
+        case RECEIVER: {
+            std::cout << "step 3" << std::endl;
+            break;
+        }
 
-    case SENDER : {
-        std::cout << "step 4" << std::endl;
-        break; }
-    }
+        case SENDER: {
+            std::cout << "step 4" << std::endl;
+            break;
+        }
+        }
 
     //QObject::connect(this, SIGNAL(signalError(const char*)),
     //                 mJackTrip, SLOT(slotStopProcesses()),
@@ -442,21 +442,25 @@ void UdpDataProtocol::run()
 #endif
     }
 
-    if (gVerboseFlag) std::cout << "    UdpDataProtocol:run" << mRunMode << " before Setup Audio Packet buffer, Full Packet buffer, Redundancy Variables" << std::endl;
+    if (gVerboseFlag)
+        std::cout << "    UdpDataProtocol:run" << mRunMode
+                  << " before Setup Audio Packet buffer, Full Packet buffer, Redundancy "
+                     "Variables"
+                  << std::endl;
     // Setup Audio Packet buffer
     size_t audio_packet_size = getAudioPacketSizeInBites();
     //cout << "audio_packet_size: " << audio_packet_size << endl;
     mAudioPacket = new int8_t[audio_packet_size];
-    std::memset(mAudioPacket, 0, audio_packet_size); // set buffer to 0
+    std::memset(mAudioPacket, 0, audio_packet_size);  // set buffer to 0
     mBuffer.resize(audio_packet_size, 0);
-    mChans = mJackTrip->getNumChannels();
+    mChans    = mJackTrip->getNumChannels();
     mSmplSize = mJackTrip->getAudioBitResolution() / 8;
 
     // Setup Full Packet buffer
     int full_packet_size = mJackTrip->getPacketSizeInBytes();
     //cout << "full_packet_size: " << full_packet_size << endl;
     mFullPacket = new int8_t[full_packet_size];
-    std::memset(mFullPacket, 0, full_packet_size); // set buffer to 0
+    std::memset(mFullPacket, 0, full_packet_size);  // set buffer to 0
 
     //  bool timeout = false; // Time out flag for packets that arrive too late
 
@@ -467,15 +471,15 @@ void UdpDataProtocol::run()
     // (Algorithm explained at the end of this file)
     // ---------------------------------------------
     int full_redundant_packet_size = full_packet_size * mUdpRedundancyFactor;
-    int8_t* full_redundant_packet = NULL;
+    int8_t* full_redundant_packet  = NULL;
 
     // Set realtime priority (function in jacktrip_globals.h)
-    if (gVerboseFlag) std::cout << "    UdpDataProtocol:run" << mRunMode << " before setRealtimeProcessPriority()" << std::endl;
+    if (gVerboseFlag)
+        std::cout << "    UdpDataProtocol:run" << mRunMode
+                  << " before setRealtimeProcessPriority()" << std::endl;
     //std::cout << "Experimental version -- not using setRealtimeProcessPriority()" << std::endl;
     // Anton Runov: making setRealtimeProcessPriority optional
-    if (mUseRtPriority) {
-        setRealtimeProcessPriority();
-    }
+    if (mUseRtPriority) { setRealtimeProcessPriority(); }
 
     /////////////////////
     // to see thread priorities
@@ -537,34 +541,39 @@ void UdpDataProtocol::run()
 
     // jack puts its clients in FF at 5 points below itself
 
-    switch ( mRunMode )
-    {
-    case RECEIVER : {
+    switch (mRunMode) {
+    case RECEIVER: {
         // Connect signals and slots for packets arriving too late notifications
-        QObject::connect(this, SIGNAL(signalWaitingTooLong(int)),
-                         this, SLOT(printUdpWaitedTooLong(int)),
-                         Qt::QueuedConnection);
+        QObject::connect(this, SIGNAL(signalWaitingTooLong(int)), this,
+                         SLOT(printUdpWaitedTooLong(int)), Qt::QueuedConnection);
         //-----------------------------------------------------------------------------------
         // Wait for the first packet to be ready and obtain address
         // from that packet
-        if (gVerboseFlag) std::cout << "    UdpDataProtocol:run" << mRunMode << " before !UdpSocket.hasPendingDatagrams()" << std::endl;
+        if (gVerboseFlag)
+            std::cout << "    UdpDataProtocol:run" << mRunMode
+                      << " before !UdpSocket.hasPendingDatagrams()" << std::endl;
         std::cout << "Waiting for Peer..." << std::endl;
         // This blocks waiting for the first packet
-        while ( !datagramAvailable() ) {
+        while (!datagramAvailable()) {
             if (mStopped) { return; }
             QThread::msleep(100);
             if (gVerboseFlag) std::cout << "100ms  " << std::flush;
         }
         full_redundant_packet_size = 0x10000;  // max UDP datagram size
-        full_redundant_packet = new int8_t[full_redundant_packet_size];
-        full_redundant_packet_size = receivePacket(reinterpret_cast<char*>(full_redundant_packet), full_redundant_packet_size);
+        full_redundant_packet      = new int8_t[full_redundant_packet_size];
+        full_redundant_packet_size = receivePacket(
+            reinterpret_cast<char*>(full_redundant_packet), full_redundant_packet_size);
         // Check that peer has the same audio settings
-        if (gVerboseFlag) std::cout << std::endl << "    UdpDataProtocol:run" << mRunMode << " before mJackTrip->checkPeerSettings()" << std::endl;
+        if (gVerboseFlag)
+            std::cout << std::endl
+                      << "    UdpDataProtocol:run" << mRunMode
+                      << " before mJackTrip->checkPeerSettings()" << std::endl;
         mJackTrip->checkPeerSettings(full_redundant_packet);
 
-        int peer_chans = mJackTrip->getPeerNumChannels(full_redundant_packet);
+        int peer_chans   = mJackTrip->getPeerNumChannels(full_redundant_packet);
         full_packet_size = mJackTrip->getHeaderSizeInBytes()
-                           + mJackTrip->getPeerBufferSize(full_redundant_packet) * peer_chans * mSmplSize;
+                           + mJackTrip->getPeerBufferSize(full_redundant_packet)
+                                 * peer_chans * mSmplSize;
         /*
         cout << "peer sizes: " << mJackTrip->getHeaderSizeInBytes()
              << " + " << mJackTrip->getPeerBufferSize(full_redundant_packet)
@@ -574,7 +583,9 @@ void UdpDataProtocol::run()
         // */
 
         if (gVerboseFlag) std::cout << "step 7" << std::endl;
-        if (gVerboseFlag) std::cout << "    UdpDataProtocol:run" << mRunMode << " before mJackTrip->parseAudioPacket()" << std::endl;
+        if (gVerboseFlag)
+            std::cout << "    UdpDataProtocol:run" << mRunMode
+                      << " before mJackTrip->parseAudioPacket()" << std::endl;
         std::cout << "Received Connection from Peer!" << std::endl;
         emit signalReceivedConnectionFromPeer();
 
@@ -582,27 +593,26 @@ void UdpDataProtocol::run()
         // --------------------
         // NOTE: These types need to be the same unsigned integer as the sequence
         // number in the header. That way, they wrap around in the "same place"
-        uint16_t current_seq_num = 0; // Store current sequence number
-        uint16_t last_seq_num = 0;    // Store last package sequence number
-        uint16_t newer_seq_num = 0;   // Store newer sequence number
-        mTotCount = 0;
-        mLostCount = 0;
-        mOutOfOrderCount = 0;
-        mLastOutOfOrderCount = 0;
-        mInitialState = true;
-        mRevivedCount = 0;
-        mStatCount = 0;
+        uint16_t current_seq_num = 0;  // Store current sequence number
+        uint16_t last_seq_num    = 0;  // Store last package sequence number
+        uint16_t newer_seq_num   = 0;  // Store newer sequence number
+        mTotCount                = 0;
+        mLostCount               = 0;
+        mOutOfOrderCount         = 0;
+        mLastOutOfOrderCount     = 0;
+        mInitialState            = true;
+        mRevivedCount            = 0;
+        mStatCount               = 0;
 
         if (gVerboseFlag) std::cout << "step 8" << std::endl;
-        while ( !mStopped )
-        {
+        while (!mStopped) {
             // Timer to report packets arriving too late
             // This QT method gave me a lot of trouble, so I replaced it with my own 'waitForReady'
             // that uses signals and slots and can also report with packets have not
             // arrive for a longer time
             //timeout = UdpSocket.waitForReadyRead(30);
             //        timeout = cc unused!
-            waitForReady(60000); //60 seconds
+            waitForReady(60000);  //60 seconds
 
             // OLD CODE WITHOUT REDUNDANCY----------------------------------------------------
             /*
@@ -617,20 +627,18 @@ void UdpDataProtocol::run()
         mJackTrip->writeAudioBuffer(mAudioPacket);
         */
             //----------------------------------------------------------------------------------
-            receivePacketRedundancy(full_redundant_packet,
-                                    full_redundant_packet_size,
-                                    full_packet_size,
-                                    current_seq_num,
-                                    last_seq_num,
+            receivePacketRedundancy(full_redundant_packet, full_redundant_packet_size,
+                                    full_packet_size, current_seq_num, last_seq_num,
                                     newer_seq_num);
         }
-        break; }
+        break;
+    }
 
-    case SENDER : {
+    case SENDER: {
         full_redundant_packet = new int8_t[full_redundant_packet_size];
-        std::memset(full_redundant_packet, 0, full_redundant_packet_size); // Initialize to 0
-        while ( !mStopped && !JackTrip::sSigInt && !JackTrip::sJackStopped )
-        {
+        std::memset(full_redundant_packet, 0,
+                    full_redundant_packet_size);  // Initialize to 0
+        while (!mStopped && !JackTrip::sSigInt && !JackTrip::sJackStopped) {
             // OLD CODE WITHOUT REDUNDANCY -----------------------------------------------------
             /*
         // We block until there's stuff available to read
@@ -641,18 +649,18 @@ void UdpDataProtocol::run()
         sendPacket( UdpSocket, PeerAddress, reinterpret_cast<char*>(mFullPacket), full_packet_size);
         */
             //----------------------------------------------------------------------------------
-            sendPacketRedundancy(full_redundant_packet,
-                                 full_redundant_packet_size,
+            sendPacketRedundancy(full_redundant_packet, full_redundant_packet_size,
                                  full_packet_size);
         }
-        
+
         // Send exit packet (with 1 redundant packet).
         cout << "sending exit packet" << endl;
         QByteArray exitPacket = QByteArray(mControlPacketSize, 0xff);
         sendPacket(exitPacket.constData(), mControlPacketSize);
         sendPacket(exitPacket.constData(), mControlPacketSize);
         emit signalCeaseTransmission();
-        break; }
+        break;
+    }
     }
 
     if (NULL != full_redundant_packet) {
@@ -661,25 +669,22 @@ void UdpDataProtocol::run()
     }
 }
 
-
 //*******************************************************************************
 //bool
 void UdpDataProtocol::waitForReady(int timeout_msec)
 {
-    int loop_resolution_usec = 100; // usecs to wait on each loop
-    int emit_resolution_usec = 10000; // 10 milliseconds
-    int timeout_usec = timeout_msec * 1000;
-    int elapsed_time_usec = 0; // Ellapsed time in milliseconds
+    int loop_resolution_usec = 100;    // usecs to wait on each loop
+    int emit_resolution_usec = 10000;  // 10 milliseconds
+    int timeout_usec         = timeout_msec * 1000;
+    int elapsed_time_usec    = 0;  // Ellapsed time in milliseconds
 
-    while ( !datagramAvailable()
-            && (elapsed_time_usec <= timeout_usec)
-            && !mStopped ){
+    while (!datagramAvailable() && (elapsed_time_usec <= timeout_usec) && !mStopped) {
         //    if (mStopped) { return false; }
         QThread::usleep(loop_resolution_usec);
         elapsed_time_usec += loop_resolution_usec;
 
-        if ( !(elapsed_time_usec % emit_resolution_usec) ) {
-            emit signalWaitingTooLong(static_cast<int>(elapsed_time_usec/1000));
+        if (!(elapsed_time_usec % emit_resolution_usec)) {
+            emit signalWaitingTooLong(static_cast<int>(elapsed_time_usec / 1000));
         }
     }
     // cc under what condition?
@@ -691,29 +696,26 @@ void UdpDataProtocol::waitForReady(int timeout_msec)
     //  return true;
 }
 
-
 //*******************************************************************************
 void UdpDataProtocol::printUdpWaitedTooLong(int wait_msec)
 {
-    int wait_time = 30; // msec
-    if ( !(wait_msec%wait_time) ) {
-        std::cerr << "UDP waiting too long (more than " << wait_time << "ms) for " << mPeerAddress.toString().toStdString() << "..." << endl;
+    int wait_time = 30;  // msec
+    if (!(wait_msec % wait_time)) {
+        std::cerr << "UDP waiting too long (more than " << wait_time << "ms) for "
+                  << mPeerAddress.toString().toStdString() << "..." << endl;
         emit signalUdpWaitingTooLong();
     }
 }
 
-
 //*******************************************************************************
-void UdpDataProtocol::receivePacketRedundancy(int8_t* full_redundant_packet,
-                                              int full_redundant_packet_size,
-                                              int full_packet_size,
-                                              uint16_t& current_seq_num,
-                                              uint16_t& last_seq_num,
-                                              uint16_t& newer_seq_num)
+void UdpDataProtocol::receivePacketRedundancy(
+    int8_t* full_redundant_packet, int full_redundant_packet_size, int full_packet_size,
+    uint16_t& current_seq_num, uint16_t& last_seq_num, uint16_t& newer_seq_num)
 {
     // This is blocking until we get a packet...
-    if (receivePacket( reinterpret_cast<char*>(full_redundant_packet), 
-                       full_redundant_packet_size) == 0) {
+    if (receivePacket(reinterpret_cast<char*>(full_redundant_packet),
+                      full_redundant_packet_size)
+        == 0) {
         return;
     }
 
@@ -721,19 +723,14 @@ void UdpDataProtocol::receivePacketRedundancy(int8_t* full_redundant_packet,
         double x = mUniformDist(mRndEngine);
         // Drop packets
         x -= mSimulatedLossRate;
-        if (0 > x) {
-            return;
-        }
+        if (0 > x) { return; }
         // Delay packets
         x -= mSimulatedJitterRate;
-        if (0 > x) {
-            usleep(mUniformDist(mRndEngine) * mSimulatedJitterMaxDelay * 1e6);
-        }
+        if (0 > x) { usleep(mUniformDist(mRndEngine) * mSimulatedJitterMaxDelay * 1e6); }
     }
 
     // Get Packet Sequence Number
-    newer_seq_num =
-            mJackTrip->getPeerSequenceNumber(full_redundant_packet);
+    newer_seq_num   = mJackTrip->getPeerSequenceNumber(full_redundant_packet);
     current_seq_num = newer_seq_num;
 
     int16_t lost = 0;
@@ -744,57 +741,55 @@ void UdpDataProtocol::receivePacketRedundancy(int8_t* full_redundant_packet,
             ++mOutOfOrderCount;
             if (5 < ++mLastOutOfOrderCount) {
                 mInitialState = true;
-                mStatCount = 0;
-                mTotCount = 0;
+                mStatCount    = 0;
+                mTotCount     = 0;
             }
             return;
-        }
-        else if (0 != lost) {
+        } else if (0 != lost) {
             mLostCount += lost;
         }
         mTotCount += 1 + lost;
     }
     mLastOutOfOrderCount = 0;
-    mInitialState = false;
+    mInitialState        = false;
 
     //cout << current_seq_num << " ";
     int redun_last_index = 0;
-    for (unsigned int i = 1; i<mUdpRedundancyFactor; i++) {
+    for (unsigned int i = 1; i < mUdpRedundancyFactor; i++) {
         // Check if the package we receive is the next one expected, i.e.,
         // current_seq_num == (last_seq_num+1)
-        if ( current_seq_num == (last_seq_num+1) ) { break; }
+        if (current_seq_num == (last_seq_num + 1)) { break; }
 
         // if it's not, check the next one until it is the corresponding packet
         // or there aren't more available packets
-        redun_last_index = i; // index of packet to use in the redundant packet
-        current_seq_num =
-                mJackTrip->getPeerSequenceNumber( full_redundant_packet + (i*full_packet_size) );
+        redun_last_index = i;  // index of packet to use in the redundant packet
+        current_seq_num  = mJackTrip->getPeerSequenceNumber(full_redundant_packet
+                                                           + (i * full_packet_size));
         //cout << current_seq_num << " ";
     }
     mRevivedCount += redun_last_index;
     //cout << endl;
 
-    int peer_chans = mJackTrip->getPeerNumChannels(full_redundant_packet);
-    int N = mJackTrip->getPeerBufferSize(full_redundant_packet);
+    int peer_chans    = mJackTrip->getPeerNumChannels(full_redundant_packet);
+    int N             = mJackTrip->getPeerBufferSize(full_redundant_packet);
     int host_buf_size = N * mChans * mSmplSize;
-    int hdr_size = mJackTrip->getHeaderSizeInBytes();
-    int gap_size = mInitialState ? 0 : (lost - redun_last_index) * host_buf_size;
+    int hdr_size      = mJackTrip->getHeaderSizeInBytes();
+    int gap_size      = mInitialState ? 0 : (lost - redun_last_index) * host_buf_size;
 
-    last_seq_num = newer_seq_num; // Save last read packet
+    last_seq_num = newer_seq_num;  // Save last read packet
 
-    if ((int)mBuffer.size() < host_buf_size) {
-        mBuffer.resize(host_buf_size, 0);
-    }
+    if ((int)mBuffer.size() < host_buf_size) { mBuffer.resize(host_buf_size, 0); }
     // Send to audio all available audio packets, in order
-    for (int i = redun_last_index; i>=0; i--) {
-        int8_t* src = full_redundant_packet + (i*full_packet_size) + hdr_size;
+    for (int i = redun_last_index; i >= 0; i--) {
+        int8_t* src = full_redundant_packet + (i * full_packet_size) + hdr_size;
         if (1 != mChans) {
             // Convert packet's non-interleaved layout to interleaved one used internally
             int8_t* dst = mBuffer.data();
-            int C = qMin(mChans, peer_chans);
-            for (int n=0; n<N; ++n) {
-                for (int c=0; c<C; ++c) {
-                    memcpy(dst + (n*mChans + c)*mSmplSize, src + (n + c*N)*mSmplSize, mSmplSize);
+            int C       = qMin(mChans, peer_chans);
+            for (int n = 0; n < N; ++n) {
+                for (int c = 0; c < C; ++c) {
+                    memcpy(dst + (n * mChans + c) * mSmplSize,
+                           src + (n + c * N) * mSmplSize, mSmplSize);
                 }
             }
             src = dst;
@@ -813,31 +808,33 @@ void UdpDataProtocol::receivePacketRedundancy(int8_t* full_redundant_packet,
 bool UdpDataProtocol::getStats(DataProtocol::PktStat* stat)
 {
     if (0 == mStatCount) {
-        mLostCount = 0;
+        mLostCount       = 0;
         mOutOfOrderCount = 0;
-        mRevivedCount = 0;
+        mRevivedCount    = 0;
     }
-    stat->tot = mTotCount;
-    stat->lost = mLostCount;
+    stat->tot        = mTotCount;
+    stat->lost       = mLostCount;
     stat->outOfOrder = mOutOfOrderCount;
-    stat->revived = mRevivedCount;
-    stat->statCount = mStatCount++;
+    stat->revived    = mRevivedCount;
+    stat->statCount  = mStatCount++;
     return true;
 }
 
 //*******************************************************************************
 void UdpDataProtocol::setIssueSimulation(double loss, double jitter, double max_delay)
 {
-    mSimulatedLossRate = loss;
-    mSimulatedJitterRate = jitter;
+    mSimulatedLossRate       = loss;
+    mSimulatedJitterRate     = jitter;
     mSimulatedJitterMaxDelay = max_delay;
 
     std::random_device r;
-    mRndEngine = std::default_random_engine(r());
+    mRndEngine   = std::default_random_engine(r());
     mUniformDist = std::uniform_real_distribution<double>(0.0, 1.0);
 
     cout << "Simulating network issues: "
-      "loss_rate=" << loss << ", jitter_rate=" << jitter << ", jitter_max_delay=" << max_delay << endl;
+            "loss_rate="
+         << loss << ", jitter_rate=" << jitter << ", jitter_max_delay=" << max_delay
+         << endl;
 }
 
 //*******************************************************************************
@@ -845,15 +842,16 @@ void UdpDataProtocol::sendPacketRedundancy(int8_t* full_redundant_packet,
                                            int full_redundant_packet_size,
                                            int full_packet_size)
 {
-    mJackTrip->readAudioBuffer( mAudioPacket );
+    mJackTrip->readAudioBuffer(mAudioPacket);
     int8_t* src = mAudioPacket;
     if (1 != mChans) {
         // Convert internal interleaved layout to non-interleaved
-        int N = getAudioPacketSizeInBites() / mChans / mSmplSize;
+        int N       = getAudioPacketSizeInBites() / mChans / mSmplSize;
         int8_t* dst = mBuffer.data();
-        for (int n=0; n<N; ++n) {
-            for (int c=0; c<mChans; ++c) {
-                memcpy(dst + (n + c*N)*mSmplSize, src + (n*mChans + c)*mSmplSize, mSmplSize);
+        for (int n = 0; n < N; ++n) {
+            for (int c = 0; c < mChans; ++c) {
+                memcpy(dst + (n + c * N) * mSmplSize, src + (n * mChans + c) * mSmplSize,
+                       mSmplSize);
             }
         }
         src = dst;
@@ -861,12 +859,10 @@ void UdpDataProtocol::sendPacketRedundancy(int8_t* full_redundant_packet,
     mJackTrip->putHeaderInPacket(mFullPacket, src);
 
     // Move older packets to end of array of redundant packets
-    std::memmove(full_redundant_packet+full_packet_size,
-                 full_redundant_packet,
-                 full_packet_size*(mUdpRedundancyFactor-1));
+    std::memmove(full_redundant_packet + full_packet_size, full_redundant_packet,
+                 full_packet_size * (mUdpRedundancyFactor - 1));
     // Copy new packet to the begining of array
-    std::memcpy(full_redundant_packet,
-                mFullPacket, full_packet_size);
+    std::memcpy(full_redundant_packet, mFullPacket, full_packet_size);
 
     // 10% (or other number) packet lost simulation.
     // Uncomment the if to activate
@@ -874,14 +870,13 @@ void UdpDataProtocol::sendPacketRedundancy(int8_t* full_redundant_packet,
     //int random_integer = rand();
     //if ( random_integer > (RAND_MAX/10) )
     //{
-    sendPacket( reinterpret_cast<char*>(full_redundant_packet),
-                full_redundant_packet_size);
+    sendPacket(reinterpret_cast<char*>(full_redundant_packet),
+               full_redundant_packet_size);
     //}
     //---------------------------------------------------------------------------------
 
     mJackTrip->increaseSequenceNumber();
 }
-
 
 /*
   The Redundancy Algorythmn works as follows. We send a packet that contains
@@ -927,14 +922,14 @@ bool UdpDataProtocol::datagramAvailable()
     //Currently using a simplified version of the way QUdpSocket checks for datagrams.
     //TODO: Consider changing to use poll() or select().
     char c;
-#if defined (__WIN_32__)
+#if defined(__WIN_32__)
     //Need to use the winsock version of the function for MSG_PEEK
     WSABUF buffer;
-    buffer.buf = &c;
-    buffer.len = sizeof(c);
-    DWORD n = 0;
+    buffer.buf  = &c;
+    buffer.len  = sizeof(c);
+    DWORD n     = 0;
     DWORD flags = MSG_PEEK;
-    int ret = WSARecv(mSocket, &buffer, 1, &n, &flags, NULL, NULL);
+    int ret     = WSARecv(mSocket, &buffer, 1, &n, &flags, NULL, NULL);
     if (ret == 0) {
         //True if no error,
         return true;

--- a/src/UdpDataProtocol.h
+++ b/src/UdpDataProtocol.h
@@ -38,17 +38,16 @@
 #ifndef __UDPDATAPROTOCOL_H__
 #define __UDPDATAPROTOCOL_H__
 
-#include <stdexcept>
-
-#include <QThread>
 #include <QHostAddress>
 #include <QMutex>
-#include <vector>
+#include <QThread>
 #include <random>
+#include <stdexcept>
+#include <vector>
 
 #include "DataProtocol.h"
-#include "jacktrip_types.h"
 #include "jacktrip_globals.h"
+#include "jacktrip_types.h"
 
 /** \brief UDP implementation of DataProtocol class
  *
@@ -68,8 +67,7 @@ class UdpDataProtocol : public DataProtocol
 {
     Q_OBJECT;
 
-public:
-
+   public:
     /** \brief The class constructor
    * \param jacktrip Pointer to the JackTrip class that connects all classes (mediator)
    * \param runmode Sets the run mode, use either SENDER or RECEIVER
@@ -77,9 +75,8 @@ public:
    * \param peer_port Peer port number (this is the receive or send port depending on the runmode)
    * \param udp_redundancy_factor Number of redundant packets
    */
-    UdpDataProtocol(JackTrip* jacktrip, const runModeT runmode,
-                    int bind_port, int peer_port,
-                    unsigned int udp_redundancy_factor = 1);
+    UdpDataProtocol(JackTrip* jacktrip, const runModeT runmode, int bind_port,
+                    int peer_port, unsigned int udp_redundancy_factor = 1);
 
     /** \brief The class destructor
    */
@@ -90,10 +87,10 @@ public:
    */
     void setPeerAddress(const char* peerHostOrIP);
 
-#if defined (__WIN_32__)
-    void setSocket(SOCKET &socket);
+#if defined(__WIN_32__)
+    void setSocket(SOCKET& socket);
 #else
-    void setSocket(int &socket);
+    void setSocket(int& socket);
 #endif
 
     /** \brief Receives a packet. It blocks until a packet is received
@@ -127,13 +124,16 @@ public:
 
     /** \brief Sets the bind port number
     */
-    void setBindPort(int port)
-    { mBindPort = port; }
+    void setBindPort(int port) { mBindPort = port; }
 
     /** \brief Sets the peer port number
     */
     void setPeerPort(int port)
-    { mPeerPort = port; mPeerAddr.sin_port = htons(mPeerPort); mPeerAddr6.sin6_port = htons(mPeerPort); }
+    {
+        mPeerPort            = port;
+        mPeerAddr.sin_port   = htons(mPeerPort);
+        mPeerAddr6.sin6_port = htons(mPeerPort);
+    }
 
     /** \brief Implements the Thread Loop. To start the thread, call start()
    * ( DO NOT CALL run() )
@@ -145,11 +145,10 @@ public:
     virtual bool getStats(PktStat* stat);
     virtual void setIssueSimulation(double loss, double jitter, double max_delay);
 
-private slots:
+   private slots:
     void printUdpWaitedTooLong(int wait_msec);
-    
 
-signals:
+   signals:
 
     /// \brief Signals when waiting every 10 milliseconds, with the total wait on wait_msec
     /// \param wait_msec Total wait in milliseconds
@@ -157,11 +156,10 @@ signals:
     void signalUdpWaitingTooLong();
 
     //private:
-protected:
-
+   protected:
     /** \brief Binds the UDP socket to the available address and specified port
    */
-#if defined (__WIN_32__)
+#if defined(__WIN_32__)
     SOCKET bindSocket();
 #else
     int bindSocket();
@@ -182,10 +180,8 @@ protected:
     */
     virtual void receivePacketRedundancy(int8_t* full_redundant_packet,
                                          int full_redundant_packet_size,
-                                         int full_packet_size,
-                                         uint16_t& current_seq_num,
-                                         uint16_t& last_seq_num,
-                                         uint16_t& newer_seq_num);
+                                         int full_packet_size, uint16_t& current_seq_num,
+                                         uint16_t& last_seq_num, uint16_t& newer_seq_num);
 
     /** \brief Redundancy algorythm at the sender's end
     */
@@ -193,39 +189,39 @@ protected:
                                       int full_redundant_packet_size,
                                       int full_packet_size);
 
-private:
+   private:
     bool datagramAvailable();
-    
-    int mBindPort; ///< Local Port number to Bind
-    int mPeerPort; ///< Peer Port number
-    const runModeT mRunMode; ///< Run mode, either SENDER or RECEIVER
-    bool mIPv6; /// Use IPv6
 
-    QHostAddress mPeerAddress; ///< The Peer Address
+    int mBindPort;            ///< Local Port number to Bind
+    int mPeerPort;            ///< Peer Port number
+    const runModeT mRunMode;  ///< Run mode, either SENDER or RECEIVER
+    bool mIPv6;               /// Use IPv6
+
+    QHostAddress mPeerAddress;  ///< The Peer Address
     struct sockaddr_in mPeerAddr;
     struct sockaddr_in6 mPeerAddr6;
-#if defined (__WIN_32__)
+#if defined(__WIN_32__)
     SOCKET mSocket;
 #else
     int mSocket;
 #endif
 
-    int8_t* mAudioPacket; ///< Buffer to store Audio Packets
-    int8_t* mFullPacket; ///< Buffer to store Full Packet (audio+header)
+    int8_t* mAudioPacket;  ///< Buffer to store Audio Packets
+    int8_t* mFullPacket;   ///< Buffer to store Full Packet (audio+header)
     std::vector<int8_t> mBuffer;
     int mChans;
     int mSmplSize;
     int mLastOutOfOrderCount;
     bool mInitialState;
 
-    unsigned int mUdpRedundancyFactor; ///< Factor of redundancy
-    static QMutex sUdpMutex; ///< Mutex to make thread safe the binding process
+    unsigned int mUdpRedundancyFactor;  ///< Factor of redundancy
+    static QMutex sUdpMutex;            ///< Mutex to make thread safe the binding process
 
-    std::atomic<uint32_t>  mTotCount;
-    std::atomic<uint32_t>  mLostCount;
-    std::atomic<uint32_t>  mOutOfOrderCount;
-    std::atomic<uint32_t>  mRevivedCount;
-    uint32_t  mStatCount;
+    std::atomic<uint32_t> mTotCount;
+    std::atomic<uint32_t> mLostCount;
+    std::atomic<uint32_t> mOutOfOrderCount;
+    std::atomic<uint32_t> mRevivedCount;
+    uint32_t mStatCount;
 
     uint8_t mControlPacketSize;
     bool mStopSignalSent;
@@ -238,4 +234,4 @@ private:
     std::uniform_real_distribution<double> mUniformDist;
 };
 
-#endif // __UDPDATAPROTOCOL_H__
+#endif  // __UDPDATAPROTOCOL_H__

--- a/src/UdpHubListener.cpp
+++ b/src/UdpHubListener.cpp
@@ -35,57 +35,60 @@
  * \date September 2008
  */
 
-#include <iostream>
-#include <cstdlib>
-#include <stdexcept>
-#include <cstring>
+#include "UdpHubListener.h"
 
+#include <QMutexLocker>
+#include <QStringList>
 #include <QTcpServer>
 #include <QTcpSocket>
-#include <QStringList>
-#include <QMutexLocker>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <stdexcept>
 
-#include "UdpHubListener.h"
 #include "JackTripWorker.h"
 #include "jacktrip_globals.h"
 
-using std::cout; using std::endl;
+using std::cout;
+using std::endl;
 
 bool UdpHubListener::sSigInt = false;
 
 //*******************************************************************************
-UdpHubListener::UdpHubListener(int server_port, int server_udp_port) :
-    //mJTWorker(NULL),
-    mTcpServer(this),
-    mServerPort(server_port),
-    mServerUdpPort(server_udp_port),//final udp base port number
-    mStopped(false),
-    #ifdef WAIR // wair
-    mWAIR(false),
-    #endif // endwhere
-    mTotalRunningThreads(0),
-    mHubPatchDescriptions({"server-to-clients", "client loopback", "client fan out/in but not loopback",
-                           "reserved for TUB", "full mix", "no auto patching"}),
-    m_connectDefaultAudioPorts(false),
-    mIOStatTimeout(0)
+UdpHubListener::UdpHubListener(int server_port, int server_udp_port)
+    :  //mJTWorker(NULL),
+    mTcpServer(this)
+    , mServerPort(server_port)
+    , mServerUdpPort(server_udp_port)
+    ,  //final udp base port number
+    mStopped(false)
+    ,
+#ifdef WAIR  // wair
+    mWAIR(false)
+    ,
+#endif  // endwhere
+    mTotalRunningThreads(0)
+    , mHubPatchDescriptions({"server-to-clients", "client loopback",
+                             "client fan out/in but not loopback", "reserved for TUB",
+                             "full mix", "no auto patching"})
+    , m_connectDefaultAudioPorts(false)
+    , mIOStatTimeout(0)
 {
     // Register JackTripWorker with the hub listener
     //mJTWorker = new JackTripWorker(this);
     mJTWorkers = new QVector<JackTripWorker*>;
-    for (int i = 0; i<gMaxThreads; i++) {
-        mJTWorkers->insert(i, NULL);
-    }
+    for (int i = 0; i < gMaxThreads; i++) { mJTWorkers->insert(i, NULL); }
 
     qDebug() << "mThreadPool default maxThreadCount =" << mThreadPool.maxThreadCount();
     mThreadPool.setMaxThreadCount(mThreadPool.maxThreadCount() * 16);
     qDebug() << "mThreadPool maxThreadCount set to" << mThreadPool.maxThreadCount();
 
     //mJTWorkers = new JackTripWorker(this);
-    mThreadPool.setExpiryTimeout(3000); // msec (-1) = forever
+    mThreadPool.setExpiryTimeout(3000);  // msec (-1) = forever
     // Inizialize IP addresses
-    for (int i = 0; i<gMaxThreads; i++) {
-        mActiveAddress[i].address = ""; // Address strings
-        mActiveAddress[i].port = 0;
+    for (int i = 0; i < gMaxThreads; i++) {
+        mActiveAddress[i].address = "";  // Address strings
+        mActiveAddress[i].port    = 0;
     }
     // Set the base dynamic port
     // The Dynamic and/or Private Ports are those from 49152 through 65535
@@ -93,26 +96,25 @@ UdpHubListener::UdpHubListener(int server_port, int server_udp_port) :
 
     // SoundWIRE ports open are UDP 61002-62000
     // (server_port - gDefaultPort) apply TCP offset to UDP too
-    if (mServerUdpPort != 0){
-      mBasePort = mServerUdpPort;
+    if (mServerUdpPort != 0) {
+        mBasePort = mServerUdpPort;
     } else {
-      mBasePort = 61002 + (server_port - gDefaultPort);
+        mBasePort = 61002 + (server_port - gDefaultPort);
     }
 
     cout << "JackTrip HUB SERVER: UDP Base Port set to " << mBasePort << endl;
 
-    mUnderRunMode = JackTrip::WAVETABLE;
+    mUnderRunMode      = JackTrip::WAVETABLE;
     mBufferQueueLength = gDefaultQueueLength;
 
-    mBufferStrategy = 1;
-    mBroadcastQueue = 0;
-    mSimulatedLossRate = 0.0;
+    mBufferStrategy      = 1;
+    mBroadcastQueue      = 0;
+    mSimulatedLossRate   = 0.0;
     mSimulatedJitterRate = 0.0;
-    mSimulatedDelayRel = 0.0;
+    mSimulatedDelayRel   = 0.0;
 
     mUseRtUdpPriority = false;
 }
-
 
 //*******************************************************************************
 UdpHubListener::~UdpHubListener()
@@ -120,12 +122,9 @@ UdpHubListener::~UdpHubListener()
     QMutexLocker lock(&mMutex);
     mThreadPool.waitForDone();
     //delete mJTWorker;
-    for (int i = 0; i<gMaxThreads; i++) {
-        delete mJTWorkers->at(i);
-    }
+    for (int i = 0; i < gMaxThreads; i++) { delete mJTWorkers->at(i); }
     delete mJTWorkers;
 }
-
 
 //*******************************************************************************
 // Now that the first handshake is with TCP server, if the addreess/peer port of
@@ -138,40 +137,42 @@ void UdpHubListener::start()
 
     // Bind the TCP server
     // ------------------------------
-    QObject::connect(&mTcpServer, &QTcpServer::newConnection, this, &UdpHubListener::receivedNewConnection);
-    if ( !mTcpServer.listen(QHostAddress::Any, mServerPort) ) {
-        QString error_message = QString("TCP Socket Server on Port %1 ERROR: %2").arg(mServerPort).arg(mTcpServer.errorString());
+    QObject::connect(&mTcpServer, &QTcpServer::newConnection, this,
+                     &UdpHubListener::receivedNewConnection);
+    if (!mTcpServer.listen(QHostAddress::Any, mServerPort)) {
+        QString error_message = QString("TCP Socket Server on Port %1 ERROR: %2")
+                                    .arg(mServerPort)
+                                    .arg(mTcpServer.errorString());
         std::cerr << error_message.toStdString() << endl;
         emit signalError(error_message);
         return;
     }
-    
+
     cout << "JackTrip HUB SERVER: Waiting for client connections..." << endl;
-    cout << "JackTrip HUB SERVER: Hub auto audio patch setting = " << mHubPatch 
-         << " (" << mHubPatchDescriptions.at(mHubPatch).toStdString() << ")" << endl;
+    cout << "JackTrip HUB SERVER: Hub auto audio patch setting = " << mHubPatch << " ("
+         << mHubPatchDescriptions.at(mHubPatch).toStdString() << ")" << endl;
     cout << "=======================================================" << endl;
-    
+
     // Start our monitoring timer
     mStopCheckTimer.setInterval(200);
     connect(&mStopCheckTimer, &QTimer::timeout, this, &UdpHubListener::stopCheck);
     mStopCheckTimer.start();
 }
-    
+
 void UdpHubListener::receivedNewConnection()
 {
-    QTcpSocket *clientSocket = mTcpServer.nextPendingConnection();
-    connect(clientSocket, &QAbstractSocket::readyRead, this, [=]{
-            receivedClientInfo(clientSocket);
-        });
+    QTcpSocket* clientSocket = mTcpServer.nextPendingConnection();
+    connect(clientSocket, &QAbstractSocket::readyRead, this,
+            [=] { receivedClientInfo(clientSocket); });
     cout << "JackTrip HUB SERVER: Client Connection Received!" << endl;
 }
 
-void UdpHubListener::receivedClientInfo(QTcpSocket *clientConnection)
+void UdpHubListener::receivedClientInfo(QTcpSocket* clientConnection)
 {
     QHostAddress PeerAddress = clientConnection->peerAddress();
     cout << "JackTrip HUB SERVER: Client Connect Received from Address : "
          << PeerAddress.toString().toStdString() << endl;
-         
+
     // Get UDP port from client
     // ------------------------
     QString clientName = QString();
@@ -180,16 +181,17 @@ void UdpHubListener::receivedClientInfo(QTcpSocket *clientConnection)
         // We don't have enough data. Wait for the next readyRead notification.
         return;
     }
-    uint16_t peer_udp_port= readClientUdpPort(clientConnection, clientName);
+    uint16_t peer_udp_port = readClientUdpPort(clientConnection, clientName);
 
     cout << "JackTrip HUB SERVER: Client UDP Port is = " << peer_udp_port << endl;
-    if ( peer_udp_port == 0 || peer_udp_port < gBindPortLow || peer_udp_port > gBindPortHigh ) {
+    if (peer_udp_port == 0 || peer_udp_port < gBindPortLow
+        || peer_udp_port > gBindPortHigh) {
         cout << "JackTrip HUB SERVER: Exiting " << endl;
         clientConnection->close();
         clientConnection->deleteLater();
         return;
     }
-    
+
     // Check is client is new or not
     // -----------------------------
     // Check if Address is not already in the thread pool
@@ -204,7 +206,7 @@ void UdpHubListener::receivedClientInfo(QTcpSocket *clientConnection)
         // stop the thread
         mJTWorkers->at(id_remove)->stopThread();
         // block until the thread has been removed from the pool
-        while ( isNewAddress(PeerAddress.toString(), peer_udp_port) == -1 ) {
+        while (isNewAddress(PeerAddress.toString(), peer_udp_port) == -1) {
             cout << "JackTrip HUB SERVER: Removing JackTripWorker from pool..." << endl;
             QThread::msleep(10);
         }
@@ -213,16 +215,17 @@ void UdpHubListener::receivedClientInfo(QTcpSocket *clientConnection)
         id = getPoolID(PeerAddress.toString(), peer_udp_port);
     }
     // Assign server port and send it to Client
-    int server_udp_port = mBasePort+id;
-    cout << "JackTrip HUB SERVER: Sending Final UDP Port to Client: " << server_udp_port << endl;
-    
-     if ( sendUdpPort(clientConnection, server_udp_port) == 0 ) {
+    int server_udp_port = mBasePort + id;
+    cout << "JackTrip HUB SERVER: Sending Final UDP Port to Client: " << server_udp_port
+         << endl;
+
+    if (sendUdpPort(clientConnection, server_udp_port) == 0) {
         clientConnection->close();
         clientConnection->deleteLater();
         releaseThread(id);
         return;
     }
-    
+
     // Close and mark socket for deletion
     // ----------------------------------
     clientConnection->close();
@@ -232,28 +235,25 @@ void UdpHubListener::receivedClientInfo(QTcpSocket *clientConnection)
     // Spawn Thread to Pool
     // --------------------
     // Register JackTripWorker with the hub listener
-    delete mJTWorkers->at(id); // just in case the Worker was previously created
-    mJTWorkers->replace(id, new JackTripWorker(this, mBufferQueueLength, mUnderRunMode, clientName));
+    delete mJTWorkers->at(id);  // just in case the Worker was previously created
+    mJTWorkers->replace(
+        id, new JackTripWorker(this, mBufferQueueLength, mUnderRunMode, clientName));
     if (mIOStatTimeout > 0) {
         mJTWorkers->at(id)->setIOStatTimeout(mIOStatTimeout);
         mJTWorkers->at(id)->setIOStatStream(mIOStatStream);
     }
     mJTWorkers->at(id)->setBufferStrategy(mBufferStrategy);
-    mJTWorkers->at(id)->setNetIssuesSimulation(mSimulatedLossRate,
-    mSimulatedJitterRate, mSimulatedDelayRel);
+    mJTWorkers->at(id)->setNetIssuesSimulation(mSimulatedLossRate, mSimulatedJitterRate,
+                                               mSimulatedDelayRel);
     mJTWorkers->at(id)->setBroadcast(mBroadcastQueue);
     mJTWorkers->at(id)->setUseRtUdpPriority(mUseRtUdpPriority);
     // redirect port and spawn listener
     cout << "JackTrip HUB SERVER: Spawning JackTripWorker..." << endl;
     {
         QMutexLocker lock(&mMutex);
-        mJTWorkers->at(id)->setJackTrip(id,
-                                        mActiveAddress[id].address,
-                                        server_udp_port,
-                                        mActiveAddress[id].port,
-                                        1,
-                                        m_connectDefaultAudioPorts
-                                        ); /// \todo temp default to 1 channel
+        mJTWorkers->at(id)->setJackTrip(
+            id, mActiveAddress[id].address, server_udp_port, mActiveAddress[id].port, 1,
+            m_connectDefaultAudioPorts);  /// \todo temp default to 1 channel
 
         //qDebug() << "mPeerAddress" << id <<  mActiveAddress[id].address << mActiveAddress[id].port;
     }
@@ -263,12 +263,13 @@ void UdpHubListener::receivedClientInfo(QTcpSocket *clientConnection)
     // wait until one is complete before another spawns
     while (mJTWorkers->at(id)->isSpawning()) { QThread::msleep(10); }
     //mTotalRunningThreads++;
-    cout << "JackTrip HUB SERVER: Total Running Threads:  " << mTotalRunningThreads << endl;
+    cout << "JackTrip HUB SERVER: Total Running Threads:  " << mTotalRunningThreads
+         << endl;
     cout << "===============================================================" << endl;
     QThread::msleep(100);
-#ifdef WAIR // WAIR
-    if (isWAIR()) connectMesh(true); // invoked with -Sw
-#endif // endwhere
+#ifdef WAIR  // WAIR
+    if (isWAIR()) connectMesh(true);  // invoked with -Sw
+#endif                                // endwhere
 
     //qDebug() << "mPeerAddress" << mActiveAddress[id].address << mActiveAddress[id].port;
 
@@ -286,7 +287,7 @@ void UdpHubListener::stopCheck()
     }
 }
 
-    /* From Old Runloop code
+/* From Old Runloop code
   // Create objects on the stack
   QUdpSocket HubUdpSocket;
   QHostAddress PeerAddress;
@@ -338,7 +339,8 @@ void UdpHubListener::stopCheck()
 
 //*******************************************************************************
 // Returns 0 on error
-uint16_t UdpHubListener::readClientUdpPort(QTcpSocket* clientConnection, QString &clientName)
+uint16_t UdpHubListener::readClientUdpPort(QTcpSocket* clientConnection,
+                                           QString& clientName)
 {
     if (gVerboseFlag) cout << "Ready To Read From Client!" << endl;
     // Read UDP Port Number from Server
@@ -348,16 +350,15 @@ uint16_t UdpHubListener::readClientUdpPort(QTcpSocket* clientConnection, QString
     char port_buf[size];
     clientConnection->read(port_buf, size);
     std::memcpy(&udp_port, port_buf, size);
-    
+
     if (clientConnection->bytesAvailable() == gMaxRemoteNameLength) {
         char name_buf[gMaxRemoteNameLength];
         clientConnection->read(name_buf, gMaxRemoteNameLength);
-        clientName = QString::fromUtf8((const char *)name_buf);
+        clientName = QString::fromUtf8((const char*)name_buf);
     }
-    
+
     return udp_port;
 }
-
 
 //*******************************************************************************
 int UdpHubListener::sendUdpPort(QTcpSocket* clientConnection, int udp_port)
@@ -367,18 +368,16 @@ int UdpHubListener::sendUdpPort(QTcpSocket* clientConnection, int udp_port)
     char port_buf[sizeof(udp_port)];
     std::memcpy(port_buf, &udp_port, sizeof(udp_port));
     clientConnection->write(port_buf, sizeof(udp_port));
-    while ( clientConnection->bytesToWrite() > 0 ) {
-        if ( clientConnection->state() == QAbstractSocket::ConnectedState ) {
+    while (clientConnection->bytesToWrite() > 0) {
+        if (clientConnection->state() == QAbstractSocket::ConnectedState) {
             clientConnection->waitForBytesWritten(-1);
-        }
-        else {
+        } else {
             return 0;
         }
     }
     return 1;
     //cout << "Port sent to Client" << endl;
 }
-
 
 //*******************************************************************************
 /*
@@ -391,22 +390,18 @@ void UdpHubListener::sendToPoolPrototype(int id)
 }
 */
 
-
 //*******************************************************************************
 void UdpHubListener::bindUdpSocket(QUdpSocket& udpsocket, int port)
 {
     // QHostAddress::Any : let the kernel decide the active address
-    if ( !udpsocket.bind(QHostAddress::Any,
-                         port, QUdpSocket::DefaultForPlatform) ) {
+    if (!udpsocket.bind(QHostAddress::Any, port, QUdpSocket::DefaultForPlatform)) {
         //std::cerr << "ERROR: could not bind UDP socket" << endl;
         //std::exit(1);
         throw std::runtime_error("Could not bind UDP socket. It may be already binded.");
-    }
-    else {
+    } else {
         cout << "UDP Socket Receiving in Port: " << port << endl;
     }
 }
-
 
 //*******************************************************************************
 // check by comparing 32-bit addresses
@@ -414,7 +409,7 @@ int UdpHubListener::isNewAddress(QString address, uint16_t port)
 {
     QMutexLocker lock(&mMutex);
     bool busyAddress = false;
-    int id = 0;
+    int id           = 0;
 
     /*
   while ( !busyAddress && (id<mThreadPool.activeThreadCount()) )
@@ -423,73 +418,71 @@ int UdpHubListener::isNewAddress(QString address, uint16_t port)
     id++;
   }
   */
-    for (int i = 0; i<gMaxThreads; i++) {
-        if ( address==mActiveAddress[i].address &&  port==mActiveAddress[i].port) {
-            id = i;
+    for (int i = 0; i < gMaxThreads; i++) {
+        if (address == mActiveAddress[i].address && port == mActiveAddress[i].port) {
+            id          = i;
             busyAddress = true;
         }
     }
-    if ( !busyAddress ) {
+    if (!busyAddress) {
         /*
     mActiveAddress[id][0] = address;
     mActiveAddress[id][1] = port;
   } else {
   */
-        id = 0;
+        id                     = 0;
         bool foundEmptyAddress = false;
-        while ( !foundEmptyAddress && (id<gMaxThreads) ) {
-            if ( mActiveAddress[id].address.isEmpty() &&  (mActiveAddress[id].port == 0) ) {
-                foundEmptyAddress = true;
+        while (!foundEmptyAddress && (id < gMaxThreads)) {
+            if (mActiveAddress[id].address.isEmpty() && (mActiveAddress[id].port == 0)) {
+                foundEmptyAddress          = true;
                 mActiveAddress[id].address = address;
-                mActiveAddress[id].port = port;
-            }  else {
+                mActiveAddress[id].port    = port;
+            } else {
                 id++;
             }
         }
     }
-    if (!busyAddress) {
-        mTotalRunningThreads++;
-    }
+    if (!busyAddress) { mTotalRunningThreads++; }
     return ((busyAddress) ? -1 : id);
 }
-
 
 //*******************************************************************************
 int UdpHubListener::getPoolID(QString address, uint16_t port)
 {
     QMutexLocker lock(&mMutex);
     //for (int id = 0; id<mThreadPool.activeThreadCount(); id++ )
-    for (int id = 0; id<gMaxThreads; id++ )
-    {
-        if ( address==mActiveAddress[id].address &&  port==mActiveAddress[id].port)
-        { return id; }
+    for (int id = 0; id < gMaxThreads; id++) {
+        if (address == mActiveAddress[id].address && port == mActiveAddress[id].port) {
+            return id;
+        }
     }
     return -1;
 }
-
 
 //*******************************************************************************
 int UdpHubListener::releaseThread(int id)
 {
     QMutexLocker lock(&mMutex);
     mActiveAddress[id].address = "";
-    mActiveAddress[id].port = 0;
+    mActiveAddress[id].port    = 0;
     mTotalRunningThreads--;
-#ifdef WAIR // wair
-    if (isWAIR()) connectMesh(false); // invoked with -Sw
-#endif // endwhere
-    if (getHubPatch()) connectPatch(false); // invoked with -p > 0
-    return 0; /// \todo Check if we really need to return an argument here
+#ifdef WAIR  // wair
+    if (isWAIR()) connectMesh(false);  // invoked with -Sw
+#endif                                 // endwhere
+    if (getHubPatch()) connectPatch(false);  // invoked with -p > 0
+    return 0;  /// \todo Check if we really need to return an argument here
 }
 
-#ifdef WAIR // wair
+#ifdef WAIR  // wair
 #include "JMess.h"
 //*******************************************************************************
 void UdpHubListener::connectMesh(bool spawn)
 {
-    cout << ((spawn)?"spawning":"releasing") << " jacktripWorker so change mesh" << endl;
+    cout << ((spawn) ? "spawning" : "releasing") << " jacktripWorker so change mesh"
+         << endl;
     JMess tmp;
-    tmp.connectSpawnedPorts(gDefaultNumInChannels); // change gDefaultNumInChannels if more than stereo LAIR interconnects
+    tmp.connectSpawnedPorts(
+        gDefaultNumInChannels);  // change gDefaultNumInChannels if more than stereo LAIR interconnects
     //  tmp.disconnectAll();
     //  enumerateRunningThreadIDs();
 }
@@ -497,32 +490,35 @@ void UdpHubListener::connectMesh(bool spawn)
 //*******************************************************************************
 void UdpHubListener::enumerateRunningThreadIDs()
 {
-    for (int id = 0; id<gMaxThreads; id++ )
-    {
-        if ( !mActiveAddress[id].address.isEmpty() )
-        { qDebug() << id; }
+    for (int id = 0; id < gMaxThreads; id++) {
+        if (!mActiveAddress[id].address.isEmpty()) { qDebug() << id; }
     }
 }
-#endif // endwhere
+#endif  // endwhere
 
 #include "JMess.h"
 void UdpHubListener::connectPatch(bool spawn)
 {
-    if ((getHubPatch() == JackTrip::NOAUTO) ||
-        (getHubPatch() == JackTrip::SERVERTOCLIENT && !m_connectDefaultAudioPorts)) {
-        cout << ((spawn)?"spawning":"releasing") << " jacktripWorker (auto hub patching disabled)" << endl;
+    if ((getHubPatch() == JackTrip::NOAUTO)
+        || (getHubPatch() == JackTrip::SERVERTOCLIENT && !m_connectDefaultAudioPorts)) {
+        cout << ((spawn) ? "spawning" : "releasing")
+             << " jacktripWorker (auto hub patching disabled)" << endl;
         return;
     }
-    cout << ((spawn)?"spawning":"releasing") << " jacktripWorker so change patch" << endl;
+    cout << ((spawn) ? "spawning" : "releasing") << " jacktripWorker so change patch"
+         << endl;
     JMess tmp;
     // default is patch 0, which connects server audio to all clients
     // these are the other cases:
-    if (getHubPatch() == JackTrip::RESERVEDMATRIX) // special patch for TU Berlin ensemble
+    if (getHubPatch()
+        == JackTrip::RESERVEDMATRIX)  // special patch for TU Berlin ensemble
         tmp.connectTUB(gDefaultNumInChannels);
-    else if ((getHubPatch() == JackTrip::CLIENTECHO) || // client loopback for testing
-             (getHubPatch() == JackTrip::CLIENTFOFI) || // all clients to all clients except self
-             (getHubPatch() == JackTrip::FULLMIX)) // all clients to all clients including self
-        tmp.connectSpawnedPorts(gDefaultNumInChannels,getHubPatch());
+    else if ((getHubPatch() == JackTrip::CLIENTECHO) ||  // client loopback for testing
+             (getHubPatch() == JackTrip::CLIENTFOFI)
+             ||  // all clients to all clients except self
+             (getHubPatch()
+              == JackTrip::FULLMIX))  // all clients to all clients including self
+        tmp.connectSpawnedPorts(gDefaultNumInChannels, getHubPatch());
     // FIXME: need change to gDefaultNumInChannels if more than stereo
 }
 

--- a/src/UdpHubListener.h
+++ b/src/UdpHubListener.h
@@ -38,22 +38,21 @@
 #ifndef __UDPHUBLISTENER_H__
 #define __UDPHUBLISTENER_H__
 
-#include <iostream>
-#include <stdexcept>
-#include <fstream>
-
+#include <QHostAddress>
+#include <QMutex>
+#include <QTcpServer>
+#include <QTcpSocket>
 #include <QThread>
 #include <QThreadPool>
 #include <QUdpSocket>
-#include <QHostAddress>
-#include <QTcpSocket>
-#include <QTcpServer>
-#include <QMutex>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
 
 #include "JackTrip.h"
-#include "jacktrip_types.h"
 #include "jacktrip_globals.h"
-class JackTripWorker; // forward declaration
+#include "jacktrip_types.h"
+class JackTripWorker;  // forward declaration
 class Settings;
 
 typedef struct {
@@ -70,7 +69,7 @@ class UdpHubListener : public QObject
 {
     Q_OBJECT;
 
-public:
+   public:
     UdpHubListener(int server_port = gServerUdpPort, int server_udp_port = 0);
     virtual ~UdpHubListener();
 
@@ -82,36 +81,43 @@ public:
 
     int releaseThread(int id);
 
-    void setConnectDefaultAudioPorts(bool connectDefaultAudioPorts) { m_connectDefaultAudioPorts = connectDefaultAudioPorts; }
-    
-    static void sigIntHandler(__attribute__((unused)) int unused)
-    { std::cout << std::endl << "Shutting Down..." << std::endl; sSigInt = true; }
+    void setConnectDefaultAudioPorts(bool connectDefaultAudioPorts)
+    {
+        m_connectDefaultAudioPorts = connectDefaultAudioPorts;
+    }
 
-private slots:
+    static void sigIntHandler(__attribute__((unused)) int unused)
+    {
+        std::cout << std::endl << "Shutting Down..." << std::endl;
+        sSigInt = true;
+    }
+
+   private slots:
     void testReceive()
-    { std::cout << "========= TEST RECEIVE SLOT ===========" << std::endl; }
+    {
+        std::cout << "========= TEST RECEIVE SLOT ===========" << std::endl;
+    }
     void receivedNewConnection();
     void stopCheck();
 
-signals:
+   signals:
     void Listening();
     void ClientAddressSet();
     void signalRemoveThread(int id);
     void signalStopped();
-    void signalError(const QString &errorMessage);
+    void signalError(const QString& errorMessage);
 
-private:
+   private:
     /** \brief Binds a QUdpSocket. It chooses the available (active) interface.
    * \param udpsocket a QUdpSocket
    * \param port Port number
    */
-    void receivedClientInfo(QTcpSocket *clientConnection);
+    void receivedClientInfo(QTcpSocket* clientConnection);
 
     static void bindUdpSocket(QUdpSocket& udpsocket, int port);
 
-    uint16_t readClientUdpPort(QTcpSocket* clientConnection, QString &clientName);
+    uint16_t readClientUdpPort(QTcpSocket* clientConnection, QString& clientName);
     int sendUdpPort(QTcpSocket* clientConnection, int udp_port);
-
 
     /** \brief Send the JackTripWorker to the thread pool. This will run
    * until it's done. We still have control over the prototype class.
@@ -129,32 +135,32 @@ private:
     * is not in the pool yet, returns -1.
     */
     int getPoolID(QString address, uint16_t port);
-    
+
     void stopAllThreads();
 
     //QUdpSocket mUdpHubSocket; ///< The UDP socket
     //QHostAddress mPeerAddress; ///< The Peer Address
 
     //JackTripWorker* mJTWorker; ///< Class that will be used as prototype
-    QVector<JackTripWorker*>* mJTWorkers; ///< Vector of JackTripWorker s
-    QThreadPool mThreadPool; ///< The Thread Pool
+    QVector<JackTripWorker*>* mJTWorkers;  ///< Vector of JackTripWorker s
+    QThreadPool mThreadPool;               ///< The Thread Pool
 
     QTcpServer mTcpServer;
-    int mServerPort; //< Server known port number
-    int mServerUdpPort; //< Server udp base port number
+    int mServerPort;     //< Server known port number
+    int mServerUdpPort;  //< Server udp base port number
     int mBasePort;
-    addressPortPair mActiveAddress[gMaxThreads]; ///< Active address pool addresses
+    addressPortPair mActiveAddress[gMaxThreads];  ///< Active address pool addresses
     QHash<QString, uint16_t> mActiveAddressPortPair;
 
     /// Boolean stop the execution of the thread
     volatile bool mStopped;
     static bool sSigInt;
     QTimer mStopCheckTimer;
-    int mTotalRunningThreads; ///< Number of Threads running in the pool
+    int mTotalRunningThreads;  ///< Number of Threads running in the pool
     QMutex mMutex;
     JackTrip::underrunModeT mUnderRunMode;
     int mBufferQueueLength;
-    
+
     QStringList mHubPatchDescriptions;
     bool m_connectDefaultAudioPorts;
 
@@ -167,38 +173,47 @@ private:
     double mSimulatedJitterRate;
     double mSimulatedDelayRel;
     bool mUseRtUdpPriority;
-    
-#ifdef WAIR // wair
+
+#ifdef WAIR  // wair
     bool mWAIR;
     void connectMesh(bool spawn);
     void enumerateRunningThreadIDs();
-public :
-    void setWAIR(int b) {mWAIR = b;}
-    bool isWAIR() {return mWAIR;}
-#endif // endwhere
-    void connectPatch(bool spawn);
-public :
-    unsigned int mHubPatch;
-    void setHubPatch(unsigned int p) {mHubPatch = p;}
-    unsigned int getHubPatch() {return mHubPatch;}
 
-    void setUnderRunMode(JackTrip::underrunModeT UnderRunMode) { mUnderRunMode = UnderRunMode; }
-    void setBufferQueueLength(int BufferQueueLength) { mBufferQueueLength = BufferQueueLength; }
-    
+   public:
+    void setWAIR(int b) { mWAIR = b; }
+    bool isWAIR() { return mWAIR; }
+#endif  // endwhere
+    void connectPatch(bool spawn);
+
+   public:
+    unsigned int mHubPatch;
+    void setHubPatch(unsigned int p) { mHubPatch = p; }
+    unsigned int getHubPatch() { return mHubPatch; }
+
+    void setUnderRunMode(JackTrip::underrunModeT UnderRunMode)
+    {
+        mUnderRunMode = UnderRunMode;
+    }
+    void setBufferQueueLength(int BufferQueueLength)
+    {
+        mBufferQueueLength = BufferQueueLength;
+    }
+
     void setIOStatTimeout(int timeout) { mIOStatTimeout = timeout; }
-    void setIOStatStream(QSharedPointer<std::ofstream> statStream) { mIOStatStream = statStream; }
+    void setIOStatStream(QSharedPointer<std::ofstream> statStream)
+    {
+        mIOStatStream = statStream;
+    }
 
     void setBufferStrategy(int BufferStrategy) { mBufferStrategy = BufferStrategy; }
     void setNetIssuesSimulation(double loss, double jitter, double delay_rel)
     {
-        mSimulatedLossRate = loss;
+        mSimulatedLossRate   = loss;
         mSimulatedJitterRate = jitter;
-        mSimulatedDelayRel = delay_rel;
+        mSimulatedDelayRel   = delay_rel;
     }
-    void setBroadcast(int broadcast_queue) {mBroadcastQueue = broadcast_queue;}
-    void setUseRtUdpPriority(bool use) {mUseRtUdpPriority = use;}
-
+    void setBroadcast(int broadcast_queue) { mBroadcastQueue = broadcast_queue; }
+    void setUseRtUdpPriority(bool use) { mUseRtUdpPriority = use; }
 };
 
-
-#endif //__UDPHUBLISTENER_H__
+#endif  //__UDPHUBLISTENER_H__

--- a/src/compressordsp.h
+++ b/src/compressordsp.h
@@ -7,8 +7,8 @@ Code generated with Faust 2.28.6 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -scal -ftz 0
 ------------------------------------------------------------ */
 
-#ifndef  __compressordsp_H__
-#define  __compressordsp_H__
+#ifndef __compressordsp_H__
+#define __compressordsp_H__
 
 // NOTE: ANY INCLUDE-GUARD HERE MUST BE DERIVED FROM THE CLASS NAME
 //
@@ -59,86 +59,83 @@ struct Meta;
  */
 
 struct dsp_memory_manager {
-    
     virtual ~dsp_memory_manager() {}
-    
+
     virtual void* allocate(size_t size) = 0;
-    virtual void destroy(void* ptr) = 0;
-    
+    virtual void destroy(void* ptr)     = 0;
 };
 
 /**
 * Signal processor definition.
 */
 
-class dsp {
+class dsp
+{
+   public:
+    dsp() {}
+    virtual ~dsp() {}
 
-    public:
+    /* Return instance number of audio inputs */
+    virtual int getNumInputs() = 0;
 
-        dsp() {}
-        virtual ~dsp() {}
+    /* Return instance number of audio outputs */
+    virtual int getNumOutputs() = 0;
 
-        /* Return instance number of audio inputs */
-        virtual int getNumInputs() = 0;
-    
-        /* Return instance number of audio outputs */
-        virtual int getNumOutputs() = 0;
-    
-        /**
+    /**
          * Trigger the ui_interface parameter with instance specific calls
          * to 'openTabBox', 'addButton', 'addVerticalSlider'... in order to build the UI.
          *
          * @param ui_interface - the user interface builder
          */
-        virtual void buildUserInterface(UI* ui_interface) = 0;
-    
-        /* Returns the sample rate currently used by the instance */
-        virtual int getSampleRate() = 0;
-    
-        /**
+    virtual void buildUserInterface(UI* ui_interface) = 0;
+
+    /* Returns the sample rate currently used by the instance */
+    virtual int getSampleRate() = 0;
+
+    /**
          * Global init, calls the following methods:
          * - static class 'classInit': static tables initialization
          * - 'instanceInit': constants and instance state initialization
          *
          * @param sample_rate - the sampling rate in Hertz
          */
-        virtual void init(int sample_rate) = 0;
+    virtual void init(int sample_rate) = 0;
 
-        /**
+    /**
          * Init instance state
          *
          * @param sample_rate - the sampling rate in Hertz
          */
-        virtual void instanceInit(int sample_rate) = 0;
+    virtual void instanceInit(int sample_rate) = 0;
 
-        /**
+    /**
          * Init instance constant state
          *
          * @param sample_rate - the sampling rate in Hertz
          */
-        virtual void instanceConstants(int sample_rate) = 0;
-    
-        /* Init default control parameters values */
-        virtual void instanceResetUserInterface() = 0;
-    
-        /* Init instance state (delay lines...) */
-        virtual void instanceClear() = 0;
- 
-        /**
+    virtual void instanceConstants(int sample_rate) = 0;
+
+    /* Init default control parameters values */
+    virtual void instanceResetUserInterface() = 0;
+
+    /* Init instance state (delay lines...) */
+    virtual void instanceClear() = 0;
+
+    /**
          * Return a clone of the instance.
          *
          * @return a copy of the instance on success, otherwise a null pointer.
          */
-        virtual dsp* clone() = 0;
-    
-        /**
+    virtual dsp* clone() = 0;
+
+    /**
          * Trigger the Meta* parameter with instance specific calls to 'declare' (key, value) metadata.
          *
          * @param m - the Meta* meta user
          */
-        virtual void metadata(Meta* m) = 0;
-    
-        /**
+    virtual void metadata(Meta* m) = 0;
+
+    /**
          * DSP instance computation, to be called with successive in/out audio buffers.
          *
          * @param count - the number of frames to compute
@@ -146,9 +143,9 @@ class dsp {
          * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
          *
          */
-        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
-    
-        /**
+    virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
+
+    /**
          * DSP instance computation: alternative method to be used by subclasses.
          *
          * @param date_usec - the timestamp in microsec given by audio driver.
@@ -157,67 +154,77 @@ class dsp {
          * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (either float, double or quad)
          *
          */
-        virtual void compute(double /*date_usec*/, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
-       
+    virtual void compute(double /*date_usec*/, int count, FAUSTFLOAT** inputs,
+                         FAUSTFLOAT** outputs)
+    {
+        compute(count, inputs, outputs);
+    }
 };
 
 /**
  * Generic DSP decorator.
  */
 
-class decorator_dsp : public dsp {
+class decorator_dsp : public dsp
+{
+   protected:
+    dsp* fDSP;
 
-    protected:
+   public:
+    decorator_dsp(dsp* dsp = nullptr) : fDSP(dsp) {}
+    virtual ~decorator_dsp() { delete fDSP; }
 
-        dsp* fDSP;
-
-    public:
-
-        decorator_dsp(dsp* dsp = nullptr):fDSP(dsp) {}
-        virtual ~decorator_dsp() { delete fDSP; }
-
-        virtual int getNumInputs() { return fDSP->getNumInputs(); }
-        virtual int getNumOutputs() { return fDSP->getNumOutputs(); }
-        virtual void buildUserInterface(UI* ui_interface) { fDSP->buildUserInterface(ui_interface); }
-        virtual int getSampleRate() { return fDSP->getSampleRate(); }
-        virtual void init(int sample_rate) { fDSP->init(sample_rate); }
-        virtual void instanceInit(int sample_rate) { fDSP->instanceInit(sample_rate); }
-        virtual void instanceConstants(int sample_rate) { fDSP->instanceConstants(sample_rate); }
-        virtual void instanceResetUserInterface() { fDSP->instanceResetUserInterface(); }
-        virtual void instanceClear() { fDSP->instanceClear(); }
-        virtual decorator_dsp* clone() { return new decorator_dsp(fDSP->clone()); }
-        virtual void metadata(Meta* m) { fDSP->metadata(m); }
-        // Beware: subclasses usually have to overload the two 'compute' methods
-        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(count, inputs, outputs); }
-        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(date_usec, count, inputs, outputs); }
-    
+    virtual int getNumInputs() { return fDSP->getNumInputs(); }
+    virtual int getNumOutputs() { return fDSP->getNumOutputs(); }
+    virtual void buildUserInterface(UI* ui_interface)
+    {
+        fDSP->buildUserInterface(ui_interface);
+    }
+    virtual int getSampleRate() { return fDSP->getSampleRate(); }
+    virtual void init(int sample_rate) { fDSP->init(sample_rate); }
+    virtual void instanceInit(int sample_rate) { fDSP->instanceInit(sample_rate); }
+    virtual void instanceConstants(int sample_rate)
+    {
+        fDSP->instanceConstants(sample_rate);
+    }
+    virtual void instanceResetUserInterface() { fDSP->instanceResetUserInterface(); }
+    virtual void instanceClear() { fDSP->instanceClear(); }
+    virtual decorator_dsp* clone() { return new decorator_dsp(fDSP->clone()); }
+    virtual void metadata(Meta* m) { fDSP->metadata(m); }
+    // Beware: subclasses usually have to overload the two 'compute' methods
+    virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+    {
+        fDSP->compute(count, inputs, outputs);
+    }
+    virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs,
+                         FAUSTFLOAT** outputs)
+    {
+        fDSP->compute(date_usec, count, inputs, outputs);
+    }
 };
 
 /**
  * DSP factory class.
  */
 
-class dsp_factory {
-    
-    protected:
-    
-        // So that to force sub-classes to use deleteDSPFactory(dsp_factory* factory);
-        virtual ~dsp_factory() {}
-    
-    public:
-    
-        virtual std::string getName() = 0;
-        virtual std::string getSHAKey() = 0;
-        virtual std::string getDSPCode() = 0;
-        virtual std::string getCompileOptions() = 0;
-        virtual std::vector<std::string> getLibraryList() = 0;
-        virtual std::vector<std::string> getIncludePathnames() = 0;
-    
-        virtual dsp* createDSPInstance() = 0;
-    
-        virtual void setMemoryManager(dsp_memory_manager* manager) = 0;
-        virtual dsp_memory_manager* getMemoryManager() = 0;
-    
+class dsp_factory
+{
+   protected:
+    // So that to force sub-classes to use deleteDSPFactory(dsp_factory* factory);
+    virtual ~dsp_factory() {}
+
+   public:
+    virtual std::string getName()                          = 0;
+    virtual std::string getSHAKey()                        = 0;
+    virtual std::string getDSPCode()                       = 0;
+    virtual std::string getCompileOptions()                = 0;
+    virtual std::vector<std::string> getLibraryList()      = 0;
+    virtual std::vector<std::string> getIncludePathnames() = 0;
+
+    virtual dsp* createDSPInstance() = 0;
+
+    virtual void setMemoryManager(dsp_memory_manager* manager) = 0;
+    virtual dsp_memory_manager* getMemoryManager()             = 0;
 };
 
 /**
@@ -226,14 +233,14 @@ class dsp_factory {
  */
 
 #ifdef __SSE__
-    #include <xmmintrin.h>
-    #ifdef __SSE2__
-        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8040)
-    #else
-        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8000)
-    #endif
+#include <xmmintrin.h>
+#ifdef __SSE2__
+#define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8040)
 #else
-    #define AVOIDDENORMALS
+#define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8000)
+#endif
+#else
+#define AVOIDDENORMALS
 #endif
 
 #endif
@@ -266,11 +273,11 @@ class dsp_factory {
 #ifndef API_UI_H
 #define API_UI_H
 
+#include <iostream>
+#include <map>
 #include <sstream>
 #include <string>
 #include <vector>
-#include <iostream>
-#include <map>
 
 /************************** BEGIN meta.h **************************/
 /************************************************************************
@@ -299,11 +306,9 @@ class dsp_factory {
 #ifndef __meta__
 #define __meta__
 
-struct Meta
-{
-    virtual ~Meta() {};
+struct Meta {
+    virtual ~Meta(){};
     virtual void declare(const char* key, const char* value) = 0;
-    
 };
 
 #endif
@@ -348,43 +353,47 @@ struct Meta
 
 struct Soundfile;
 
-template <typename REAL>
-struct UIReal
-{
+template<typename REAL>
+struct UIReal {
     UIReal() {}
     virtual ~UIReal() {}
-    
+
     // -- widget's layouts
-    
-    virtual void openTabBox(const char* label) = 0;
+
+    virtual void openTabBox(const char* label)        = 0;
     virtual void openHorizontalBox(const char* label) = 0;
-    virtual void openVerticalBox(const char* label) = 0;
-    virtual void closeBox() = 0;
-    
+    virtual void openVerticalBox(const char* label)   = 0;
+    virtual void closeBox()                           = 0;
+
     // -- active widgets
-    
-    virtual void addButton(const char* label, REAL* zone) = 0;
+
+    virtual void addButton(const char* label, REAL* zone)      = 0;
     virtual void addCheckButton(const char* label, REAL* zone) = 0;
-    virtual void addVerticalSlider(const char* label, REAL* zone, REAL init, REAL min, REAL max, REAL step) = 0;
-    virtual void addHorizontalSlider(const char* label, REAL* zone, REAL init, REAL min, REAL max, REAL step) = 0;
-    virtual void addNumEntry(const char* label, REAL* zone, REAL init, REAL min, REAL max, REAL step) = 0;
-    
+    virtual void addVerticalSlider(const char* label, REAL* zone, REAL init, REAL min,
+                                   REAL max, REAL step)        = 0;
+    virtual void addHorizontalSlider(const char* label, REAL* zone, REAL init, REAL min,
+                                     REAL max, REAL step)      = 0;
+    virtual void addNumEntry(const char* label, REAL* zone, REAL init, REAL min, REAL max,
+                             REAL step)                        = 0;
+
     // -- passive widgets
-    
-    virtual void addHorizontalBargraph(const char* label, REAL* zone, REAL min, REAL max) = 0;
-    virtual void addVerticalBargraph(const char* label, REAL* zone, REAL min, REAL max) = 0;
-    
+
+    virtual void addHorizontalBargraph(const char* label, REAL* zone, REAL min,
+                                       REAL max) = 0;
+    virtual void addVerticalBargraph(const char* label, REAL* zone, REAL min,
+                                     REAL max)   = 0;
+
     // -- soundfiles
-    
-    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) = 0;
-    
+
+    virtual void addSoundfile(const char* label, const char* filename,
+                              Soundfile** sf_zone) = 0;
+
     // -- metadata declarations
-    
+
     virtual void declare(REAL* zone, const char* key, const char* val) {}
 };
 
-struct UI : public UIReal<FAUSTFLOAT>
-{
+struct UI : public UIReal<FAUSTFLOAT> {
     UI() {}
     virtual ~UI() {}
 };
@@ -418,9 +427,9 @@ struct UI : public UIReal<FAUSTFLOAT>
 #ifndef FAUST_PATHBUILDER_H
 #define FAUST_PATHBUILDER_H
 
-#include <vector>
-#include <string>
 #include <algorithm>
+#include <string>
+#include <vector>
 
 /*******************************************************************************
  * PathBuilder : Faust User Interface
@@ -429,37 +438,33 @@ struct UI : public UIReal<FAUSTFLOAT>
 
 class PathBuilder
 {
+   protected:
+    std::vector<std::string> fControlsLevel;
 
-    protected:
-    
-        std::vector<std::string> fControlsLevel;
-       
-    public:
-    
-        PathBuilder() {}
-        virtual ~PathBuilder() {}
-    
-        std::string buildPath(const std::string& label) 
-        {
-            std::string res = "/";
-            for (size_t i = 0; i < fControlsLevel.size(); i++) {
-                res += fControlsLevel[i];
-                res += "/";
-            }
-            res += label;
-            std::replace(res.begin(), res.end(), ' ', '_');
-            return res;
+   public:
+    PathBuilder() {}
+    virtual ~PathBuilder() {}
+
+    std::string buildPath(const std::string& label)
+    {
+        std::string res = "/";
+        for (size_t i = 0; i < fControlsLevel.size(); i++) {
+            res += fControlsLevel[i];
+            res += "/";
         }
-    
-        std::string buildLabel(std::string label)
-        {
-            std::replace(label.begin(), label.end(), ' ', '_');
-            return label;
-        }
-    
-        void pushLabel(const std::string& label) { fControlsLevel.push_back(label); }
-        void popLabel() { fControlsLevel.pop_back(); }
-    
+        res += label;
+        std::replace(res.begin(), res.end(), ' ', '_');
+        return res;
+    }
+
+    std::string buildLabel(std::string label)
+    {
+        std::replace(label.begin(), label.end(), ' ', '_');
+        return label;
+    }
+
+    void pushLabel(const std::string& label) { fControlsLevel.push_back(label); }
+    void popLabel() { fControlsLevel.pop_back(); }
 };
 
 #endif  // FAUST_PATHBUILDER_H
@@ -534,11 +539,12 @@ ZoneReader(zone, valueConverter) : a zone with a data converter
 
 ****************************************************************************************/
 
+#include <assert.h>
 #include <float.h>
-#include <algorithm>    // std::max
+
+#include <algorithm>  // std::max
 #include <cmath>
 #include <vector>
-#include <assert.h>
 
 //--------------------------------------------------------------------------------------
 // Interpolator(lo,hi,v1,v2)
@@ -551,50 +557,49 @@ ZoneReader(zone, valueConverter) : a zone with a data converter
 //--------------------------------------------------------------------------------------
 class Interpolator
 {
-    private:
+   private:
+    //--------------------------------------------------------------------------------------
+    // Range(lo,hi) clip a value between lo and hi
+    //--------------------------------------------------------------------------------------
+    struct Range {
+        double fLo;
+        double fHi;
 
-        //--------------------------------------------------------------------------------------
-        // Range(lo,hi) clip a value between lo and hi
-        //--------------------------------------------------------------------------------------
-        struct Range
+        Range(double x, double y)
+            : fLo(std::min<double>(x, y)), fHi(std::max<double>(x, y))
         {
-            double fLo;
-            double fHi;
-
-            Range(double x, double y) : fLo(std::min<double>(x,y)), fHi(std::max<double>(x,y)) {}
-            double operator()(double x) { return (x<fLo) ? fLo : (x>fHi) ? fHi : x; }
-        };
-
-
-        Range fRange;
-        double fCoef;
-        double fOffset;
-
-    public:
-
-        Interpolator(double lo, double hi, double v1, double v2) : fRange(lo,hi)
-        {
-            if (hi != lo) {
-                // regular case
-                fCoef = (v2-v1)/(hi-lo);
-                fOffset = v1 - lo*fCoef;
-            } else {
-                // degenerate case, avoids division by zero
-                fCoef = 0;
-                fOffset = (v1+v2)/2;
-            }
         }
-        double operator()(double v)
-        {
-            double x = fRange(v);
-            return  fOffset + x*fCoef;
-        }
+        double operator()(double x) { return (x < fLo) ? fLo : (x > fHi) ? fHi : x; }
+    };
 
-        void getLowHigh(double& amin, double& amax)
-        {
-            amin = fRange.fLo;
-            amax = fRange.fHi;
+    Range fRange;
+    double fCoef;
+    double fOffset;
+
+   public:
+    Interpolator(double lo, double hi, double v1, double v2) : fRange(lo, hi)
+    {
+        if (hi != lo) {
+            // regular case
+            fCoef   = (v2 - v1) / (hi - lo);
+            fOffset = v1 - lo * fCoef;
+        } else {
+            // degenerate case, avoids division by zero
+            fCoef   = 0;
+            fOffset = (v1 + v2) / 2;
         }
+    }
+    double operator()(double v)
+    {
+        double x = fRange(v);
+        return fOffset + x * fCoef;
+    }
+
+    void getLowHigh(double& amin, double& amax)
+    {
+        amin = fRange.fLo;
+        amax = fRange.fHi;
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -603,26 +608,23 @@ class Interpolator
 //--------------------------------------------------------------------------------------
 class Interpolator3pt
 {
+   private:
+    Interpolator fSegment1;
+    Interpolator fSegment2;
+    double fMid;
 
-    private:
+   public:
+    Interpolator3pt(double lo, double mi, double hi, double v1, double vm, double v2)
+        : fSegment1(lo, mi, v1, vm), fSegment2(mi, hi, vm, v2), fMid(mi)
+    {
+    }
+    double operator()(double x) { return (x < fMid) ? fSegment1(x) : fSegment2(x); }
 
-        Interpolator fSegment1;
-        Interpolator fSegment2;
-        double fMid;
-
-    public:
-
-        Interpolator3pt(double lo, double mi, double hi, double v1, double vm, double v2) :
-            fSegment1(lo, mi, v1, vm),
-            fSegment2(mi, hi, vm, v2),
-            fMid(mi) {}
-        double operator()(double x) { return  (x < fMid) ? fSegment1(x) : fSegment2(x); }
-
-        void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fSegment1.getLowHigh(amin, amid);
-            fSegment2.getLowHigh(amid, amax);
-        }
+    void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fSegment1.getLowHigh(amin, amid);
+        fSegment2.getLowHigh(amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -630,62 +632,51 @@ class Interpolator3pt
 //--------------------------------------------------------------------------------------
 class ValueConverter
 {
-
-    public:
-
-        virtual ~ValueConverter() {}
-        virtual double ui2faust(double x) = 0;
-        virtual double faust2ui(double x) = 0;
+   public:
+    virtual ~ValueConverter() {}
+    virtual double ui2faust(double x) = 0;
+    virtual double faust2ui(double x) = 0;
 };
 
 //--------------------------------------------------------------------------------------
 // A converter than can be updated
 //--------------------------------------------------------------------------------------
 
-class UpdatableValueConverter : public ValueConverter {
-    
-    protected:
-        
-        bool fActive;
-        
-    public:
-        
-        UpdatableValueConverter():fActive(true)
-        {}
-        virtual ~UpdatableValueConverter()
-        {}
-        
-        virtual void setMappingValues(double amin, double amid, double amax, double min, double init, double max) = 0;
-        virtual void getMappingValues(double& amin, double& amid, double& amax) = 0;
-        
-        void setActive(bool on_off) { fActive = on_off; }
-        bool getActive() { return fActive; }
-    
-};
+class UpdatableValueConverter : public ValueConverter
+{
+   protected:
+    bool fActive;
 
+   public:
+    UpdatableValueConverter() : fActive(true) {}
+    virtual ~UpdatableValueConverter() {}
+
+    virtual void setMappingValues(double amin, double amid, double amax, double min,
+                                  double init, double max)                  = 0;
+    virtual void getMappingValues(double& amin, double& amid, double& amax) = 0;
+
+    void setActive(bool on_off) { fActive = on_off; }
+    bool getActive() { return fActive; }
+};
 
 //--------------------------------------------------------------------------------------
 // Linear conversion between ui and Faust values
 //--------------------------------------------------------------------------------------
 class LinearValueConverter : public ValueConverter
 {
-    
-    private:
-        
-        Interpolator fUI2F;
-        Interpolator fF2UI;
-        
-    public:
-        
-        LinearValueConverter(double umin, double umax, double fmin, double fmax) :
-            fUI2F(umin,umax,fmin,fmax), fF2UI(fmin,fmax,umin,umax)
-        {}
-        
-        LinearValueConverter() : fUI2F(0.,0.,0.,0.), fF2UI(0.,0.,0.,0.)
-        {}
-        virtual double ui2faust(double x) { return fUI2F(x); }
-        virtual double faust2ui(double x) { return fF2UI(x); }
-    
+   private:
+    Interpolator fUI2F;
+    Interpolator fF2UI;
+
+   public:
+    LinearValueConverter(double umin, double umax, double fmin, double fmax)
+        : fUI2F(umin, umax, fmin, fmax), fF2UI(fmin, fmax, umin, umax)
+    {
+    }
+
+    LinearValueConverter() : fUI2F(0., 0., 0., 0.), fF2UI(0., 0., 0., 0.) {}
+    virtual double ui2faust(double x) { return fUI2F(x); }
+    virtual double faust2ui(double x) { return fF2UI(x); }
 };
 
 //--------------------------------------------------------------------------------------
@@ -693,35 +684,35 @@ class LinearValueConverter : public ValueConverter
 //--------------------------------------------------------------------------------------
 class LinearValueConverter2 : public UpdatableValueConverter
 {
-    
-    private:
-    
-        Interpolator3pt fUI2F;
-        Interpolator3pt fF2UI;
-        
-    public:
-    
-        LinearValueConverter2(double amin, double amid, double amax, double min, double init, double max) :
-            fUI2F(amin, amid, amax, min, init, max), fF2UI(min, init, max, amin, amid, amax)
-        {}
-        
-        LinearValueConverter2() : fUI2F(0.,0.,0.,0.,0.,0.), fF2UI(0.,0.,0.,0.,0.,0.)
-        {}
-    
-        virtual double ui2faust(double x) { return fUI2F(x); }
-        virtual double faust2ui(double x) { return fF2UI(x); }
-    
-        virtual void setMappingValues(double amin, double amid, double amax, double min, double init, double max)
-        {
-            fUI2F = Interpolator3pt(amin, amid, amax, min, init, max);
-            fF2UI = Interpolator3pt(min, init, max, amin, amid, amax);
-        }
+   private:
+    Interpolator3pt fUI2F;
+    Interpolator3pt fF2UI;
 
-        virtual void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fUI2F.getMappingValues(amin, amid, amax);
-        }
-    
+   public:
+    LinearValueConverter2(double amin, double amid, double amax, double min, double init,
+                          double max)
+        : fUI2F(amin, amid, amax, min, init, max), fF2UI(min, init, max, amin, amid, amax)
+    {
+    }
+
+    LinearValueConverter2() : fUI2F(0., 0., 0., 0., 0., 0.), fF2UI(0., 0., 0., 0., 0., 0.)
+    {
+    }
+
+    virtual double ui2faust(double x) { return fUI2F(x); }
+    virtual double faust2ui(double x) { return fF2UI(x); }
+
+    virtual void setMappingValues(double amin, double amid, double amax, double min,
+                                  double init, double max)
+    {
+        fUI2F = Interpolator3pt(amin, amid, amax, min, init, max);
+        fF2UI = Interpolator3pt(min, init, max, amin, amid, amax);
+    }
+
+    virtual void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fUI2F.getMappingValues(amin, amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -729,16 +720,21 @@ class LinearValueConverter2 : public UpdatableValueConverter
 //--------------------------------------------------------------------------------------
 class LogValueConverter : public LinearValueConverter
 {
+   public:
+    LogValueConverter(double umin, double umax, double fmin, double fmax)
+        : LinearValueConverter(umin, umax, std::log(std::max<double>(DBL_MIN, fmin)),
+                               std::log(std::max<double>(DBL_MIN, fmax)))
+    {
+    }
 
-    public:
-
-        LogValueConverter(double umin, double umax, double fmin, double fmax) :
-            LinearValueConverter(umin, umax, std::log(std::max<double>(DBL_MIN, fmin)), std::log(std::max<double>(DBL_MIN, fmax)))
-        {}
-
-        virtual double ui2faust(double x) { return std::exp(LinearValueConverter::ui2faust(x)); }
-        virtual double faust2ui(double x) { return LinearValueConverter::faust2ui(std::log(std::max<double>(x, DBL_MIN))); }
-
+    virtual double ui2faust(double x)
+    {
+        return std::exp(LinearValueConverter::ui2faust(x));
+    }
+    virtual double faust2ui(double x)
+    {
+        return LinearValueConverter::faust2ui(std::log(std::max<double>(x, DBL_MIN)));
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -746,16 +742,21 @@ class LogValueConverter : public LinearValueConverter
 //--------------------------------------------------------------------------------------
 class ExpValueConverter : public LinearValueConverter
 {
+   public:
+    ExpValueConverter(double umin, double umax, double fmin, double fmax)
+        : LinearValueConverter(umin, umax, std::min<double>(DBL_MAX, std::exp(fmin)),
+                               std::min<double>(DBL_MAX, std::exp(fmax)))
+    {
+    }
 
-    public:
-
-        ExpValueConverter(double umin, double umax, double fmin, double fmax) :
-            LinearValueConverter(umin, umax, std::min<double>(DBL_MAX, std::exp(fmin)), std::min<double>(DBL_MAX, std::exp(fmax)))
-        {}
-
-        virtual double ui2faust(double x) { return std::log(LinearValueConverter::ui2faust(x)); }
-        virtual double faust2ui(double x) { return LinearValueConverter::faust2ui(std::min<double>(DBL_MAX, std::exp(x))); }
-
+    virtual double ui2faust(double x)
+    {
+        return std::log(LinearValueConverter::ui2faust(x));
+    }
+    virtual double faust2ui(double x)
+    {
+        return LinearValueConverter::faust2ui(std::min<double>(DBL_MAX, std::exp(x)));
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -764,34 +765,33 @@ class ExpValueConverter : public LinearValueConverter
 //--------------------------------------------------------------------------------------
 class AccUpConverter : public UpdatableValueConverter
 {
+   private:
+    Interpolator3pt fA2F;
+    Interpolator3pt fF2A;
 
-    private:
+   public:
+    AccUpConverter(double amin, double amid, double amax, double fmin, double fmid,
+                   double fmax)
+        : fA2F(amin, amid, amax, fmin, fmid, fmax)
+        , fF2A(fmin, fmid, fmax, amin, amid, amax)
+    {
+    }
 
-        Interpolator3pt fA2F;
-        Interpolator3pt fF2A;
+    virtual double ui2faust(double x) { return fA2F(x); }
+    virtual double faust2ui(double x) { return fF2A(x); }
 
-    public:
+    virtual void setMappingValues(double amin, double amid, double amax, double fmin,
+                                  double fmid, double fmax)
+    {
+        //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccUpConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
+        fA2F = Interpolator3pt(amin, amid, amax, fmin, fmid, fmax);
+        fF2A = Interpolator3pt(fmin, fmid, fmax, amin, amid, amax);
+    }
 
-        AccUpConverter(double amin, double amid, double amax, double fmin, double fmid, double fmax) :
-            fA2F(amin,amid,amax,fmin,fmid,fmax),
-            fF2A(fmin,fmid,fmax,amin,amid,amax)
-        {}
-
-        virtual double ui2faust(double x) { return fA2F(x); }
-        virtual double faust2ui(double x) { return fF2A(x); }
-
-        virtual void setMappingValues(double amin, double amid, double amax, double fmin, double fmid, double fmax)
-        {
-            //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccUpConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
-            fA2F = Interpolator3pt(amin, amid, amax, fmin, fmid, fmax);
-            fF2A = Interpolator3pt(fmin, fmid, fmax, amin, amid, amax);
-        }
-
-        virtual void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fA2F.getMappingValues(amin, amid, amax);
-        }
-
+    virtual void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fA2F.getMappingValues(amin, amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -800,33 +800,33 @@ class AccUpConverter : public UpdatableValueConverter
 //--------------------------------------------------------------------------------------
 class AccDownConverter : public UpdatableValueConverter
 {
+   private:
+    Interpolator3pt fA2F;
+    Interpolator3pt fF2A;
 
-    private:
+   public:
+    AccDownConverter(double amin, double amid, double amax, double fmin, double fmid,
+                     double fmax)
+        : fA2F(amin, amid, amax, fmax, fmid, fmin)
+        , fF2A(fmin, fmid, fmax, amax, amid, amin)
+    {
+    }
 
-        Interpolator3pt	fA2F;
-        Interpolator3pt	fF2A;
+    virtual double ui2faust(double x) { return fA2F(x); }
+    virtual double faust2ui(double x) { return fF2A(x); }
 
-    public:
+    virtual void setMappingValues(double amin, double amid, double amax, double fmin,
+                                  double fmid, double fmax)
+    {
+        //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccDownConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
+        fA2F = Interpolator3pt(amin, amid, amax, fmax, fmid, fmin);
+        fF2A = Interpolator3pt(fmin, fmid, fmax, amax, amid, amin);
+    }
 
-        AccDownConverter(double amin, double amid, double amax, double fmin, double fmid, double fmax) :
-            fA2F(amin,amid,amax,fmax,fmid,fmin),
-            fF2A(fmin,fmid,fmax,amax,amid,amin)
-        {}
-
-        virtual double ui2faust(double x) { return fA2F(x); }
-        virtual double faust2ui(double x) { return fF2A(x); }
-
-        virtual void setMappingValues(double amin, double amid, double amax, double fmin, double fmid, double fmax)
-        {
-             //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccDownConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
-            fA2F = Interpolator3pt(amin, amid, amax, fmax, fmid, fmin);
-            fF2A = Interpolator3pt(fmin, fmid, fmax, amax, amid, amin);
-        }
-
-        virtual void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fA2F.getMappingValues(amin, amid, amax);
-        }
+    virtual void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fA2F.getMappingValues(amin, amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -835,33 +835,34 @@ class AccDownConverter : public UpdatableValueConverter
 //--------------------------------------------------------------------------------------
 class AccUpDownConverter : public UpdatableValueConverter
 {
+   private:
+    Interpolator3pt fA2F;
+    Interpolator fF2A;
 
-    private:
+   public:
+    AccUpDownConverter(double amin, double amid, double amax, double fmin, double fmid,
+                       double fmax)
+        : fA2F(amin, amid, amax, fmin, fmax, fmin)
+        , fF2A(fmin, fmax, amin,
+               amax)  // Special, pseudo inverse of a non monotonic function
+    {
+    }
 
-        Interpolator3pt	fA2F;
-        Interpolator fF2A;
+    virtual double ui2faust(double x) { return fA2F(x); }
+    virtual double faust2ui(double x) { return fF2A(x); }
 
-    public:
+    virtual void setMappingValues(double amin, double amid, double amax, double fmin,
+                                  double fmid, double fmax)
+    {
+        //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccUpDownConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
+        fA2F = Interpolator3pt(amin, amid, amax, fmin, fmax, fmin);
+        fF2A = Interpolator(fmin, fmax, amin, amax);
+    }
 
-        AccUpDownConverter(double amin, double amid, double amax, double fmin, double fmid, double fmax) :
-            fA2F(amin,amid,amax,fmin,fmax,fmin),
-            fF2A(fmin,fmax,amin,amax)				// Special, pseudo inverse of a non monotonic function
-        {}
-
-        virtual double ui2faust(double x) { return fA2F(x); }
-        virtual double faust2ui(double x) { return fF2A(x); }
-
-        virtual void setMappingValues(double amin, double amid, double amax, double fmin, double fmid, double fmax)
-        {
-            //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccUpDownConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
-            fA2F = Interpolator3pt(amin, amid, amax, fmin, fmax, fmin);
-            fF2A = Interpolator(fmin, fmax, amin, amax);
-        }
-
-        virtual void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fA2F.getMappingValues(amin, amid, amax);
-        }
+    virtual void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fA2F.getMappingValues(amin, amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -870,33 +871,34 @@ class AccUpDownConverter : public UpdatableValueConverter
 //--------------------------------------------------------------------------------------
 class AccDownUpConverter : public UpdatableValueConverter
 {
+   private:
+    Interpolator3pt fA2F;
+    Interpolator fF2A;
 
-    private:
+   public:
+    AccDownUpConverter(double amin, double amid, double amax, double fmin, double fmid,
+                       double fmax)
+        : fA2F(amin, amid, amax, fmax, fmin, fmax)
+        , fF2A(fmin, fmax, amin,
+               amax)  // Special, pseudo inverse of a non monotonic function
+    {
+    }
 
-        Interpolator3pt	fA2F;
-        Interpolator fF2A;
+    virtual double ui2faust(double x) { return fA2F(x); }
+    virtual double faust2ui(double x) { return fF2A(x); }
 
-    public:
+    virtual void setMappingValues(double amin, double amid, double amax, double fmin,
+                                  double fmid, double fmax)
+    {
+        //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccDownUpConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
+        fA2F = Interpolator3pt(amin, amid, amax, fmax, fmin, fmax);
+        fF2A = Interpolator(fmin, fmax, amin, amax);
+    }
 
-        AccDownUpConverter(double amin, double amid, double amax, double fmin, double fmid, double fmax) :
-            fA2F(amin,amid,amax,fmax,fmin,fmax),
-            fF2A(fmin,fmax,amin,amax)				// Special, pseudo inverse of a non monotonic function
-        {}
-
-        virtual double ui2faust(double x) { return fA2F(x); }
-        virtual double faust2ui(double x) { return fF2A(x); }
-
-        virtual void setMappingValues(double amin, double amid, double amax, double fmin, double fmid, double fmax)
-        {
-            //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccDownUpConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
-            fA2F = Interpolator3pt(amin, amid, amax, fmax, fmin, fmax);
-            fF2A = Interpolator(fmin, fmax, amin, amax);
-        }
-
-        virtual void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fA2F.getMappingValues(amin, amid, amax);
-        }
+    virtual void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fA2F.getMappingValues(amin, amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -904,28 +906,27 @@ class AccDownUpConverter : public UpdatableValueConverter
 //--------------------------------------------------------------------------------------
 class ZoneControl
 {
+   protected:
+    FAUSTFLOAT* fZone;
 
-    protected:
+   public:
+    ZoneControl(FAUSTFLOAT* zone) : fZone(zone) {}
+    virtual ~ZoneControl() {}
 
-        FAUSTFLOAT*	fZone;
+    virtual void update(double v) const {}
 
-    public:
+    virtual void setMappingValues(int curve, double amin, double amid, double amax,
+                                  double min, double init, double max)
+    {
+    }
+    virtual void getMappingValues(double& amin, double& amid, double& amax) {}
 
-        ZoneControl(FAUSTFLOAT* zone) : fZone(zone) {}
-        virtual ~ZoneControl() {}
+    FAUSTFLOAT* getZone() { return fZone; }
 
-        virtual void update(double v) const {}
+    virtual void setActive(bool on_off) {}
+    virtual bool getActive() { return false; }
 
-        virtual void setMappingValues(int curve, double amin, double amid, double amax, double min, double init, double max) {}
-        virtual void getMappingValues(double& amin, double& amid, double& amax) {}
-
-        FAUSTFLOAT* getZone() { return fZone; }
-
-        virtual void setActive(bool on_off) {}
-        virtual bool getActive() { return false; }
-
-        virtual int getCurve() { return -1; }
-
+    virtual int getCurve() { return -1; }
 };
 
 //--------------------------------------------------------------------------------------
@@ -933,20 +934,22 @@ class ZoneControl
 //--------------------------------------------------------------------------------------
 class ConverterZoneControl : public ZoneControl
 {
+   protected:
+    ValueConverter* fValueConverter;
 
-    protected:
+   public:
+    ConverterZoneControl(FAUSTFLOAT* zone, ValueConverter* converter)
+        : ZoneControl(zone), fValueConverter(converter)
+    {
+    }
+    virtual ~ConverterZoneControl()
+    {
+        delete fValueConverter;
+    }  // Assuming fValueConverter is not kept elsewhere...
 
-        ValueConverter* fValueConverter;
+    virtual void update(double v) const { *fZone = fValueConverter->ui2faust(v); }
 
-    public:
-
-        ConverterZoneControl(FAUSTFLOAT* zone, ValueConverter* converter) : ZoneControl(zone), fValueConverter(converter) {}
-        virtual ~ConverterZoneControl() { delete fValueConverter; } // Assuming fValueConverter is not kept elsewhere...
-
-        virtual void update(double v) const { *fZone = fValueConverter->ui2faust(v); }
-
-        ValueConverter* getConverter() { return fValueConverter; }
-
+    ValueConverter* getConverter() { return fValueConverter; }
 };
 
 //--------------------------------------------------------------------------------------
@@ -955,477 +958,496 @@ class ConverterZoneControl : public ZoneControl
 //--------------------------------------------------------------------------------------
 class CurveZoneControl : public ZoneControl
 {
+   private:
+    std::vector<UpdatableValueConverter*> fValueConverters;
+    int fCurve;
 
-    private:
-
-        std::vector<UpdatableValueConverter*> fValueConverters;
-        int fCurve;
-
-    public:
-
-        CurveZoneControl(FAUSTFLOAT* zone, int curve, double amin, double amid, double amax, double min, double init, double max) : ZoneControl(zone), fCurve(0)
-        {
-            assert(curve >= 0 && curve <= 3);
-            fValueConverters.push_back(new AccUpConverter(amin, amid, amax, min, init, max));
-            fValueConverters.push_back(new AccDownConverter(amin, amid, amax, min, init, max));
-            fValueConverters.push_back(new AccUpDownConverter(amin, amid, amax, min, init, max));
-            fValueConverters.push_back(new AccDownUpConverter(amin, amid, amax, min, init, max));
-            fCurve = curve;
+   public:
+    CurveZoneControl(FAUSTFLOAT* zone, int curve, double amin, double amid, double amax,
+                     double min, double init, double max)
+        : ZoneControl(zone), fCurve(0)
+    {
+        assert(curve >= 0 && curve <= 3);
+        fValueConverters.push_back(new AccUpConverter(amin, amid, amax, min, init, max));
+        fValueConverters.push_back(
+            new AccDownConverter(amin, amid, amax, min, init, max));
+        fValueConverters.push_back(
+            new AccUpDownConverter(amin, amid, amax, min, init, max));
+        fValueConverters.push_back(
+            new AccDownUpConverter(amin, amid, amax, min, init, max));
+        fCurve = curve;
+    }
+    virtual ~CurveZoneControl()
+    {
+        std::vector<UpdatableValueConverter*>::iterator it;
+        for (it = fValueConverters.begin(); it != fValueConverters.end(); it++) {
+            delete (*it);
         }
-        virtual ~CurveZoneControl()
-        {
-            std::vector<UpdatableValueConverter*>::iterator it;
-            for (it = fValueConverters.begin(); it != fValueConverters.end(); it++) {
-                delete(*it);
-            }
-        }
-        void update(double v) const { if (fValueConverters[fCurve]->getActive()) *fZone = fValueConverters[fCurve]->ui2faust(v); }
+    }
+    void update(double v) const
+    {
+        if (fValueConverters[fCurve]->getActive())
+            *fZone = fValueConverters[fCurve]->ui2faust(v);
+    }
 
-        void setMappingValues(int curve, double amin, double amid, double amax, double min, double init, double max)
-        {
-            fValueConverters[curve]->setMappingValues(amin, amid, amax, min, init, max);
-            fCurve = curve;
-        }
+    void setMappingValues(int curve, double amin, double amid, double amax, double min,
+                          double init, double max)
+    {
+        fValueConverters[curve]->setMappingValues(amin, amid, amax, min, init, max);
+        fCurve = curve;
+    }
 
-        void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fValueConverters[fCurve]->getMappingValues(amin, amid, amax);
-        }
+    void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fValueConverters[fCurve]->getMappingValues(amin, amid, amax);
+    }
 
-        void setActive(bool on_off)
-        {
-            std::vector<UpdatableValueConverter*>::iterator it;
-            for (it = fValueConverters.begin(); it != fValueConverters.end(); it++) {
-                (*it)->setActive(on_off);
-            }
+    void setActive(bool on_off)
+    {
+        std::vector<UpdatableValueConverter*>::iterator it;
+        for (it = fValueConverters.begin(); it != fValueConverters.end(); it++) {
+            (*it)->setActive(on_off);
         }
+    }
 
-        int getCurve() { return fCurve; }
+    int getCurve() { return fCurve; }
 };
 
 class ZoneReader
 {
+   private:
+    FAUSTFLOAT* fZone;
+    Interpolator fInterpolator;
 
-    private:
+   public:
+    ZoneReader(FAUSTFLOAT* zone, double lo, double hi)
+        : fZone(zone), fInterpolator(lo, hi, 0, 255)
+    {
+    }
 
-        FAUSTFLOAT* fZone;
-        Interpolator fInterpolator;
+    virtual ~ZoneReader() {}
 
-    public:
-
-        ZoneReader(FAUSTFLOAT* zone, double lo, double hi) : fZone(zone), fInterpolator(lo, hi, 0, 255) {}
-
-        virtual ~ZoneReader() {}
-
-        int getValue()
-        {
-            return (fZone != nullptr) ? int(fInterpolator(*fZone)) : 127;
-        }
-
+    int getValue() { return (fZone != nullptr) ? int(fInterpolator(*fZone)) : 127; }
 };
 
 #endif
 /**************************  END  ValueConverter.h **************************/
 
-class APIUI : public PathBuilder, public Meta, public UI
+class APIUI
+    : public PathBuilder
+    , public Meta
+    , public UI
 {
-    public:
-    
-        enum ItemType { kButton = 0, kCheckButton, kVSlider, kHSlider, kNumEntry, kHBargraph, kVBargraph };
-  
-    protected:
-    
-        enum { kLin = 0, kLog = 1, kExp = 2 };
-    
-        int fNumParameters;
-        std::vector<std::string> fPaths;
-        std::vector<std::string> fLabels;
-        std::map<std::string, int> fPathMap;
-        std::map<std::string, int> fLabelMap;
-        std::vector<ValueConverter*> fConversion;
-        std::vector<FAUSTFLOAT*> fZone;
-        std::vector<FAUSTFLOAT> fInit;
-        std::vector<FAUSTFLOAT> fMin;
-        std::vector<FAUSTFLOAT> fMax;
-        std::vector<FAUSTFLOAT> fStep;
-        std::vector<ItemType> fItemType;
-        std::vector<std::map<std::string, std::string> > fMetaData;
-        std::vector<ZoneControl*> fAcc[3];
-        std::vector<ZoneControl*> fGyr[3];
+   public:
+    enum ItemType {
+        kButton = 0,
+        kCheckButton,
+        kVSlider,
+        kHSlider,
+        kNumEntry,
+        kHBargraph,
+        kVBargraph
+    };
 
-        // Screen color control
-        // "...[screencolor:red]..." etc.
-        bool fHasScreenControl;      // true if control screen color metadata
-        ZoneReader* fRedReader;
-        ZoneReader* fGreenReader;
-        ZoneReader* fBlueReader;
+   protected:
+    enum { kLin = 0, kLog = 1, kExp = 2 };
 
-        // Current values controlled by metadata
-        std::string fCurrentUnit;
-        int fCurrentScale;
-        std::string fCurrentAcc;
-        std::string fCurrentGyr;
-        std::string fCurrentColor;
-        std::string fCurrentTooltip;
-        std::map<std::string, std::string> fCurrentMetadata;
-    
-        // Add a generic parameter
-        virtual void addParameter(const char* label,
-                                FAUSTFLOAT* zone,
-                                FAUSTFLOAT init,
-                                FAUSTFLOAT min,
-                                FAUSTFLOAT max,
-                                FAUSTFLOAT step,
-                                ItemType type)
-        {
-            std::string path = buildPath(label);
-            fPathMap[path] = fLabelMap[label] = fNumParameters++;
-            fPaths.push_back(path);
-            fLabels.push_back(label);
-            fZone.push_back(zone);
-            fInit.push_back(init);
-            fMin.push_back(min);
-            fMax.push_back(max);
-            fStep.push_back(step);
-            fItemType.push_back(type);
-            
-            // handle scale metadata
-            switch (fCurrentScale) {
-                case kLin:
-                    fConversion.push_back(new LinearValueConverter(0, 1, min, max));
-                    break;
-                case kLog:
-                    fConversion.push_back(new LogValueConverter(0, 1, min, max));
-                    break;
-                case kExp: fConversion.push_back(new ExpValueConverter(0, 1, min, max));
-                    break;
-            }
-            fCurrentScale = kLin;
-            
-            if (fCurrentAcc.size() > 0 && fCurrentGyr.size() > 0) {
-                std::cerr << "warning : 'acc' and 'gyr' metadata used for the same " << label << " parameter !!\n";
-            }
+    int fNumParameters;
+    std::vector<std::string> fPaths;
+    std::vector<std::string> fLabels;
+    std::map<std::string, int> fPathMap;
+    std::map<std::string, int> fLabelMap;
+    std::vector<ValueConverter*> fConversion;
+    std::vector<FAUSTFLOAT*> fZone;
+    std::vector<FAUSTFLOAT> fInit;
+    std::vector<FAUSTFLOAT> fMin;
+    std::vector<FAUSTFLOAT> fMax;
+    std::vector<FAUSTFLOAT> fStep;
+    std::vector<ItemType> fItemType;
+    std::vector<std::map<std::string, std::string> > fMetaData;
+    std::vector<ZoneControl*> fAcc[3];
+    std::vector<ZoneControl*> fGyr[3];
 
-            // handle acc metadata "...[acc : <axe> <curve> <amin> <amid> <amax>]..."
-            if (fCurrentAcc.size() > 0) {
-                std::istringstream iss(fCurrentAcc);
-                int axe, curve;
-                double amin, amid, amax;
-                iss >> axe >> curve >> amin >> amid >> amax;
+    // Screen color control
+    // "...[screencolor:red]..." etc.
+    bool fHasScreenControl;  // true if control screen color metadata
+    ZoneReader* fRedReader;
+    ZoneReader* fGreenReader;
+    ZoneReader* fBlueReader;
 
-                if ((0 <= axe) && (axe < 3) &&
-                    (0 <= curve) && (curve < 4) &&
-                    (amin < amax) && (amin <= amid) && (amid <= amax))
-                {
-                    fAcc[axe].push_back(new CurveZoneControl(zone, curve, amin, amid, amax, min, init, max));
-                } else {
-                    std::cerr << "incorrect acc metadata : " << fCurrentAcc << std::endl;
-                }
-                fCurrentAcc = "";
-            }
-       
-            // handle gyr metadata "...[gyr : <axe> <curve> <amin> <amid> <amax>]..."
-            if (fCurrentGyr.size() > 0) {
-                std::istringstream iss(fCurrentGyr);
-                int axe, curve;
-                double amin, amid, amax;
-                iss >> axe >> curve >> amin >> amid >> amax;
+    // Current values controlled by metadata
+    std::string fCurrentUnit;
+    int fCurrentScale;
+    std::string fCurrentAcc;
+    std::string fCurrentGyr;
+    std::string fCurrentColor;
+    std::string fCurrentTooltip;
+    std::map<std::string, std::string> fCurrentMetadata;
 
-                if ((0 <= axe) && (axe < 3) &&
-                    (0 <= curve) && (curve < 4) &&
-                    (amin < amax) && (amin <= amid) && (amid <= amax))
-                {
-                    fGyr[axe].push_back(new CurveZoneControl(zone, curve, amin, amid, amax, min, init, max));
-                } else {
-                    std::cerr << "incorrect gyr metadata : " << fCurrentGyr << std::endl;
-                }
-                fCurrentGyr = "";
-            }
-        
-            // handle screencolor metadata "...[screencolor:red|green|blue|white]..."
-            if (fCurrentColor.size() > 0) {
-                if ((fCurrentColor == "red") && (fRedReader == 0)) {
-                    fRedReader = new ZoneReader(zone, min, max);
-                    fHasScreenControl = true;
-                } else if ((fCurrentColor == "green") && (fGreenReader == 0)) {
-                    fGreenReader = new ZoneReader(zone, min, max);
-                    fHasScreenControl = true;
-                } else if ((fCurrentColor == "blue") && (fBlueReader == 0)) {
-                    fBlueReader = new ZoneReader(zone, min, max);
-                    fHasScreenControl = true;
-                } else if ((fCurrentColor == "white") && (fRedReader == 0) && (fGreenReader == 0) && (fBlueReader == 0)) {
-                    fRedReader = new ZoneReader(zone, min, max);
-                    fGreenReader = new ZoneReader(zone, min, max);
-                    fBlueReader = new ZoneReader(zone, min, max);
-                    fHasScreenControl = true;
-                } else {
-                    std::cerr << "incorrect screencolor metadata : " << fCurrentColor << std::endl;
-                }
-            }
-            fCurrentColor = "";
-            
-            fMetaData.push_back(fCurrentMetadata);
-            fCurrentMetadata.clear();
+    // Add a generic parameter
+    virtual void addParameter(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init,
+                              FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step,
+                              ItemType type)
+    {
+        std::string path = buildPath(label);
+        fPathMap[path] = fLabelMap[label] = fNumParameters++;
+        fPaths.push_back(path);
+        fLabels.push_back(label);
+        fZone.push_back(zone);
+        fInit.push_back(init);
+        fMin.push_back(min);
+        fMax.push_back(max);
+        fStep.push_back(step);
+        fItemType.push_back(type);
+
+        // handle scale metadata
+        switch (fCurrentScale) {
+        case kLin:
+            fConversion.push_back(new LinearValueConverter(0, 1, min, max));
+            break;
+        case kLog:
+            fConversion.push_back(new LogValueConverter(0, 1, min, max));
+            break;
+        case kExp:
+            fConversion.push_back(new ExpValueConverter(0, 1, min, max));
+            break;
+        }
+        fCurrentScale = kLin;
+
+        if (fCurrentAcc.size() > 0 && fCurrentGyr.size() > 0) {
+            std::cerr << "warning : 'acc' and 'gyr' metadata used for the same " << label
+                      << " parameter !!\n";
         }
 
-        int getZoneIndex(std::vector<ZoneControl*>* table, int p, int val)
-        {
-            FAUSTFLOAT* zone = fZone[p];
-            for (size_t i = 0; i < table[val].size(); i++) {
-                if (zone == table[val][i]->getZone()) return int(i);
+        // handle acc metadata "...[acc : <axe> <curve> <amin> <amid> <amax>]..."
+        if (fCurrentAcc.size() > 0) {
+            std::istringstream iss(fCurrentAcc);
+            int axe, curve;
+            double amin, amid, amax;
+            iss >> axe >> curve >> amin >> amid >> amax;
+
+            if ((0 <= axe) && (axe < 3) && (0 <= curve) && (curve < 4) && (amin < amax)
+                && (amin <= amid) && (amid <= amax)) {
+                fAcc[axe].push_back(
+                    new CurveZoneControl(zone, curve, amin, amid, amax, min, init, max));
+            } else {
+                std::cerr << "incorrect acc metadata : " << fCurrentAcc << std::endl;
             }
+            fCurrentAcc = "";
+        }
+
+        // handle gyr metadata "...[gyr : <axe> <curve> <amin> <amid> <amax>]..."
+        if (fCurrentGyr.size() > 0) {
+            std::istringstream iss(fCurrentGyr);
+            int axe, curve;
+            double amin, amid, amax;
+            iss >> axe >> curve >> amin >> amid >> amax;
+
+            if ((0 <= axe) && (axe < 3) && (0 <= curve) && (curve < 4) && (amin < amax)
+                && (amin <= amid) && (amid <= amax)) {
+                fGyr[axe].push_back(
+                    new CurveZoneControl(zone, curve, amin, amid, amax, min, init, max));
+            } else {
+                std::cerr << "incorrect gyr metadata : " << fCurrentGyr << std::endl;
+            }
+            fCurrentGyr = "";
+        }
+
+        // handle screencolor metadata "...[screencolor:red|green|blue|white]..."
+        if (fCurrentColor.size() > 0) {
+            if ((fCurrentColor == "red") && (fRedReader == 0)) {
+                fRedReader        = new ZoneReader(zone, min, max);
+                fHasScreenControl = true;
+            } else if ((fCurrentColor == "green") && (fGreenReader == 0)) {
+                fGreenReader      = new ZoneReader(zone, min, max);
+                fHasScreenControl = true;
+            } else if ((fCurrentColor == "blue") && (fBlueReader == 0)) {
+                fBlueReader       = new ZoneReader(zone, min, max);
+                fHasScreenControl = true;
+            } else if ((fCurrentColor == "white") && (fRedReader == 0)
+                       && (fGreenReader == 0) && (fBlueReader == 0)) {
+                fRedReader        = new ZoneReader(zone, min, max);
+                fGreenReader      = new ZoneReader(zone, min, max);
+                fBlueReader       = new ZoneReader(zone, min, max);
+                fHasScreenControl = true;
+            } else {
+                std::cerr << "incorrect screencolor metadata : " << fCurrentColor
+                          << std::endl;
+            }
+        }
+        fCurrentColor = "";
+
+        fMetaData.push_back(fCurrentMetadata);
+        fCurrentMetadata.clear();
+    }
+
+    int getZoneIndex(std::vector<ZoneControl*>* table, int p, int val)
+    {
+        FAUSTFLOAT* zone = fZone[p];
+        for (size_t i = 0; i < table[val].size(); i++) {
+            if (zone == table[val][i]->getZone()) return int(i);
+        }
+        return -1;
+    }
+
+    void setConverter(std::vector<ZoneControl*>* table, int p, int val, int curve,
+                      double amin, double amid, double amax)
+    {
+        int id1 = getZoneIndex(table, p, 0);
+        int id2 = getZoneIndex(table, p, 1);
+        int id3 = getZoneIndex(table, p, 2);
+
+        // Deactivates everywhere..
+        if (id1 != -1) table[0][id1]->setActive(false);
+        if (id2 != -1) table[1][id2]->setActive(false);
+        if (id3 != -1) table[2][id3]->setActive(false);
+
+        if (val == -1) {  // Means: no more mapping...
+            // So stay all deactivated...
+        } else {
+            int id4 = getZoneIndex(table, p, val);
+            if (id4 != -1) {
+                // Reactivate the one we edit...
+                table[val][id4]->setMappingValues(curve, amin, amid, amax, fMin[p],
+                                                  fInit[p], fMax[p]);
+                table[val][id4]->setActive(true);
+            } else {
+                // Allocate a new CurveZoneControl which is 'active' by default
+                FAUSTFLOAT* zone = fZone[p];
+                table[val].push_back(new CurveZoneControl(zone, curve, amin, amid, amax,
+                                                          fMin[p], fInit[p], fMax[p]));
+            }
+        }
+    }
+
+    void getConverter(std::vector<ZoneControl*>* table, int p, int& val, int& curve,
+                      double& amin, double& amid, double& amax)
+    {
+        int id1 = getZoneIndex(table, p, 0);
+        int id2 = getZoneIndex(table, p, 1);
+        int id3 = getZoneIndex(table, p, 2);
+
+        if (id1 != -1) {
+            val   = 0;
+            curve = table[val][id1]->getCurve();
+            table[val][id1]->getMappingValues(amin, amid, amax);
+        } else if (id2 != -1) {
+            val   = 1;
+            curve = table[val][id2]->getCurve();
+            table[val][id2]->getMappingValues(amin, amid, amax);
+        } else if (id3 != -1) {
+            val   = 2;
+            curve = table[val][id3]->getCurve();
+            table[val][id3]->getMappingValues(amin, amid, amax);
+        } else {
+            val   = -1;  // No mapping
+            curve = 0;
+            amin  = -100.;
+            amid  = 0.;
+            amax  = 100.;
+        }
+    }
+
+   public:
+    enum Type { kAcc = 0, kGyr = 1, kNoType };
+
+    APIUI()
+        : fNumParameters(0)
+        , fHasScreenControl(false)
+        , fRedReader(0)
+        , fGreenReader(0)
+        , fBlueReader(0)
+        , fCurrentScale(kLin)
+    {
+    }
+
+    virtual ~APIUI()
+    {
+        for (auto& it : fConversion) delete it;
+        for (int i = 0; i < 3; i++) {
+            for (auto& it : fAcc[i]) delete it;
+            for (auto& it : fGyr[i]) delete it;
+        }
+        delete fRedReader;
+        delete fGreenReader;
+        delete fBlueReader;
+    }
+
+    // -- widget's layouts
+
+    virtual void openTabBox(const char* label) { pushLabel(label); }
+    virtual void openHorizontalBox(const char* label) { pushLabel(label); }
+    virtual void openVerticalBox(const char* label) { pushLabel(label); }
+    virtual void closeBox() { popLabel(); }
+
+    // -- active widgets
+
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    {
+        addParameter(label, zone, 0, 0, 1, 1, kButton);
+    }
+
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    {
+        addParameter(label, zone, 0, 0, 1, 1, kCheckButton);
+    }
+
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init,
+                                   FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addParameter(label, zone, init, min, max, step, kVSlider);
+    }
+
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init,
+                                     FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addParameter(label, zone, init, min, max, step, kHSlider);
+    }
+
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init,
+                             FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addParameter(label, zone, init, min, max, step, kNumEntry);
+    }
+
+    // -- passive widgets
+
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone,
+                                       FAUSTFLOAT min, FAUSTFLOAT max)
+    {
+        addParameter(label, zone, min, min, max, (max - min) / 1000.0, kHBargraph);
+    }
+
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min,
+                                     FAUSTFLOAT max)
+    {
+        addParameter(label, zone, min, min, max, (max - min) / 1000.0, kVBargraph);
+    }
+
+    // -- soundfiles
+
+    virtual void addSoundfile(const char* label, const char* filename,
+                              Soundfile** sf_zone)
+    {
+    }
+
+    // -- metadata declarations
+
+    virtual void declare(FAUSTFLOAT* zone, const char* key, const char* val)
+    {
+        // Keep metadata
+        fCurrentMetadata[key] = val;
+
+        if (strcmp(key, "scale") == 0) {
+            if (strcmp(val, "log") == 0) {
+                fCurrentScale = kLog;
+            } else if (strcmp(val, "exp") == 0) {
+                fCurrentScale = kExp;
+            } else {
+                fCurrentScale = kLin;
+            }
+        } else if (strcmp(key, "unit") == 0) {
+            fCurrentUnit = val;
+        } else if (strcmp(key, "acc") == 0) {
+            fCurrentAcc = val;
+        } else if (strcmp(key, "gyr") == 0) {
+            fCurrentGyr = val;
+        } else if (strcmp(key, "screencolor") == 0) {
+            fCurrentColor = val;  // val = "red", "green", "blue" or "white"
+        } else if (strcmp(key, "tooltip") == 0) {
+            fCurrentTooltip = val;
+        }
+    }
+
+    virtual void declare(const char* key, const char* val) {}
+
+    //-------------------------------------------------------------------------------
+    // Simple API part
+    //-------------------------------------------------------------------------------
+    int getParamsCount() { return fNumParameters; }
+    int getParamIndex(const char* path)
+    {
+        if (fPathMap.find(path) != fPathMap.end()) {
+            return fPathMap[path];
+        } else if (fLabelMap.find(path) != fLabelMap.end()) {
+            return fLabelMap[path];
+        } else {
             return -1;
         }
-    
-        void setConverter(std::vector<ZoneControl*>* table, int p, int val, int curve, double amin, double amid, double amax)
-        {
-            int id1 = getZoneIndex(table, p, 0);
-            int id2 = getZoneIndex(table, p, 1);
-            int id3 = getZoneIndex(table, p, 2);
-            
-            // Deactivates everywhere..
-            if (id1 != -1) table[0][id1]->setActive(false);
-            if (id2 != -1) table[1][id2]->setActive(false);
-            if (id3 != -1) table[2][id3]->setActive(false);
-            
-            if (val == -1) { // Means: no more mapping...
-                // So stay all deactivated...
-            } else {
-                int id4 = getZoneIndex(table, p, val);
-                if (id4 != -1) {
-                    // Reactivate the one we edit...
-                    table[val][id4]->setMappingValues(curve, amin, amid, amax, fMin[p], fInit[p], fMax[p]);
-                    table[val][id4]->setActive(true);
-                } else {
-                    // Allocate a new CurveZoneControl which is 'active' by default
-                    FAUSTFLOAT* zone = fZone[p];
-                    table[val].push_back(new CurveZoneControl(zone, curve, amin, amid, amax, fMin[p], fInit[p], fMax[p]));
-                }
-            }
-        }
-    
-        void getConverter(std::vector<ZoneControl*>* table, int p, int& val, int& curve, double& amin, double& amid, double& amax)
-        {
-            int id1 = getZoneIndex(table, p, 0);
-            int id2 = getZoneIndex(table, p, 1);
-            int id3 = getZoneIndex(table, p, 2);
-            
-            if (id1 != -1) {
-                val = 0;
-                curve = table[val][id1]->getCurve();
-                table[val][id1]->getMappingValues(amin, amid, amax);
-            } else if (id2 != -1) {
-                val = 1;
-                curve = table[val][id2]->getCurve();
-                table[val][id2]->getMappingValues(amin, amid, amax);
-            } else if (id3 != -1) {
-                val = 2;
-                curve = table[val][id3]->getCurve();
-                table[val][id3]->getMappingValues(amin, amid, amax);
-            } else {
-                val = -1; // No mapping
-                curve = 0;
-                amin = -100.;
-                amid = 0.;
-                amax = 100.;
-            }
-        }
+    }
+    const char* getParamAddress(int p) { return fPaths[p].c_str(); }
+    const char* getParamLabel(int p) { return fLabels[p].c_str(); }
+    std::map<const char*, const char*> getMetadata(int p)
+    {
+        std::map<const char*, const char*> res;
+        std::map<std::string, std::string> metadata = fMetaData[p];
+        for (auto it : metadata) { res[it.first.c_str()] = it.second.c_str(); }
+        return res;
+    }
 
-     public:
-    
-        enum Type { kAcc = 0, kGyr = 1, kNoType };
-   
-        APIUI() : fNumParameters(0), fHasScreenControl(false), fRedReader(0), fGreenReader(0), fBlueReader(0), fCurrentScale(kLin)
-        {}
+    const char* getMetadata(int p, const char* key)
+    {
+        return (fMetaData[p].find(key) != fMetaData[p].end()) ? fMetaData[p][key].c_str()
+                                                              : "";
+    }
+    FAUSTFLOAT getParamMin(int p) { return fMin[p]; }
+    FAUSTFLOAT getParamMax(int p) { return fMax[p]; }
+    FAUSTFLOAT getParamStep(int p) { return fStep[p]; }
+    FAUSTFLOAT getParamInit(int p) { return fInit[p]; }
 
-        virtual ~APIUI()
-        {
-            for (auto& it : fConversion) delete it;
-            for (int i = 0; i < 3; i++) {
-                for (auto& it : fAcc[i]) delete it;
-                for (auto& it : fGyr[i]) delete it;
-            }
-            delete fRedReader;
-            delete fGreenReader;
-            delete fBlueReader;
-        }
-    
-        // -- widget's layouts
+    FAUSTFLOAT* getParamZone(int p) { return fZone[p]; }
+    FAUSTFLOAT getParamValue(int p) { return *fZone[p]; }
+    void setParamValue(int p, FAUSTFLOAT v) { *fZone[p] = v; }
 
-        virtual void openTabBox(const char* label) { pushLabel(label); }
-        virtual void openHorizontalBox(const char* label) { pushLabel(label); }
-        virtual void openVerticalBox(const char* label) { pushLabel(label); }
-        virtual void closeBox() { popLabel(); }
+    double getParamRatio(int p) { return fConversion[p]->faust2ui(*fZone[p]); }
+    void setParamRatio(int p, double r) { *fZone[p] = fConversion[p]->ui2faust(r); }
 
-        // -- active widgets
+    double value2ratio(int p, double r) { return fConversion[p]->faust2ui(r); }
+    double ratio2value(int p, double r) { return fConversion[p]->ui2faust(r); }
 
-        virtual void addButton(const char* label, FAUSTFLOAT* zone)
-        {
-            addParameter(label, zone, 0, 0, 1, 1, kButton);
-        }
-
-        virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
-        {
-            addParameter(label, zone, 0, 0, 1, 1, kCheckButton);
-        }
-
-        virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
-        {
-            addParameter(label, zone, init, min, max, step, kVSlider);
-        }
-
-        virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
-        {
-            addParameter(label, zone, init, min, max, step, kHSlider);
-        }
-
-        virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
-        {
-            addParameter(label, zone, init, min, max, step, kNumEntry);
-        }
-
-        // -- passive widgets
-
-        virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
-        {
-            addParameter(label, zone, min, min, max, (max-min)/1000.0, kHBargraph);
-        }
-
-        virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
-        {
-            addParameter(label, zone, min, min, max, (max-min)/1000.0, kVBargraph);
-        }
-    
-        // -- soundfiles
-    
-        virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
-
-        // -- metadata declarations
-
-        virtual void declare(FAUSTFLOAT* zone, const char* key, const char* val)
-        {
-            // Keep metadata
-            fCurrentMetadata[key] = val;
-            
-            if (strcmp(key, "scale") == 0) {
-                if (strcmp(val, "log") == 0) {
-                    fCurrentScale = kLog;
-                } else if (strcmp(val, "exp") == 0) {
-                    fCurrentScale = kExp;
-                } else {
-                    fCurrentScale = kLin;
-                }
-            } else if (strcmp(key, "unit") == 0) {
-                fCurrentUnit = val;
-            } else if (strcmp(key, "acc") == 0) {
-                fCurrentAcc = val;
-            } else if (strcmp(key, "gyr") == 0) {
-                fCurrentGyr = val;
-            } else if (strcmp(key, "screencolor") == 0) {
-                fCurrentColor = val; // val = "red", "green", "blue" or "white"
-            } else if (strcmp(key, "tooltip") == 0) {
-                fCurrentTooltip = val;
-            }
-        }
-
-        virtual void declare(const char* key, const char* val)
-        {}
-
-		//-------------------------------------------------------------------------------
-		// Simple API part
-		//-------------------------------------------------------------------------------
-		int getParamsCount() { return fNumParameters; }
-        int getParamIndex(const char* path)
-        {
-            if (fPathMap.find(path) != fPathMap.end()) {
-                return fPathMap[path];
-            } else if (fLabelMap.find(path) != fLabelMap.end()) {
-                return fLabelMap[path];
-            } else {
-                return -1;
-            }
-        }
-        const char* getParamAddress(int p) { return fPaths[p].c_str(); }
-        const char* getParamLabel(int p) { return fLabels[p].c_str(); }
-        std::map<const char*, const char*> getMetadata(int p)
-        {
-            std::map<const char*, const char*> res;
-            std::map<std::string, std::string> metadata = fMetaData[p];
-            for (auto it : metadata) {
-                res[it.first.c_str()] = it.second.c_str();
-            }
-            return res;
-        }
-
-        const char* getMetadata(int p, const char* key)
-        {
-            return (fMetaData[p].find(key) != fMetaData[p].end()) ? fMetaData[p][key].c_str() : "";
-        }
-        FAUSTFLOAT getParamMin(int p) { return fMin[p]; }
-        FAUSTFLOAT getParamMax(int p) { return fMax[p]; }
-        FAUSTFLOAT getParamStep(int p) { return fStep[p]; }
-        FAUSTFLOAT getParamInit(int p) { return fInit[p]; }
-
-        FAUSTFLOAT* getParamZone(int p) { return fZone[p]; }
-        FAUSTFLOAT getParamValue(int p) { return *fZone[p]; }
-        void setParamValue(int p, FAUSTFLOAT v) { *fZone[p] = v; }
-
-        double getParamRatio(int p) { return fConversion[p]->faust2ui(*fZone[p]); }
-        void setParamRatio(int p, double r) { *fZone[p] = fConversion[p]->ui2faust(r); }
-
-        double value2ratio(int p, double r)	{ return fConversion[p]->faust2ui(r); }
-        double ratio2value(int p, double r)	{ return fConversion[p]->ui2faust(r); }
-    
-        /**
+    /**
          * Return the control type (kAcc, kGyr, or -1) for a given parameter
          *
          * @param p - the UI parameter index
          *
          * @return the type
          */
-        Type getParamType(int p)
-        {
-            if (p >= 0) {
-                if (getZoneIndex(fAcc, p, 0) != -1
-                    || getZoneIndex(fAcc, p, 1) != -1
-                    || getZoneIndex(fAcc, p, 2) != -1) {
-                    return kAcc;
-                } else if (getZoneIndex(fGyr, p, 0) != -1
-                           || getZoneIndex(fGyr, p, 1) != -1
-                           || getZoneIndex(fGyr, p, 2) != -1) {
-                    return kGyr;
-                }
+    Type getParamType(int p)
+    {
+        if (p >= 0) {
+            if (getZoneIndex(fAcc, p, 0) != -1 || getZoneIndex(fAcc, p, 1) != -1
+                || getZoneIndex(fAcc, p, 2) != -1) {
+                return kAcc;
+            } else if (getZoneIndex(fGyr, p, 0) != -1 || getZoneIndex(fGyr, p, 1) != -1
+                       || getZoneIndex(fGyr, p, 2) != -1) {
+                return kGyr;
             }
-            return kNoType;
         }
-    
-        /**
+        return kNoType;
+    }
+
+    /**
          * Return the Item type (kButton = 0, kCheckButton, kVSlider, kHSlider, kNumEntry, kHBargraph, kVBargraph) for a given parameter
          *
          * @param p - the UI parameter index
          *
          * @return the Item type
          */
-        ItemType getParamItemType(int p)
-        {
-            return fItemType[p];
-        }
-   
-        /**
+    ItemType getParamItemType(int p) { return fItemType[p]; }
+
+    /**
          * Set a new value coming from an accelerometer, propagate it to all relevant FAUSTFLOAT* zones.
          *
          * @param acc - 0 for X accelerometer, 1 for Y accelerometer, 2 for Z accelerometer
          * @param value - the new value
          *
          */
-        void propagateAcc(int acc, double value)
-        {
-            for (size_t i = 0; i < fAcc[acc].size(); i++) {
-                fAcc[acc][i]->update(value);
-            }
-        }
-    
-        /**
+    void propagateAcc(int acc, double value)
+    {
+        for (size_t i = 0; i < fAcc[acc].size(); i++) { fAcc[acc][i]->update(value); }
+    }
+
+    /**
          * Used to edit accelerometer curves and mapping. Set curve and related mapping for a given UI parameter.
          *
          * @param p - the UI parameter index
@@ -1436,12 +1458,12 @@ class APIUI : public PathBuilder, public Meta, public UI
          * @param amax - mapping 'max' point
          *
          */
-        void setAccConverter(int p, int acc, int curve, double amin, double amid, double amax)
-        {
-            setConverter(fAcc, p, acc, curve, amin, amid, amax);
-        }
-    
-        /**
+    void setAccConverter(int p, int acc, int curve, double amin, double amid, double amax)
+    {
+        setConverter(fAcc, p, acc, curve, amin, amid, amax);
+    }
+
+    /**
          * Used to edit gyroscope curves and mapping. Set curve and related mapping for a given UI parameter.
          *
          * @param p - the UI parameter index
@@ -1452,12 +1474,12 @@ class APIUI : public PathBuilder, public Meta, public UI
          * @param amax - mapping 'max' point
          *
          */
-        void setGyrConverter(int p, int gyr, int curve, double amin, double amid, double amax)
-        {
-             setConverter(fGyr, p, gyr, curve, amin, amid, amax);
-        }
-    
-        /**
+    void setGyrConverter(int p, int gyr, int curve, double amin, double amid, double amax)
+    {
+        setConverter(fGyr, p, gyr, curve, amin, amid, amax);
+    }
+
+    /**
          * Used to edit accelerometer curves and mapping. Get curve and related mapping for a given UI parameter.
          *
          * @param p - the UI parameter index
@@ -1468,12 +1490,13 @@ class APIUI : public PathBuilder, public Meta, public UI
          * @param amax - the amax value to be retrieved
          *
          */
-        void getAccConverter(int p, int& acc, int& curve, double& amin, double& amid, double& amax)
-        {
-            getConverter(fAcc, p, acc, curve, amin, amid, amax);
-        }
+    void getAccConverter(int p, int& acc, int& curve, double& amin, double& amid,
+                         double& amax)
+    {
+        getConverter(fAcc, p, acc, curve, amin, amid, amax);
+    }
 
-        /**
+    /**
          * Used to edit gyroscope curves and mapping. Get curve and related mapping for a given UI parameter.
          *
          * @param p - the UI parameter index
@@ -1484,63 +1507,55 @@ class APIUI : public PathBuilder, public Meta, public UI
          * @param amax - the amax value to be retrieved
          *
          */
-        void getGyrConverter(int p, int& gyr, int& curve, double& amin, double& amid, double& amax)
-        {
-            getConverter(fGyr, p, gyr, curve, amin, amid, amax);
-        }
-    
-        /**
+    void getGyrConverter(int p, int& gyr, int& curve, double& amin, double& amid,
+                         double& amax)
+    {
+        getConverter(fGyr, p, gyr, curve, amin, amid, amax);
+    }
+
+    /**
          * Set a new value coming from an gyroscope, propagate it to all relevant FAUSTFLOAT* zones.
          *
          * @param gyr - 0 for X gyroscope, 1 for Y gyroscope, 2 for Z gyroscope
          * @param value - the new value
          *
          */
-        void propagateGyr(int gyr, double value)
-        {
-            for (size_t i = 0; i < fGyr[gyr].size(); i++) {
-                fGyr[gyr][i]->update(value);
-            }
-        }
-    
-        /**
+    void propagateGyr(int gyr, double value)
+    {
+        for (size_t i = 0; i < fGyr[gyr].size(); i++) { fGyr[gyr][i]->update(value); }
+    }
+
+    /**
          * Get the number of FAUSTFLOAT* zones controlled with the accelerometer
          *
          * @param acc - 0 for X accelerometer, 1 for Y accelerometer, 2 for Z accelerometer
          * @return the number of zones
          *
          */
-        int getAccCount(int acc)
-        {
-            return (acc >= 0 && acc < 3) ? int(fAcc[acc].size()) : 0;
-        }
-    
-        /**
+    int getAccCount(int acc) { return (acc >= 0 && acc < 3) ? int(fAcc[acc].size()) : 0; }
+
+    /**
          * Get the number of FAUSTFLOAT* zones controlled with the gyroscope
          *
          * @param gyr - 0 for X gyroscope, 1 for Y gyroscope, 2 for Z gyroscope
          * @param the number of zones
          *
          */
-        int getGyrCount(int gyr)
-        {
-            return (gyr >= 0 && gyr < 3) ? int(fGyr[gyr].size()) : 0;
+    int getGyrCount(int gyr) { return (gyr >= 0 && gyr < 3) ? int(fGyr[gyr].size()) : 0; }
+
+    // getScreenColor() : -1 means no screen color control (no screencolor metadata found)
+    // otherwise return 0x00RRGGBB a ready to use color
+    int getScreenColor()
+    {
+        if (fHasScreenControl) {
+            int r = (fRedReader) ? fRedReader->getValue() : 0;
+            int g = (fGreenReader) ? fGreenReader->getValue() : 0;
+            int b = (fBlueReader) ? fBlueReader->getValue() : 0;
+            return (r << 16) | (g << 8) | b;
+        } else {
+            return -1;
         }
-   
-        // getScreenColor() : -1 means no screen color control (no screencolor metadata found)
-        // otherwise return 0x00RRGGBB a ready to use color
-        int getScreenColor()
-        {
-            if (fHasScreenControl) {
-                int r = (fRedReader) ? fRedReader->getValue() : 0;
-                int g = (fGreenReader) ? fGreenReader->getValue() : 0;
-                int b = (fBlueReader) ? fBlueReader->getValue() : 0;
-                return (r<<16) | (g<<8) | b;
-            } else {
-                return -1;
-            }
-        }
- 
+    }
 };
 
 #endif
@@ -1553,264 +1568,304 @@ class APIUI : public PathBuilder, public Meta, public UI
 //  FAUST Generated Code
 //----------------------------------------------------------------------------
 
-
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
+
+#include <math.h>
 
 #include <algorithm>
 #include <cmath>
-#include <math.h>
 
-
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS compressordsp
 #endif
 
-#ifdef __APPLE__ 
+#ifdef __APPLE__
 #define exp10f __exp10f
-#define exp10 __exp10
+#define exp10  __exp10
 #endif
 
-class compressordsp : public dsp {
-	
- private:
-	
-	FAUSTFLOAT fCheckbox0;
-	FAUSTFLOAT fHslider0;
-	int fSampleRate;
-	float fConst0;
-	FAUSTFLOAT fHslider1;
-	FAUSTFLOAT fHslider2;
-	FAUSTFLOAT fHslider3;
-	float fRec5[2];
-	float fRec4[2];
-	FAUSTFLOAT fHslider4;
-	float fRec3[2];
-	float fRec2[2];
-	float fRec1[2];
-	float fRec0[2];
-	FAUSTFLOAT fHbargraph0;
-	
- public:
-	
-	void metadata(Meta* m) { 
-		m->declare("analyzers.lib/name", "Faust Analyzer Library");
-		m->declare("analyzers.lib/version", "0.1");
-		m->declare("author", "Julius Smith");
-		m->declare("basics.lib/name", "Faust Basic Element Library");
-		m->declare("basics.lib/version", "0.1");
-		m->declare("compressors.lib/compression_gain_mono:author", "Julius O. Smith III");
-		m->declare("compressors.lib/compression_gain_mono:copyright", "Copyright (C) 2014-2020 by Julius O. Smith III <jos@ccrma.stanford.edu>");
-		m->declare("compressors.lib/compression_gain_mono:license", "MIT-style STK-4.3 license");
-		m->declare("compressors.lib/compressor_lad_mono:author", "Julius O. Smith III");
-		m->declare("compressors.lib/compressor_lad_mono:copyright", "Copyright (C) 2014-2020 by Julius O. Smith III <jos@ccrma.stanford.edu>");
-		m->declare("compressors.lib/compressor_lad_mono:license", "MIT-style STK-4.3 license");
-		m->declare("compressors.lib/compressor_mono:author", "Julius O. Smith III");
-		m->declare("compressors.lib/compressor_mono:copyright", "Copyright (C) 2014-2020 by Julius O. Smith III <jos@ccrma.stanford.edu>");
-		m->declare("compressors.lib/compressor_mono:license", "MIT-style STK-4.3 license");
-		m->declare("compressors.lib/name", "Faust Compressor Effect Library");
-		m->declare("compressors.lib/version", "0.0");
-		m->declare("description", "Compressor demo application, adapted from the Faust Library's dm.compressor_demo in demos.lib");
-		m->declare("documentation", "https://faustlibraries.grame.fr/libs/compressors/#cocompressor_mono");
-		m->declare("filename", "compressordsp.dsp");
-		m->declare("license", "MIT Style STK-4.2");
-		m->declare("maths.lib/author", "GRAME");
-		m->declare("maths.lib/copyright", "GRAME");
-		m->declare("maths.lib/license", "LGPL with exception");
-		m->declare("maths.lib/name", "Faust Math Library");
-		m->declare("maths.lib/version", "2.3");
-		m->declare("name", "compressor");
-		m->declare("platform.lib/name", "Generic Platform Library");
-		m->declare("platform.lib/version", "0.1");
-		m->declare("signals.lib/name", "Faust Signal Routing Library");
-		m->declare("signals.lib/version", "0.0");
-		m->declare("version", "0.0");
-	}
+class compressordsp : public dsp
+{
+   private:
+    FAUSTFLOAT fCheckbox0;
+    FAUSTFLOAT fHslider0;
+    int fSampleRate;
+    float fConst0;
+    FAUSTFLOAT fHslider1;
+    FAUSTFLOAT fHslider2;
+    FAUSTFLOAT fHslider3;
+    float fRec5[2];
+    float fRec4[2];
+    FAUSTFLOAT fHslider4;
+    float fRec3[2];
+    float fRec2[2];
+    float fRec1[2];
+    float fRec0[2];
+    FAUSTFLOAT fHbargraph0;
 
-	virtual int getNumInputs() {
-		return 1;
-	}
-	virtual int getNumOutputs() {
-		return 1;
-	}
-	virtual int getInputRate(int channel) {
-		int rate;
-		switch ((channel)) {
-			case 0: {
-				rate = 1;
-				break;
-			}
-			default: {
-				rate = -1;
-				break;
-			}
-		}
-		return rate;
-	}
-	virtual int getOutputRate(int channel) {
-		int rate;
-		switch ((channel)) {
-			case 0: {
-				rate = 1;
-				break;
-			}
-			default: {
-				rate = -1;
-				break;
-			}
-		}
-		return rate;
-	}
-	
-	static void classInit(int sample_rate) {
-	}
-	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (1.0f / std::min<float>(192000.0f, std::max<float>(1.0f, float(fSampleRate))));
-	}
-	
-	virtual void instanceResetUserInterface() {
-		fCheckbox0 = FAUSTFLOAT(0.0f);
-		fHslider0 = FAUSTFLOAT(2.0f);
-		fHslider1 = FAUSTFLOAT(15.0f);
-		fHslider2 = FAUSTFLOAT(2.0f);
-		fHslider3 = FAUSTFLOAT(40.0f);
-		fHslider4 = FAUSTFLOAT(-24.0f);
-	}
-	
-	virtual void instanceClear() {
-		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
-			fRec5[l0] = 0.0f;
-		}
-		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
-			fRec4[l1] = 0.0f;
-		}
-		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
-			fRec3[l2] = 0.0f;
-		}
-		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
-			fRec2[l3] = 0.0f;
-		}
-		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
-			fRec1[l4] = 0.0f;
-		}
-		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
-			fRec0[l5] = 0.0f;
-		}
-	}
-	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
-	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
-		instanceResetUserInterface();
-		instanceClear();
-	}
-	
-	virtual compressordsp* clone() {
-		return new compressordsp();
-	}
-	
-	virtual int getSampleRate() {
-		return fSampleRate;
-	}
-	
-	virtual void buildUserInterface(UI* ui_interface) {
-		ui_interface->declare(0, "tooltip", "References:                 https://faustlibraries.grame.fr/libs/compressors/                 http://en.wikipedia.org/wiki/Dynamic_range_compression");
-		ui_interface->openVerticalBox("COMPRESSOR");
-		ui_interface->declare(0, "0", "");
-		ui_interface->openHorizontalBox("0x00");
-		ui_interface->declare(&fCheckbox0, "0", "");
-		ui_interface->declare(&fCheckbox0, "tooltip", "When this is checked, the compressor                 has no effect");
-		ui_interface->addCheckButton("Bypass", &fCheckbox0);
-		ui_interface->declare(&fHbargraph0, "1", "");
-		ui_interface->declare(&fHbargraph0, "tooltip", "Compressor gain in dB");
-		ui_interface->declare(&fHbargraph0, "unit", "dB");
-		ui_interface->addHorizontalBargraph("Compressor Gain", &fHbargraph0, -50.0f, 10.0f);
-		ui_interface->closeBox();
-		ui_interface->declare(0, "1", "");
-		ui_interface->openHorizontalBox("0x00");
-		ui_interface->declare(0, "3", "");
-		ui_interface->openHorizontalBox("Compression Control");
-		ui_interface->declare(&fHslider2, "0", "");
-		ui_interface->declare(&fHslider2, "style", "knob");
-		ui_interface->declare(&fHslider2, "tooltip", "A compression Ratio of N means that for each N dB increase in input         signal level above Threshold, the output level goes up 1 dB");
-		ui_interface->addHorizontalSlider("Ratio", &fHslider2, 2.0f, 1.0f, 20.0f, 0.100000001f);
-		ui_interface->declare(&fHslider4, "1", "");
-		ui_interface->declare(&fHslider4, "style", "knob");
-		ui_interface->declare(&fHslider4, "tooltip", "When the signal level exceeds the Threshold (in dB), its level         is compressed according to the Ratio");
-		ui_interface->declare(&fHslider4, "unit", "dB");
-		ui_interface->addHorizontalSlider("Threshold", &fHslider4, -24.0f, -100.0f, 10.0f, 0.100000001f);
-		ui_interface->closeBox();
-		ui_interface->declare(0, "4", "");
-		ui_interface->openHorizontalBox("Compression Response");
-		ui_interface->declare(&fHslider1, "1", "");
-		ui_interface->declare(&fHslider1, "scale", "log");
-		ui_interface->declare(&fHslider1, "style", "knob");
-		ui_interface->declare(&fHslider1, "tooltip", "Time constant in ms (1/e smoothing time) for the compression gain         to approach (exponentially) a new lower target level (the compression         `kicking in')");
-		ui_interface->declare(&fHslider1, "unit", "ms");
-		ui_interface->addHorizontalSlider("Attack", &fHslider1, 15.0f, 1.0f, 1000.0f, 0.100000001f);
-		ui_interface->declare(&fHslider3, "2", "");
-		ui_interface->declare(&fHslider3, "scale", "log");
-		ui_interface->declare(&fHslider3, "style", "knob");
-		ui_interface->declare(&fHslider3, "tooltip", "Time constant in ms (1/e smoothing time) for the compression gain         to approach (exponentially) a new higher target level (the compression         'releasing')");
-		ui_interface->declare(&fHslider3, "unit", "ms");
-		ui_interface->addHorizontalSlider("Release", &fHslider3, 40.0f, 1.0f, 1000.0f, 0.100000001f);
-		ui_interface->closeBox();
-		ui_interface->closeBox();
-		ui_interface->declare(&fHslider0, "5", "");
-		ui_interface->declare(&fHslider0, "tooltip", "The compressed-signal output level is increased by this amount         (in dB) to make up for the level lost due to compression");
-		ui_interface->declare(&fHslider0, "unit", "dB");
-		ui_interface->addHorizontalSlider("MakeUpGain", &fHslider0, 2.0f, -96.0f, 96.0f, 0.100000001f);
-		ui_interface->closeBox();
-	}
-	
-	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
-		FAUSTFLOAT* input0 = inputs[0];
-		FAUSTFLOAT* output0 = outputs[0];
-		int iSlow0 = int(float(fCheckbox0));
-		float fSlow1 = std::pow(10.0f, (0.0500000007f * float(fHslider0)));
-		float fSlow2 = std::max<float>(fConst0, (0.00100000005f * float(fHslider1)));
-		float fSlow3 = (0.5f * fSlow2);
-		int iSlow4 = (std::fabs(fSlow3) < 1.1920929e-07f);
-		float fSlow5 = (iSlow4 ? 0.0f : std::exp((0.0f - (fConst0 / (iSlow4 ? 1.0f : fSlow3)))));
-		float fSlow6 = ((1.0f / std::max<float>(1.00000001e-07f, float(fHslider2))) + -1.0f);
-		int iSlow7 = (std::fabs(fSlow2) < 1.1920929e-07f);
-		float fSlow8 = (iSlow7 ? 0.0f : std::exp((0.0f - (fConst0 / (iSlow7 ? 1.0f : fSlow2)))));
-		float fSlow9 = std::max<float>(fConst0, (0.00100000005f * float(fHslider3)));
-		int iSlow10 = (std::fabs(fSlow9) < 1.1920929e-07f);
-		float fSlow11 = (iSlow10 ? 0.0f : std::exp((0.0f - (fConst0 / (iSlow10 ? 1.0f : fSlow9)))));
-		float fSlow12 = float(fHslider4);
-		float fSlow13 = (1.0f - fSlow5);
-		for (int i = 0; (i < count); i = (i + 1)) {
-			float fTemp0 = float(input0[i]);
-			float fTemp1 = (iSlow0 ? 0.0f : fTemp0);
-			float fTemp2 = std::fabs(fTemp1);
-			float fTemp3 = ((fRec4[1] > fTemp2) ? fSlow11 : fSlow8);
-			fRec5[0] = ((fRec5[1] * fTemp3) + (fTemp2 * (1.0f - fTemp3)));
-			fRec4[0] = fRec5[0];
-			fRec3[0] = ((fRec3[1] * fSlow5) + (fSlow6 * (std::max<float>(((20.0f * std::log10(fRec4[0])) - fSlow12), 0.0f) * fSlow13)));
-			float fTemp4 = (fTemp1 * std::pow(10.0f, (0.0500000007f * fRec3[0])));
-			float fTemp5 = std::fabs(fTemp4);
-			float fTemp6 = ((fRec1[1] > fTemp5) ? fSlow11 : fSlow8);
-			fRec2[0] = ((fRec2[1] * fTemp6) + (fTemp5 * (1.0f - fTemp6)));
-			fRec1[0] = fRec2[0];
-			fRec0[0] = ((fSlow5 * fRec0[1]) + (fSlow6 * (std::max<float>(((20.0f * std::log10(fRec1[0])) - fSlow12), 0.0f) * fSlow13)));
-			fHbargraph0 = FAUSTFLOAT((20.0f * std::log10(std::pow(10.0f, (0.0500000007f * fRec0[0])))));
-			output0[i] = FAUSTFLOAT((iSlow0 ? fTemp0 : (fSlow1 * fTemp4)));
-			fRec5[1] = fRec5[0];
-			fRec4[1] = fRec4[0];
-			fRec3[1] = fRec3[0];
-			fRec2[1] = fRec2[0];
-			fRec1[1] = fRec1[0];
-			fRec0[1] = fRec0[0];
-		}
-	}
+   public:
+    void metadata(Meta* m)
+    {
+        m->declare("analyzers.lib/name", "Faust Analyzer Library");
+        m->declare("analyzers.lib/version", "0.1");
+        m->declare("author", "Julius Smith");
+        m->declare("basics.lib/name", "Faust Basic Element Library");
+        m->declare("basics.lib/version", "0.1");
+        m->declare("compressors.lib/compression_gain_mono:author", "Julius O. Smith III");
+        m->declare(
+            "compressors.lib/compression_gain_mono:copyright",
+            "Copyright (C) 2014-2020 by Julius O. Smith III <jos@ccrma.stanford.edu>");
+        m->declare("compressors.lib/compression_gain_mono:license",
+                   "MIT-style STK-4.3 license");
+        m->declare("compressors.lib/compressor_lad_mono:author", "Julius O. Smith III");
+        m->declare(
+            "compressors.lib/compressor_lad_mono:copyright",
+            "Copyright (C) 2014-2020 by Julius O. Smith III <jos@ccrma.stanford.edu>");
+        m->declare("compressors.lib/compressor_lad_mono:license",
+                   "MIT-style STK-4.3 license");
+        m->declare("compressors.lib/compressor_mono:author", "Julius O. Smith III");
+        m->declare(
+            "compressors.lib/compressor_mono:copyright",
+            "Copyright (C) 2014-2020 by Julius O. Smith III <jos@ccrma.stanford.edu>");
+        m->declare("compressors.lib/compressor_mono:license",
+                   "MIT-style STK-4.3 license");
+        m->declare("compressors.lib/name", "Faust Compressor Effect Library");
+        m->declare("compressors.lib/version", "0.0");
+        m->declare("description",
+                   "Compressor demo application, adapted from the Faust Library's "
+                   "dm.compressor_demo in demos.lib");
+        m->declare("documentation",
+                   "https://faustlibraries.grame.fr/libs/compressors/#cocompressor_mono");
+        m->declare("filename", "compressordsp.dsp");
+        m->declare("license", "MIT Style STK-4.2");
+        m->declare("maths.lib/author", "GRAME");
+        m->declare("maths.lib/copyright", "GRAME");
+        m->declare("maths.lib/license", "LGPL with exception");
+        m->declare("maths.lib/name", "Faust Math Library");
+        m->declare("maths.lib/version", "2.3");
+        m->declare("name", "compressor");
+        m->declare("platform.lib/name", "Generic Platform Library");
+        m->declare("platform.lib/version", "0.1");
+        m->declare("signals.lib/name", "Faust Signal Routing Library");
+        m->declare("signals.lib/version", "0.0");
+        m->declare("version", "0.0");
+    }
 
+    virtual int getNumInputs() { return 1; }
+    virtual int getNumOutputs() { return 1; }
+    virtual int getInputRate(int channel)
+    {
+        int rate;
+        switch ((channel)) {
+        case 0: {
+            rate = 1;
+            break;
+        }
+        default: {
+            rate = -1;
+            break;
+        }
+        }
+        return rate;
+    }
+    virtual int getOutputRate(int channel)
+    {
+        int rate;
+        switch ((channel)) {
+        case 0: {
+            rate = 1;
+            break;
+        }
+        default: {
+            rate = -1;
+            break;
+        }
+        }
+        return rate;
+    }
+
+    static void classInit(int sample_rate) {}
+
+    virtual void instanceConstants(int sample_rate)
+    {
+        fSampleRate = sample_rate;
+        fConst0 =
+            (1.0f
+             / std::min<float>(192000.0f, std::max<float>(1.0f, float(fSampleRate))));
+    }
+
+    virtual void instanceResetUserInterface()
+    {
+        fCheckbox0 = FAUSTFLOAT(0.0f);
+        fHslider0  = FAUSTFLOAT(2.0f);
+        fHslider1  = FAUSTFLOAT(15.0f);
+        fHslider2  = FAUSTFLOAT(2.0f);
+        fHslider3  = FAUSTFLOAT(40.0f);
+        fHslider4  = FAUSTFLOAT(-24.0f);
+    }
+
+    virtual void instanceClear()
+    {
+        for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) { fRec5[l0] = 0.0f; }
+        for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) { fRec4[l1] = 0.0f; }
+        for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) { fRec3[l2] = 0.0f; }
+        for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) { fRec2[l3] = 0.0f; }
+        for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) { fRec1[l4] = 0.0f; }
+        for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) { fRec0[l5] = 0.0f; }
+    }
+
+    virtual void init(int sample_rate)
+    {
+        classInit(sample_rate);
+        instanceInit(sample_rate);
+    }
+    virtual void instanceInit(int sample_rate)
+    {
+        instanceConstants(sample_rate);
+        instanceResetUserInterface();
+        instanceClear();
+    }
+
+    virtual compressordsp* clone() { return new compressordsp(); }
+
+    virtual int getSampleRate() { return fSampleRate; }
+
+    virtual void buildUserInterface(UI* ui_interface)
+    {
+        ui_interface->declare(
+            0, "tooltip",
+            "References:                 "
+            "https://faustlibraries.grame.fr/libs/compressors/                 "
+            "http://en.wikipedia.org/wiki/Dynamic_range_compression");
+        ui_interface->openVerticalBox("COMPRESSOR");
+        ui_interface->declare(0, "0", "");
+        ui_interface->openHorizontalBox("0x00");
+        ui_interface->declare(&fCheckbox0, "0", "");
+        ui_interface->declare(
+            &fCheckbox0, "tooltip",
+            "When this is checked, the compressor                 has no effect");
+        ui_interface->addCheckButton("Bypass", &fCheckbox0);
+        ui_interface->declare(&fHbargraph0, "1", "");
+        ui_interface->declare(&fHbargraph0, "tooltip", "Compressor gain in dB");
+        ui_interface->declare(&fHbargraph0, "unit", "dB");
+        ui_interface->addHorizontalBargraph("Compressor Gain", &fHbargraph0, -50.0f,
+                                            10.0f);
+        ui_interface->closeBox();
+        ui_interface->declare(0, "1", "");
+        ui_interface->openHorizontalBox("0x00");
+        ui_interface->declare(0, "3", "");
+        ui_interface->openHorizontalBox("Compression Control");
+        ui_interface->declare(&fHslider2, "0", "");
+        ui_interface->declare(&fHslider2, "style", "knob");
+        ui_interface->declare(
+            &fHslider2, "tooltip",
+            "A compression Ratio of N means that for each N dB increase in input         "
+            "signal level above Threshold, the output level goes up 1 dB");
+        ui_interface->addHorizontalSlider("Ratio", &fHslider2, 2.0f, 1.0f, 20.0f,
+                                          0.100000001f);
+        ui_interface->declare(&fHslider4, "1", "");
+        ui_interface->declare(&fHslider4, "style", "knob");
+        ui_interface->declare(&fHslider4, "tooltip",
+                              "When the signal level exceeds the Threshold (in dB), its "
+                              "level         is compressed according to the Ratio");
+        ui_interface->declare(&fHslider4, "unit", "dB");
+        ui_interface->addHorizontalSlider("Threshold", &fHslider4, -24.0f, -100.0f, 10.0f,
+                                          0.100000001f);
+        ui_interface->closeBox();
+        ui_interface->declare(0, "4", "");
+        ui_interface->openHorizontalBox("Compression Response");
+        ui_interface->declare(&fHslider1, "1", "");
+        ui_interface->declare(&fHslider1, "scale", "log");
+        ui_interface->declare(&fHslider1, "style", "knob");
+        ui_interface->declare(
+            &fHslider1, "tooltip",
+            "Time constant in ms (1/e smoothing time) for the compression gain         "
+            "to approach (exponentially) a new lower target level (the compression       "
+            "  `kicking in')");
+        ui_interface->declare(&fHslider1, "unit", "ms");
+        ui_interface->addHorizontalSlider("Attack", &fHslider1, 15.0f, 1.0f, 1000.0f,
+                                          0.100000001f);
+        ui_interface->declare(&fHslider3, "2", "");
+        ui_interface->declare(&fHslider3, "scale", "log");
+        ui_interface->declare(&fHslider3, "style", "knob");
+        ui_interface->declare(
+            &fHslider3, "tooltip",
+            "Time constant in ms (1/e smoothing time) for the compression gain         "
+            "to approach (exponentially) a new higher target level (the compression      "
+            "   'releasing')");
+        ui_interface->declare(&fHslider3, "unit", "ms");
+        ui_interface->addHorizontalSlider("Release", &fHslider3, 40.0f, 1.0f, 1000.0f,
+                                          0.100000001f);
+        ui_interface->closeBox();
+        ui_interface->closeBox();
+        ui_interface->declare(&fHslider0, "5", "");
+        ui_interface->declare(
+            &fHslider0, "tooltip",
+            "The compressed-signal output level is increased by this amount         (in "
+            "dB) to make up for the level lost due to compression");
+        ui_interface->declare(&fHslider0, "unit", "dB");
+        ui_interface->addHorizontalSlider("MakeUpGain", &fHslider0, 2.0f, -96.0f, 96.0f,
+                                          0.100000001f);
+        ui_interface->closeBox();
+    }
+
+    virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+    {
+        FAUSTFLOAT* input0  = inputs[0];
+        FAUSTFLOAT* output0 = outputs[0];
+        int iSlow0          = int(float(fCheckbox0));
+        float fSlow1        = std::pow(10.0f, (0.0500000007f * float(fHslider0)));
+        float fSlow2 = std::max<float>(fConst0, (0.00100000005f * float(fHslider1)));
+        float fSlow3 = (0.5f * fSlow2);
+        int iSlow4   = (std::fabs(fSlow3) < 1.1920929e-07f);
+        float fSlow5 =
+            (iSlow4 ? 0.0f : std::exp((0.0f - (fConst0 / (iSlow4 ? 1.0f : fSlow3)))));
+        float fSlow6 =
+            ((1.0f / std::max<float>(1.00000001e-07f, float(fHslider2))) + -1.0f);
+        int iSlow7 = (std::fabs(fSlow2) < 1.1920929e-07f);
+        float fSlow8 =
+            (iSlow7 ? 0.0f : std::exp((0.0f - (fConst0 / (iSlow7 ? 1.0f : fSlow2)))));
+        float fSlow9 = std::max<float>(fConst0, (0.00100000005f * float(fHslider3)));
+        int iSlow10  = (std::fabs(fSlow9) < 1.1920929e-07f);
+        float fSlow11 =
+            (iSlow10 ? 0.0f : std::exp((0.0f - (fConst0 / (iSlow10 ? 1.0f : fSlow9)))));
+        float fSlow12 = float(fHslider4);
+        float fSlow13 = (1.0f - fSlow5);
+        for (int i = 0; (i < count); i = (i + 1)) {
+            float fTemp0 = float(input0[i]);
+            float fTemp1 = (iSlow0 ? 0.0f : fTemp0);
+            float fTemp2 = std::fabs(fTemp1);
+            float fTemp3 = ((fRec4[1] > fTemp2) ? fSlow11 : fSlow8);
+            fRec5[0]     = ((fRec5[1] * fTemp3) + (fTemp2 * (1.0f - fTemp3)));
+            fRec4[0]     = fRec5[0];
+            fRec3[0] =
+                ((fRec3[1] * fSlow5)
+                 + (fSlow6
+                    * (std::max<float>(((20.0f * std::log10(fRec4[0])) - fSlow12), 0.0f)
+                       * fSlow13)));
+            float fTemp4 = (fTemp1 * std::pow(10.0f, (0.0500000007f * fRec3[0])));
+            float fTemp5 = std::fabs(fTemp4);
+            float fTemp6 = ((fRec1[1] > fTemp5) ? fSlow11 : fSlow8);
+            fRec2[0]     = ((fRec2[1] * fTemp6) + (fTemp5 * (1.0f - fTemp6)));
+            fRec1[0]     = fRec2[0];
+            fRec0[0] =
+                ((fSlow5 * fRec0[1])
+                 + (fSlow6
+                    * (std::max<float>(((20.0f * std::log10(fRec1[0])) - fSlow12), 0.0f)
+                       * fSlow13)));
+            fHbargraph0 = FAUSTFLOAT(
+                (20.0f * std::log10(std::pow(10.0f, (0.0500000007f * fRec0[0])))));
+            output0[i] = FAUSTFLOAT((iSlow0 ? fTemp0 : (fSlow1 * fTemp4)));
+            fRec5[1]   = fRec5[0];
+            fRec4[1]   = fRec4[0];
+            fRec3[1]   = fRec3[0];
+            fRec2[1]   = fRec2[0];
+            fRec1[1]   = fRec1[0];
+            fRec0[1]   = fRec0[0];
+        }
+    }
 };
 
 #endif

--- a/src/freeverbdsp.h
+++ b/src/freeverbdsp.h
@@ -7,8 +7,8 @@ Code generated with Faust 2.28.6 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -scal -ftz 0
 ------------------------------------------------------------ */
 
-#ifndef  __freeverbdsp_H__
-#define  __freeverbdsp_H__
+#ifndef __freeverbdsp_H__
+#define __freeverbdsp_H__
 
 // NOTE: ANY INCLUDE-GUARD HERE MUST BE DERIVED FROM THE CLASS NAME
 //
@@ -59,86 +59,83 @@ struct Meta;
  */
 
 struct dsp_memory_manager {
-    
     virtual ~dsp_memory_manager() {}
-    
+
     virtual void* allocate(size_t size) = 0;
-    virtual void destroy(void* ptr) = 0;
-    
+    virtual void destroy(void* ptr)     = 0;
 };
 
 /**
 * Signal processor definition.
 */
 
-class dsp {
+class dsp
+{
+   public:
+    dsp() {}
+    virtual ~dsp() {}
 
-    public:
+    /* Return instance number of audio inputs */
+    virtual int getNumInputs() = 0;
 
-        dsp() {}
-        virtual ~dsp() {}
+    /* Return instance number of audio outputs */
+    virtual int getNumOutputs() = 0;
 
-        /* Return instance number of audio inputs */
-        virtual int getNumInputs() = 0;
-    
-        /* Return instance number of audio outputs */
-        virtual int getNumOutputs() = 0;
-    
-        /**
+    /**
          * Trigger the ui_interface parameter with instance specific calls
          * to 'openTabBox', 'addButton', 'addVerticalSlider'... in order to build the UI.
          *
          * @param ui_interface - the user interface builder
          */
-        virtual void buildUserInterface(UI* ui_interface) = 0;
-    
-        /* Returns the sample rate currently used by the instance */
-        virtual int getSampleRate() = 0;
-    
-        /**
+    virtual void buildUserInterface(UI* ui_interface) = 0;
+
+    /* Returns the sample rate currently used by the instance */
+    virtual int getSampleRate() = 0;
+
+    /**
          * Global init, calls the following methods:
          * - static class 'classInit': static tables initialization
          * - 'instanceInit': constants and instance state initialization
          *
          * @param sample_rate - the sampling rate in Hertz
          */
-        virtual void init(int sample_rate) = 0;
+    virtual void init(int sample_rate) = 0;
 
-        /**
+    /**
          * Init instance state
          *
          * @param sample_rate - the sampling rate in Hertz
          */
-        virtual void instanceInit(int sample_rate) = 0;
+    virtual void instanceInit(int sample_rate) = 0;
 
-        /**
+    /**
          * Init instance constant state
          *
          * @param sample_rate - the sampling rate in Hertz
          */
-        virtual void instanceConstants(int sample_rate) = 0;
-    
-        /* Init default control parameters values */
-        virtual void instanceResetUserInterface() = 0;
-    
-        /* Init instance state (delay lines...) */
-        virtual void instanceClear() = 0;
- 
-        /**
+    virtual void instanceConstants(int sample_rate) = 0;
+
+    /* Init default control parameters values */
+    virtual void instanceResetUserInterface() = 0;
+
+    /* Init instance state (delay lines...) */
+    virtual void instanceClear() = 0;
+
+    /**
          * Return a clone of the instance.
          *
          * @return a copy of the instance on success, otherwise a null pointer.
          */
-        virtual dsp* clone() = 0;
-    
-        /**
+    virtual dsp* clone() = 0;
+
+    /**
          * Trigger the Meta* parameter with instance specific calls to 'declare' (key, value) metadata.
          *
          * @param m - the Meta* meta user
          */
-        virtual void metadata(Meta* m) = 0;
-    
-        /**
+    virtual void metadata(Meta* m) = 0;
+
+    /**
          * DSP instance computation, to be called with successive in/out audio buffers.
          *
          * @param count - the number of frames to compute
@@ -146,9 +143,9 @@ class dsp {
          * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
          *
          */
-        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
-    
-        /**
+    virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
+
+    /**
          * DSP instance computation: alternative method to be used by subclasses.
          *
          * @param date_usec - the timestamp in microsec given by audio driver.
@@ -157,67 +154,77 @@ class dsp {
          * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (either float, double or quad)
          *
          */
-        virtual void compute(double /*date_usec*/, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
-       
+    virtual void compute(double /*date_usec*/, int count, FAUSTFLOAT** inputs,
+                         FAUSTFLOAT** outputs)
+    {
+        compute(count, inputs, outputs);
+    }
 };
 
 /**
  * Generic DSP decorator.
  */
 
-class decorator_dsp : public dsp {
+class decorator_dsp : public dsp
+{
+   protected:
+    dsp* fDSP;
 
-    protected:
+   public:
+    decorator_dsp(dsp* dsp = nullptr) : fDSP(dsp) {}
+    virtual ~decorator_dsp() { delete fDSP; }
 
-        dsp* fDSP;
-
-    public:
-
-        decorator_dsp(dsp* dsp = nullptr):fDSP(dsp) {}
-        virtual ~decorator_dsp() { delete fDSP; }
-
-        virtual int getNumInputs() { return fDSP->getNumInputs(); }
-        virtual int getNumOutputs() { return fDSP->getNumOutputs(); }
-        virtual void buildUserInterface(UI* ui_interface) { fDSP->buildUserInterface(ui_interface); }
-        virtual int getSampleRate() { return fDSP->getSampleRate(); }
-        virtual void init(int sample_rate) { fDSP->init(sample_rate); }
-        virtual void instanceInit(int sample_rate) { fDSP->instanceInit(sample_rate); }
-        virtual void instanceConstants(int sample_rate) { fDSP->instanceConstants(sample_rate); }
-        virtual void instanceResetUserInterface() { fDSP->instanceResetUserInterface(); }
-        virtual void instanceClear() { fDSP->instanceClear(); }
-        virtual decorator_dsp* clone() { return new decorator_dsp(fDSP->clone()); }
-        virtual void metadata(Meta* m) { fDSP->metadata(m); }
-        // Beware: subclasses usually have to overload the two 'compute' methods
-        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(count, inputs, outputs); }
-        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(date_usec, count, inputs, outputs); }
-    
+    virtual int getNumInputs() { return fDSP->getNumInputs(); }
+    virtual int getNumOutputs() { return fDSP->getNumOutputs(); }
+    virtual void buildUserInterface(UI* ui_interface)
+    {
+        fDSP->buildUserInterface(ui_interface);
+    }
+    virtual int getSampleRate() { return fDSP->getSampleRate(); }
+    virtual void init(int sample_rate) { fDSP->init(sample_rate); }
+    virtual void instanceInit(int sample_rate) { fDSP->instanceInit(sample_rate); }
+    virtual void instanceConstants(int sample_rate)
+    {
+        fDSP->instanceConstants(sample_rate);
+    }
+    virtual void instanceResetUserInterface() { fDSP->instanceResetUserInterface(); }
+    virtual void instanceClear() { fDSP->instanceClear(); }
+    virtual decorator_dsp* clone() { return new decorator_dsp(fDSP->clone()); }
+    virtual void metadata(Meta* m) { fDSP->metadata(m); }
+    // Beware: subclasses usually have to overload the two 'compute' methods
+    virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+    {
+        fDSP->compute(count, inputs, outputs);
+    }
+    virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs,
+                         FAUSTFLOAT** outputs)
+    {
+        fDSP->compute(date_usec, count, inputs, outputs);
+    }
 };
 
 /**
  * DSP factory class.
  */
 
-class dsp_factory {
-    
-    protected:
-    
-        // So that to force sub-classes to use deleteDSPFactory(dsp_factory* factory);
-        virtual ~dsp_factory() {}
-    
-    public:
-    
-        virtual std::string getName() = 0;
-        virtual std::string getSHAKey() = 0;
-        virtual std::string getDSPCode() = 0;
-        virtual std::string getCompileOptions() = 0;
-        virtual std::vector<std::string> getLibraryList() = 0;
-        virtual std::vector<std::string> getIncludePathnames() = 0;
-    
-        virtual dsp* createDSPInstance() = 0;
-    
-        virtual void setMemoryManager(dsp_memory_manager* manager) = 0;
-        virtual dsp_memory_manager* getMemoryManager() = 0;
-    
+class dsp_factory
+{
+   protected:
+    // So that to force sub-classes to use deleteDSPFactory(dsp_factory* factory);
+    virtual ~dsp_factory() {}
+
+   public:
+    virtual std::string getName()                          = 0;
+    virtual std::string getSHAKey()                        = 0;
+    virtual std::string getDSPCode()                       = 0;
+    virtual std::string getCompileOptions()                = 0;
+    virtual std::vector<std::string> getLibraryList()      = 0;
+    virtual std::vector<std::string> getIncludePathnames() = 0;
+
+    virtual dsp* createDSPInstance() = 0;
+
+    virtual void setMemoryManager(dsp_memory_manager* manager) = 0;
+    virtual dsp_memory_manager* getMemoryManager()             = 0;
 };
 
 /**
@@ -226,14 +233,14 @@ class dsp_factory {
  */
 
 #ifdef __SSE__
-    #include <xmmintrin.h>
-    #ifdef __SSE2__
-        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8040)
-    #else
-        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8000)
-    #endif
+#include <xmmintrin.h>
+#ifdef __SSE2__
+#define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8040)
 #else
-    #define AVOIDDENORMALS
+#define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8000)
+#endif
+#else
+#define AVOIDDENORMALS
 #endif
 
 #endif
@@ -266,11 +273,11 @@ class dsp_factory {
 #ifndef API_UI_H
 #define API_UI_H
 
+#include <iostream>
+#include <map>
 #include <sstream>
 #include <string>
 #include <vector>
-#include <iostream>
-#include <map>
 
 /************************** BEGIN meta.h **************************/
 /************************************************************************
@@ -299,11 +306,9 @@ class dsp_factory {
 #ifndef __meta__
 #define __meta__
 
-struct Meta
-{
-    virtual ~Meta() {};
+struct Meta {
+    virtual ~Meta(){};
     virtual void declare(const char* key, const char* value) = 0;
-    
 };
 
 #endif
@@ -348,43 +353,47 @@ struct Meta
 
 struct Soundfile;
 
-template <typename REAL>
-struct UIReal
-{
+template<typename REAL>
+struct UIReal {
     UIReal() {}
     virtual ~UIReal() {}
-    
+
     // -- widget's layouts
-    
-    virtual void openTabBox(const char* label) = 0;
+
+    virtual void openTabBox(const char* label)        = 0;
     virtual void openHorizontalBox(const char* label) = 0;
-    virtual void openVerticalBox(const char* label) = 0;
-    virtual void closeBox() = 0;
-    
+    virtual void openVerticalBox(const char* label)   = 0;
+    virtual void closeBox()                           = 0;
+
     // -- active widgets
-    
-    virtual void addButton(const char* label, REAL* zone) = 0;
+
+    virtual void addButton(const char* label, REAL* zone)      = 0;
     virtual void addCheckButton(const char* label, REAL* zone) = 0;
-    virtual void addVerticalSlider(const char* label, REAL* zone, REAL init, REAL min, REAL max, REAL step) = 0;
-    virtual void addHorizontalSlider(const char* label, REAL* zone, REAL init, REAL min, REAL max, REAL step) = 0;
-    virtual void addNumEntry(const char* label, REAL* zone, REAL init, REAL min, REAL max, REAL step) = 0;
-    
+    virtual void addVerticalSlider(const char* label, REAL* zone, REAL init, REAL min,
+                                   REAL max, REAL step)        = 0;
+    virtual void addHorizontalSlider(const char* label, REAL* zone, REAL init, REAL min,
+                                     REAL max, REAL step)      = 0;
+    virtual void addNumEntry(const char* label, REAL* zone, REAL init, REAL min, REAL max,
+                             REAL step)                        = 0;
+
     // -- passive widgets
-    
-    virtual void addHorizontalBargraph(const char* label, REAL* zone, REAL min, REAL max) = 0;
-    virtual void addVerticalBargraph(const char* label, REAL* zone, REAL min, REAL max) = 0;
-    
+
+    virtual void addHorizontalBargraph(const char* label, REAL* zone, REAL min,
+                                       REAL max) = 0;
+    virtual void addVerticalBargraph(const char* label, REAL* zone, REAL min,
+                                     REAL max)   = 0;
+
     // -- soundfiles
-    
-    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) = 0;
-    
+
+    virtual void addSoundfile(const char* label, const char* filename,
+                              Soundfile** sf_zone) = 0;
+
     // -- metadata declarations
-    
+
     virtual void declare(REAL* zone, const char* key, const char* val) {}
 };
 
-struct UI : public UIReal<FAUSTFLOAT>
-{
+struct UI : public UIReal<FAUSTFLOAT> {
     UI() {}
     virtual ~UI() {}
 };
@@ -418,9 +427,9 @@ struct UI : public UIReal<FAUSTFLOAT>
 #ifndef FAUST_PATHBUILDER_H
 #define FAUST_PATHBUILDER_H
 
-#include <vector>
-#include <string>
 #include <algorithm>
+#include <string>
+#include <vector>
 
 /*******************************************************************************
  * PathBuilder : Faust User Interface
@@ -429,37 +438,33 @@ struct UI : public UIReal<FAUSTFLOAT>
 
 class PathBuilder
 {
+   protected:
+    std::vector<std::string> fControlsLevel;
 
-    protected:
-    
-        std::vector<std::string> fControlsLevel;
-       
-    public:
-    
-        PathBuilder() {}
-        virtual ~PathBuilder() {}
-    
-        std::string buildPath(const std::string& label) 
-        {
-            std::string res = "/";
-            for (size_t i = 0; i < fControlsLevel.size(); i++) {
-                res += fControlsLevel[i];
-                res += "/";
-            }
-            res += label;
-            std::replace(res.begin(), res.end(), ' ', '_');
-            return res;
+   public:
+    PathBuilder() {}
+    virtual ~PathBuilder() {}
+
+    std::string buildPath(const std::string& label)
+    {
+        std::string res = "/";
+        for (size_t i = 0; i < fControlsLevel.size(); i++) {
+            res += fControlsLevel[i];
+            res += "/";
         }
-    
-        std::string buildLabel(std::string label)
-        {
-            std::replace(label.begin(), label.end(), ' ', '_');
-            return label;
-        }
-    
-        void pushLabel(const std::string& label) { fControlsLevel.push_back(label); }
-        void popLabel() { fControlsLevel.pop_back(); }
-    
+        res += label;
+        std::replace(res.begin(), res.end(), ' ', '_');
+        return res;
+    }
+
+    std::string buildLabel(std::string label)
+    {
+        std::replace(label.begin(), label.end(), ' ', '_');
+        return label;
+    }
+
+    void pushLabel(const std::string& label) { fControlsLevel.push_back(label); }
+    void popLabel() { fControlsLevel.pop_back(); }
 };
 
 #endif  // FAUST_PATHBUILDER_H
@@ -534,11 +539,12 @@ ZoneReader(zone, valueConverter) : a zone with a data converter
 
 ****************************************************************************************/
 
+#include <assert.h>
 #include <float.h>
-#include <algorithm>    // std::max
+
+#include <algorithm>  // std::max
 #include <cmath>
 #include <vector>
-#include <assert.h>
 
 //--------------------------------------------------------------------------------------
 // Interpolator(lo,hi,v1,v2)
@@ -551,50 +557,49 @@ ZoneReader(zone, valueConverter) : a zone with a data converter
 //--------------------------------------------------------------------------------------
 class Interpolator
 {
-    private:
+   private:
+    //--------------------------------------------------------------------------------------
+    // Range(lo,hi) clip a value between lo and hi
+    //--------------------------------------------------------------------------------------
+    struct Range {
+        double fLo;
+        double fHi;
 
-        //--------------------------------------------------------------------------------------
-        // Range(lo,hi) clip a value between lo and hi
-        //--------------------------------------------------------------------------------------
-        struct Range
+        Range(double x, double y)
+            : fLo(std::min<double>(x, y)), fHi(std::max<double>(x, y))
         {
-            double fLo;
-            double fHi;
-
-            Range(double x, double y) : fLo(std::min<double>(x,y)), fHi(std::max<double>(x,y)) {}
-            double operator()(double x) { return (x<fLo) ? fLo : (x>fHi) ? fHi : x; }
-        };
-
-
-        Range fRange;
-        double fCoef;
-        double fOffset;
-
-    public:
-
-        Interpolator(double lo, double hi, double v1, double v2) : fRange(lo,hi)
-        {
-            if (hi != lo) {
-                // regular case
-                fCoef = (v2-v1)/(hi-lo);
-                fOffset = v1 - lo*fCoef;
-            } else {
-                // degenerate case, avoids division by zero
-                fCoef = 0;
-                fOffset = (v1+v2)/2;
-            }
         }
-        double operator()(double v)
-        {
-            double x = fRange(v);
-            return  fOffset + x*fCoef;
-        }
+        double operator()(double x) { return (x < fLo) ? fLo : (x > fHi) ? fHi : x; }
+    };
 
-        void getLowHigh(double& amin, double& amax)
-        {
-            amin = fRange.fLo;
-            amax = fRange.fHi;
+    Range fRange;
+    double fCoef;
+    double fOffset;
+
+   public:
+    Interpolator(double lo, double hi, double v1, double v2) : fRange(lo, hi)
+    {
+        if (hi != lo) {
+            // regular case
+            fCoef   = (v2 - v1) / (hi - lo);
+            fOffset = v1 - lo * fCoef;
+        } else {
+            // degenerate case, avoids division by zero
+            fCoef   = 0;
+            fOffset = (v1 + v2) / 2;
         }
+    }
+    double operator()(double v)
+    {
+        double x = fRange(v);
+        return fOffset + x * fCoef;
+    }
+
+    void getLowHigh(double& amin, double& amax)
+    {
+        amin = fRange.fLo;
+        amax = fRange.fHi;
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -603,26 +608,23 @@ class Interpolator
 //--------------------------------------------------------------------------------------
 class Interpolator3pt
 {
+   private:
+    Interpolator fSegment1;
+    Interpolator fSegment2;
+    double fMid;
 
-    private:
+   public:
+    Interpolator3pt(double lo, double mi, double hi, double v1, double vm, double v2)
+        : fSegment1(lo, mi, v1, vm), fSegment2(mi, hi, vm, v2), fMid(mi)
+    {
+    }
+    double operator()(double x) { return (x < fMid) ? fSegment1(x) : fSegment2(x); }
 
-        Interpolator fSegment1;
-        Interpolator fSegment2;
-        double fMid;
-
-    public:
-
-        Interpolator3pt(double lo, double mi, double hi, double v1, double vm, double v2) :
-            fSegment1(lo, mi, v1, vm),
-            fSegment2(mi, hi, vm, v2),
-            fMid(mi) {}
-        double operator()(double x) { return  (x < fMid) ? fSegment1(x) : fSegment2(x); }
-
-        void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fSegment1.getLowHigh(amin, amid);
-            fSegment2.getLowHigh(amid, amax);
-        }
+    void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fSegment1.getLowHigh(amin, amid);
+        fSegment2.getLowHigh(amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -630,62 +632,51 @@ class Interpolator3pt
 //--------------------------------------------------------------------------------------
 class ValueConverter
 {
-
-    public:
-
-        virtual ~ValueConverter() {}
-        virtual double ui2faust(double x) = 0;
-        virtual double faust2ui(double x) = 0;
+   public:
+    virtual ~ValueConverter() {}
+    virtual double ui2faust(double x) = 0;
+    virtual double faust2ui(double x) = 0;
 };
 
 //--------------------------------------------------------------------------------------
 // A converter than can be updated
 //--------------------------------------------------------------------------------------
 
-class UpdatableValueConverter : public ValueConverter {
-    
-    protected:
-        
-        bool fActive;
-        
-    public:
-        
-        UpdatableValueConverter():fActive(true)
-        {}
-        virtual ~UpdatableValueConverter()
-        {}
-        
-        virtual void setMappingValues(double amin, double amid, double amax, double min, double init, double max) = 0;
-        virtual void getMappingValues(double& amin, double& amid, double& amax) = 0;
-        
-        void setActive(bool on_off) { fActive = on_off; }
-        bool getActive() { return fActive; }
-    
-};
+class UpdatableValueConverter : public ValueConverter
+{
+   protected:
+    bool fActive;
 
+   public:
+    UpdatableValueConverter() : fActive(true) {}
+    virtual ~UpdatableValueConverter() {}
+
+    virtual void setMappingValues(double amin, double amid, double amax, double min,
+                                  double init, double max)                  = 0;
+    virtual void getMappingValues(double& amin, double& amid, double& amax) = 0;
+
+    void setActive(bool on_off) { fActive = on_off; }
+    bool getActive() { return fActive; }
+};
 
 //--------------------------------------------------------------------------------------
 // Linear conversion between ui and Faust values
 //--------------------------------------------------------------------------------------
 class LinearValueConverter : public ValueConverter
 {
-    
-    private:
-        
-        Interpolator fUI2F;
-        Interpolator fF2UI;
-        
-    public:
-        
-        LinearValueConverter(double umin, double umax, double fmin, double fmax) :
-            fUI2F(umin,umax,fmin,fmax), fF2UI(fmin,fmax,umin,umax)
-        {}
-        
-        LinearValueConverter() : fUI2F(0.,0.,0.,0.), fF2UI(0.,0.,0.,0.)
-        {}
-        virtual double ui2faust(double x) { return fUI2F(x); }
-        virtual double faust2ui(double x) { return fF2UI(x); }
-    
+   private:
+    Interpolator fUI2F;
+    Interpolator fF2UI;
+
+   public:
+    LinearValueConverter(double umin, double umax, double fmin, double fmax)
+        : fUI2F(umin, umax, fmin, fmax), fF2UI(fmin, fmax, umin, umax)
+    {
+    }
+
+    LinearValueConverter() : fUI2F(0., 0., 0., 0.), fF2UI(0., 0., 0., 0.) {}
+    virtual double ui2faust(double x) { return fUI2F(x); }
+    virtual double faust2ui(double x) { return fF2UI(x); }
 };
 
 //--------------------------------------------------------------------------------------
@@ -693,35 +684,35 @@ class LinearValueConverter : public ValueConverter
 //--------------------------------------------------------------------------------------
 class LinearValueConverter2 : public UpdatableValueConverter
 {
-    
-    private:
-    
-        Interpolator3pt fUI2F;
-        Interpolator3pt fF2UI;
-        
-    public:
-    
-        LinearValueConverter2(double amin, double amid, double amax, double min, double init, double max) :
-            fUI2F(amin, amid, amax, min, init, max), fF2UI(min, init, max, amin, amid, amax)
-        {}
-        
-        LinearValueConverter2() : fUI2F(0.,0.,0.,0.,0.,0.), fF2UI(0.,0.,0.,0.,0.,0.)
-        {}
-    
-        virtual double ui2faust(double x) { return fUI2F(x); }
-        virtual double faust2ui(double x) { return fF2UI(x); }
-    
-        virtual void setMappingValues(double amin, double amid, double amax, double min, double init, double max)
-        {
-            fUI2F = Interpolator3pt(amin, amid, amax, min, init, max);
-            fF2UI = Interpolator3pt(min, init, max, amin, amid, amax);
-        }
+   private:
+    Interpolator3pt fUI2F;
+    Interpolator3pt fF2UI;
 
-        virtual void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fUI2F.getMappingValues(amin, amid, amax);
-        }
-    
+   public:
+    LinearValueConverter2(double amin, double amid, double amax, double min, double init,
+                          double max)
+        : fUI2F(amin, amid, amax, min, init, max), fF2UI(min, init, max, amin, amid, amax)
+    {
+    }
+
+    LinearValueConverter2() : fUI2F(0., 0., 0., 0., 0., 0.), fF2UI(0., 0., 0., 0., 0., 0.)
+    {
+    }
+
+    virtual double ui2faust(double x) { return fUI2F(x); }
+    virtual double faust2ui(double x) { return fF2UI(x); }
+
+    virtual void setMappingValues(double amin, double amid, double amax, double min,
+                                  double init, double max)
+    {
+        fUI2F = Interpolator3pt(amin, amid, amax, min, init, max);
+        fF2UI = Interpolator3pt(min, init, max, amin, amid, amax);
+    }
+
+    virtual void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fUI2F.getMappingValues(amin, amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -729,16 +720,21 @@ class LinearValueConverter2 : public UpdatableValueConverter
 //--------------------------------------------------------------------------------------
 class LogValueConverter : public LinearValueConverter
 {
+   public:
+    LogValueConverter(double umin, double umax, double fmin, double fmax)
+        : LinearValueConverter(umin, umax, std::log(std::max<double>(DBL_MIN, fmin)),
+                               std::log(std::max<double>(DBL_MIN, fmax)))
+    {
+    }
 
-    public:
-
-        LogValueConverter(double umin, double umax, double fmin, double fmax) :
-            LinearValueConverter(umin, umax, std::log(std::max<double>(DBL_MIN, fmin)), std::log(std::max<double>(DBL_MIN, fmax)))
-        {}
-
-        virtual double ui2faust(double x) { return std::exp(LinearValueConverter::ui2faust(x)); }
-        virtual double faust2ui(double x) { return LinearValueConverter::faust2ui(std::log(std::max<double>(x, DBL_MIN))); }
-
+    virtual double ui2faust(double x)
+    {
+        return std::exp(LinearValueConverter::ui2faust(x));
+    }
+    virtual double faust2ui(double x)
+    {
+        return LinearValueConverter::faust2ui(std::log(std::max<double>(x, DBL_MIN)));
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -746,16 +742,21 @@ class LogValueConverter : public LinearValueConverter
 //--------------------------------------------------------------------------------------
 class ExpValueConverter : public LinearValueConverter
 {
+   public:
+    ExpValueConverter(double umin, double umax, double fmin, double fmax)
+        : LinearValueConverter(umin, umax, std::min<double>(DBL_MAX, std::exp(fmin)),
+                               std::min<double>(DBL_MAX, std::exp(fmax)))
+    {
+    }
 
-    public:
-
-        ExpValueConverter(double umin, double umax, double fmin, double fmax) :
-            LinearValueConverter(umin, umax, std::min<double>(DBL_MAX, std::exp(fmin)), std::min<double>(DBL_MAX, std::exp(fmax)))
-        {}
-
-        virtual double ui2faust(double x) { return std::log(LinearValueConverter::ui2faust(x)); }
-        virtual double faust2ui(double x) { return LinearValueConverter::faust2ui(std::min<double>(DBL_MAX, std::exp(x))); }
-
+    virtual double ui2faust(double x)
+    {
+        return std::log(LinearValueConverter::ui2faust(x));
+    }
+    virtual double faust2ui(double x)
+    {
+        return LinearValueConverter::faust2ui(std::min<double>(DBL_MAX, std::exp(x)));
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -764,34 +765,33 @@ class ExpValueConverter : public LinearValueConverter
 //--------------------------------------------------------------------------------------
 class AccUpConverter : public UpdatableValueConverter
 {
+   private:
+    Interpolator3pt fA2F;
+    Interpolator3pt fF2A;
 
-    private:
+   public:
+    AccUpConverter(double amin, double amid, double amax, double fmin, double fmid,
+                   double fmax)
+        : fA2F(amin, amid, amax, fmin, fmid, fmax)
+        , fF2A(fmin, fmid, fmax, amin, amid, amax)
+    {
+    }
 
-        Interpolator3pt fA2F;
-        Interpolator3pt fF2A;
+    virtual double ui2faust(double x) { return fA2F(x); }
+    virtual double faust2ui(double x) { return fF2A(x); }
 
-    public:
+    virtual void setMappingValues(double amin, double amid, double amax, double fmin,
+                                  double fmid, double fmax)
+    {
+        //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccUpConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
+        fA2F = Interpolator3pt(amin, amid, amax, fmin, fmid, fmax);
+        fF2A = Interpolator3pt(fmin, fmid, fmax, amin, amid, amax);
+    }
 
-        AccUpConverter(double amin, double amid, double amax, double fmin, double fmid, double fmax) :
-            fA2F(amin,amid,amax,fmin,fmid,fmax),
-            fF2A(fmin,fmid,fmax,amin,amid,amax)
-        {}
-
-        virtual double ui2faust(double x) { return fA2F(x); }
-        virtual double faust2ui(double x) { return fF2A(x); }
-
-        virtual void setMappingValues(double amin, double amid, double amax, double fmin, double fmid, double fmax)
-        {
-            //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccUpConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
-            fA2F = Interpolator3pt(amin, amid, amax, fmin, fmid, fmax);
-            fF2A = Interpolator3pt(fmin, fmid, fmax, amin, amid, amax);
-        }
-
-        virtual void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fA2F.getMappingValues(amin, amid, amax);
-        }
-
+    virtual void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fA2F.getMappingValues(amin, amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -800,33 +800,33 @@ class AccUpConverter : public UpdatableValueConverter
 //--------------------------------------------------------------------------------------
 class AccDownConverter : public UpdatableValueConverter
 {
+   private:
+    Interpolator3pt fA2F;
+    Interpolator3pt fF2A;
 
-    private:
+   public:
+    AccDownConverter(double amin, double amid, double amax, double fmin, double fmid,
+                     double fmax)
+        : fA2F(amin, amid, amax, fmax, fmid, fmin)
+        , fF2A(fmin, fmid, fmax, amax, amid, amin)
+    {
+    }
 
-        Interpolator3pt	fA2F;
-        Interpolator3pt	fF2A;
+    virtual double ui2faust(double x) { return fA2F(x); }
+    virtual double faust2ui(double x) { return fF2A(x); }
 
-    public:
+    virtual void setMappingValues(double amin, double amid, double amax, double fmin,
+                                  double fmid, double fmax)
+    {
+        //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccDownConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
+        fA2F = Interpolator3pt(amin, amid, amax, fmax, fmid, fmin);
+        fF2A = Interpolator3pt(fmin, fmid, fmax, amax, amid, amin);
+    }
 
-        AccDownConverter(double amin, double amid, double amax, double fmin, double fmid, double fmax) :
-            fA2F(amin,amid,amax,fmax,fmid,fmin),
-            fF2A(fmin,fmid,fmax,amax,amid,amin)
-        {}
-
-        virtual double ui2faust(double x) { return fA2F(x); }
-        virtual double faust2ui(double x) { return fF2A(x); }
-
-        virtual void setMappingValues(double amin, double amid, double amax, double fmin, double fmid, double fmax)
-        {
-             //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccDownConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
-            fA2F = Interpolator3pt(amin, amid, amax, fmax, fmid, fmin);
-            fF2A = Interpolator3pt(fmin, fmid, fmax, amax, amid, amin);
-        }
-
-        virtual void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fA2F.getMappingValues(amin, amid, amax);
-        }
+    virtual void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fA2F.getMappingValues(amin, amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -835,33 +835,34 @@ class AccDownConverter : public UpdatableValueConverter
 //--------------------------------------------------------------------------------------
 class AccUpDownConverter : public UpdatableValueConverter
 {
+   private:
+    Interpolator3pt fA2F;
+    Interpolator fF2A;
 
-    private:
+   public:
+    AccUpDownConverter(double amin, double amid, double amax, double fmin, double fmid,
+                       double fmax)
+        : fA2F(amin, amid, amax, fmin, fmax, fmin)
+        , fF2A(fmin, fmax, amin,
+               amax)  // Special, pseudo inverse of a non monotonic function
+    {
+    }
 
-        Interpolator3pt	fA2F;
-        Interpolator fF2A;
+    virtual double ui2faust(double x) { return fA2F(x); }
+    virtual double faust2ui(double x) { return fF2A(x); }
 
-    public:
+    virtual void setMappingValues(double amin, double amid, double amax, double fmin,
+                                  double fmid, double fmax)
+    {
+        //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccUpDownConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
+        fA2F = Interpolator3pt(amin, amid, amax, fmin, fmax, fmin);
+        fF2A = Interpolator(fmin, fmax, amin, amax);
+    }
 
-        AccUpDownConverter(double amin, double amid, double amax, double fmin, double fmid, double fmax) :
-            fA2F(amin,amid,amax,fmin,fmax,fmin),
-            fF2A(fmin,fmax,amin,amax)				// Special, pseudo inverse of a non monotonic function
-        {}
-
-        virtual double ui2faust(double x) { return fA2F(x); }
-        virtual double faust2ui(double x) { return fF2A(x); }
-
-        virtual void setMappingValues(double amin, double amid, double amax, double fmin, double fmid, double fmax)
-        {
-            //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccUpDownConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
-            fA2F = Interpolator3pt(amin, amid, amax, fmin, fmax, fmin);
-            fF2A = Interpolator(fmin, fmax, amin, amax);
-        }
-
-        virtual void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fA2F.getMappingValues(amin, amid, amax);
-        }
+    virtual void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fA2F.getMappingValues(amin, amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -870,33 +871,34 @@ class AccUpDownConverter : public UpdatableValueConverter
 //--------------------------------------------------------------------------------------
 class AccDownUpConverter : public UpdatableValueConverter
 {
+   private:
+    Interpolator3pt fA2F;
+    Interpolator fF2A;
 
-    private:
+   public:
+    AccDownUpConverter(double amin, double amid, double amax, double fmin, double fmid,
+                       double fmax)
+        : fA2F(amin, amid, amax, fmax, fmin, fmax)
+        , fF2A(fmin, fmax, amin,
+               amax)  // Special, pseudo inverse of a non monotonic function
+    {
+    }
 
-        Interpolator3pt	fA2F;
-        Interpolator fF2A;
+    virtual double ui2faust(double x) { return fA2F(x); }
+    virtual double faust2ui(double x) { return fF2A(x); }
 
-    public:
+    virtual void setMappingValues(double amin, double amid, double amax, double fmin,
+                                  double fmid, double fmax)
+    {
+        //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccDownUpConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
+        fA2F = Interpolator3pt(amin, amid, amax, fmax, fmin, fmax);
+        fF2A = Interpolator(fmin, fmax, amin, amax);
+    }
 
-        AccDownUpConverter(double amin, double amid, double amax, double fmin, double fmid, double fmax) :
-            fA2F(amin,amid,amax,fmax,fmin,fmax),
-            fF2A(fmin,fmax,amin,amax)				// Special, pseudo inverse of a non monotonic function
-        {}
-
-        virtual double ui2faust(double x) { return fA2F(x); }
-        virtual double faust2ui(double x) { return fF2A(x); }
-
-        virtual void setMappingValues(double amin, double amid, double amax, double fmin, double fmid, double fmax)
-        {
-            //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccDownUpConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
-            fA2F = Interpolator3pt(amin, amid, amax, fmax, fmin, fmax);
-            fF2A = Interpolator(fmin, fmax, amin, amax);
-        }
-
-        virtual void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fA2F.getMappingValues(amin, amid, amax);
-        }
+    virtual void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fA2F.getMappingValues(amin, amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -904,28 +906,27 @@ class AccDownUpConverter : public UpdatableValueConverter
 //--------------------------------------------------------------------------------------
 class ZoneControl
 {
+   protected:
+    FAUSTFLOAT* fZone;
 
-    protected:
+   public:
+    ZoneControl(FAUSTFLOAT* zone) : fZone(zone) {}
+    virtual ~ZoneControl() {}
 
-        FAUSTFLOAT*	fZone;
+    virtual void update(double v) const {}
 
-    public:
+    virtual void setMappingValues(int curve, double amin, double amid, double amax,
+                                  double min, double init, double max)
+    {
+    }
+    virtual void getMappingValues(double& amin, double& amid, double& amax) {}
 
-        ZoneControl(FAUSTFLOAT* zone) : fZone(zone) {}
-        virtual ~ZoneControl() {}
+    FAUSTFLOAT* getZone() { return fZone; }
 
-        virtual void update(double v) const {}
+    virtual void setActive(bool on_off) {}
+    virtual bool getActive() { return false; }
 
-        virtual void setMappingValues(int curve, double amin, double amid, double amax, double min, double init, double max) {}
-        virtual void getMappingValues(double& amin, double& amid, double& amax) {}
-
-        FAUSTFLOAT* getZone() { return fZone; }
-
-        virtual void setActive(bool on_off) {}
-        virtual bool getActive() { return false; }
-
-        virtual int getCurve() { return -1; }
-
+    virtual int getCurve() { return -1; }
 };
 
 //--------------------------------------------------------------------------------------
@@ -933,20 +934,22 @@ class ZoneControl
 //--------------------------------------------------------------------------------------
 class ConverterZoneControl : public ZoneControl
 {
+   protected:
+    ValueConverter* fValueConverter;
 
-    protected:
+   public:
+    ConverterZoneControl(FAUSTFLOAT* zone, ValueConverter* converter)
+        : ZoneControl(zone), fValueConverter(converter)
+    {
+    }
+    virtual ~ConverterZoneControl()
+    {
+        delete fValueConverter;
+    }  // Assuming fValueConverter is not kept elsewhere...
 
-        ValueConverter* fValueConverter;
+    virtual void update(double v) const { *fZone = fValueConverter->ui2faust(v); }
 
-    public:
-
-        ConverterZoneControl(FAUSTFLOAT* zone, ValueConverter* converter) : ZoneControl(zone), fValueConverter(converter) {}
-        virtual ~ConverterZoneControl() { delete fValueConverter; } // Assuming fValueConverter is not kept elsewhere...
-
-        virtual void update(double v) const { *fZone = fValueConverter->ui2faust(v); }
-
-        ValueConverter* getConverter() { return fValueConverter; }
-
+    ValueConverter* getConverter() { return fValueConverter; }
 };
 
 //--------------------------------------------------------------------------------------
@@ -955,477 +958,496 @@ class ConverterZoneControl : public ZoneControl
 //--------------------------------------------------------------------------------------
 class CurveZoneControl : public ZoneControl
 {
+   private:
+    std::vector<UpdatableValueConverter*> fValueConverters;
+    int fCurve;
 
-    private:
-
-        std::vector<UpdatableValueConverter*> fValueConverters;
-        int fCurve;
-
-    public:
-
-        CurveZoneControl(FAUSTFLOAT* zone, int curve, double amin, double amid, double amax, double min, double init, double max) : ZoneControl(zone), fCurve(0)
-        {
-            assert(curve >= 0 && curve <= 3);
-            fValueConverters.push_back(new AccUpConverter(amin, amid, amax, min, init, max));
-            fValueConverters.push_back(new AccDownConverter(amin, amid, amax, min, init, max));
-            fValueConverters.push_back(new AccUpDownConverter(amin, amid, amax, min, init, max));
-            fValueConverters.push_back(new AccDownUpConverter(amin, amid, amax, min, init, max));
-            fCurve = curve;
+   public:
+    CurveZoneControl(FAUSTFLOAT* zone, int curve, double amin, double amid, double amax,
+                     double min, double init, double max)
+        : ZoneControl(zone), fCurve(0)
+    {
+        assert(curve >= 0 && curve <= 3);
+        fValueConverters.push_back(new AccUpConverter(amin, amid, amax, min, init, max));
+        fValueConverters.push_back(
+            new AccDownConverter(amin, amid, amax, min, init, max));
+        fValueConverters.push_back(
+            new AccUpDownConverter(amin, amid, amax, min, init, max));
+        fValueConverters.push_back(
+            new AccDownUpConverter(amin, amid, amax, min, init, max));
+        fCurve = curve;
+    }
+    virtual ~CurveZoneControl()
+    {
+        std::vector<UpdatableValueConverter*>::iterator it;
+        for (it = fValueConverters.begin(); it != fValueConverters.end(); it++) {
+            delete (*it);
         }
-        virtual ~CurveZoneControl()
-        {
-            std::vector<UpdatableValueConverter*>::iterator it;
-            for (it = fValueConverters.begin(); it != fValueConverters.end(); it++) {
-                delete(*it);
-            }
-        }
-        void update(double v) const { if (fValueConverters[fCurve]->getActive()) *fZone = fValueConverters[fCurve]->ui2faust(v); }
+    }
+    void update(double v) const
+    {
+        if (fValueConverters[fCurve]->getActive())
+            *fZone = fValueConverters[fCurve]->ui2faust(v);
+    }
 
-        void setMappingValues(int curve, double amin, double amid, double amax, double min, double init, double max)
-        {
-            fValueConverters[curve]->setMappingValues(amin, amid, amax, min, init, max);
-            fCurve = curve;
-        }
+    void setMappingValues(int curve, double amin, double amid, double amax, double min,
+                          double init, double max)
+    {
+        fValueConverters[curve]->setMappingValues(amin, amid, amax, min, init, max);
+        fCurve = curve;
+    }
 
-        void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fValueConverters[fCurve]->getMappingValues(amin, amid, amax);
-        }
+    void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fValueConverters[fCurve]->getMappingValues(amin, amid, amax);
+    }
 
-        void setActive(bool on_off)
-        {
-            std::vector<UpdatableValueConverter*>::iterator it;
-            for (it = fValueConverters.begin(); it != fValueConverters.end(); it++) {
-                (*it)->setActive(on_off);
-            }
+    void setActive(bool on_off)
+    {
+        std::vector<UpdatableValueConverter*>::iterator it;
+        for (it = fValueConverters.begin(); it != fValueConverters.end(); it++) {
+            (*it)->setActive(on_off);
         }
+    }
 
-        int getCurve() { return fCurve; }
+    int getCurve() { return fCurve; }
 };
 
 class ZoneReader
 {
+   private:
+    FAUSTFLOAT* fZone;
+    Interpolator fInterpolator;
 
-    private:
+   public:
+    ZoneReader(FAUSTFLOAT* zone, double lo, double hi)
+        : fZone(zone), fInterpolator(lo, hi, 0, 255)
+    {
+    }
 
-        FAUSTFLOAT* fZone;
-        Interpolator fInterpolator;
+    virtual ~ZoneReader() {}
 
-    public:
-
-        ZoneReader(FAUSTFLOAT* zone, double lo, double hi) : fZone(zone), fInterpolator(lo, hi, 0, 255) {}
-
-        virtual ~ZoneReader() {}
-
-        int getValue()
-        {
-            return (fZone != nullptr) ? int(fInterpolator(*fZone)) : 127;
-        }
-
+    int getValue() { return (fZone != nullptr) ? int(fInterpolator(*fZone)) : 127; }
 };
 
 #endif
 /**************************  END  ValueConverter.h **************************/
 
-class APIUI : public PathBuilder, public Meta, public UI
+class APIUI
+    : public PathBuilder
+    , public Meta
+    , public UI
 {
-    public:
-    
-        enum ItemType { kButton = 0, kCheckButton, kVSlider, kHSlider, kNumEntry, kHBargraph, kVBargraph };
-  
-    protected:
-    
-        enum { kLin = 0, kLog = 1, kExp = 2 };
-    
-        int fNumParameters;
-        std::vector<std::string> fPaths;
-        std::vector<std::string> fLabels;
-        std::map<std::string, int> fPathMap;
-        std::map<std::string, int> fLabelMap;
-        std::vector<ValueConverter*> fConversion;
-        std::vector<FAUSTFLOAT*> fZone;
-        std::vector<FAUSTFLOAT> fInit;
-        std::vector<FAUSTFLOAT> fMin;
-        std::vector<FAUSTFLOAT> fMax;
-        std::vector<FAUSTFLOAT> fStep;
-        std::vector<ItemType> fItemType;
-        std::vector<std::map<std::string, std::string> > fMetaData;
-        std::vector<ZoneControl*> fAcc[3];
-        std::vector<ZoneControl*> fGyr[3];
+   public:
+    enum ItemType {
+        kButton = 0,
+        kCheckButton,
+        kVSlider,
+        kHSlider,
+        kNumEntry,
+        kHBargraph,
+        kVBargraph
+    };
 
-        // Screen color control
-        // "...[screencolor:red]..." etc.
-        bool fHasScreenControl;      // true if control screen color metadata
-        ZoneReader* fRedReader;
-        ZoneReader* fGreenReader;
-        ZoneReader* fBlueReader;
+   protected:
+    enum { kLin = 0, kLog = 1, kExp = 2 };
 
-        // Current values controlled by metadata
-        std::string fCurrentUnit;
-        int fCurrentScale;
-        std::string fCurrentAcc;
-        std::string fCurrentGyr;
-        std::string fCurrentColor;
-        std::string fCurrentTooltip;
-        std::map<std::string, std::string> fCurrentMetadata;
-    
-        // Add a generic parameter
-        virtual void addParameter(const char* label,
-                                FAUSTFLOAT* zone,
-                                FAUSTFLOAT init,
-                                FAUSTFLOAT min,
-                                FAUSTFLOAT max,
-                                FAUSTFLOAT step,
-                                ItemType type)
-        {
-            std::string path = buildPath(label);
-            fPathMap[path] = fLabelMap[label] = fNumParameters++;
-            fPaths.push_back(path);
-            fLabels.push_back(label);
-            fZone.push_back(zone);
-            fInit.push_back(init);
-            fMin.push_back(min);
-            fMax.push_back(max);
-            fStep.push_back(step);
-            fItemType.push_back(type);
-            
-            // handle scale metadata
-            switch (fCurrentScale) {
-                case kLin:
-                    fConversion.push_back(new LinearValueConverter(0, 1, min, max));
-                    break;
-                case kLog:
-                    fConversion.push_back(new LogValueConverter(0, 1, min, max));
-                    break;
-                case kExp: fConversion.push_back(new ExpValueConverter(0, 1, min, max));
-                    break;
-            }
-            fCurrentScale = kLin;
-            
-            if (fCurrentAcc.size() > 0 && fCurrentGyr.size() > 0) {
-                std::cerr << "warning : 'acc' and 'gyr' metadata used for the same " << label << " parameter !!\n";
-            }
+    int fNumParameters;
+    std::vector<std::string> fPaths;
+    std::vector<std::string> fLabels;
+    std::map<std::string, int> fPathMap;
+    std::map<std::string, int> fLabelMap;
+    std::vector<ValueConverter*> fConversion;
+    std::vector<FAUSTFLOAT*> fZone;
+    std::vector<FAUSTFLOAT> fInit;
+    std::vector<FAUSTFLOAT> fMin;
+    std::vector<FAUSTFLOAT> fMax;
+    std::vector<FAUSTFLOAT> fStep;
+    std::vector<ItemType> fItemType;
+    std::vector<std::map<std::string, std::string> > fMetaData;
+    std::vector<ZoneControl*> fAcc[3];
+    std::vector<ZoneControl*> fGyr[3];
 
-            // handle acc metadata "...[acc : <axe> <curve> <amin> <amid> <amax>]..."
-            if (fCurrentAcc.size() > 0) {
-                std::istringstream iss(fCurrentAcc);
-                int axe, curve;
-                double amin, amid, amax;
-                iss >> axe >> curve >> amin >> amid >> amax;
+    // Screen color control
+    // "...[screencolor:red]..." etc.
+    bool fHasScreenControl;  // true if control screen color metadata
+    ZoneReader* fRedReader;
+    ZoneReader* fGreenReader;
+    ZoneReader* fBlueReader;
 
-                if ((0 <= axe) && (axe < 3) &&
-                    (0 <= curve) && (curve < 4) &&
-                    (amin < amax) && (amin <= amid) && (amid <= amax))
-                {
-                    fAcc[axe].push_back(new CurveZoneControl(zone, curve, amin, amid, amax, min, init, max));
-                } else {
-                    std::cerr << "incorrect acc metadata : " << fCurrentAcc << std::endl;
-                }
-                fCurrentAcc = "";
-            }
-       
-            // handle gyr metadata "...[gyr : <axe> <curve> <amin> <amid> <amax>]..."
-            if (fCurrentGyr.size() > 0) {
-                std::istringstream iss(fCurrentGyr);
-                int axe, curve;
-                double amin, amid, amax;
-                iss >> axe >> curve >> amin >> amid >> amax;
+    // Current values controlled by metadata
+    std::string fCurrentUnit;
+    int fCurrentScale;
+    std::string fCurrentAcc;
+    std::string fCurrentGyr;
+    std::string fCurrentColor;
+    std::string fCurrentTooltip;
+    std::map<std::string, std::string> fCurrentMetadata;
 
-                if ((0 <= axe) && (axe < 3) &&
-                    (0 <= curve) && (curve < 4) &&
-                    (amin < amax) && (amin <= amid) && (amid <= amax))
-                {
-                    fGyr[axe].push_back(new CurveZoneControl(zone, curve, amin, amid, amax, min, init, max));
-                } else {
-                    std::cerr << "incorrect gyr metadata : " << fCurrentGyr << std::endl;
-                }
-                fCurrentGyr = "";
-            }
-        
-            // handle screencolor metadata "...[screencolor:red|green|blue|white]..."
-            if (fCurrentColor.size() > 0) {
-                if ((fCurrentColor == "red") && (fRedReader == 0)) {
-                    fRedReader = new ZoneReader(zone, min, max);
-                    fHasScreenControl = true;
-                } else if ((fCurrentColor == "green") && (fGreenReader == 0)) {
-                    fGreenReader = new ZoneReader(zone, min, max);
-                    fHasScreenControl = true;
-                } else if ((fCurrentColor == "blue") && (fBlueReader == 0)) {
-                    fBlueReader = new ZoneReader(zone, min, max);
-                    fHasScreenControl = true;
-                } else if ((fCurrentColor == "white") && (fRedReader == 0) && (fGreenReader == 0) && (fBlueReader == 0)) {
-                    fRedReader = new ZoneReader(zone, min, max);
-                    fGreenReader = new ZoneReader(zone, min, max);
-                    fBlueReader = new ZoneReader(zone, min, max);
-                    fHasScreenControl = true;
-                } else {
-                    std::cerr << "incorrect screencolor metadata : " << fCurrentColor << std::endl;
-                }
-            }
-            fCurrentColor = "";
-            
-            fMetaData.push_back(fCurrentMetadata);
-            fCurrentMetadata.clear();
+    // Add a generic parameter
+    virtual void addParameter(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init,
+                              FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step,
+                              ItemType type)
+    {
+        std::string path = buildPath(label);
+        fPathMap[path] = fLabelMap[label] = fNumParameters++;
+        fPaths.push_back(path);
+        fLabels.push_back(label);
+        fZone.push_back(zone);
+        fInit.push_back(init);
+        fMin.push_back(min);
+        fMax.push_back(max);
+        fStep.push_back(step);
+        fItemType.push_back(type);
+
+        // handle scale metadata
+        switch (fCurrentScale) {
+        case kLin:
+            fConversion.push_back(new LinearValueConverter(0, 1, min, max));
+            break;
+        case kLog:
+            fConversion.push_back(new LogValueConverter(0, 1, min, max));
+            break;
+        case kExp:
+            fConversion.push_back(new ExpValueConverter(0, 1, min, max));
+            break;
+        }
+        fCurrentScale = kLin;
+
+        if (fCurrentAcc.size() > 0 && fCurrentGyr.size() > 0) {
+            std::cerr << "warning : 'acc' and 'gyr' metadata used for the same " << label
+                      << " parameter !!\n";
         }
 
-        int getZoneIndex(std::vector<ZoneControl*>* table, int p, int val)
-        {
-            FAUSTFLOAT* zone = fZone[p];
-            for (size_t i = 0; i < table[val].size(); i++) {
-                if (zone == table[val][i]->getZone()) return int(i);
+        // handle acc metadata "...[acc : <axe> <curve> <amin> <amid> <amax>]..."
+        if (fCurrentAcc.size() > 0) {
+            std::istringstream iss(fCurrentAcc);
+            int axe, curve;
+            double amin, amid, amax;
+            iss >> axe >> curve >> amin >> amid >> amax;
+
+            if ((0 <= axe) && (axe < 3) && (0 <= curve) && (curve < 4) && (amin < amax)
+                && (amin <= amid) && (amid <= amax)) {
+                fAcc[axe].push_back(
+                    new CurveZoneControl(zone, curve, amin, amid, amax, min, init, max));
+            } else {
+                std::cerr << "incorrect acc metadata : " << fCurrentAcc << std::endl;
             }
+            fCurrentAcc = "";
+        }
+
+        // handle gyr metadata "...[gyr : <axe> <curve> <amin> <amid> <amax>]..."
+        if (fCurrentGyr.size() > 0) {
+            std::istringstream iss(fCurrentGyr);
+            int axe, curve;
+            double amin, amid, amax;
+            iss >> axe >> curve >> amin >> amid >> amax;
+
+            if ((0 <= axe) && (axe < 3) && (0 <= curve) && (curve < 4) && (amin < amax)
+                && (amin <= amid) && (amid <= amax)) {
+                fGyr[axe].push_back(
+                    new CurveZoneControl(zone, curve, amin, amid, amax, min, init, max));
+            } else {
+                std::cerr << "incorrect gyr metadata : " << fCurrentGyr << std::endl;
+            }
+            fCurrentGyr = "";
+        }
+
+        // handle screencolor metadata "...[screencolor:red|green|blue|white]..."
+        if (fCurrentColor.size() > 0) {
+            if ((fCurrentColor == "red") && (fRedReader == 0)) {
+                fRedReader        = new ZoneReader(zone, min, max);
+                fHasScreenControl = true;
+            } else if ((fCurrentColor == "green") && (fGreenReader == 0)) {
+                fGreenReader      = new ZoneReader(zone, min, max);
+                fHasScreenControl = true;
+            } else if ((fCurrentColor == "blue") && (fBlueReader == 0)) {
+                fBlueReader       = new ZoneReader(zone, min, max);
+                fHasScreenControl = true;
+            } else if ((fCurrentColor == "white") && (fRedReader == 0)
+                       && (fGreenReader == 0) && (fBlueReader == 0)) {
+                fRedReader        = new ZoneReader(zone, min, max);
+                fGreenReader      = new ZoneReader(zone, min, max);
+                fBlueReader       = new ZoneReader(zone, min, max);
+                fHasScreenControl = true;
+            } else {
+                std::cerr << "incorrect screencolor metadata : " << fCurrentColor
+                          << std::endl;
+            }
+        }
+        fCurrentColor = "";
+
+        fMetaData.push_back(fCurrentMetadata);
+        fCurrentMetadata.clear();
+    }
+
+    int getZoneIndex(std::vector<ZoneControl*>* table, int p, int val)
+    {
+        FAUSTFLOAT* zone = fZone[p];
+        for (size_t i = 0; i < table[val].size(); i++) {
+            if (zone == table[val][i]->getZone()) return int(i);
+        }
+        return -1;
+    }
+
+    void setConverter(std::vector<ZoneControl*>* table, int p, int val, int curve,
+                      double amin, double amid, double amax)
+    {
+        int id1 = getZoneIndex(table, p, 0);
+        int id2 = getZoneIndex(table, p, 1);
+        int id3 = getZoneIndex(table, p, 2);
+
+        // Deactivates everywhere..
+        if (id1 != -1) table[0][id1]->setActive(false);
+        if (id2 != -1) table[1][id2]->setActive(false);
+        if (id3 != -1) table[2][id3]->setActive(false);
+
+        if (val == -1) {  // Means: no more mapping...
+            // So stay all deactivated...
+        } else {
+            int id4 = getZoneIndex(table, p, val);
+            if (id4 != -1) {
+                // Reactivate the one we edit...
+                table[val][id4]->setMappingValues(curve, amin, amid, amax, fMin[p],
+                                                  fInit[p], fMax[p]);
+                table[val][id4]->setActive(true);
+            } else {
+                // Allocate a new CurveZoneControl which is 'active' by default
+                FAUSTFLOAT* zone = fZone[p];
+                table[val].push_back(new CurveZoneControl(zone, curve, amin, amid, amax,
+                                                          fMin[p], fInit[p], fMax[p]));
+            }
+        }
+    }
+
+    void getConverter(std::vector<ZoneControl*>* table, int p, int& val, int& curve,
+                      double& amin, double& amid, double& amax)
+    {
+        int id1 = getZoneIndex(table, p, 0);
+        int id2 = getZoneIndex(table, p, 1);
+        int id3 = getZoneIndex(table, p, 2);
+
+        if (id1 != -1) {
+            val   = 0;
+            curve = table[val][id1]->getCurve();
+            table[val][id1]->getMappingValues(amin, amid, amax);
+        } else if (id2 != -1) {
+            val   = 1;
+            curve = table[val][id2]->getCurve();
+            table[val][id2]->getMappingValues(amin, amid, amax);
+        } else if (id3 != -1) {
+            val   = 2;
+            curve = table[val][id3]->getCurve();
+            table[val][id3]->getMappingValues(amin, amid, amax);
+        } else {
+            val   = -1;  // No mapping
+            curve = 0;
+            amin  = -100.;
+            amid  = 0.;
+            amax  = 100.;
+        }
+    }
+
+   public:
+    enum Type { kAcc = 0, kGyr = 1, kNoType };
+
+    APIUI()
+        : fNumParameters(0)
+        , fHasScreenControl(false)
+        , fRedReader(0)
+        , fGreenReader(0)
+        , fBlueReader(0)
+        , fCurrentScale(kLin)
+    {
+    }
+
+    virtual ~APIUI()
+    {
+        for (auto& it : fConversion) delete it;
+        for (int i = 0; i < 3; i++) {
+            for (auto& it : fAcc[i]) delete it;
+            for (auto& it : fGyr[i]) delete it;
+        }
+        delete fRedReader;
+        delete fGreenReader;
+        delete fBlueReader;
+    }
+
+    // -- widget's layouts
+
+    virtual void openTabBox(const char* label) { pushLabel(label); }
+    virtual void openHorizontalBox(const char* label) { pushLabel(label); }
+    virtual void openVerticalBox(const char* label) { pushLabel(label); }
+    virtual void closeBox() { popLabel(); }
+
+    // -- active widgets
+
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    {
+        addParameter(label, zone, 0, 0, 1, 1, kButton);
+    }
+
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    {
+        addParameter(label, zone, 0, 0, 1, 1, kCheckButton);
+    }
+
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init,
+                                   FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addParameter(label, zone, init, min, max, step, kVSlider);
+    }
+
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init,
+                                     FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addParameter(label, zone, init, min, max, step, kHSlider);
+    }
+
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init,
+                             FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addParameter(label, zone, init, min, max, step, kNumEntry);
+    }
+
+    // -- passive widgets
+
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone,
+                                       FAUSTFLOAT min, FAUSTFLOAT max)
+    {
+        addParameter(label, zone, min, min, max, (max - min) / 1000.0, kHBargraph);
+    }
+
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min,
+                                     FAUSTFLOAT max)
+    {
+        addParameter(label, zone, min, min, max, (max - min) / 1000.0, kVBargraph);
+    }
+
+    // -- soundfiles
+
+    virtual void addSoundfile(const char* label, const char* filename,
+                              Soundfile** sf_zone)
+    {
+    }
+
+    // -- metadata declarations
+
+    virtual void declare(FAUSTFLOAT* zone, const char* key, const char* val)
+    {
+        // Keep metadata
+        fCurrentMetadata[key] = val;
+
+        if (strcmp(key, "scale") == 0) {
+            if (strcmp(val, "log") == 0) {
+                fCurrentScale = kLog;
+            } else if (strcmp(val, "exp") == 0) {
+                fCurrentScale = kExp;
+            } else {
+                fCurrentScale = kLin;
+            }
+        } else if (strcmp(key, "unit") == 0) {
+            fCurrentUnit = val;
+        } else if (strcmp(key, "acc") == 0) {
+            fCurrentAcc = val;
+        } else if (strcmp(key, "gyr") == 0) {
+            fCurrentGyr = val;
+        } else if (strcmp(key, "screencolor") == 0) {
+            fCurrentColor = val;  // val = "red", "green", "blue" or "white"
+        } else if (strcmp(key, "tooltip") == 0) {
+            fCurrentTooltip = val;
+        }
+    }
+
+    virtual void declare(const char* key, const char* val) {}
+
+    //-------------------------------------------------------------------------------
+    // Simple API part
+    //-------------------------------------------------------------------------------
+    int getParamsCount() { return fNumParameters; }
+    int getParamIndex(const char* path)
+    {
+        if (fPathMap.find(path) != fPathMap.end()) {
+            return fPathMap[path];
+        } else if (fLabelMap.find(path) != fLabelMap.end()) {
+            return fLabelMap[path];
+        } else {
             return -1;
         }
-    
-        void setConverter(std::vector<ZoneControl*>* table, int p, int val, int curve, double amin, double amid, double amax)
-        {
-            int id1 = getZoneIndex(table, p, 0);
-            int id2 = getZoneIndex(table, p, 1);
-            int id3 = getZoneIndex(table, p, 2);
-            
-            // Deactivates everywhere..
-            if (id1 != -1) table[0][id1]->setActive(false);
-            if (id2 != -1) table[1][id2]->setActive(false);
-            if (id3 != -1) table[2][id3]->setActive(false);
-            
-            if (val == -1) { // Means: no more mapping...
-                // So stay all deactivated...
-            } else {
-                int id4 = getZoneIndex(table, p, val);
-                if (id4 != -1) {
-                    // Reactivate the one we edit...
-                    table[val][id4]->setMappingValues(curve, amin, amid, amax, fMin[p], fInit[p], fMax[p]);
-                    table[val][id4]->setActive(true);
-                } else {
-                    // Allocate a new CurveZoneControl which is 'active' by default
-                    FAUSTFLOAT* zone = fZone[p];
-                    table[val].push_back(new CurveZoneControl(zone, curve, amin, amid, amax, fMin[p], fInit[p], fMax[p]));
-                }
-            }
-        }
-    
-        void getConverter(std::vector<ZoneControl*>* table, int p, int& val, int& curve, double& amin, double& amid, double& amax)
-        {
-            int id1 = getZoneIndex(table, p, 0);
-            int id2 = getZoneIndex(table, p, 1);
-            int id3 = getZoneIndex(table, p, 2);
-            
-            if (id1 != -1) {
-                val = 0;
-                curve = table[val][id1]->getCurve();
-                table[val][id1]->getMappingValues(amin, amid, amax);
-            } else if (id2 != -1) {
-                val = 1;
-                curve = table[val][id2]->getCurve();
-                table[val][id2]->getMappingValues(amin, amid, amax);
-            } else if (id3 != -1) {
-                val = 2;
-                curve = table[val][id3]->getCurve();
-                table[val][id3]->getMappingValues(amin, amid, amax);
-            } else {
-                val = -1; // No mapping
-                curve = 0;
-                amin = -100.;
-                amid = 0.;
-                amax = 100.;
-            }
-        }
+    }
+    const char* getParamAddress(int p) { return fPaths[p].c_str(); }
+    const char* getParamLabel(int p) { return fLabels[p].c_str(); }
+    std::map<const char*, const char*> getMetadata(int p)
+    {
+        std::map<const char*, const char*> res;
+        std::map<std::string, std::string> metadata = fMetaData[p];
+        for (auto it : metadata) { res[it.first.c_str()] = it.second.c_str(); }
+        return res;
+    }
 
-     public:
-    
-        enum Type { kAcc = 0, kGyr = 1, kNoType };
-   
-        APIUI() : fNumParameters(0), fHasScreenControl(false), fRedReader(0), fGreenReader(0), fBlueReader(0), fCurrentScale(kLin)
-        {}
+    const char* getMetadata(int p, const char* key)
+    {
+        return (fMetaData[p].find(key) != fMetaData[p].end()) ? fMetaData[p][key].c_str()
+                                                              : "";
+    }
+    FAUSTFLOAT getParamMin(int p) { return fMin[p]; }
+    FAUSTFLOAT getParamMax(int p) { return fMax[p]; }
+    FAUSTFLOAT getParamStep(int p) { return fStep[p]; }
+    FAUSTFLOAT getParamInit(int p) { return fInit[p]; }
 
-        virtual ~APIUI()
-        {
-            for (auto& it : fConversion) delete it;
-            for (int i = 0; i < 3; i++) {
-                for (auto& it : fAcc[i]) delete it;
-                for (auto& it : fGyr[i]) delete it;
-            }
-            delete fRedReader;
-            delete fGreenReader;
-            delete fBlueReader;
-        }
-    
-        // -- widget's layouts
+    FAUSTFLOAT* getParamZone(int p) { return fZone[p]; }
+    FAUSTFLOAT getParamValue(int p) { return *fZone[p]; }
+    void setParamValue(int p, FAUSTFLOAT v) { *fZone[p] = v; }
 
-        virtual void openTabBox(const char* label) { pushLabel(label); }
-        virtual void openHorizontalBox(const char* label) { pushLabel(label); }
-        virtual void openVerticalBox(const char* label) { pushLabel(label); }
-        virtual void closeBox() { popLabel(); }
+    double getParamRatio(int p) { return fConversion[p]->faust2ui(*fZone[p]); }
+    void setParamRatio(int p, double r) { *fZone[p] = fConversion[p]->ui2faust(r); }
 
-        // -- active widgets
+    double value2ratio(int p, double r) { return fConversion[p]->faust2ui(r); }
+    double ratio2value(int p, double r) { return fConversion[p]->ui2faust(r); }
 
-        virtual void addButton(const char* label, FAUSTFLOAT* zone)
-        {
-            addParameter(label, zone, 0, 0, 1, 1, kButton);
-        }
-
-        virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
-        {
-            addParameter(label, zone, 0, 0, 1, 1, kCheckButton);
-        }
-
-        virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
-        {
-            addParameter(label, zone, init, min, max, step, kVSlider);
-        }
-
-        virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
-        {
-            addParameter(label, zone, init, min, max, step, kHSlider);
-        }
-
-        virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
-        {
-            addParameter(label, zone, init, min, max, step, kNumEntry);
-        }
-
-        // -- passive widgets
-
-        virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
-        {
-            addParameter(label, zone, min, min, max, (max-min)/1000.0, kHBargraph);
-        }
-
-        virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
-        {
-            addParameter(label, zone, min, min, max, (max-min)/1000.0, kVBargraph);
-        }
-    
-        // -- soundfiles
-    
-        virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
-
-        // -- metadata declarations
-
-        virtual void declare(FAUSTFLOAT* zone, const char* key, const char* val)
-        {
-            // Keep metadata
-            fCurrentMetadata[key] = val;
-            
-            if (strcmp(key, "scale") == 0) {
-                if (strcmp(val, "log") == 0) {
-                    fCurrentScale = kLog;
-                } else if (strcmp(val, "exp") == 0) {
-                    fCurrentScale = kExp;
-                } else {
-                    fCurrentScale = kLin;
-                }
-            } else if (strcmp(key, "unit") == 0) {
-                fCurrentUnit = val;
-            } else if (strcmp(key, "acc") == 0) {
-                fCurrentAcc = val;
-            } else if (strcmp(key, "gyr") == 0) {
-                fCurrentGyr = val;
-            } else if (strcmp(key, "screencolor") == 0) {
-                fCurrentColor = val; // val = "red", "green", "blue" or "white"
-            } else if (strcmp(key, "tooltip") == 0) {
-                fCurrentTooltip = val;
-            }
-        }
-
-        virtual void declare(const char* key, const char* val)
-        {}
-
-		//-------------------------------------------------------------------------------
-		// Simple API part
-		//-------------------------------------------------------------------------------
-		int getParamsCount() { return fNumParameters; }
-        int getParamIndex(const char* path)
-        {
-            if (fPathMap.find(path) != fPathMap.end()) {
-                return fPathMap[path];
-            } else if (fLabelMap.find(path) != fLabelMap.end()) {
-                return fLabelMap[path];
-            } else {
-                return -1;
-            }
-        }
-        const char* getParamAddress(int p) { return fPaths[p].c_str(); }
-        const char* getParamLabel(int p) { return fLabels[p].c_str(); }
-        std::map<const char*, const char*> getMetadata(int p)
-        {
-            std::map<const char*, const char*> res;
-            std::map<std::string, std::string> metadata = fMetaData[p];
-            for (auto it : metadata) {
-                res[it.first.c_str()] = it.second.c_str();
-            }
-            return res;
-        }
-
-        const char* getMetadata(int p, const char* key)
-        {
-            return (fMetaData[p].find(key) != fMetaData[p].end()) ? fMetaData[p][key].c_str() : "";
-        }
-        FAUSTFLOAT getParamMin(int p) { return fMin[p]; }
-        FAUSTFLOAT getParamMax(int p) { return fMax[p]; }
-        FAUSTFLOAT getParamStep(int p) { return fStep[p]; }
-        FAUSTFLOAT getParamInit(int p) { return fInit[p]; }
-
-        FAUSTFLOAT* getParamZone(int p) { return fZone[p]; }
-        FAUSTFLOAT getParamValue(int p) { return *fZone[p]; }
-        void setParamValue(int p, FAUSTFLOAT v) { *fZone[p] = v; }
-
-        double getParamRatio(int p) { return fConversion[p]->faust2ui(*fZone[p]); }
-        void setParamRatio(int p, double r) { *fZone[p] = fConversion[p]->ui2faust(r); }
-
-        double value2ratio(int p, double r)	{ return fConversion[p]->faust2ui(r); }
-        double ratio2value(int p, double r)	{ return fConversion[p]->ui2faust(r); }
-    
-        /**
+    /**
          * Return the control type (kAcc, kGyr, or -1) for a given parameter
          *
          * @param p - the UI parameter index
          *
          * @return the type
          */
-        Type getParamType(int p)
-        {
-            if (p >= 0) {
-                if (getZoneIndex(fAcc, p, 0) != -1
-                    || getZoneIndex(fAcc, p, 1) != -1
-                    || getZoneIndex(fAcc, p, 2) != -1) {
-                    return kAcc;
-                } else if (getZoneIndex(fGyr, p, 0) != -1
-                           || getZoneIndex(fGyr, p, 1) != -1
-                           || getZoneIndex(fGyr, p, 2) != -1) {
-                    return kGyr;
-                }
+    Type getParamType(int p)
+    {
+        if (p >= 0) {
+            if (getZoneIndex(fAcc, p, 0) != -1 || getZoneIndex(fAcc, p, 1) != -1
+                || getZoneIndex(fAcc, p, 2) != -1) {
+                return kAcc;
+            } else if (getZoneIndex(fGyr, p, 0) != -1 || getZoneIndex(fGyr, p, 1) != -1
+                       || getZoneIndex(fGyr, p, 2) != -1) {
+                return kGyr;
             }
-            return kNoType;
         }
-    
-        /**
+        return kNoType;
+    }
+
+    /**
          * Return the Item type (kButton = 0, kCheckButton, kVSlider, kHSlider, kNumEntry, kHBargraph, kVBargraph) for a given parameter
          *
          * @param p - the UI parameter index
          *
          * @return the Item type
          */
-        ItemType getParamItemType(int p)
-        {
-            return fItemType[p];
-        }
-   
-        /**
+    ItemType getParamItemType(int p) { return fItemType[p]; }
+
+    /**
          * Set a new value coming from an accelerometer, propagate it to all relevant FAUSTFLOAT* zones.
          *
          * @param acc - 0 for X accelerometer, 1 for Y accelerometer, 2 for Z accelerometer
          * @param value - the new value
          *
          */
-        void propagateAcc(int acc, double value)
-        {
-            for (size_t i = 0; i < fAcc[acc].size(); i++) {
-                fAcc[acc][i]->update(value);
-            }
-        }
-    
-        /**
+    void propagateAcc(int acc, double value)
+    {
+        for (size_t i = 0; i < fAcc[acc].size(); i++) { fAcc[acc][i]->update(value); }
+    }
+
+    /**
          * Used to edit accelerometer curves and mapping. Set curve and related mapping for a given UI parameter.
          *
          * @param p - the UI parameter index
@@ -1436,12 +1458,12 @@ class APIUI : public PathBuilder, public Meta, public UI
          * @param amax - mapping 'max' point
          *
          */
-        void setAccConverter(int p, int acc, int curve, double amin, double amid, double amax)
-        {
-            setConverter(fAcc, p, acc, curve, amin, amid, amax);
-        }
-    
-        /**
+    void setAccConverter(int p, int acc, int curve, double amin, double amid, double amax)
+    {
+        setConverter(fAcc, p, acc, curve, amin, amid, amax);
+    }
+
+    /**
          * Used to edit gyroscope curves and mapping. Set curve and related mapping for a given UI parameter.
          *
          * @param p - the UI parameter index
@@ -1452,12 +1474,12 @@ class APIUI : public PathBuilder, public Meta, public UI
          * @param amax - mapping 'max' point
          *
          */
-        void setGyrConverter(int p, int gyr, int curve, double amin, double amid, double amax)
-        {
-             setConverter(fGyr, p, gyr, curve, amin, amid, amax);
-        }
-    
-        /**
+    void setGyrConverter(int p, int gyr, int curve, double amin, double amid, double amax)
+    {
+        setConverter(fGyr, p, gyr, curve, amin, amid, amax);
+    }
+
+    /**
          * Used to edit accelerometer curves and mapping. Get curve and related mapping for a given UI parameter.
          *
          * @param p - the UI parameter index
@@ -1468,12 +1490,13 @@ class APIUI : public PathBuilder, public Meta, public UI
          * @param amax - the amax value to be retrieved
          *
          */
-        void getAccConverter(int p, int& acc, int& curve, double& amin, double& amid, double& amax)
-        {
-            getConverter(fAcc, p, acc, curve, amin, amid, amax);
-        }
+    void getAccConverter(int p, int& acc, int& curve, double& amin, double& amid,
+                         double& amax)
+    {
+        getConverter(fAcc, p, acc, curve, amin, amid, amax);
+    }
 
-        /**
+    /**
          * Used to edit gyroscope curves and mapping. Get curve and related mapping for a given UI parameter.
          *
          * @param p - the UI parameter index
@@ -1484,63 +1507,55 @@ class APIUI : public PathBuilder, public Meta, public UI
          * @param amax - the amax value to be retrieved
          *
          */
-        void getGyrConverter(int p, int& gyr, int& curve, double& amin, double& amid, double& amax)
-        {
-            getConverter(fGyr, p, gyr, curve, amin, amid, amax);
-        }
-    
-        /**
+    void getGyrConverter(int p, int& gyr, int& curve, double& amin, double& amid,
+                         double& amax)
+    {
+        getConverter(fGyr, p, gyr, curve, amin, amid, amax);
+    }
+
+    /**
          * Set a new value coming from an gyroscope, propagate it to all relevant FAUSTFLOAT* zones.
          *
          * @param gyr - 0 for X gyroscope, 1 for Y gyroscope, 2 for Z gyroscope
          * @param value - the new value
          *
          */
-        void propagateGyr(int gyr, double value)
-        {
-            for (size_t i = 0; i < fGyr[gyr].size(); i++) {
-                fGyr[gyr][i]->update(value);
-            }
-        }
-    
-        /**
+    void propagateGyr(int gyr, double value)
+    {
+        for (size_t i = 0; i < fGyr[gyr].size(); i++) { fGyr[gyr][i]->update(value); }
+    }
+
+    /**
          * Get the number of FAUSTFLOAT* zones controlled with the accelerometer
          *
          * @param acc - 0 for X accelerometer, 1 for Y accelerometer, 2 for Z accelerometer
          * @return the number of zones
          *
          */
-        int getAccCount(int acc)
-        {
-            return (acc >= 0 && acc < 3) ? int(fAcc[acc].size()) : 0;
-        }
-    
-        /**
+    int getAccCount(int acc) { return (acc >= 0 && acc < 3) ? int(fAcc[acc].size()) : 0; }
+
+    /**
          * Get the number of FAUSTFLOAT* zones controlled with the gyroscope
          *
          * @param gyr - 0 for X gyroscope, 1 for Y gyroscope, 2 for Z gyroscope
          * @param the number of zones
          *
          */
-        int getGyrCount(int gyr)
-        {
-            return (gyr >= 0 && gyr < 3) ? int(fGyr[gyr].size()) : 0;
+    int getGyrCount(int gyr) { return (gyr >= 0 && gyr < 3) ? int(fGyr[gyr].size()) : 0; }
+
+    // getScreenColor() : -1 means no screen color control (no screencolor metadata found)
+    // otherwise return 0x00RRGGBB a ready to use color
+    int getScreenColor()
+    {
+        if (fHasScreenControl) {
+            int r = (fRedReader) ? fRedReader->getValue() : 0;
+            int g = (fGreenReader) ? fGreenReader->getValue() : 0;
+            int b = (fBlueReader) ? fBlueReader->getValue() : 0;
+            return (r << 16) | (g << 8) | b;
+        } else {
+            return -1;
         }
-   
-        // getScreenColor() : -1 means no screen color control (no screencolor metadata found)
-        // otherwise return 0x00RRGGBB a ready to use color
-        int getScreenColor()
-        {
-            if (fHasScreenControl) {
-                int r = (fRedReader) ? fRedReader->getValue() : 0;
-                int g = (fGreenReader) ? fGreenReader->getValue() : 0;
-                int b = (fBlueReader) ? fBlueReader->getValue() : 0;
-                return (r<<16) | (g<<8) | b;
-            } else {
-                return -1;
-            }
-        }
- 
+    }
 };
 
 #endif
@@ -1553,616 +1568,510 @@ class APIUI : public PathBuilder, public Meta, public UI
 //  FAUST Generated Code
 //----------------------------------------------------------------------------
 
-
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
+
+#include <math.h>
 
 #include <algorithm>
 #include <cmath>
-#include <math.h>
 
-
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS freeverbdsp
 #endif
 
-#ifdef __APPLE__ 
+#ifdef __APPLE__
 #define exp10f __exp10f
-#define exp10 __exp10
+#define exp10  __exp10
 #endif
 
-class freeverbdsp : public dsp {
-	
- private:
-	
-	int fSampleRate;
-	float fConst0;
-	float fConst1;
-	FAUSTFLOAT fVslider0;
-	float fConst2;
-	FAUSTFLOAT fVslider1;
-	float fRec9[2];
-	FAUSTFLOAT fVslider2;
-	int IOTA;
-	float fVec0[8192];
-	int iConst3;
-	float fRec8[2];
-	float fRec11[2];
-	float fVec1[8192];
-	int iConst4;
-	float fRec10[2];
-	float fRec13[2];
-	float fVec2[8192];
-	int iConst5;
-	float fRec12[2];
-	float fRec15[2];
-	float fVec3[8192];
-	int iConst6;
-	float fRec14[2];
-	float fRec17[2];
-	float fVec4[8192];
-	int iConst7;
-	float fRec16[2];
-	float fRec19[2];
-	float fVec5[8192];
-	int iConst8;
-	float fRec18[2];
-	float fRec21[2];
-	float fVec6[8192];
-	int iConst9;
-	float fRec20[2];
-	float fRec23[2];
-	float fVec7[8192];
-	int iConst10;
-	float fRec22[2];
-	float fVec8[2048];
-	int iConst11;
-	int iConst12;
-	float fRec6[2];
-	float fVec9[2048];
-	int iConst13;
-	int iConst14;
-	float fRec4[2];
-	float fVec10[2048];
-	int iConst15;
-	int iConst16;
-	float fRec2[2];
-	float fVec11[1024];
-	int iConst17;
-	int iConst18;
-	float fRec0[2];
-	float fRec33[2];
-	float fVec12[8192];
-	float fConst19;
-	FAUSTFLOAT fVslider3;
-	float fRec32[2];
-	float fRec35[2];
-	float fVec13[8192];
-	float fRec34[2];
-	float fRec37[2];
-	float fVec14[8192];
-	float fRec36[2];
-	float fRec39[2];
-	float fVec15[8192];
-	float fRec38[2];
-	float fRec41[2];
-	float fVec16[8192];
-	float fRec40[2];
-	float fRec43[2];
-	float fVec17[8192];
-	float fRec42[2];
-	float fRec45[2];
-	float fVec18[8192];
-	float fRec44[2];
-	float fRec47[2];
-	float fVec19[8192];
-	float fRec46[2];
-	float fVec20[2048];
-	float fRec30[2];
-	float fVec21[2048];
-	float fRec28[2];
-	float fVec22[2048];
-	float fRec26[2];
-	float fVec23[2048];
-	float fRec24[2];
-	
- public:
-	
-	void metadata(Meta* m) { 
-		m->declare("author", "Romain Michon");
-		m->declare("delays.lib/name", "Faust Delay Library");
-		m->declare("delays.lib/version", "0.1");
-		m->declare("description", "Freeverb implementation in Faust, from the Faust Library's dm.freeverb_demo in demos.lib");
-		m->declare("filename", "freeverbdsp.dsp");
-		m->declare("filters.lib/allpass_comb:author", "Julius O. Smith III");
-		m->declare("filters.lib/allpass_comb:copyright", "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
-		m->declare("filters.lib/allpass_comb:license", "MIT-style STK-4.3 license");
-		m->declare("filters.lib/lowpass0_highpass1", "MIT-style STK-4.3 license");
-		m->declare("filters.lib/name", "Faust Filters Library");
-		m->declare("license", "LGPL");
-		m->declare("maths.lib/author", "GRAME");
-		m->declare("maths.lib/copyright", "GRAME");
-		m->declare("maths.lib/license", "LGPL with exception");
-		m->declare("maths.lib/name", "Faust Math Library");
-		m->declare("maths.lib/version", "2.3");
-		m->declare("name", "freeverb");
-		m->declare("platform.lib/name", "Generic Platform Library");
-		m->declare("platform.lib/version", "0.1");
-		m->declare("reverbs.lib/name", "Faust Reverb Library");
-		m->declare("reverbs.lib/version", "0.0");
-		m->declare("version", "0.0");
-	}
+class freeverbdsp : public dsp
+{
+   private:
+    int fSampleRate;
+    float fConst0;
+    float fConst1;
+    FAUSTFLOAT fVslider0;
+    float fConst2;
+    FAUSTFLOAT fVslider1;
+    float fRec9[2];
+    FAUSTFLOAT fVslider2;
+    int IOTA;
+    float fVec0[8192];
+    int iConst3;
+    float fRec8[2];
+    float fRec11[2];
+    float fVec1[8192];
+    int iConst4;
+    float fRec10[2];
+    float fRec13[2];
+    float fVec2[8192];
+    int iConst5;
+    float fRec12[2];
+    float fRec15[2];
+    float fVec3[8192];
+    int iConst6;
+    float fRec14[2];
+    float fRec17[2];
+    float fVec4[8192];
+    int iConst7;
+    float fRec16[2];
+    float fRec19[2];
+    float fVec5[8192];
+    int iConst8;
+    float fRec18[2];
+    float fRec21[2];
+    float fVec6[8192];
+    int iConst9;
+    float fRec20[2];
+    float fRec23[2];
+    float fVec7[8192];
+    int iConst10;
+    float fRec22[2];
+    float fVec8[2048];
+    int iConst11;
+    int iConst12;
+    float fRec6[2];
+    float fVec9[2048];
+    int iConst13;
+    int iConst14;
+    float fRec4[2];
+    float fVec10[2048];
+    int iConst15;
+    int iConst16;
+    float fRec2[2];
+    float fVec11[1024];
+    int iConst17;
+    int iConst18;
+    float fRec0[2];
+    float fRec33[2];
+    float fVec12[8192];
+    float fConst19;
+    FAUSTFLOAT fVslider3;
+    float fRec32[2];
+    float fRec35[2];
+    float fVec13[8192];
+    float fRec34[2];
+    float fRec37[2];
+    float fVec14[8192];
+    float fRec36[2];
+    float fRec39[2];
+    float fVec15[8192];
+    float fRec38[2];
+    float fRec41[2];
+    float fVec16[8192];
+    float fRec40[2];
+    float fRec43[2];
+    float fVec17[8192];
+    float fRec42[2];
+    float fRec45[2];
+    float fVec18[8192];
+    float fRec44[2];
+    float fRec47[2];
+    float fVec19[8192];
+    float fRec46[2];
+    float fVec20[2048];
+    float fRec30[2];
+    float fVec21[2048];
+    float fRec28[2];
+    float fVec22[2048];
+    float fRec26[2];
+    float fVec23[2048];
+    float fRec24[2];
 
-	virtual int getNumInputs() {
-		return 2;
-	}
-	virtual int getNumOutputs() {
-		return 2;
-	}
-	virtual int getInputRate(int channel) {
-		int rate;
-		switch ((channel)) {
-			case 0: {
-				rate = 1;
-				break;
-			}
-			case 1: {
-				rate = 1;
-				break;
-			}
-			default: {
-				rate = -1;
-				break;
-			}
-		}
-		return rate;
-	}
-	virtual int getOutputRate(int channel) {
-		int rate;
-		switch ((channel)) {
-			case 0: {
-				rate = 1;
-				break;
-			}
-			case 1: {
-				rate = 1;
-				break;
-			}
-			default: {
-				rate = -1;
-				break;
-			}
-		}
-		return rate;
-	}
-	
-	static void classInit(int sample_rate) {
-	}
-	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = std::min<float>(192000.0f, std::max<float>(1.0f, float(fSampleRate)));
-		fConst1 = (12348.0f / fConst0);
-		fConst2 = (17640.0f / fConst0);
-		iConst3 = int((0.0253061224f * fConst0));
-		iConst4 = int((0.0269387756f * fConst0));
-		iConst5 = int((0.0289569162f * fConst0));
-		iConst6 = int((0.0307482984f * fConst0));
-		iConst7 = int((0.0322448984f * fConst0));
-		iConst8 = int((0.033809524f * fConst0));
-		iConst9 = int((0.0353061222f * fConst0));
-		iConst10 = int((0.0366666652f * fConst0));
-		iConst11 = int((0.0126077095f * fConst0));
-		iConst12 = std::min<int>(1024, std::max<int>(0, (iConst11 + -1)));
-		iConst13 = int((0.00999999978f * fConst0));
-		iConst14 = std::min<int>(1024, std::max<int>(0, (iConst13 + -1)));
-		iConst15 = int((0.00773242628f * fConst0));
-		iConst16 = std::min<int>(1024, std::max<int>(0, (iConst15 + -1)));
-		iConst17 = int((0.00510204071f * fConst0));
-		iConst18 = std::min<int>(1024, std::max<int>(0, (iConst17 + -1)));
-		fConst19 = (0.00104308384f * fConst0);
-	}
-	
-	virtual void instanceResetUserInterface() {
-		fVslider0 = FAUSTFLOAT(0.10000000000000001f);
-		fVslider1 = FAUSTFLOAT(0.5f);
-		fVslider2 = FAUSTFLOAT(0.10000000000000001f);
-		fVslider3 = FAUSTFLOAT(0.5f);
-	}
-	
-	virtual void instanceClear() {
-		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
-			fRec9[l0] = 0.0f;
-		}
-		IOTA = 0;
-		for (int l1 = 0; (l1 < 8192); l1 = (l1 + 1)) {
-			fVec0[l1] = 0.0f;
-		}
-		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
-			fRec8[l2] = 0.0f;
-		}
-		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
-			fRec11[l3] = 0.0f;
-		}
-		for (int l4 = 0; (l4 < 8192); l4 = (l4 + 1)) {
-			fVec1[l4] = 0.0f;
-		}
-		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
-			fRec10[l5] = 0.0f;
-		}
-		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
-			fRec13[l6] = 0.0f;
-		}
-		for (int l7 = 0; (l7 < 8192); l7 = (l7 + 1)) {
-			fVec2[l7] = 0.0f;
-		}
-		for (int l8 = 0; (l8 < 2); l8 = (l8 + 1)) {
-			fRec12[l8] = 0.0f;
-		}
-		for (int l9 = 0; (l9 < 2); l9 = (l9 + 1)) {
-			fRec15[l9] = 0.0f;
-		}
-		for (int l10 = 0; (l10 < 8192); l10 = (l10 + 1)) {
-			fVec3[l10] = 0.0f;
-		}
-		for (int l11 = 0; (l11 < 2); l11 = (l11 + 1)) {
-			fRec14[l11] = 0.0f;
-		}
-		for (int l12 = 0; (l12 < 2); l12 = (l12 + 1)) {
-			fRec17[l12] = 0.0f;
-		}
-		for (int l13 = 0; (l13 < 8192); l13 = (l13 + 1)) {
-			fVec4[l13] = 0.0f;
-		}
-		for (int l14 = 0; (l14 < 2); l14 = (l14 + 1)) {
-			fRec16[l14] = 0.0f;
-		}
-		for (int l15 = 0; (l15 < 2); l15 = (l15 + 1)) {
-			fRec19[l15] = 0.0f;
-		}
-		for (int l16 = 0; (l16 < 8192); l16 = (l16 + 1)) {
-			fVec5[l16] = 0.0f;
-		}
-		for (int l17 = 0; (l17 < 2); l17 = (l17 + 1)) {
-			fRec18[l17] = 0.0f;
-		}
-		for (int l18 = 0; (l18 < 2); l18 = (l18 + 1)) {
-			fRec21[l18] = 0.0f;
-		}
-		for (int l19 = 0; (l19 < 8192); l19 = (l19 + 1)) {
-			fVec6[l19] = 0.0f;
-		}
-		for (int l20 = 0; (l20 < 2); l20 = (l20 + 1)) {
-			fRec20[l20] = 0.0f;
-		}
-		for (int l21 = 0; (l21 < 2); l21 = (l21 + 1)) {
-			fRec23[l21] = 0.0f;
-		}
-		for (int l22 = 0; (l22 < 8192); l22 = (l22 + 1)) {
-			fVec7[l22] = 0.0f;
-		}
-		for (int l23 = 0; (l23 < 2); l23 = (l23 + 1)) {
-			fRec22[l23] = 0.0f;
-		}
-		for (int l24 = 0; (l24 < 2048); l24 = (l24 + 1)) {
-			fVec8[l24] = 0.0f;
-		}
-		for (int l25 = 0; (l25 < 2); l25 = (l25 + 1)) {
-			fRec6[l25] = 0.0f;
-		}
-		for (int l26 = 0; (l26 < 2048); l26 = (l26 + 1)) {
-			fVec9[l26] = 0.0f;
-		}
-		for (int l27 = 0; (l27 < 2); l27 = (l27 + 1)) {
-			fRec4[l27] = 0.0f;
-		}
-		for (int l28 = 0; (l28 < 2048); l28 = (l28 + 1)) {
-			fVec10[l28] = 0.0f;
-		}
-		for (int l29 = 0; (l29 < 2); l29 = (l29 + 1)) {
-			fRec2[l29] = 0.0f;
-		}
-		for (int l30 = 0; (l30 < 1024); l30 = (l30 + 1)) {
-			fVec11[l30] = 0.0f;
-		}
-		for (int l31 = 0; (l31 < 2); l31 = (l31 + 1)) {
-			fRec0[l31] = 0.0f;
-		}
-		for (int l32 = 0; (l32 < 2); l32 = (l32 + 1)) {
-			fRec33[l32] = 0.0f;
-		}
-		for (int l33 = 0; (l33 < 8192); l33 = (l33 + 1)) {
-			fVec12[l33] = 0.0f;
-		}
-		for (int l34 = 0; (l34 < 2); l34 = (l34 + 1)) {
-			fRec32[l34] = 0.0f;
-		}
-		for (int l35 = 0; (l35 < 2); l35 = (l35 + 1)) {
-			fRec35[l35] = 0.0f;
-		}
-		for (int l36 = 0; (l36 < 8192); l36 = (l36 + 1)) {
-			fVec13[l36] = 0.0f;
-		}
-		for (int l37 = 0; (l37 < 2); l37 = (l37 + 1)) {
-			fRec34[l37] = 0.0f;
-		}
-		for (int l38 = 0; (l38 < 2); l38 = (l38 + 1)) {
-			fRec37[l38] = 0.0f;
-		}
-		for (int l39 = 0; (l39 < 8192); l39 = (l39 + 1)) {
-			fVec14[l39] = 0.0f;
-		}
-		for (int l40 = 0; (l40 < 2); l40 = (l40 + 1)) {
-			fRec36[l40] = 0.0f;
-		}
-		for (int l41 = 0; (l41 < 2); l41 = (l41 + 1)) {
-			fRec39[l41] = 0.0f;
-		}
-		for (int l42 = 0; (l42 < 8192); l42 = (l42 + 1)) {
-			fVec15[l42] = 0.0f;
-		}
-		for (int l43 = 0; (l43 < 2); l43 = (l43 + 1)) {
-			fRec38[l43] = 0.0f;
-		}
-		for (int l44 = 0; (l44 < 2); l44 = (l44 + 1)) {
-			fRec41[l44] = 0.0f;
-		}
-		for (int l45 = 0; (l45 < 8192); l45 = (l45 + 1)) {
-			fVec16[l45] = 0.0f;
-		}
-		for (int l46 = 0; (l46 < 2); l46 = (l46 + 1)) {
-			fRec40[l46] = 0.0f;
-		}
-		for (int l47 = 0; (l47 < 2); l47 = (l47 + 1)) {
-			fRec43[l47] = 0.0f;
-		}
-		for (int l48 = 0; (l48 < 8192); l48 = (l48 + 1)) {
-			fVec17[l48] = 0.0f;
-		}
-		for (int l49 = 0; (l49 < 2); l49 = (l49 + 1)) {
-			fRec42[l49] = 0.0f;
-		}
-		for (int l50 = 0; (l50 < 2); l50 = (l50 + 1)) {
-			fRec45[l50] = 0.0f;
-		}
-		for (int l51 = 0; (l51 < 8192); l51 = (l51 + 1)) {
-			fVec18[l51] = 0.0f;
-		}
-		for (int l52 = 0; (l52 < 2); l52 = (l52 + 1)) {
-			fRec44[l52] = 0.0f;
-		}
-		for (int l53 = 0; (l53 < 2); l53 = (l53 + 1)) {
-			fRec47[l53] = 0.0f;
-		}
-		for (int l54 = 0; (l54 < 8192); l54 = (l54 + 1)) {
-			fVec19[l54] = 0.0f;
-		}
-		for (int l55 = 0; (l55 < 2); l55 = (l55 + 1)) {
-			fRec46[l55] = 0.0f;
-		}
-		for (int l56 = 0; (l56 < 2048); l56 = (l56 + 1)) {
-			fVec20[l56] = 0.0f;
-		}
-		for (int l57 = 0; (l57 < 2); l57 = (l57 + 1)) {
-			fRec30[l57] = 0.0f;
-		}
-		for (int l58 = 0; (l58 < 2048); l58 = (l58 + 1)) {
-			fVec21[l58] = 0.0f;
-		}
-		for (int l59 = 0; (l59 < 2); l59 = (l59 + 1)) {
-			fRec28[l59] = 0.0f;
-		}
-		for (int l60 = 0; (l60 < 2048); l60 = (l60 + 1)) {
-			fVec22[l60] = 0.0f;
-		}
-		for (int l61 = 0; (l61 < 2); l61 = (l61 + 1)) {
-			fRec26[l61] = 0.0f;
-		}
-		for (int l62 = 0; (l62 < 2048); l62 = (l62 + 1)) {
-			fVec23[l62] = 0.0f;
-		}
-		for (int l63 = 0; (l63 < 2); l63 = (l63 + 1)) {
-			fRec24[l63] = 0.0f;
-		}
-	}
-	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
-	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
-		instanceResetUserInterface();
-		instanceClear();
-	}
-	
-	virtual freeverbdsp* clone() {
-		return new freeverbdsp();
-	}
-	
-	virtual int getSampleRate() {
-		return fSampleRate;
-	}
-	
-	virtual void buildUserInterface(UI* ui_interface) {
-		ui_interface->openHorizontalBox("Freeverb");
-		ui_interface->declare(0, "0", "");
-		ui_interface->openVerticalBox("0x00");
-		ui_interface->declare(&fVslider1, "0", "");
-		ui_interface->declare(&fVslider1, "style", "knob");
-		ui_interface->declare(&fVslider1, "tooltip", "Somehow control the   density of the reverb.");
-		ui_interface->addVerticalSlider("Damp", &fVslider1, 0.5f, 0.0f, 1.0f, 0.0250000004f);
-		ui_interface->declare(&fVslider0, "1", "");
-		ui_interface->declare(&fVslider0, "style", "knob");
-		ui_interface->declare(&fVslider0, "tooltip", "The room size   between 0 and 1 with 1 for the largest room.");
-		ui_interface->addVerticalSlider("RoomSize", &fVslider0, 0.100000001f, 0.0f, 1.0f, 0.0250000004f);
-		ui_interface->declare(&fVslider3, "2", "");
-		ui_interface->declare(&fVslider3, "style", "knob");
-		ui_interface->declare(&fVslider3, "tooltip", "Spatial   spread between 0 and 1 with 1 for maximum spread.");
-		ui_interface->addVerticalSlider("Stereo Spread", &fVslider3, 0.5f, 0.0f, 1.0f, 0.00999999978f);
-		ui_interface->closeBox();
-		ui_interface->declare(&fVslider2, "1", "");
-		ui_interface->declare(&fVslider2, "tooltip", "The amount of reverb applied to the signal   between 0 and 1 with 1 for the maximum amount of reverb.");
-		ui_interface->addVerticalSlider("Wet", &fVslider2, 0.100000001f, 0.0f, 1.0f, 0.0250000004f);
-		ui_interface->closeBox();
-	}
-	
-	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
-		FAUSTFLOAT* input0 = inputs[0];
-		FAUSTFLOAT* input1 = inputs[1];
-		FAUSTFLOAT* output0 = outputs[0];
-		FAUSTFLOAT* output1 = outputs[1];
-		float fSlow0 = ((fConst1 * float(fVslider0)) + 0.699999988f);
-		float fSlow1 = (fConst2 * float(fVslider1));
-		float fSlow2 = (1.0f - fSlow1);
-		float fSlow3 = float(fVslider2);
-		float fSlow4 = (0.100000001f * fSlow3);
-		float fSlow5 = (1.0f - fSlow3);
-		int iSlow6 = int((fConst19 * float(fVslider3)));
-		int iSlow7 = (iConst3 + iSlow6);
-		int iSlow8 = (iConst4 + iSlow6);
-		int iSlow9 = (iConst5 + iSlow6);
-		int iSlow10 = (iConst6 + iSlow6);
-		int iSlow11 = (iConst7 + iSlow6);
-		int iSlow12 = (iConst8 + iSlow6);
-		int iSlow13 = (iConst9 + iSlow6);
-		int iSlow14 = (iConst10 + iSlow6);
-		int iSlow15 = (iSlow6 + -1);
-		int iSlow16 = std::min<int>(1024, std::max<int>(0, (iConst11 + iSlow15)));
-		int iSlow17 = std::min<int>(1024, std::max<int>(0, (iConst13 + iSlow15)));
-		int iSlow18 = std::min<int>(1024, std::max<int>(0, (iConst15 + iSlow15)));
-		int iSlow19 = std::min<int>(1024, std::max<int>(0, (iConst17 + iSlow15)));
-		for (int i = 0; (i < count); i = (i + 1)) {
-			float fTemp0 = float(input0[i]);
-			float fTemp1 = float(input1[i]);
-			fRec9[0] = ((fSlow1 * fRec9[1]) + (fSlow2 * fRec8[1]));
-			float fTemp2 = (fSlow4 * (fTemp0 + fTemp1));
-			fVec0[(IOTA & 8191)] = ((fSlow0 * fRec9[0]) + fTemp2);
-			fRec8[0] = fVec0[((IOTA - iConst3) & 8191)];
-			fRec11[0] = ((fSlow1 * fRec11[1]) + (fSlow2 * fRec10[1]));
-			fVec1[(IOTA & 8191)] = (fTemp2 + (fSlow0 * fRec11[0]));
-			fRec10[0] = fVec1[((IOTA - iConst4) & 8191)];
-			fRec13[0] = ((fSlow1 * fRec13[1]) + (fSlow2 * fRec12[1]));
-			fVec2[(IOTA & 8191)] = (fTemp2 + (fSlow0 * fRec13[0]));
-			fRec12[0] = fVec2[((IOTA - iConst5) & 8191)];
-			fRec15[0] = ((fSlow1 * fRec15[1]) + (fSlow2 * fRec14[1]));
-			fVec3[(IOTA & 8191)] = (fTemp2 + (fSlow0 * fRec15[0]));
-			fRec14[0] = fVec3[((IOTA - iConst6) & 8191)];
-			fRec17[0] = ((fSlow1 * fRec17[1]) + (fSlow2 * fRec16[1]));
-			fVec4[(IOTA & 8191)] = (fTemp2 + (fSlow0 * fRec17[0]));
-			fRec16[0] = fVec4[((IOTA - iConst7) & 8191)];
-			fRec19[0] = ((fSlow1 * fRec19[1]) + (fSlow2 * fRec18[1]));
-			fVec5[(IOTA & 8191)] = (fTemp2 + (fSlow0 * fRec19[0]));
-			fRec18[0] = fVec5[((IOTA - iConst8) & 8191)];
-			fRec21[0] = ((fSlow1 * fRec21[1]) + (fSlow2 * fRec20[1]));
-			fVec6[(IOTA & 8191)] = (fTemp2 + (fSlow0 * fRec21[0]));
-			fRec20[0] = fVec6[((IOTA - iConst9) & 8191)];
-			fRec23[0] = ((fSlow1 * fRec23[1]) + (fSlow2 * fRec22[1]));
-			fVec7[(IOTA & 8191)] = (fTemp2 + (fSlow0 * fRec23[0]));
-			fRec22[0] = fVec7[((IOTA - iConst10) & 8191)];
-			float fTemp3 = ((((((((fRec8[0] + fRec10[0]) + fRec12[0]) + fRec14[0]) + fRec16[0]) + fRec18[0]) + fRec20[0]) + fRec22[0]) + (0.5f * fRec6[1]));
-			fVec8[(IOTA & 2047)] = fTemp3;
-			fRec6[0] = fVec8[((IOTA - iConst12) & 2047)];
-			float fRec7 = (0.0f - (0.5f * fTemp3));
-			float fTemp4 = (fRec6[1] + (fRec7 + (0.5f * fRec4[1])));
-			fVec9[(IOTA & 2047)] = fTemp4;
-			fRec4[0] = fVec9[((IOTA - iConst14) & 2047)];
-			float fRec5 = (0.0f - (0.5f * fTemp4));
-			float fTemp5 = (fRec4[1] + (fRec5 + (0.5f * fRec2[1])));
-			fVec10[(IOTA & 2047)] = fTemp5;
-			fRec2[0] = fVec10[((IOTA - iConst16) & 2047)];
-			float fRec3 = (0.0f - (0.5f * fTemp5));
-			float fTemp6 = (fRec2[1] + (fRec3 + (0.5f * fRec0[1])));
-			fVec11[(IOTA & 1023)] = fTemp6;
-			fRec0[0] = fVec11[((IOTA - iConst18) & 1023)];
-			float fRec1 = (0.0f - (0.5f * fTemp6));
-			output0[i] = FAUSTFLOAT(((fRec1 + fRec0[1]) + (fSlow5 * fTemp0)));
-			fRec33[0] = ((fSlow1 * fRec33[1]) + (fSlow2 * fRec32[1]));
-			fVec12[(IOTA & 8191)] = (fTemp2 + (fSlow0 * fRec33[0]));
-			fRec32[0] = fVec12[((IOTA - iSlow7) & 8191)];
-			fRec35[0] = ((fSlow1 * fRec35[1]) + (fSlow2 * fRec34[1]));
-			fVec13[(IOTA & 8191)] = (fTemp2 + (fSlow0 * fRec35[0]));
-			fRec34[0] = fVec13[((IOTA - iSlow8) & 8191)];
-			fRec37[0] = ((fSlow1 * fRec37[1]) + (fSlow2 * fRec36[1]));
-			fVec14[(IOTA & 8191)] = (fTemp2 + (fSlow0 * fRec37[0]));
-			fRec36[0] = fVec14[((IOTA - iSlow9) & 8191)];
-			fRec39[0] = ((fSlow1 * fRec39[1]) + (fSlow2 * fRec38[1]));
-			fVec15[(IOTA & 8191)] = (fTemp2 + (fSlow0 * fRec39[0]));
-			fRec38[0] = fVec15[((IOTA - iSlow10) & 8191)];
-			fRec41[0] = ((fSlow1 * fRec41[1]) + (fSlow2 * fRec40[1]));
-			fVec16[(IOTA & 8191)] = (fTemp2 + (fSlow0 * fRec41[0]));
-			fRec40[0] = fVec16[((IOTA - iSlow11) & 8191)];
-			fRec43[0] = ((fSlow1 * fRec43[1]) + (fSlow2 * fRec42[1]));
-			fVec17[(IOTA & 8191)] = (fTemp2 + (fSlow0 * fRec43[0]));
-			fRec42[0] = fVec17[((IOTA - iSlow12) & 8191)];
-			fRec45[0] = ((fSlow1 * fRec45[1]) + (fSlow2 * fRec44[1]));
-			fVec18[(IOTA & 8191)] = (fTemp2 + (fSlow0 * fRec45[0]));
-			fRec44[0] = fVec18[((IOTA - iSlow13) & 8191)];
-			fRec47[0] = ((fSlow1 * fRec47[1]) + (fSlow2 * fRec46[1]));
-			fVec19[(IOTA & 8191)] = (fTemp2 + (fSlow0 * fRec47[0]));
-			fRec46[0] = fVec19[((IOTA - iSlow14) & 8191)];
-			float fTemp7 = ((((((((fRec32[0] + fRec34[0]) + fRec36[0]) + fRec38[0]) + fRec40[0]) + fRec42[0]) + fRec44[0]) + fRec46[0]) + (0.5f * fRec30[1]));
-			fVec20[(IOTA & 2047)] = fTemp7;
-			fRec30[0] = fVec20[((IOTA - iSlow16) & 2047)];
-			float fRec31 = (0.0f - (0.5f * fTemp7));
-			float fTemp8 = (fRec30[1] + (fRec31 + (0.5f * fRec28[1])));
-			fVec21[(IOTA & 2047)] = fTemp8;
-			fRec28[0] = fVec21[((IOTA - iSlow17) & 2047)];
-			float fRec29 = (0.0f - (0.5f * fTemp8));
-			float fTemp9 = (fRec28[1] + (fRec29 + (0.5f * fRec26[1])));
-			fVec22[(IOTA & 2047)] = fTemp9;
-			fRec26[0] = fVec22[((IOTA - iSlow18) & 2047)];
-			float fRec27 = (0.0f - (0.5f * fTemp9));
-			float fTemp10 = (fRec26[1] + (fRec27 + (0.5f * fRec24[1])));
-			fVec23[(IOTA & 2047)] = fTemp10;
-			fRec24[0] = fVec23[((IOTA - iSlow19) & 2047)];
-			float fRec25 = (0.0f - (0.5f * fTemp10));
-			output1[i] = FAUSTFLOAT(((fRec25 + fRec24[1]) + (fSlow5 * fTemp1)));
-			fRec9[1] = fRec9[0];
-			IOTA = (IOTA + 1);
-			fRec8[1] = fRec8[0];
-			fRec11[1] = fRec11[0];
-			fRec10[1] = fRec10[0];
-			fRec13[1] = fRec13[0];
-			fRec12[1] = fRec12[0];
-			fRec15[1] = fRec15[0];
-			fRec14[1] = fRec14[0];
-			fRec17[1] = fRec17[0];
-			fRec16[1] = fRec16[0];
-			fRec19[1] = fRec19[0];
-			fRec18[1] = fRec18[0];
-			fRec21[1] = fRec21[0];
-			fRec20[1] = fRec20[0];
-			fRec23[1] = fRec23[0];
-			fRec22[1] = fRec22[0];
-			fRec6[1] = fRec6[0];
-			fRec4[1] = fRec4[0];
-			fRec2[1] = fRec2[0];
-			fRec0[1] = fRec0[0];
-			fRec33[1] = fRec33[0];
-			fRec32[1] = fRec32[0];
-			fRec35[1] = fRec35[0];
-			fRec34[1] = fRec34[0];
-			fRec37[1] = fRec37[0];
-			fRec36[1] = fRec36[0];
-			fRec39[1] = fRec39[0];
-			fRec38[1] = fRec38[0];
-			fRec41[1] = fRec41[0];
-			fRec40[1] = fRec40[0];
-			fRec43[1] = fRec43[0];
-			fRec42[1] = fRec42[0];
-			fRec45[1] = fRec45[0];
-			fRec44[1] = fRec44[0];
-			fRec47[1] = fRec47[0];
-			fRec46[1] = fRec46[0];
-			fRec30[1] = fRec30[0];
-			fRec28[1] = fRec28[0];
-			fRec26[1] = fRec26[0];
-			fRec24[1] = fRec24[0];
-		}
-	}
+   public:
+    void metadata(Meta* m)
+    {
+        m->declare("author", "Romain Michon");
+        m->declare("delays.lib/name", "Faust Delay Library");
+        m->declare("delays.lib/version", "0.1");
+        m->declare("description",
+                   "Freeverb implementation in Faust, from the Faust Library's "
+                   "dm.freeverb_demo in demos.lib");
+        m->declare("filename", "freeverbdsp.dsp");
+        m->declare("filters.lib/allpass_comb:author", "Julius O. Smith III");
+        m->declare(
+            "filters.lib/allpass_comb:copyright",
+            "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
+        m->declare("filters.lib/allpass_comb:license", "MIT-style STK-4.3 license");
+        m->declare("filters.lib/lowpass0_highpass1", "MIT-style STK-4.3 license");
+        m->declare("filters.lib/name", "Faust Filters Library");
+        m->declare("license", "LGPL");
+        m->declare("maths.lib/author", "GRAME");
+        m->declare("maths.lib/copyright", "GRAME");
+        m->declare("maths.lib/license", "LGPL with exception");
+        m->declare("maths.lib/name", "Faust Math Library");
+        m->declare("maths.lib/version", "2.3");
+        m->declare("name", "freeverb");
+        m->declare("platform.lib/name", "Generic Platform Library");
+        m->declare("platform.lib/version", "0.1");
+        m->declare("reverbs.lib/name", "Faust Reverb Library");
+        m->declare("reverbs.lib/version", "0.0");
+        m->declare("version", "0.0");
+    }
 
+    virtual int getNumInputs() { return 2; }
+    virtual int getNumOutputs() { return 2; }
+    virtual int getInputRate(int channel)
+    {
+        int rate;
+        switch ((channel)) {
+        case 0: {
+            rate = 1;
+            break;
+        }
+        case 1: {
+            rate = 1;
+            break;
+        }
+        default: {
+            rate = -1;
+            break;
+        }
+        }
+        return rate;
+    }
+    virtual int getOutputRate(int channel)
+    {
+        int rate;
+        switch ((channel)) {
+        case 0: {
+            rate = 1;
+            break;
+        }
+        case 1: {
+            rate = 1;
+            break;
+        }
+        default: {
+            rate = -1;
+            break;
+        }
+        }
+        return rate;
+    }
+
+    static void classInit(int sample_rate) {}
+
+    virtual void instanceConstants(int sample_rate)
+    {
+        fSampleRate = sample_rate;
+        fConst0  = std::min<float>(192000.0f, std::max<float>(1.0f, float(fSampleRate)));
+        fConst1  = (12348.0f / fConst0);
+        fConst2  = (17640.0f / fConst0);
+        iConst3  = int((0.0253061224f * fConst0));
+        iConst4  = int((0.0269387756f * fConst0));
+        iConst5  = int((0.0289569162f * fConst0));
+        iConst6  = int((0.0307482984f * fConst0));
+        iConst7  = int((0.0322448984f * fConst0));
+        iConst8  = int((0.033809524f * fConst0));
+        iConst9  = int((0.0353061222f * fConst0));
+        iConst10 = int((0.0366666652f * fConst0));
+        iConst11 = int((0.0126077095f * fConst0));
+        iConst12 = std::min<int>(1024, std::max<int>(0, (iConst11 + -1)));
+        iConst13 = int((0.00999999978f * fConst0));
+        iConst14 = std::min<int>(1024, std::max<int>(0, (iConst13 + -1)));
+        iConst15 = int((0.00773242628f * fConst0));
+        iConst16 = std::min<int>(1024, std::max<int>(0, (iConst15 + -1)));
+        iConst17 = int((0.00510204071f * fConst0));
+        iConst18 = std::min<int>(1024, std::max<int>(0, (iConst17 + -1)));
+        fConst19 = (0.00104308384f * fConst0);
+    }
+
+    virtual void instanceResetUserInterface()
+    {
+        fVslider0 = FAUSTFLOAT(0.10000000000000001f);
+        fVslider1 = FAUSTFLOAT(0.5f);
+        fVslider2 = FAUSTFLOAT(0.10000000000000001f);
+        fVslider3 = FAUSTFLOAT(0.5f);
+    }
+
+    virtual void instanceClear()
+    {
+        for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) { fRec9[l0] = 0.0f; }
+        IOTA = 0;
+        for (int l1 = 0; (l1 < 8192); l1 = (l1 + 1)) { fVec0[l1] = 0.0f; }
+        for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) { fRec8[l2] = 0.0f; }
+        for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) { fRec11[l3] = 0.0f; }
+        for (int l4 = 0; (l4 < 8192); l4 = (l4 + 1)) { fVec1[l4] = 0.0f; }
+        for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) { fRec10[l5] = 0.0f; }
+        for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) { fRec13[l6] = 0.0f; }
+        for (int l7 = 0; (l7 < 8192); l7 = (l7 + 1)) { fVec2[l7] = 0.0f; }
+        for (int l8 = 0; (l8 < 2); l8 = (l8 + 1)) { fRec12[l8] = 0.0f; }
+        for (int l9 = 0; (l9 < 2); l9 = (l9 + 1)) { fRec15[l9] = 0.0f; }
+        for (int l10 = 0; (l10 < 8192); l10 = (l10 + 1)) { fVec3[l10] = 0.0f; }
+        for (int l11 = 0; (l11 < 2); l11 = (l11 + 1)) { fRec14[l11] = 0.0f; }
+        for (int l12 = 0; (l12 < 2); l12 = (l12 + 1)) { fRec17[l12] = 0.0f; }
+        for (int l13 = 0; (l13 < 8192); l13 = (l13 + 1)) { fVec4[l13] = 0.0f; }
+        for (int l14 = 0; (l14 < 2); l14 = (l14 + 1)) { fRec16[l14] = 0.0f; }
+        for (int l15 = 0; (l15 < 2); l15 = (l15 + 1)) { fRec19[l15] = 0.0f; }
+        for (int l16 = 0; (l16 < 8192); l16 = (l16 + 1)) { fVec5[l16] = 0.0f; }
+        for (int l17 = 0; (l17 < 2); l17 = (l17 + 1)) { fRec18[l17] = 0.0f; }
+        for (int l18 = 0; (l18 < 2); l18 = (l18 + 1)) { fRec21[l18] = 0.0f; }
+        for (int l19 = 0; (l19 < 8192); l19 = (l19 + 1)) { fVec6[l19] = 0.0f; }
+        for (int l20 = 0; (l20 < 2); l20 = (l20 + 1)) { fRec20[l20] = 0.0f; }
+        for (int l21 = 0; (l21 < 2); l21 = (l21 + 1)) { fRec23[l21] = 0.0f; }
+        for (int l22 = 0; (l22 < 8192); l22 = (l22 + 1)) { fVec7[l22] = 0.0f; }
+        for (int l23 = 0; (l23 < 2); l23 = (l23 + 1)) { fRec22[l23] = 0.0f; }
+        for (int l24 = 0; (l24 < 2048); l24 = (l24 + 1)) { fVec8[l24] = 0.0f; }
+        for (int l25 = 0; (l25 < 2); l25 = (l25 + 1)) { fRec6[l25] = 0.0f; }
+        for (int l26 = 0; (l26 < 2048); l26 = (l26 + 1)) { fVec9[l26] = 0.0f; }
+        for (int l27 = 0; (l27 < 2); l27 = (l27 + 1)) { fRec4[l27] = 0.0f; }
+        for (int l28 = 0; (l28 < 2048); l28 = (l28 + 1)) { fVec10[l28] = 0.0f; }
+        for (int l29 = 0; (l29 < 2); l29 = (l29 + 1)) { fRec2[l29] = 0.0f; }
+        for (int l30 = 0; (l30 < 1024); l30 = (l30 + 1)) { fVec11[l30] = 0.0f; }
+        for (int l31 = 0; (l31 < 2); l31 = (l31 + 1)) { fRec0[l31] = 0.0f; }
+        for (int l32 = 0; (l32 < 2); l32 = (l32 + 1)) { fRec33[l32] = 0.0f; }
+        for (int l33 = 0; (l33 < 8192); l33 = (l33 + 1)) { fVec12[l33] = 0.0f; }
+        for (int l34 = 0; (l34 < 2); l34 = (l34 + 1)) { fRec32[l34] = 0.0f; }
+        for (int l35 = 0; (l35 < 2); l35 = (l35 + 1)) { fRec35[l35] = 0.0f; }
+        for (int l36 = 0; (l36 < 8192); l36 = (l36 + 1)) { fVec13[l36] = 0.0f; }
+        for (int l37 = 0; (l37 < 2); l37 = (l37 + 1)) { fRec34[l37] = 0.0f; }
+        for (int l38 = 0; (l38 < 2); l38 = (l38 + 1)) { fRec37[l38] = 0.0f; }
+        for (int l39 = 0; (l39 < 8192); l39 = (l39 + 1)) { fVec14[l39] = 0.0f; }
+        for (int l40 = 0; (l40 < 2); l40 = (l40 + 1)) { fRec36[l40] = 0.0f; }
+        for (int l41 = 0; (l41 < 2); l41 = (l41 + 1)) { fRec39[l41] = 0.0f; }
+        for (int l42 = 0; (l42 < 8192); l42 = (l42 + 1)) { fVec15[l42] = 0.0f; }
+        for (int l43 = 0; (l43 < 2); l43 = (l43 + 1)) { fRec38[l43] = 0.0f; }
+        for (int l44 = 0; (l44 < 2); l44 = (l44 + 1)) { fRec41[l44] = 0.0f; }
+        for (int l45 = 0; (l45 < 8192); l45 = (l45 + 1)) { fVec16[l45] = 0.0f; }
+        for (int l46 = 0; (l46 < 2); l46 = (l46 + 1)) { fRec40[l46] = 0.0f; }
+        for (int l47 = 0; (l47 < 2); l47 = (l47 + 1)) { fRec43[l47] = 0.0f; }
+        for (int l48 = 0; (l48 < 8192); l48 = (l48 + 1)) { fVec17[l48] = 0.0f; }
+        for (int l49 = 0; (l49 < 2); l49 = (l49 + 1)) { fRec42[l49] = 0.0f; }
+        for (int l50 = 0; (l50 < 2); l50 = (l50 + 1)) { fRec45[l50] = 0.0f; }
+        for (int l51 = 0; (l51 < 8192); l51 = (l51 + 1)) { fVec18[l51] = 0.0f; }
+        for (int l52 = 0; (l52 < 2); l52 = (l52 + 1)) { fRec44[l52] = 0.0f; }
+        for (int l53 = 0; (l53 < 2); l53 = (l53 + 1)) { fRec47[l53] = 0.0f; }
+        for (int l54 = 0; (l54 < 8192); l54 = (l54 + 1)) { fVec19[l54] = 0.0f; }
+        for (int l55 = 0; (l55 < 2); l55 = (l55 + 1)) { fRec46[l55] = 0.0f; }
+        for (int l56 = 0; (l56 < 2048); l56 = (l56 + 1)) { fVec20[l56] = 0.0f; }
+        for (int l57 = 0; (l57 < 2); l57 = (l57 + 1)) { fRec30[l57] = 0.0f; }
+        for (int l58 = 0; (l58 < 2048); l58 = (l58 + 1)) { fVec21[l58] = 0.0f; }
+        for (int l59 = 0; (l59 < 2); l59 = (l59 + 1)) { fRec28[l59] = 0.0f; }
+        for (int l60 = 0; (l60 < 2048); l60 = (l60 + 1)) { fVec22[l60] = 0.0f; }
+        for (int l61 = 0; (l61 < 2); l61 = (l61 + 1)) { fRec26[l61] = 0.0f; }
+        for (int l62 = 0; (l62 < 2048); l62 = (l62 + 1)) { fVec23[l62] = 0.0f; }
+        for (int l63 = 0; (l63 < 2); l63 = (l63 + 1)) { fRec24[l63] = 0.0f; }
+    }
+
+    virtual void init(int sample_rate)
+    {
+        classInit(sample_rate);
+        instanceInit(sample_rate);
+    }
+    virtual void instanceInit(int sample_rate)
+    {
+        instanceConstants(sample_rate);
+        instanceResetUserInterface();
+        instanceClear();
+    }
+
+    virtual freeverbdsp* clone() { return new freeverbdsp(); }
+
+    virtual int getSampleRate() { return fSampleRate; }
+
+    virtual void buildUserInterface(UI* ui_interface)
+    {
+        ui_interface->openHorizontalBox("Freeverb");
+        ui_interface->declare(0, "0", "");
+        ui_interface->openVerticalBox("0x00");
+        ui_interface->declare(&fVslider1, "0", "");
+        ui_interface->declare(&fVslider1, "style", "knob");
+        ui_interface->declare(&fVslider1, "tooltip",
+                              "Somehow control the   density of the reverb.");
+        ui_interface->addVerticalSlider("Damp", &fVslider1, 0.5f, 0.0f, 1.0f,
+                                        0.0250000004f);
+        ui_interface->declare(&fVslider0, "1", "");
+        ui_interface->declare(&fVslider0, "style", "knob");
+        ui_interface->declare(
+            &fVslider0, "tooltip",
+            "The room size   between 0 and 1 with 1 for the largest room.");
+        ui_interface->addVerticalSlider("RoomSize", &fVslider0, 0.100000001f, 0.0f, 1.0f,
+                                        0.0250000004f);
+        ui_interface->declare(&fVslider3, "2", "");
+        ui_interface->declare(&fVslider3, "style", "knob");
+        ui_interface->declare(
+            &fVslider3, "tooltip",
+            "Spatial   spread between 0 and 1 with 1 for maximum spread.");
+        ui_interface->addVerticalSlider("Stereo Spread", &fVslider3, 0.5f, 0.0f, 1.0f,
+                                        0.00999999978f);
+        ui_interface->closeBox();
+        ui_interface->declare(&fVslider2, "1", "");
+        ui_interface->declare(&fVslider2, "tooltip",
+                              "The amount of reverb applied to the signal   between 0 "
+                              "and 1 with 1 for the maximum amount of reverb.");
+        ui_interface->addVerticalSlider("Wet", &fVslider2, 0.100000001f, 0.0f, 1.0f,
+                                        0.0250000004f);
+        ui_interface->closeBox();
+    }
+
+    virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+    {
+        FAUSTFLOAT* input0  = inputs[0];
+        FAUSTFLOAT* input1  = inputs[1];
+        FAUSTFLOAT* output0 = outputs[0];
+        FAUSTFLOAT* output1 = outputs[1];
+        float fSlow0        = ((fConst1 * float(fVslider0)) + 0.699999988f);
+        float fSlow1        = (fConst2 * float(fVslider1));
+        float fSlow2        = (1.0f - fSlow1);
+        float fSlow3        = float(fVslider2);
+        float fSlow4        = (0.100000001f * fSlow3);
+        float fSlow5        = (1.0f - fSlow3);
+        int iSlow6          = int((fConst19 * float(fVslider3)));
+        int iSlow7          = (iConst3 + iSlow6);
+        int iSlow8          = (iConst4 + iSlow6);
+        int iSlow9          = (iConst5 + iSlow6);
+        int iSlow10         = (iConst6 + iSlow6);
+        int iSlow11         = (iConst7 + iSlow6);
+        int iSlow12         = (iConst8 + iSlow6);
+        int iSlow13         = (iConst9 + iSlow6);
+        int iSlow14         = (iConst10 + iSlow6);
+        int iSlow15         = (iSlow6 + -1);
+        int iSlow16         = std::min<int>(1024, std::max<int>(0, (iConst11 + iSlow15)));
+        int iSlow17         = std::min<int>(1024, std::max<int>(0, (iConst13 + iSlow15)));
+        int iSlow18         = std::min<int>(1024, std::max<int>(0, (iConst15 + iSlow15)));
+        int iSlow19         = std::min<int>(1024, std::max<int>(0, (iConst17 + iSlow15)));
+        for (int i = 0; (i < count); i = (i + 1)) {
+            float fTemp0         = float(input0[i]);
+            float fTemp1         = float(input1[i]);
+            fRec9[0]             = ((fSlow1 * fRec9[1]) + (fSlow2 * fRec8[1]));
+            float fTemp2         = (fSlow4 * (fTemp0 + fTemp1));
+            fVec0[(IOTA & 8191)] = ((fSlow0 * fRec9[0]) + fTemp2);
+            fRec8[0]             = fVec0[((IOTA - iConst3) & 8191)];
+            fRec11[0]            = ((fSlow1 * fRec11[1]) + (fSlow2 * fRec10[1]));
+            fVec1[(IOTA & 8191)] = (fTemp2 + (fSlow0 * fRec11[0]));
+            fRec10[0]            = fVec1[((IOTA - iConst4) & 8191)];
+            fRec13[0]            = ((fSlow1 * fRec13[1]) + (fSlow2 * fRec12[1]));
+            fVec2[(IOTA & 8191)] = (fTemp2 + (fSlow0 * fRec13[0]));
+            fRec12[0]            = fVec2[((IOTA - iConst5) & 8191)];
+            fRec15[0]            = ((fSlow1 * fRec15[1]) + (fSlow2 * fRec14[1]));
+            fVec3[(IOTA & 8191)] = (fTemp2 + (fSlow0 * fRec15[0]));
+            fRec14[0]            = fVec3[((IOTA - iConst6) & 8191)];
+            fRec17[0]            = ((fSlow1 * fRec17[1]) + (fSlow2 * fRec16[1]));
+            fVec4[(IOTA & 8191)] = (fTemp2 + (fSlow0 * fRec17[0]));
+            fRec16[0]            = fVec4[((IOTA - iConst7) & 8191)];
+            fRec19[0]            = ((fSlow1 * fRec19[1]) + (fSlow2 * fRec18[1]));
+            fVec5[(IOTA & 8191)] = (fTemp2 + (fSlow0 * fRec19[0]));
+            fRec18[0]            = fVec5[((IOTA - iConst8) & 8191)];
+            fRec21[0]            = ((fSlow1 * fRec21[1]) + (fSlow2 * fRec20[1]));
+            fVec6[(IOTA & 8191)] = (fTemp2 + (fSlow0 * fRec21[0]));
+            fRec20[0]            = fVec6[((IOTA - iConst9) & 8191)];
+            fRec23[0]            = ((fSlow1 * fRec23[1]) + (fSlow2 * fRec22[1]));
+            fVec7[(IOTA & 8191)] = (fTemp2 + (fSlow0 * fRec23[0]));
+            fRec22[0]            = fVec7[((IOTA - iConst10) & 8191)];
+            float fTemp3 =
+                ((((((((fRec8[0] + fRec10[0]) + fRec12[0]) + fRec14[0]) + fRec16[0])
+                    + fRec18[0])
+                   + fRec20[0])
+                  + fRec22[0])
+                 + (0.5f * fRec6[1]));
+            fVec8[(IOTA & 2047)]  = fTemp3;
+            fRec6[0]              = fVec8[((IOTA - iConst12) & 2047)];
+            float fRec7           = (0.0f - (0.5f * fTemp3));
+            float fTemp4          = (fRec6[1] + (fRec7 + (0.5f * fRec4[1])));
+            fVec9[(IOTA & 2047)]  = fTemp4;
+            fRec4[0]              = fVec9[((IOTA - iConst14) & 2047)];
+            float fRec5           = (0.0f - (0.5f * fTemp4));
+            float fTemp5          = (fRec4[1] + (fRec5 + (0.5f * fRec2[1])));
+            fVec10[(IOTA & 2047)] = fTemp5;
+            fRec2[0]              = fVec10[((IOTA - iConst16) & 2047)];
+            float fRec3           = (0.0f - (0.5f * fTemp5));
+            float fTemp6          = (fRec2[1] + (fRec3 + (0.5f * fRec0[1])));
+            fVec11[(IOTA & 1023)] = fTemp6;
+            fRec0[0]              = fVec11[((IOTA - iConst18) & 1023)];
+            float fRec1           = (0.0f - (0.5f * fTemp6));
+            output0[i]            = FAUSTFLOAT(((fRec1 + fRec0[1]) + (fSlow5 * fTemp0)));
+            fRec33[0]             = ((fSlow1 * fRec33[1]) + (fSlow2 * fRec32[1]));
+            fVec12[(IOTA & 8191)] = (fTemp2 + (fSlow0 * fRec33[0]));
+            fRec32[0]             = fVec12[((IOTA - iSlow7) & 8191)];
+            fRec35[0]             = ((fSlow1 * fRec35[1]) + (fSlow2 * fRec34[1]));
+            fVec13[(IOTA & 8191)] = (fTemp2 + (fSlow0 * fRec35[0]));
+            fRec34[0]             = fVec13[((IOTA - iSlow8) & 8191)];
+            fRec37[0]             = ((fSlow1 * fRec37[1]) + (fSlow2 * fRec36[1]));
+            fVec14[(IOTA & 8191)] = (fTemp2 + (fSlow0 * fRec37[0]));
+            fRec36[0]             = fVec14[((IOTA - iSlow9) & 8191)];
+            fRec39[0]             = ((fSlow1 * fRec39[1]) + (fSlow2 * fRec38[1]));
+            fVec15[(IOTA & 8191)] = (fTemp2 + (fSlow0 * fRec39[0]));
+            fRec38[0]             = fVec15[((IOTA - iSlow10) & 8191)];
+            fRec41[0]             = ((fSlow1 * fRec41[1]) + (fSlow2 * fRec40[1]));
+            fVec16[(IOTA & 8191)] = (fTemp2 + (fSlow0 * fRec41[0]));
+            fRec40[0]             = fVec16[((IOTA - iSlow11) & 8191)];
+            fRec43[0]             = ((fSlow1 * fRec43[1]) + (fSlow2 * fRec42[1]));
+            fVec17[(IOTA & 8191)] = (fTemp2 + (fSlow0 * fRec43[0]));
+            fRec42[0]             = fVec17[((IOTA - iSlow12) & 8191)];
+            fRec45[0]             = ((fSlow1 * fRec45[1]) + (fSlow2 * fRec44[1]));
+            fVec18[(IOTA & 8191)] = (fTemp2 + (fSlow0 * fRec45[0]));
+            fRec44[0]             = fVec18[((IOTA - iSlow13) & 8191)];
+            fRec47[0]             = ((fSlow1 * fRec47[1]) + (fSlow2 * fRec46[1]));
+            fVec19[(IOTA & 8191)] = (fTemp2 + (fSlow0 * fRec47[0]));
+            fRec46[0]             = fVec19[((IOTA - iSlow14) & 8191)];
+            float fTemp7 =
+                ((((((((fRec32[0] + fRec34[0]) + fRec36[0]) + fRec38[0]) + fRec40[0])
+                    + fRec42[0])
+                   + fRec44[0])
+                  + fRec46[0])
+                 + (0.5f * fRec30[1]));
+            fVec20[(IOTA & 2047)] = fTemp7;
+            fRec30[0]             = fVec20[((IOTA - iSlow16) & 2047)];
+            float fRec31          = (0.0f - (0.5f * fTemp7));
+            float fTemp8          = (fRec30[1] + (fRec31 + (0.5f * fRec28[1])));
+            fVec21[(IOTA & 2047)] = fTemp8;
+            fRec28[0]             = fVec21[((IOTA - iSlow17) & 2047)];
+            float fRec29          = (0.0f - (0.5f * fTemp8));
+            float fTemp9          = (fRec28[1] + (fRec29 + (0.5f * fRec26[1])));
+            fVec22[(IOTA & 2047)] = fTemp9;
+            fRec26[0]             = fVec22[((IOTA - iSlow18) & 2047)];
+            float fRec27          = (0.0f - (0.5f * fTemp9));
+            float fTemp10         = (fRec26[1] + (fRec27 + (0.5f * fRec24[1])));
+            fVec23[(IOTA & 2047)] = fTemp10;
+            fRec24[0]             = fVec23[((IOTA - iSlow19) & 2047)];
+            float fRec25          = (0.0f - (0.5f * fTemp10));
+            output1[i] = FAUSTFLOAT(((fRec25 + fRec24[1]) + (fSlow5 * fTemp1)));
+            fRec9[1]   = fRec9[0];
+            IOTA       = (IOTA + 1);
+            fRec8[1]   = fRec8[0];
+            fRec11[1]  = fRec11[0];
+            fRec10[1]  = fRec10[0];
+            fRec13[1]  = fRec13[0];
+            fRec12[1]  = fRec12[0];
+            fRec15[1]  = fRec15[0];
+            fRec14[1]  = fRec14[0];
+            fRec17[1]  = fRec17[0];
+            fRec16[1]  = fRec16[0];
+            fRec19[1]  = fRec19[0];
+            fRec18[1]  = fRec18[0];
+            fRec21[1]  = fRec21[0];
+            fRec20[1]  = fRec20[0];
+            fRec23[1]  = fRec23[0];
+            fRec22[1]  = fRec22[0];
+            fRec6[1]   = fRec6[0];
+            fRec4[1]   = fRec4[0];
+            fRec2[1]   = fRec2[0];
+            fRec0[1]   = fRec0[0];
+            fRec33[1]  = fRec33[0];
+            fRec32[1]  = fRec32[0];
+            fRec35[1]  = fRec35[0];
+            fRec34[1]  = fRec34[0];
+            fRec37[1]  = fRec37[0];
+            fRec36[1]  = fRec36[0];
+            fRec39[1]  = fRec39[0];
+            fRec38[1]  = fRec38[0];
+            fRec41[1]  = fRec41[0];
+            fRec40[1]  = fRec40[0];
+            fRec43[1]  = fRec43[0];
+            fRec42[1]  = fRec42[0];
+            fRec45[1]  = fRec45[0];
+            fRec44[1]  = fRec44[0];
+            fRec47[1]  = fRec47[0];
+            fRec46[1]  = fRec46[0];
+            fRec30[1]  = fRec30[0];
+            fRec28[1]  = fRec28[0];
+            fRec26[1]  = fRec26[0];
+            fRec24[1]  = fRec24[0];
+        }
+    }
 };
 
 #endif

--- a/src/freeverbmonodsp.h
+++ b/src/freeverbmonodsp.h
@@ -4,8 +4,8 @@ Code generated with Faust 2.28.6 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -scal -ftz 0
 ------------------------------------------------------------ */
 
-#ifndef  __freeverbmonodsp_H__
-#define  __freeverbmonodsp_H__
+#ifndef __freeverbmonodsp_H__
+#define __freeverbmonodsp_H__
 
 // NOTE: ANY INCLUDE-GUARD HERE MUST BE DERIVED FROM THE CLASS NAME
 //
@@ -56,86 +56,83 @@ struct Meta;
  */
 
 struct dsp_memory_manager {
-    
     virtual ~dsp_memory_manager() {}
-    
+
     virtual void* allocate(size_t size) = 0;
-    virtual void destroy(void* ptr) = 0;
-    
+    virtual void destroy(void* ptr)     = 0;
 };
 
 /**
 * Signal processor definition.
 */
 
-class dsp {
+class dsp
+{
+   public:
+    dsp() {}
+    virtual ~dsp() {}
 
-    public:
+    /* Return instance number of audio inputs */
+    virtual int getNumInputs() = 0;
 
-        dsp() {}
-        virtual ~dsp() {}
+    /* Return instance number of audio outputs */
+    virtual int getNumOutputs() = 0;
 
-        /* Return instance number of audio inputs */
-        virtual int getNumInputs() = 0;
-    
-        /* Return instance number of audio outputs */
-        virtual int getNumOutputs() = 0;
-    
-        /**
+    /**
          * Trigger the ui_interface parameter with instance specific calls
          * to 'openTabBox', 'addButton', 'addVerticalSlider'... in order to build the UI.
          *
          * @param ui_interface - the user interface builder
          */
-        virtual void buildUserInterface(UI* ui_interface) = 0;
-    
-        /* Returns the sample rate currently used by the instance */
-        virtual int getSampleRate() = 0;
-    
-        /**
+    virtual void buildUserInterface(UI* ui_interface) = 0;
+
+    /* Returns the sample rate currently used by the instance */
+    virtual int getSampleRate() = 0;
+
+    /**
          * Global init, calls the following methods:
          * - static class 'classInit': static tables initialization
          * - 'instanceInit': constants and instance state initialization
          *
          * @param sample_rate - the sampling rate in Hertz
          */
-        virtual void init(int sample_rate) = 0;
+    virtual void init(int sample_rate) = 0;
 
-        /**
+    /**
          * Init instance state
          *
          * @param sample_rate - the sampling rate in Hertz
          */
-        virtual void instanceInit(int sample_rate) = 0;
+    virtual void instanceInit(int sample_rate) = 0;
 
-        /**
+    /**
          * Init instance constant state
          *
          * @param sample_rate - the sampling rate in Hertz
          */
-        virtual void instanceConstants(int sample_rate) = 0;
-    
-        /* Init default control parameters values */
-        virtual void instanceResetUserInterface() = 0;
-    
-        /* Init instance state (delay lines...) */
-        virtual void instanceClear() = 0;
- 
-        /**
+    virtual void instanceConstants(int sample_rate) = 0;
+
+    /* Init default control parameters values */
+    virtual void instanceResetUserInterface() = 0;
+
+    /* Init instance state (delay lines...) */
+    virtual void instanceClear() = 0;
+
+    /**
          * Return a clone of the instance.
          *
          * @return a copy of the instance on success, otherwise a null pointer.
          */
-        virtual dsp* clone() = 0;
-    
-        /**
+    virtual dsp* clone() = 0;
+
+    /**
          * Trigger the Meta* parameter with instance specific calls to 'declare' (key, value) metadata.
          *
          * @param m - the Meta* meta user
          */
-        virtual void metadata(Meta* m) = 0;
-    
-        /**
+    virtual void metadata(Meta* m) = 0;
+
+    /**
          * DSP instance computation, to be called with successive in/out audio buffers.
          *
          * @param count - the number of frames to compute
@@ -143,9 +140,9 @@ class dsp {
          * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
          *
          */
-        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
-    
-        /**
+    virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
+
+    /**
          * DSP instance computation: alternative method to be used by subclasses.
          *
          * @param date_usec - the timestamp in microsec given by audio driver.
@@ -154,67 +151,77 @@ class dsp {
          * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (either float, double or quad)
          *
          */
-        virtual void compute(double /*date_usec*/, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
-       
+    virtual void compute(double /*date_usec*/, int count, FAUSTFLOAT** inputs,
+                         FAUSTFLOAT** outputs)
+    {
+        compute(count, inputs, outputs);
+    }
 };
 
 /**
  * Generic DSP decorator.
  */
 
-class decorator_dsp : public dsp {
+class decorator_dsp : public dsp
+{
+   protected:
+    dsp* fDSP;
 
-    protected:
+   public:
+    decorator_dsp(dsp* dsp = nullptr) : fDSP(dsp) {}
+    virtual ~decorator_dsp() { delete fDSP; }
 
-        dsp* fDSP;
-
-    public:
-
-        decorator_dsp(dsp* dsp = nullptr):fDSP(dsp) {}
-        virtual ~decorator_dsp() { delete fDSP; }
-
-        virtual int getNumInputs() { return fDSP->getNumInputs(); }
-        virtual int getNumOutputs() { return fDSP->getNumOutputs(); }
-        virtual void buildUserInterface(UI* ui_interface) { fDSP->buildUserInterface(ui_interface); }
-        virtual int getSampleRate() { return fDSP->getSampleRate(); }
-        virtual void init(int sample_rate) { fDSP->init(sample_rate); }
-        virtual void instanceInit(int sample_rate) { fDSP->instanceInit(sample_rate); }
-        virtual void instanceConstants(int sample_rate) { fDSP->instanceConstants(sample_rate); }
-        virtual void instanceResetUserInterface() { fDSP->instanceResetUserInterface(); }
-        virtual void instanceClear() { fDSP->instanceClear(); }
-        virtual decorator_dsp* clone() { return new decorator_dsp(fDSP->clone()); }
-        virtual void metadata(Meta* m) { fDSP->metadata(m); }
-        // Beware: subclasses usually have to overload the two 'compute' methods
-        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(count, inputs, outputs); }
-        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(date_usec, count, inputs, outputs); }
-    
+    virtual int getNumInputs() { return fDSP->getNumInputs(); }
+    virtual int getNumOutputs() { return fDSP->getNumOutputs(); }
+    virtual void buildUserInterface(UI* ui_interface)
+    {
+        fDSP->buildUserInterface(ui_interface);
+    }
+    virtual int getSampleRate() { return fDSP->getSampleRate(); }
+    virtual void init(int sample_rate) { fDSP->init(sample_rate); }
+    virtual void instanceInit(int sample_rate) { fDSP->instanceInit(sample_rate); }
+    virtual void instanceConstants(int sample_rate)
+    {
+        fDSP->instanceConstants(sample_rate);
+    }
+    virtual void instanceResetUserInterface() { fDSP->instanceResetUserInterface(); }
+    virtual void instanceClear() { fDSP->instanceClear(); }
+    virtual decorator_dsp* clone() { return new decorator_dsp(fDSP->clone()); }
+    virtual void metadata(Meta* m) { fDSP->metadata(m); }
+    // Beware: subclasses usually have to overload the two 'compute' methods
+    virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+    {
+        fDSP->compute(count, inputs, outputs);
+    }
+    virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs,
+                         FAUSTFLOAT** outputs)
+    {
+        fDSP->compute(date_usec, count, inputs, outputs);
+    }
 };
 
 /**
  * DSP factory class.
  */
 
-class dsp_factory {
-    
-    protected:
-    
-        // So that to force sub-classes to use deleteDSPFactory(dsp_factory* factory);
-        virtual ~dsp_factory() {}
-    
-    public:
-    
-        virtual std::string getName() = 0;
-        virtual std::string getSHAKey() = 0;
-        virtual std::string getDSPCode() = 0;
-        virtual std::string getCompileOptions() = 0;
-        virtual std::vector<std::string> getLibraryList() = 0;
-        virtual std::vector<std::string> getIncludePathnames() = 0;
-    
-        virtual dsp* createDSPInstance() = 0;
-    
-        virtual void setMemoryManager(dsp_memory_manager* manager) = 0;
-        virtual dsp_memory_manager* getMemoryManager() = 0;
-    
+class dsp_factory
+{
+   protected:
+    // So that to force sub-classes to use deleteDSPFactory(dsp_factory* factory);
+    virtual ~dsp_factory() {}
+
+   public:
+    virtual std::string getName()                          = 0;
+    virtual std::string getSHAKey()                        = 0;
+    virtual std::string getDSPCode()                       = 0;
+    virtual std::string getCompileOptions()                = 0;
+    virtual std::vector<std::string> getLibraryList()      = 0;
+    virtual std::vector<std::string> getIncludePathnames() = 0;
+
+    virtual dsp* createDSPInstance() = 0;
+
+    virtual void setMemoryManager(dsp_memory_manager* manager) = 0;
+    virtual dsp_memory_manager* getMemoryManager()             = 0;
 };
 
 /**
@@ -223,14 +230,14 @@ class dsp_factory {
  */
 
 #ifdef __SSE__
-    #include <xmmintrin.h>
-    #ifdef __SSE2__
-        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8040)
-    #else
-        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8000)
-    #endif
+#include <xmmintrin.h>
+#ifdef __SSE2__
+#define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8040)
 #else
-    #define AVOIDDENORMALS
+#define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8000)
+#endif
+#else
+#define AVOIDDENORMALS
 #endif
 
 #endif
@@ -263,11 +270,11 @@ class dsp_factory {
 #ifndef API_UI_H
 #define API_UI_H
 
+#include <iostream>
+#include <map>
 #include <sstream>
 #include <string>
 #include <vector>
-#include <iostream>
-#include <map>
 
 /************************** BEGIN meta.h **************************/
 /************************************************************************
@@ -296,11 +303,9 @@ class dsp_factory {
 #ifndef __meta__
 #define __meta__
 
-struct Meta
-{
-    virtual ~Meta() {};
+struct Meta {
+    virtual ~Meta(){};
     virtual void declare(const char* key, const char* value) = 0;
-    
 };
 
 #endif
@@ -345,43 +350,47 @@ struct Meta
 
 struct Soundfile;
 
-template <typename REAL>
-struct UIReal
-{
+template<typename REAL>
+struct UIReal {
     UIReal() {}
     virtual ~UIReal() {}
-    
+
     // -- widget's layouts
-    
-    virtual void openTabBox(const char* label) = 0;
+
+    virtual void openTabBox(const char* label)        = 0;
     virtual void openHorizontalBox(const char* label) = 0;
-    virtual void openVerticalBox(const char* label) = 0;
-    virtual void closeBox() = 0;
-    
+    virtual void openVerticalBox(const char* label)   = 0;
+    virtual void closeBox()                           = 0;
+
     // -- active widgets
-    
-    virtual void addButton(const char* label, REAL* zone) = 0;
+
+    virtual void addButton(const char* label, REAL* zone)      = 0;
     virtual void addCheckButton(const char* label, REAL* zone) = 0;
-    virtual void addVerticalSlider(const char* label, REAL* zone, REAL init, REAL min, REAL max, REAL step) = 0;
-    virtual void addHorizontalSlider(const char* label, REAL* zone, REAL init, REAL min, REAL max, REAL step) = 0;
-    virtual void addNumEntry(const char* label, REAL* zone, REAL init, REAL min, REAL max, REAL step) = 0;
-    
+    virtual void addVerticalSlider(const char* label, REAL* zone, REAL init, REAL min,
+                                   REAL max, REAL step)        = 0;
+    virtual void addHorizontalSlider(const char* label, REAL* zone, REAL init, REAL min,
+                                     REAL max, REAL step)      = 0;
+    virtual void addNumEntry(const char* label, REAL* zone, REAL init, REAL min, REAL max,
+                             REAL step)                        = 0;
+
     // -- passive widgets
-    
-    virtual void addHorizontalBargraph(const char* label, REAL* zone, REAL min, REAL max) = 0;
-    virtual void addVerticalBargraph(const char* label, REAL* zone, REAL min, REAL max) = 0;
-    
+
+    virtual void addHorizontalBargraph(const char* label, REAL* zone, REAL min,
+                                       REAL max) = 0;
+    virtual void addVerticalBargraph(const char* label, REAL* zone, REAL min,
+                                     REAL max)   = 0;
+
     // -- soundfiles
-    
-    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) = 0;
-    
+
+    virtual void addSoundfile(const char* label, const char* filename,
+                              Soundfile** sf_zone) = 0;
+
     // -- metadata declarations
-    
+
     virtual void declare(REAL* zone, const char* key, const char* val) {}
 };
 
-struct UI : public UIReal<FAUSTFLOAT>
-{
+struct UI : public UIReal<FAUSTFLOAT> {
     UI() {}
     virtual ~UI() {}
 };
@@ -415,9 +424,9 @@ struct UI : public UIReal<FAUSTFLOAT>
 #ifndef FAUST_PATHBUILDER_H
 #define FAUST_PATHBUILDER_H
 
-#include <vector>
-#include <string>
 #include <algorithm>
+#include <string>
+#include <vector>
 
 /*******************************************************************************
  * PathBuilder : Faust User Interface
@@ -426,37 +435,33 @@ struct UI : public UIReal<FAUSTFLOAT>
 
 class PathBuilder
 {
+   protected:
+    std::vector<std::string> fControlsLevel;
 
-    protected:
-    
-        std::vector<std::string> fControlsLevel;
-       
-    public:
-    
-        PathBuilder() {}
-        virtual ~PathBuilder() {}
-    
-        std::string buildPath(const std::string& label) 
-        {
-            std::string res = "/";
-            for (size_t i = 0; i < fControlsLevel.size(); i++) {
-                res += fControlsLevel[i];
-                res += "/";
-            }
-            res += label;
-            std::replace(res.begin(), res.end(), ' ', '_');
-            return res;
+   public:
+    PathBuilder() {}
+    virtual ~PathBuilder() {}
+
+    std::string buildPath(const std::string& label)
+    {
+        std::string res = "/";
+        for (size_t i = 0; i < fControlsLevel.size(); i++) {
+            res += fControlsLevel[i];
+            res += "/";
         }
-    
-        std::string buildLabel(std::string label)
-        {
-            std::replace(label.begin(), label.end(), ' ', '_');
-            return label;
-        }
-    
-        void pushLabel(const std::string& label) { fControlsLevel.push_back(label); }
-        void popLabel() { fControlsLevel.pop_back(); }
-    
+        res += label;
+        std::replace(res.begin(), res.end(), ' ', '_');
+        return res;
+    }
+
+    std::string buildLabel(std::string label)
+    {
+        std::replace(label.begin(), label.end(), ' ', '_');
+        return label;
+    }
+
+    void pushLabel(const std::string& label) { fControlsLevel.push_back(label); }
+    void popLabel() { fControlsLevel.pop_back(); }
 };
 
 #endif  // FAUST_PATHBUILDER_H
@@ -531,11 +536,12 @@ ZoneReader(zone, valueConverter) : a zone with a data converter
 
 ****************************************************************************************/
 
+#include <assert.h>
 #include <float.h>
-#include <algorithm>    // std::max
+
+#include <algorithm>  // std::max
 #include <cmath>
 #include <vector>
-#include <assert.h>
 
 //--------------------------------------------------------------------------------------
 // Interpolator(lo,hi,v1,v2)
@@ -548,50 +554,49 @@ ZoneReader(zone, valueConverter) : a zone with a data converter
 //--------------------------------------------------------------------------------------
 class Interpolator
 {
-    private:
+   private:
+    //--------------------------------------------------------------------------------------
+    // Range(lo,hi) clip a value between lo and hi
+    //--------------------------------------------------------------------------------------
+    struct Range {
+        double fLo;
+        double fHi;
 
-        //--------------------------------------------------------------------------------------
-        // Range(lo,hi) clip a value between lo and hi
-        //--------------------------------------------------------------------------------------
-        struct Range
+        Range(double x, double y)
+            : fLo(std::min<double>(x, y)), fHi(std::max<double>(x, y))
         {
-            double fLo;
-            double fHi;
-
-            Range(double x, double y) : fLo(std::min<double>(x,y)), fHi(std::max<double>(x,y)) {}
-            double operator()(double x) { return (x<fLo) ? fLo : (x>fHi) ? fHi : x; }
-        };
-
-
-        Range fRange;
-        double fCoef;
-        double fOffset;
-
-    public:
-
-        Interpolator(double lo, double hi, double v1, double v2) : fRange(lo,hi)
-        {
-            if (hi != lo) {
-                // regular case
-                fCoef = (v2-v1)/(hi-lo);
-                fOffset = v1 - lo*fCoef;
-            } else {
-                // degenerate case, avoids division by zero
-                fCoef = 0;
-                fOffset = (v1+v2)/2;
-            }
         }
-        double operator()(double v)
-        {
-            double x = fRange(v);
-            return  fOffset + x*fCoef;
-        }
+        double operator()(double x) { return (x < fLo) ? fLo : (x > fHi) ? fHi : x; }
+    };
 
-        void getLowHigh(double& amin, double& amax)
-        {
-            amin = fRange.fLo;
-            amax = fRange.fHi;
+    Range fRange;
+    double fCoef;
+    double fOffset;
+
+   public:
+    Interpolator(double lo, double hi, double v1, double v2) : fRange(lo, hi)
+    {
+        if (hi != lo) {
+            // regular case
+            fCoef   = (v2 - v1) / (hi - lo);
+            fOffset = v1 - lo * fCoef;
+        } else {
+            // degenerate case, avoids division by zero
+            fCoef   = 0;
+            fOffset = (v1 + v2) / 2;
         }
+    }
+    double operator()(double v)
+    {
+        double x = fRange(v);
+        return fOffset + x * fCoef;
+    }
+
+    void getLowHigh(double& amin, double& amax)
+    {
+        amin = fRange.fLo;
+        amax = fRange.fHi;
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -600,26 +605,23 @@ class Interpolator
 //--------------------------------------------------------------------------------------
 class Interpolator3pt
 {
+   private:
+    Interpolator fSegment1;
+    Interpolator fSegment2;
+    double fMid;
 
-    private:
+   public:
+    Interpolator3pt(double lo, double mi, double hi, double v1, double vm, double v2)
+        : fSegment1(lo, mi, v1, vm), fSegment2(mi, hi, vm, v2), fMid(mi)
+    {
+    }
+    double operator()(double x) { return (x < fMid) ? fSegment1(x) : fSegment2(x); }
 
-        Interpolator fSegment1;
-        Interpolator fSegment2;
-        double fMid;
-
-    public:
-
-        Interpolator3pt(double lo, double mi, double hi, double v1, double vm, double v2) :
-            fSegment1(lo, mi, v1, vm),
-            fSegment2(mi, hi, vm, v2),
-            fMid(mi) {}
-        double operator()(double x) { return  (x < fMid) ? fSegment1(x) : fSegment2(x); }
-
-        void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fSegment1.getLowHigh(amin, amid);
-            fSegment2.getLowHigh(amid, amax);
-        }
+    void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fSegment1.getLowHigh(amin, amid);
+        fSegment2.getLowHigh(amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -627,62 +629,51 @@ class Interpolator3pt
 //--------------------------------------------------------------------------------------
 class ValueConverter
 {
-
-    public:
-
-        virtual ~ValueConverter() {}
-        virtual double ui2faust(double x) = 0;
-        virtual double faust2ui(double x) = 0;
+   public:
+    virtual ~ValueConverter() {}
+    virtual double ui2faust(double x) = 0;
+    virtual double faust2ui(double x) = 0;
 };
 
 //--------------------------------------------------------------------------------------
 // A converter than can be updated
 //--------------------------------------------------------------------------------------
 
-class UpdatableValueConverter : public ValueConverter {
-    
-    protected:
-        
-        bool fActive;
-        
-    public:
-        
-        UpdatableValueConverter():fActive(true)
-        {}
-        virtual ~UpdatableValueConverter()
-        {}
-        
-        virtual void setMappingValues(double amin, double amid, double amax, double min, double init, double max) = 0;
-        virtual void getMappingValues(double& amin, double& amid, double& amax) = 0;
-        
-        void setActive(bool on_off) { fActive = on_off; }
-        bool getActive() { return fActive; }
-    
-};
+class UpdatableValueConverter : public ValueConverter
+{
+   protected:
+    bool fActive;
 
+   public:
+    UpdatableValueConverter() : fActive(true) {}
+    virtual ~UpdatableValueConverter() {}
+
+    virtual void setMappingValues(double amin, double amid, double amax, double min,
+                                  double init, double max)                  = 0;
+    virtual void getMappingValues(double& amin, double& amid, double& amax) = 0;
+
+    void setActive(bool on_off) { fActive = on_off; }
+    bool getActive() { return fActive; }
+};
 
 //--------------------------------------------------------------------------------------
 // Linear conversion between ui and Faust values
 //--------------------------------------------------------------------------------------
 class LinearValueConverter : public ValueConverter
 {
-    
-    private:
-        
-        Interpolator fUI2F;
-        Interpolator fF2UI;
-        
-    public:
-        
-        LinearValueConverter(double umin, double umax, double fmin, double fmax) :
-            fUI2F(umin,umax,fmin,fmax), fF2UI(fmin,fmax,umin,umax)
-        {}
-        
-        LinearValueConverter() : fUI2F(0.,0.,0.,0.), fF2UI(0.,0.,0.,0.)
-        {}
-        virtual double ui2faust(double x) { return fUI2F(x); }
-        virtual double faust2ui(double x) { return fF2UI(x); }
-    
+   private:
+    Interpolator fUI2F;
+    Interpolator fF2UI;
+
+   public:
+    LinearValueConverter(double umin, double umax, double fmin, double fmax)
+        : fUI2F(umin, umax, fmin, fmax), fF2UI(fmin, fmax, umin, umax)
+    {
+    }
+
+    LinearValueConverter() : fUI2F(0., 0., 0., 0.), fF2UI(0., 0., 0., 0.) {}
+    virtual double ui2faust(double x) { return fUI2F(x); }
+    virtual double faust2ui(double x) { return fF2UI(x); }
 };
 
 //--------------------------------------------------------------------------------------
@@ -690,35 +681,35 @@ class LinearValueConverter : public ValueConverter
 //--------------------------------------------------------------------------------------
 class LinearValueConverter2 : public UpdatableValueConverter
 {
-    
-    private:
-    
-        Interpolator3pt fUI2F;
-        Interpolator3pt fF2UI;
-        
-    public:
-    
-        LinearValueConverter2(double amin, double amid, double amax, double min, double init, double max) :
-            fUI2F(amin, amid, amax, min, init, max), fF2UI(min, init, max, amin, amid, amax)
-        {}
-        
-        LinearValueConverter2() : fUI2F(0.,0.,0.,0.,0.,0.), fF2UI(0.,0.,0.,0.,0.,0.)
-        {}
-    
-        virtual double ui2faust(double x) { return fUI2F(x); }
-        virtual double faust2ui(double x) { return fF2UI(x); }
-    
-        virtual void setMappingValues(double amin, double amid, double amax, double min, double init, double max)
-        {
-            fUI2F = Interpolator3pt(amin, amid, amax, min, init, max);
-            fF2UI = Interpolator3pt(min, init, max, amin, amid, amax);
-        }
+   private:
+    Interpolator3pt fUI2F;
+    Interpolator3pt fF2UI;
 
-        virtual void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fUI2F.getMappingValues(amin, amid, amax);
-        }
-    
+   public:
+    LinearValueConverter2(double amin, double amid, double amax, double min, double init,
+                          double max)
+        : fUI2F(amin, amid, amax, min, init, max), fF2UI(min, init, max, amin, amid, amax)
+    {
+    }
+
+    LinearValueConverter2() : fUI2F(0., 0., 0., 0., 0., 0.), fF2UI(0., 0., 0., 0., 0., 0.)
+    {
+    }
+
+    virtual double ui2faust(double x) { return fUI2F(x); }
+    virtual double faust2ui(double x) { return fF2UI(x); }
+
+    virtual void setMappingValues(double amin, double amid, double amax, double min,
+                                  double init, double max)
+    {
+        fUI2F = Interpolator3pt(amin, amid, amax, min, init, max);
+        fF2UI = Interpolator3pt(min, init, max, amin, amid, amax);
+    }
+
+    virtual void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fUI2F.getMappingValues(amin, amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -726,16 +717,21 @@ class LinearValueConverter2 : public UpdatableValueConverter
 //--------------------------------------------------------------------------------------
 class LogValueConverter : public LinearValueConverter
 {
+   public:
+    LogValueConverter(double umin, double umax, double fmin, double fmax)
+        : LinearValueConverter(umin, umax, std::log(std::max<double>(DBL_MIN, fmin)),
+                               std::log(std::max<double>(DBL_MIN, fmax)))
+    {
+    }
 
-    public:
-
-        LogValueConverter(double umin, double umax, double fmin, double fmax) :
-            LinearValueConverter(umin, umax, std::log(std::max<double>(DBL_MIN, fmin)), std::log(std::max<double>(DBL_MIN, fmax)))
-        {}
-
-        virtual double ui2faust(double x) { return std::exp(LinearValueConverter::ui2faust(x)); }
-        virtual double faust2ui(double x) { return LinearValueConverter::faust2ui(std::log(std::max<double>(x, DBL_MIN))); }
-
+    virtual double ui2faust(double x)
+    {
+        return std::exp(LinearValueConverter::ui2faust(x));
+    }
+    virtual double faust2ui(double x)
+    {
+        return LinearValueConverter::faust2ui(std::log(std::max<double>(x, DBL_MIN)));
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -743,16 +739,21 @@ class LogValueConverter : public LinearValueConverter
 //--------------------------------------------------------------------------------------
 class ExpValueConverter : public LinearValueConverter
 {
+   public:
+    ExpValueConverter(double umin, double umax, double fmin, double fmax)
+        : LinearValueConverter(umin, umax, std::min<double>(DBL_MAX, std::exp(fmin)),
+                               std::min<double>(DBL_MAX, std::exp(fmax)))
+    {
+    }
 
-    public:
-
-        ExpValueConverter(double umin, double umax, double fmin, double fmax) :
-            LinearValueConverter(umin, umax, std::min<double>(DBL_MAX, std::exp(fmin)), std::min<double>(DBL_MAX, std::exp(fmax)))
-        {}
-
-        virtual double ui2faust(double x) { return std::log(LinearValueConverter::ui2faust(x)); }
-        virtual double faust2ui(double x) { return LinearValueConverter::faust2ui(std::min<double>(DBL_MAX, std::exp(x))); }
-
+    virtual double ui2faust(double x)
+    {
+        return std::log(LinearValueConverter::ui2faust(x));
+    }
+    virtual double faust2ui(double x)
+    {
+        return LinearValueConverter::faust2ui(std::min<double>(DBL_MAX, std::exp(x)));
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -761,34 +762,33 @@ class ExpValueConverter : public LinearValueConverter
 //--------------------------------------------------------------------------------------
 class AccUpConverter : public UpdatableValueConverter
 {
+   private:
+    Interpolator3pt fA2F;
+    Interpolator3pt fF2A;
 
-    private:
+   public:
+    AccUpConverter(double amin, double amid, double amax, double fmin, double fmid,
+                   double fmax)
+        : fA2F(amin, amid, amax, fmin, fmid, fmax)
+        , fF2A(fmin, fmid, fmax, amin, amid, amax)
+    {
+    }
 
-        Interpolator3pt fA2F;
-        Interpolator3pt fF2A;
+    virtual double ui2faust(double x) { return fA2F(x); }
+    virtual double faust2ui(double x) { return fF2A(x); }
 
-    public:
+    virtual void setMappingValues(double amin, double amid, double amax, double fmin,
+                                  double fmid, double fmax)
+    {
+        //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccUpConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
+        fA2F = Interpolator3pt(amin, amid, amax, fmin, fmid, fmax);
+        fF2A = Interpolator3pt(fmin, fmid, fmax, amin, amid, amax);
+    }
 
-        AccUpConverter(double amin, double amid, double amax, double fmin, double fmid, double fmax) :
-            fA2F(amin,amid,amax,fmin,fmid,fmax),
-            fF2A(fmin,fmid,fmax,amin,amid,amax)
-        {}
-
-        virtual double ui2faust(double x) { return fA2F(x); }
-        virtual double faust2ui(double x) { return fF2A(x); }
-
-        virtual void setMappingValues(double amin, double amid, double amax, double fmin, double fmid, double fmax)
-        {
-            //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccUpConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
-            fA2F = Interpolator3pt(amin, amid, amax, fmin, fmid, fmax);
-            fF2A = Interpolator3pt(fmin, fmid, fmax, amin, amid, amax);
-        }
-
-        virtual void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fA2F.getMappingValues(amin, amid, amax);
-        }
-
+    virtual void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fA2F.getMappingValues(amin, amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -797,33 +797,33 @@ class AccUpConverter : public UpdatableValueConverter
 //--------------------------------------------------------------------------------------
 class AccDownConverter : public UpdatableValueConverter
 {
+   private:
+    Interpolator3pt fA2F;
+    Interpolator3pt fF2A;
 
-    private:
+   public:
+    AccDownConverter(double amin, double amid, double amax, double fmin, double fmid,
+                     double fmax)
+        : fA2F(amin, amid, amax, fmax, fmid, fmin)
+        , fF2A(fmin, fmid, fmax, amax, amid, amin)
+    {
+    }
 
-        Interpolator3pt	fA2F;
-        Interpolator3pt	fF2A;
+    virtual double ui2faust(double x) { return fA2F(x); }
+    virtual double faust2ui(double x) { return fF2A(x); }
 
-    public:
+    virtual void setMappingValues(double amin, double amid, double amax, double fmin,
+                                  double fmid, double fmax)
+    {
+        //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccDownConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
+        fA2F = Interpolator3pt(amin, amid, amax, fmax, fmid, fmin);
+        fF2A = Interpolator3pt(fmin, fmid, fmax, amax, amid, amin);
+    }
 
-        AccDownConverter(double amin, double amid, double amax, double fmin, double fmid, double fmax) :
-            fA2F(amin,amid,amax,fmax,fmid,fmin),
-            fF2A(fmin,fmid,fmax,amax,amid,amin)
-        {}
-
-        virtual double ui2faust(double x) { return fA2F(x); }
-        virtual double faust2ui(double x) { return fF2A(x); }
-
-        virtual void setMappingValues(double amin, double amid, double amax, double fmin, double fmid, double fmax)
-        {
-             //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccDownConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
-            fA2F = Interpolator3pt(amin, amid, amax, fmax, fmid, fmin);
-            fF2A = Interpolator3pt(fmin, fmid, fmax, amax, amid, amin);
-        }
-
-        virtual void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fA2F.getMappingValues(amin, amid, amax);
-        }
+    virtual void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fA2F.getMappingValues(amin, amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -832,33 +832,34 @@ class AccDownConverter : public UpdatableValueConverter
 //--------------------------------------------------------------------------------------
 class AccUpDownConverter : public UpdatableValueConverter
 {
+   private:
+    Interpolator3pt fA2F;
+    Interpolator fF2A;
 
-    private:
+   public:
+    AccUpDownConverter(double amin, double amid, double amax, double fmin, double fmid,
+                       double fmax)
+        : fA2F(amin, amid, amax, fmin, fmax, fmin)
+        , fF2A(fmin, fmax, amin,
+               amax)  // Special, pseudo inverse of a non monotonic function
+    {
+    }
 
-        Interpolator3pt	fA2F;
-        Interpolator fF2A;
+    virtual double ui2faust(double x) { return fA2F(x); }
+    virtual double faust2ui(double x) { return fF2A(x); }
 
-    public:
+    virtual void setMappingValues(double amin, double amid, double amax, double fmin,
+                                  double fmid, double fmax)
+    {
+        //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccUpDownConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
+        fA2F = Interpolator3pt(amin, amid, amax, fmin, fmax, fmin);
+        fF2A = Interpolator(fmin, fmax, amin, amax);
+    }
 
-        AccUpDownConverter(double amin, double amid, double amax, double fmin, double fmid, double fmax) :
-            fA2F(amin,amid,amax,fmin,fmax,fmin),
-            fF2A(fmin,fmax,amin,amax)				// Special, pseudo inverse of a non monotonic function
-        {}
-
-        virtual double ui2faust(double x) { return fA2F(x); }
-        virtual double faust2ui(double x) { return fF2A(x); }
-
-        virtual void setMappingValues(double amin, double amid, double amax, double fmin, double fmid, double fmax)
-        {
-            //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccUpDownConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
-            fA2F = Interpolator3pt(amin, amid, amax, fmin, fmax, fmin);
-            fF2A = Interpolator(fmin, fmax, amin, amax);
-        }
-
-        virtual void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fA2F.getMappingValues(amin, amid, amax);
-        }
+    virtual void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fA2F.getMappingValues(amin, amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -867,33 +868,34 @@ class AccUpDownConverter : public UpdatableValueConverter
 //--------------------------------------------------------------------------------------
 class AccDownUpConverter : public UpdatableValueConverter
 {
+   private:
+    Interpolator3pt fA2F;
+    Interpolator fF2A;
 
-    private:
+   public:
+    AccDownUpConverter(double amin, double amid, double amax, double fmin, double fmid,
+                       double fmax)
+        : fA2F(amin, amid, amax, fmax, fmin, fmax)
+        , fF2A(fmin, fmax, amin,
+               amax)  // Special, pseudo inverse of a non monotonic function
+    {
+    }
 
-        Interpolator3pt	fA2F;
-        Interpolator fF2A;
+    virtual double ui2faust(double x) { return fA2F(x); }
+    virtual double faust2ui(double x) { return fF2A(x); }
 
-    public:
+    virtual void setMappingValues(double amin, double amid, double amax, double fmin,
+                                  double fmid, double fmax)
+    {
+        //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccDownUpConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
+        fA2F = Interpolator3pt(amin, amid, amax, fmax, fmin, fmax);
+        fF2A = Interpolator(fmin, fmax, amin, amax);
+    }
 
-        AccDownUpConverter(double amin, double amid, double amax, double fmin, double fmid, double fmax) :
-            fA2F(amin,amid,amax,fmax,fmin,fmax),
-            fF2A(fmin,fmax,amin,amax)				// Special, pseudo inverse of a non monotonic function
-        {}
-
-        virtual double ui2faust(double x) { return fA2F(x); }
-        virtual double faust2ui(double x) { return fF2A(x); }
-
-        virtual void setMappingValues(double amin, double amid, double amax, double fmin, double fmid, double fmax)
-        {
-            //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccDownUpConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
-            fA2F = Interpolator3pt(amin, amid, amax, fmax, fmin, fmax);
-            fF2A = Interpolator(fmin, fmax, amin, amax);
-        }
-
-        virtual void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fA2F.getMappingValues(amin, amid, amax);
-        }
+    virtual void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fA2F.getMappingValues(amin, amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -901,28 +903,27 @@ class AccDownUpConverter : public UpdatableValueConverter
 //--------------------------------------------------------------------------------------
 class ZoneControl
 {
+   protected:
+    FAUSTFLOAT* fZone;
 
-    protected:
+   public:
+    ZoneControl(FAUSTFLOAT* zone) : fZone(zone) {}
+    virtual ~ZoneControl() {}
 
-        FAUSTFLOAT*	fZone;
+    virtual void update(double v) const {}
 
-    public:
+    virtual void setMappingValues(int curve, double amin, double amid, double amax,
+                                  double min, double init, double max)
+    {
+    }
+    virtual void getMappingValues(double& amin, double& amid, double& amax) {}
 
-        ZoneControl(FAUSTFLOAT* zone) : fZone(zone) {}
-        virtual ~ZoneControl() {}
+    FAUSTFLOAT* getZone() { return fZone; }
 
-        virtual void update(double v) const {}
+    virtual void setActive(bool on_off) {}
+    virtual bool getActive() { return false; }
 
-        virtual void setMappingValues(int curve, double amin, double amid, double amax, double min, double init, double max) {}
-        virtual void getMappingValues(double& amin, double& amid, double& amax) {}
-
-        FAUSTFLOAT* getZone() { return fZone; }
-
-        virtual void setActive(bool on_off) {}
-        virtual bool getActive() { return false; }
-
-        virtual int getCurve() { return -1; }
-
+    virtual int getCurve() { return -1; }
 };
 
 //--------------------------------------------------------------------------------------
@@ -930,20 +931,22 @@ class ZoneControl
 //--------------------------------------------------------------------------------------
 class ConverterZoneControl : public ZoneControl
 {
+   protected:
+    ValueConverter* fValueConverter;
 
-    protected:
+   public:
+    ConverterZoneControl(FAUSTFLOAT* zone, ValueConverter* converter)
+        : ZoneControl(zone), fValueConverter(converter)
+    {
+    }
+    virtual ~ConverterZoneControl()
+    {
+        delete fValueConverter;
+    }  // Assuming fValueConverter is not kept elsewhere...
 
-        ValueConverter* fValueConverter;
+    virtual void update(double v) const { *fZone = fValueConverter->ui2faust(v); }
 
-    public:
-
-        ConverterZoneControl(FAUSTFLOAT* zone, ValueConverter* converter) : ZoneControl(zone), fValueConverter(converter) {}
-        virtual ~ConverterZoneControl() { delete fValueConverter; } // Assuming fValueConverter is not kept elsewhere...
-
-        virtual void update(double v) const { *fZone = fValueConverter->ui2faust(v); }
-
-        ValueConverter* getConverter() { return fValueConverter; }
-
+    ValueConverter* getConverter() { return fValueConverter; }
 };
 
 //--------------------------------------------------------------------------------------
@@ -952,477 +955,496 @@ class ConverterZoneControl : public ZoneControl
 //--------------------------------------------------------------------------------------
 class CurveZoneControl : public ZoneControl
 {
+   private:
+    std::vector<UpdatableValueConverter*> fValueConverters;
+    int fCurve;
 
-    private:
-
-        std::vector<UpdatableValueConverter*> fValueConverters;
-        int fCurve;
-
-    public:
-
-        CurveZoneControl(FAUSTFLOAT* zone, int curve, double amin, double amid, double amax, double min, double init, double max) : ZoneControl(zone), fCurve(0)
-        {
-            assert(curve >= 0 && curve <= 3);
-            fValueConverters.push_back(new AccUpConverter(amin, amid, amax, min, init, max));
-            fValueConverters.push_back(new AccDownConverter(amin, amid, amax, min, init, max));
-            fValueConverters.push_back(new AccUpDownConverter(amin, amid, amax, min, init, max));
-            fValueConverters.push_back(new AccDownUpConverter(amin, amid, amax, min, init, max));
-            fCurve = curve;
+   public:
+    CurveZoneControl(FAUSTFLOAT* zone, int curve, double amin, double amid, double amax,
+                     double min, double init, double max)
+        : ZoneControl(zone), fCurve(0)
+    {
+        assert(curve >= 0 && curve <= 3);
+        fValueConverters.push_back(new AccUpConverter(amin, amid, amax, min, init, max));
+        fValueConverters.push_back(
+            new AccDownConverter(amin, amid, amax, min, init, max));
+        fValueConverters.push_back(
+            new AccUpDownConverter(amin, amid, amax, min, init, max));
+        fValueConverters.push_back(
+            new AccDownUpConverter(amin, amid, amax, min, init, max));
+        fCurve = curve;
+    }
+    virtual ~CurveZoneControl()
+    {
+        std::vector<UpdatableValueConverter*>::iterator it;
+        for (it = fValueConverters.begin(); it != fValueConverters.end(); it++) {
+            delete (*it);
         }
-        virtual ~CurveZoneControl()
-        {
-            std::vector<UpdatableValueConverter*>::iterator it;
-            for (it = fValueConverters.begin(); it != fValueConverters.end(); it++) {
-                delete(*it);
-            }
-        }
-        void update(double v) const { if (fValueConverters[fCurve]->getActive()) *fZone = fValueConverters[fCurve]->ui2faust(v); }
+    }
+    void update(double v) const
+    {
+        if (fValueConverters[fCurve]->getActive())
+            *fZone = fValueConverters[fCurve]->ui2faust(v);
+    }
 
-        void setMappingValues(int curve, double amin, double amid, double amax, double min, double init, double max)
-        {
-            fValueConverters[curve]->setMappingValues(amin, amid, amax, min, init, max);
-            fCurve = curve;
-        }
+    void setMappingValues(int curve, double amin, double amid, double amax, double min,
+                          double init, double max)
+    {
+        fValueConverters[curve]->setMappingValues(amin, amid, amax, min, init, max);
+        fCurve = curve;
+    }
 
-        void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fValueConverters[fCurve]->getMappingValues(amin, amid, amax);
-        }
+    void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fValueConverters[fCurve]->getMappingValues(amin, amid, amax);
+    }
 
-        void setActive(bool on_off)
-        {
-            std::vector<UpdatableValueConverter*>::iterator it;
-            for (it = fValueConverters.begin(); it != fValueConverters.end(); it++) {
-                (*it)->setActive(on_off);
-            }
+    void setActive(bool on_off)
+    {
+        std::vector<UpdatableValueConverter*>::iterator it;
+        for (it = fValueConverters.begin(); it != fValueConverters.end(); it++) {
+            (*it)->setActive(on_off);
         }
+    }
 
-        int getCurve() { return fCurve; }
+    int getCurve() { return fCurve; }
 };
 
 class ZoneReader
 {
+   private:
+    FAUSTFLOAT* fZone;
+    Interpolator fInterpolator;
 
-    private:
+   public:
+    ZoneReader(FAUSTFLOAT* zone, double lo, double hi)
+        : fZone(zone), fInterpolator(lo, hi, 0, 255)
+    {
+    }
 
-        FAUSTFLOAT* fZone;
-        Interpolator fInterpolator;
+    virtual ~ZoneReader() {}
 
-    public:
-
-        ZoneReader(FAUSTFLOAT* zone, double lo, double hi) : fZone(zone), fInterpolator(lo, hi, 0, 255) {}
-
-        virtual ~ZoneReader() {}
-
-        int getValue()
-        {
-            return (fZone != nullptr) ? int(fInterpolator(*fZone)) : 127;
-        }
-
+    int getValue() { return (fZone != nullptr) ? int(fInterpolator(*fZone)) : 127; }
 };
 
 #endif
 /**************************  END  ValueConverter.h **************************/
 
-class APIUI : public PathBuilder, public Meta, public UI
+class APIUI
+    : public PathBuilder
+    , public Meta
+    , public UI
 {
-    public:
-    
-        enum ItemType { kButton = 0, kCheckButton, kVSlider, kHSlider, kNumEntry, kHBargraph, kVBargraph };
-  
-    protected:
-    
-        enum { kLin = 0, kLog = 1, kExp = 2 };
-    
-        int fNumParameters;
-        std::vector<std::string> fPaths;
-        std::vector<std::string> fLabels;
-        std::map<std::string, int> fPathMap;
-        std::map<std::string, int> fLabelMap;
-        std::vector<ValueConverter*> fConversion;
-        std::vector<FAUSTFLOAT*> fZone;
-        std::vector<FAUSTFLOAT> fInit;
-        std::vector<FAUSTFLOAT> fMin;
-        std::vector<FAUSTFLOAT> fMax;
-        std::vector<FAUSTFLOAT> fStep;
-        std::vector<ItemType> fItemType;
-        std::vector<std::map<std::string, std::string> > fMetaData;
-        std::vector<ZoneControl*> fAcc[3];
-        std::vector<ZoneControl*> fGyr[3];
+   public:
+    enum ItemType {
+        kButton = 0,
+        kCheckButton,
+        kVSlider,
+        kHSlider,
+        kNumEntry,
+        kHBargraph,
+        kVBargraph
+    };
 
-        // Screen color control
-        // "...[screencolor:red]..." etc.
-        bool fHasScreenControl;      // true if control screen color metadata
-        ZoneReader* fRedReader;
-        ZoneReader* fGreenReader;
-        ZoneReader* fBlueReader;
+   protected:
+    enum { kLin = 0, kLog = 1, kExp = 2 };
 
-        // Current values controlled by metadata
-        std::string fCurrentUnit;
-        int fCurrentScale;
-        std::string fCurrentAcc;
-        std::string fCurrentGyr;
-        std::string fCurrentColor;
-        std::string fCurrentTooltip;
-        std::map<std::string, std::string> fCurrentMetadata;
-    
-        // Add a generic parameter
-        virtual void addParameter(const char* label,
-                                FAUSTFLOAT* zone,
-                                FAUSTFLOAT init,
-                                FAUSTFLOAT min,
-                                FAUSTFLOAT max,
-                                FAUSTFLOAT step,
-                                ItemType type)
-        {
-            std::string path = buildPath(label);
-            fPathMap[path] = fLabelMap[label] = fNumParameters++;
-            fPaths.push_back(path);
-            fLabels.push_back(label);
-            fZone.push_back(zone);
-            fInit.push_back(init);
-            fMin.push_back(min);
-            fMax.push_back(max);
-            fStep.push_back(step);
-            fItemType.push_back(type);
-            
-            // handle scale metadata
-            switch (fCurrentScale) {
-                case kLin:
-                    fConversion.push_back(new LinearValueConverter(0, 1, min, max));
-                    break;
-                case kLog:
-                    fConversion.push_back(new LogValueConverter(0, 1, min, max));
-                    break;
-                case kExp: fConversion.push_back(new ExpValueConverter(0, 1, min, max));
-                    break;
-            }
-            fCurrentScale = kLin;
-            
-            if (fCurrentAcc.size() > 0 && fCurrentGyr.size() > 0) {
-                std::cerr << "warning : 'acc' and 'gyr' metadata used for the same " << label << " parameter !!\n";
-            }
+    int fNumParameters;
+    std::vector<std::string> fPaths;
+    std::vector<std::string> fLabels;
+    std::map<std::string, int> fPathMap;
+    std::map<std::string, int> fLabelMap;
+    std::vector<ValueConverter*> fConversion;
+    std::vector<FAUSTFLOAT*> fZone;
+    std::vector<FAUSTFLOAT> fInit;
+    std::vector<FAUSTFLOAT> fMin;
+    std::vector<FAUSTFLOAT> fMax;
+    std::vector<FAUSTFLOAT> fStep;
+    std::vector<ItemType> fItemType;
+    std::vector<std::map<std::string, std::string> > fMetaData;
+    std::vector<ZoneControl*> fAcc[3];
+    std::vector<ZoneControl*> fGyr[3];
 
-            // handle acc metadata "...[acc : <axe> <curve> <amin> <amid> <amax>]..."
-            if (fCurrentAcc.size() > 0) {
-                std::istringstream iss(fCurrentAcc);
-                int axe, curve;
-                double amin, amid, amax;
-                iss >> axe >> curve >> amin >> amid >> amax;
+    // Screen color control
+    // "...[screencolor:red]..." etc.
+    bool fHasScreenControl;  // true if control screen color metadata
+    ZoneReader* fRedReader;
+    ZoneReader* fGreenReader;
+    ZoneReader* fBlueReader;
 
-                if ((0 <= axe) && (axe < 3) &&
-                    (0 <= curve) && (curve < 4) &&
-                    (amin < amax) && (amin <= amid) && (amid <= amax))
-                {
-                    fAcc[axe].push_back(new CurveZoneControl(zone, curve, amin, amid, amax, min, init, max));
-                } else {
-                    std::cerr << "incorrect acc metadata : " << fCurrentAcc << std::endl;
-                }
-                fCurrentAcc = "";
-            }
-       
-            // handle gyr metadata "...[gyr : <axe> <curve> <amin> <amid> <amax>]..."
-            if (fCurrentGyr.size() > 0) {
-                std::istringstream iss(fCurrentGyr);
-                int axe, curve;
-                double amin, amid, amax;
-                iss >> axe >> curve >> amin >> amid >> amax;
+    // Current values controlled by metadata
+    std::string fCurrentUnit;
+    int fCurrentScale;
+    std::string fCurrentAcc;
+    std::string fCurrentGyr;
+    std::string fCurrentColor;
+    std::string fCurrentTooltip;
+    std::map<std::string, std::string> fCurrentMetadata;
 
-                if ((0 <= axe) && (axe < 3) &&
-                    (0 <= curve) && (curve < 4) &&
-                    (amin < amax) && (amin <= amid) && (amid <= amax))
-                {
-                    fGyr[axe].push_back(new CurveZoneControl(zone, curve, amin, amid, amax, min, init, max));
-                } else {
-                    std::cerr << "incorrect gyr metadata : " << fCurrentGyr << std::endl;
-                }
-                fCurrentGyr = "";
-            }
-        
-            // handle screencolor metadata "...[screencolor:red|green|blue|white]..."
-            if (fCurrentColor.size() > 0) {
-                if ((fCurrentColor == "red") && (fRedReader == 0)) {
-                    fRedReader = new ZoneReader(zone, min, max);
-                    fHasScreenControl = true;
-                } else if ((fCurrentColor == "green") && (fGreenReader == 0)) {
-                    fGreenReader = new ZoneReader(zone, min, max);
-                    fHasScreenControl = true;
-                } else if ((fCurrentColor == "blue") && (fBlueReader == 0)) {
-                    fBlueReader = new ZoneReader(zone, min, max);
-                    fHasScreenControl = true;
-                } else if ((fCurrentColor == "white") && (fRedReader == 0) && (fGreenReader == 0) && (fBlueReader == 0)) {
-                    fRedReader = new ZoneReader(zone, min, max);
-                    fGreenReader = new ZoneReader(zone, min, max);
-                    fBlueReader = new ZoneReader(zone, min, max);
-                    fHasScreenControl = true;
-                } else {
-                    std::cerr << "incorrect screencolor metadata : " << fCurrentColor << std::endl;
-                }
-            }
-            fCurrentColor = "";
-            
-            fMetaData.push_back(fCurrentMetadata);
-            fCurrentMetadata.clear();
+    // Add a generic parameter
+    virtual void addParameter(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init,
+                              FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step,
+                              ItemType type)
+    {
+        std::string path = buildPath(label);
+        fPathMap[path] = fLabelMap[label] = fNumParameters++;
+        fPaths.push_back(path);
+        fLabels.push_back(label);
+        fZone.push_back(zone);
+        fInit.push_back(init);
+        fMin.push_back(min);
+        fMax.push_back(max);
+        fStep.push_back(step);
+        fItemType.push_back(type);
+
+        // handle scale metadata
+        switch (fCurrentScale) {
+        case kLin:
+            fConversion.push_back(new LinearValueConverter(0, 1, min, max));
+            break;
+        case kLog:
+            fConversion.push_back(new LogValueConverter(0, 1, min, max));
+            break;
+        case kExp:
+            fConversion.push_back(new ExpValueConverter(0, 1, min, max));
+            break;
+        }
+        fCurrentScale = kLin;
+
+        if (fCurrentAcc.size() > 0 && fCurrentGyr.size() > 0) {
+            std::cerr << "warning : 'acc' and 'gyr' metadata used for the same " << label
+                      << " parameter !!\n";
         }
 
-        int getZoneIndex(std::vector<ZoneControl*>* table, int p, int val)
-        {
-            FAUSTFLOAT* zone = fZone[p];
-            for (size_t i = 0; i < table[val].size(); i++) {
-                if (zone == table[val][i]->getZone()) return int(i);
+        // handle acc metadata "...[acc : <axe> <curve> <amin> <amid> <amax>]..."
+        if (fCurrentAcc.size() > 0) {
+            std::istringstream iss(fCurrentAcc);
+            int axe, curve;
+            double amin, amid, amax;
+            iss >> axe >> curve >> amin >> amid >> amax;
+
+            if ((0 <= axe) && (axe < 3) && (0 <= curve) && (curve < 4) && (amin < amax)
+                && (amin <= amid) && (amid <= amax)) {
+                fAcc[axe].push_back(
+                    new CurveZoneControl(zone, curve, amin, amid, amax, min, init, max));
+            } else {
+                std::cerr << "incorrect acc metadata : " << fCurrentAcc << std::endl;
             }
+            fCurrentAcc = "";
+        }
+
+        // handle gyr metadata "...[gyr : <axe> <curve> <amin> <amid> <amax>]..."
+        if (fCurrentGyr.size() > 0) {
+            std::istringstream iss(fCurrentGyr);
+            int axe, curve;
+            double amin, amid, amax;
+            iss >> axe >> curve >> amin >> amid >> amax;
+
+            if ((0 <= axe) && (axe < 3) && (0 <= curve) && (curve < 4) && (amin < amax)
+                && (amin <= amid) && (amid <= amax)) {
+                fGyr[axe].push_back(
+                    new CurveZoneControl(zone, curve, amin, amid, amax, min, init, max));
+            } else {
+                std::cerr << "incorrect gyr metadata : " << fCurrentGyr << std::endl;
+            }
+            fCurrentGyr = "";
+        }
+
+        // handle screencolor metadata "...[screencolor:red|green|blue|white]..."
+        if (fCurrentColor.size() > 0) {
+            if ((fCurrentColor == "red") && (fRedReader == 0)) {
+                fRedReader        = new ZoneReader(zone, min, max);
+                fHasScreenControl = true;
+            } else if ((fCurrentColor == "green") && (fGreenReader == 0)) {
+                fGreenReader      = new ZoneReader(zone, min, max);
+                fHasScreenControl = true;
+            } else if ((fCurrentColor == "blue") && (fBlueReader == 0)) {
+                fBlueReader       = new ZoneReader(zone, min, max);
+                fHasScreenControl = true;
+            } else if ((fCurrentColor == "white") && (fRedReader == 0)
+                       && (fGreenReader == 0) && (fBlueReader == 0)) {
+                fRedReader        = new ZoneReader(zone, min, max);
+                fGreenReader      = new ZoneReader(zone, min, max);
+                fBlueReader       = new ZoneReader(zone, min, max);
+                fHasScreenControl = true;
+            } else {
+                std::cerr << "incorrect screencolor metadata : " << fCurrentColor
+                          << std::endl;
+            }
+        }
+        fCurrentColor = "";
+
+        fMetaData.push_back(fCurrentMetadata);
+        fCurrentMetadata.clear();
+    }
+
+    int getZoneIndex(std::vector<ZoneControl*>* table, int p, int val)
+    {
+        FAUSTFLOAT* zone = fZone[p];
+        for (size_t i = 0; i < table[val].size(); i++) {
+            if (zone == table[val][i]->getZone()) return int(i);
+        }
+        return -1;
+    }
+
+    void setConverter(std::vector<ZoneControl*>* table, int p, int val, int curve,
+                      double amin, double amid, double amax)
+    {
+        int id1 = getZoneIndex(table, p, 0);
+        int id2 = getZoneIndex(table, p, 1);
+        int id3 = getZoneIndex(table, p, 2);
+
+        // Deactivates everywhere..
+        if (id1 != -1) table[0][id1]->setActive(false);
+        if (id2 != -1) table[1][id2]->setActive(false);
+        if (id3 != -1) table[2][id3]->setActive(false);
+
+        if (val == -1) {  // Means: no more mapping...
+            // So stay all deactivated...
+        } else {
+            int id4 = getZoneIndex(table, p, val);
+            if (id4 != -1) {
+                // Reactivate the one we edit...
+                table[val][id4]->setMappingValues(curve, amin, amid, amax, fMin[p],
+                                                  fInit[p], fMax[p]);
+                table[val][id4]->setActive(true);
+            } else {
+                // Allocate a new CurveZoneControl which is 'active' by default
+                FAUSTFLOAT* zone = fZone[p];
+                table[val].push_back(new CurveZoneControl(zone, curve, amin, amid, amax,
+                                                          fMin[p], fInit[p], fMax[p]));
+            }
+        }
+    }
+
+    void getConverter(std::vector<ZoneControl*>* table, int p, int& val, int& curve,
+                      double& amin, double& amid, double& amax)
+    {
+        int id1 = getZoneIndex(table, p, 0);
+        int id2 = getZoneIndex(table, p, 1);
+        int id3 = getZoneIndex(table, p, 2);
+
+        if (id1 != -1) {
+            val   = 0;
+            curve = table[val][id1]->getCurve();
+            table[val][id1]->getMappingValues(amin, amid, amax);
+        } else if (id2 != -1) {
+            val   = 1;
+            curve = table[val][id2]->getCurve();
+            table[val][id2]->getMappingValues(amin, amid, amax);
+        } else if (id3 != -1) {
+            val   = 2;
+            curve = table[val][id3]->getCurve();
+            table[val][id3]->getMappingValues(amin, amid, amax);
+        } else {
+            val   = -1;  // No mapping
+            curve = 0;
+            amin  = -100.;
+            amid  = 0.;
+            amax  = 100.;
+        }
+    }
+
+   public:
+    enum Type { kAcc = 0, kGyr = 1, kNoType };
+
+    APIUI()
+        : fNumParameters(0)
+        , fHasScreenControl(false)
+        , fRedReader(0)
+        , fGreenReader(0)
+        , fBlueReader(0)
+        , fCurrentScale(kLin)
+    {
+    }
+
+    virtual ~APIUI()
+    {
+        for (auto& it : fConversion) delete it;
+        for (int i = 0; i < 3; i++) {
+            for (auto& it : fAcc[i]) delete it;
+            for (auto& it : fGyr[i]) delete it;
+        }
+        delete fRedReader;
+        delete fGreenReader;
+        delete fBlueReader;
+    }
+
+    // -- widget's layouts
+
+    virtual void openTabBox(const char* label) { pushLabel(label); }
+    virtual void openHorizontalBox(const char* label) { pushLabel(label); }
+    virtual void openVerticalBox(const char* label) { pushLabel(label); }
+    virtual void closeBox() { popLabel(); }
+
+    // -- active widgets
+
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    {
+        addParameter(label, zone, 0, 0, 1, 1, kButton);
+    }
+
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    {
+        addParameter(label, zone, 0, 0, 1, 1, kCheckButton);
+    }
+
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init,
+                                   FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addParameter(label, zone, init, min, max, step, kVSlider);
+    }
+
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init,
+                                     FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addParameter(label, zone, init, min, max, step, kHSlider);
+    }
+
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init,
+                             FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addParameter(label, zone, init, min, max, step, kNumEntry);
+    }
+
+    // -- passive widgets
+
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone,
+                                       FAUSTFLOAT min, FAUSTFLOAT max)
+    {
+        addParameter(label, zone, min, min, max, (max - min) / 1000.0, kHBargraph);
+    }
+
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min,
+                                     FAUSTFLOAT max)
+    {
+        addParameter(label, zone, min, min, max, (max - min) / 1000.0, kVBargraph);
+    }
+
+    // -- soundfiles
+
+    virtual void addSoundfile(const char* label, const char* filename,
+                              Soundfile** sf_zone)
+    {
+    }
+
+    // -- metadata declarations
+
+    virtual void declare(FAUSTFLOAT* zone, const char* key, const char* val)
+    {
+        // Keep metadata
+        fCurrentMetadata[key] = val;
+
+        if (strcmp(key, "scale") == 0) {
+            if (strcmp(val, "log") == 0) {
+                fCurrentScale = kLog;
+            } else if (strcmp(val, "exp") == 0) {
+                fCurrentScale = kExp;
+            } else {
+                fCurrentScale = kLin;
+            }
+        } else if (strcmp(key, "unit") == 0) {
+            fCurrentUnit = val;
+        } else if (strcmp(key, "acc") == 0) {
+            fCurrentAcc = val;
+        } else if (strcmp(key, "gyr") == 0) {
+            fCurrentGyr = val;
+        } else if (strcmp(key, "screencolor") == 0) {
+            fCurrentColor = val;  // val = "red", "green", "blue" or "white"
+        } else if (strcmp(key, "tooltip") == 0) {
+            fCurrentTooltip = val;
+        }
+    }
+
+    virtual void declare(const char* key, const char* val) {}
+
+    //-------------------------------------------------------------------------------
+    // Simple API part
+    //-------------------------------------------------------------------------------
+    int getParamsCount() { return fNumParameters; }
+    int getParamIndex(const char* path)
+    {
+        if (fPathMap.find(path) != fPathMap.end()) {
+            return fPathMap[path];
+        } else if (fLabelMap.find(path) != fLabelMap.end()) {
+            return fLabelMap[path];
+        } else {
             return -1;
         }
-    
-        void setConverter(std::vector<ZoneControl*>* table, int p, int val, int curve, double amin, double amid, double amax)
-        {
-            int id1 = getZoneIndex(table, p, 0);
-            int id2 = getZoneIndex(table, p, 1);
-            int id3 = getZoneIndex(table, p, 2);
-            
-            // Deactivates everywhere..
-            if (id1 != -1) table[0][id1]->setActive(false);
-            if (id2 != -1) table[1][id2]->setActive(false);
-            if (id3 != -1) table[2][id3]->setActive(false);
-            
-            if (val == -1) { // Means: no more mapping...
-                // So stay all deactivated...
-            } else {
-                int id4 = getZoneIndex(table, p, val);
-                if (id4 != -1) {
-                    // Reactivate the one we edit...
-                    table[val][id4]->setMappingValues(curve, amin, amid, amax, fMin[p], fInit[p], fMax[p]);
-                    table[val][id4]->setActive(true);
-                } else {
-                    // Allocate a new CurveZoneControl which is 'active' by default
-                    FAUSTFLOAT* zone = fZone[p];
-                    table[val].push_back(new CurveZoneControl(zone, curve, amin, amid, amax, fMin[p], fInit[p], fMax[p]));
-                }
-            }
-        }
-    
-        void getConverter(std::vector<ZoneControl*>* table, int p, int& val, int& curve, double& amin, double& amid, double& amax)
-        {
-            int id1 = getZoneIndex(table, p, 0);
-            int id2 = getZoneIndex(table, p, 1);
-            int id3 = getZoneIndex(table, p, 2);
-            
-            if (id1 != -1) {
-                val = 0;
-                curve = table[val][id1]->getCurve();
-                table[val][id1]->getMappingValues(amin, amid, amax);
-            } else if (id2 != -1) {
-                val = 1;
-                curve = table[val][id2]->getCurve();
-                table[val][id2]->getMappingValues(amin, amid, amax);
-            } else if (id3 != -1) {
-                val = 2;
-                curve = table[val][id3]->getCurve();
-                table[val][id3]->getMappingValues(amin, amid, amax);
-            } else {
-                val = -1; // No mapping
-                curve = 0;
-                amin = -100.;
-                amid = 0.;
-                amax = 100.;
-            }
-        }
+    }
+    const char* getParamAddress(int p) { return fPaths[p].c_str(); }
+    const char* getParamLabel(int p) { return fLabels[p].c_str(); }
+    std::map<const char*, const char*> getMetadata(int p)
+    {
+        std::map<const char*, const char*> res;
+        std::map<std::string, std::string> metadata = fMetaData[p];
+        for (auto it : metadata) { res[it.first.c_str()] = it.second.c_str(); }
+        return res;
+    }
 
-     public:
-    
-        enum Type { kAcc = 0, kGyr = 1, kNoType };
-   
-        APIUI() : fNumParameters(0), fHasScreenControl(false), fRedReader(0), fGreenReader(0), fBlueReader(0), fCurrentScale(kLin)
-        {}
+    const char* getMetadata(int p, const char* key)
+    {
+        return (fMetaData[p].find(key) != fMetaData[p].end()) ? fMetaData[p][key].c_str()
+                                                              : "";
+    }
+    FAUSTFLOAT getParamMin(int p) { return fMin[p]; }
+    FAUSTFLOAT getParamMax(int p) { return fMax[p]; }
+    FAUSTFLOAT getParamStep(int p) { return fStep[p]; }
+    FAUSTFLOAT getParamInit(int p) { return fInit[p]; }
 
-        virtual ~APIUI()
-        {
-            for (auto& it : fConversion) delete it;
-            for (int i = 0; i < 3; i++) {
-                for (auto& it : fAcc[i]) delete it;
-                for (auto& it : fGyr[i]) delete it;
-            }
-            delete fRedReader;
-            delete fGreenReader;
-            delete fBlueReader;
-        }
-    
-        // -- widget's layouts
+    FAUSTFLOAT* getParamZone(int p) { return fZone[p]; }
+    FAUSTFLOAT getParamValue(int p) { return *fZone[p]; }
+    void setParamValue(int p, FAUSTFLOAT v) { *fZone[p] = v; }
 
-        virtual void openTabBox(const char* label) { pushLabel(label); }
-        virtual void openHorizontalBox(const char* label) { pushLabel(label); }
-        virtual void openVerticalBox(const char* label) { pushLabel(label); }
-        virtual void closeBox() { popLabel(); }
+    double getParamRatio(int p) { return fConversion[p]->faust2ui(*fZone[p]); }
+    void setParamRatio(int p, double r) { *fZone[p] = fConversion[p]->ui2faust(r); }
 
-        // -- active widgets
+    double value2ratio(int p, double r) { return fConversion[p]->faust2ui(r); }
+    double ratio2value(int p, double r) { return fConversion[p]->ui2faust(r); }
 
-        virtual void addButton(const char* label, FAUSTFLOAT* zone)
-        {
-            addParameter(label, zone, 0, 0, 1, 1, kButton);
-        }
-
-        virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
-        {
-            addParameter(label, zone, 0, 0, 1, 1, kCheckButton);
-        }
-
-        virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
-        {
-            addParameter(label, zone, init, min, max, step, kVSlider);
-        }
-
-        virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
-        {
-            addParameter(label, zone, init, min, max, step, kHSlider);
-        }
-
-        virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
-        {
-            addParameter(label, zone, init, min, max, step, kNumEntry);
-        }
-
-        // -- passive widgets
-
-        virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
-        {
-            addParameter(label, zone, min, min, max, (max-min)/1000.0, kHBargraph);
-        }
-
-        virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
-        {
-            addParameter(label, zone, min, min, max, (max-min)/1000.0, kVBargraph);
-        }
-    
-        // -- soundfiles
-    
-        virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
-
-        // -- metadata declarations
-
-        virtual void declare(FAUSTFLOAT* zone, const char* key, const char* val)
-        {
-            // Keep metadata
-            fCurrentMetadata[key] = val;
-            
-            if (strcmp(key, "scale") == 0) {
-                if (strcmp(val, "log") == 0) {
-                    fCurrentScale = kLog;
-                } else if (strcmp(val, "exp") == 0) {
-                    fCurrentScale = kExp;
-                } else {
-                    fCurrentScale = kLin;
-                }
-            } else if (strcmp(key, "unit") == 0) {
-                fCurrentUnit = val;
-            } else if (strcmp(key, "acc") == 0) {
-                fCurrentAcc = val;
-            } else if (strcmp(key, "gyr") == 0) {
-                fCurrentGyr = val;
-            } else if (strcmp(key, "screencolor") == 0) {
-                fCurrentColor = val; // val = "red", "green", "blue" or "white"
-            } else if (strcmp(key, "tooltip") == 0) {
-                fCurrentTooltip = val;
-            }
-        }
-
-        virtual void declare(const char* key, const char* val)
-        {}
-
-		//-------------------------------------------------------------------------------
-		// Simple API part
-		//-------------------------------------------------------------------------------
-		int getParamsCount() { return fNumParameters; }
-        int getParamIndex(const char* path)
-        {
-            if (fPathMap.find(path) != fPathMap.end()) {
-                return fPathMap[path];
-            } else if (fLabelMap.find(path) != fLabelMap.end()) {
-                return fLabelMap[path];
-            } else {
-                return -1;
-            }
-        }
-        const char* getParamAddress(int p) { return fPaths[p].c_str(); }
-        const char* getParamLabel(int p) { return fLabels[p].c_str(); }
-        std::map<const char*, const char*> getMetadata(int p)
-        {
-            std::map<const char*, const char*> res;
-            std::map<std::string, std::string> metadata = fMetaData[p];
-            for (auto it : metadata) {
-                res[it.first.c_str()] = it.second.c_str();
-            }
-            return res;
-        }
-
-        const char* getMetadata(int p, const char* key)
-        {
-            return (fMetaData[p].find(key) != fMetaData[p].end()) ? fMetaData[p][key].c_str() : "";
-        }
-        FAUSTFLOAT getParamMin(int p) { return fMin[p]; }
-        FAUSTFLOAT getParamMax(int p) { return fMax[p]; }
-        FAUSTFLOAT getParamStep(int p) { return fStep[p]; }
-        FAUSTFLOAT getParamInit(int p) { return fInit[p]; }
-
-        FAUSTFLOAT* getParamZone(int p) { return fZone[p]; }
-        FAUSTFLOAT getParamValue(int p) { return *fZone[p]; }
-        void setParamValue(int p, FAUSTFLOAT v) { *fZone[p] = v; }
-
-        double getParamRatio(int p) { return fConversion[p]->faust2ui(*fZone[p]); }
-        void setParamRatio(int p, double r) { *fZone[p] = fConversion[p]->ui2faust(r); }
-
-        double value2ratio(int p, double r)	{ return fConversion[p]->faust2ui(r); }
-        double ratio2value(int p, double r)	{ return fConversion[p]->ui2faust(r); }
-    
-        /**
+    /**
          * Return the control type (kAcc, kGyr, or -1) for a given parameter
          *
          * @param p - the UI parameter index
          *
          * @return the type
          */
-        Type getParamType(int p)
-        {
-            if (p >= 0) {
-                if (getZoneIndex(fAcc, p, 0) != -1
-                    || getZoneIndex(fAcc, p, 1) != -1
-                    || getZoneIndex(fAcc, p, 2) != -1) {
-                    return kAcc;
-                } else if (getZoneIndex(fGyr, p, 0) != -1
-                           || getZoneIndex(fGyr, p, 1) != -1
-                           || getZoneIndex(fGyr, p, 2) != -1) {
-                    return kGyr;
-                }
+    Type getParamType(int p)
+    {
+        if (p >= 0) {
+            if (getZoneIndex(fAcc, p, 0) != -1 || getZoneIndex(fAcc, p, 1) != -1
+                || getZoneIndex(fAcc, p, 2) != -1) {
+                return kAcc;
+            } else if (getZoneIndex(fGyr, p, 0) != -1 || getZoneIndex(fGyr, p, 1) != -1
+                       || getZoneIndex(fGyr, p, 2) != -1) {
+                return kGyr;
             }
-            return kNoType;
         }
-    
-        /**
+        return kNoType;
+    }
+
+    /**
          * Return the Item type (kButton = 0, kCheckButton, kVSlider, kHSlider, kNumEntry, kHBargraph, kVBargraph) for a given parameter
          *
          * @param p - the UI parameter index
          *
          * @return the Item type
          */
-        ItemType getParamItemType(int p)
-        {
-            return fItemType[p];
-        }
-   
-        /**
+    ItemType getParamItemType(int p) { return fItemType[p]; }
+
+    /**
          * Set a new value coming from an accelerometer, propagate it to all relevant FAUSTFLOAT* zones.
          *
          * @param acc - 0 for X accelerometer, 1 for Y accelerometer, 2 for Z accelerometer
          * @param value - the new value
          *
          */
-        void propagateAcc(int acc, double value)
-        {
-            for (size_t i = 0; i < fAcc[acc].size(); i++) {
-                fAcc[acc][i]->update(value);
-            }
-        }
-    
-        /**
+    void propagateAcc(int acc, double value)
+    {
+        for (size_t i = 0; i < fAcc[acc].size(); i++) { fAcc[acc][i]->update(value); }
+    }
+
+    /**
          * Used to edit accelerometer curves and mapping. Set curve and related mapping for a given UI parameter.
          *
          * @param p - the UI parameter index
@@ -1433,12 +1455,12 @@ class APIUI : public PathBuilder, public Meta, public UI
          * @param amax - mapping 'max' point
          *
          */
-        void setAccConverter(int p, int acc, int curve, double amin, double amid, double amax)
-        {
-            setConverter(fAcc, p, acc, curve, amin, amid, amax);
-        }
-    
-        /**
+    void setAccConverter(int p, int acc, int curve, double amin, double amid, double amax)
+    {
+        setConverter(fAcc, p, acc, curve, amin, amid, amax);
+    }
+
+    /**
          * Used to edit gyroscope curves and mapping. Set curve and related mapping for a given UI parameter.
          *
          * @param p - the UI parameter index
@@ -1449,12 +1471,12 @@ class APIUI : public PathBuilder, public Meta, public UI
          * @param amax - mapping 'max' point
          *
          */
-        void setGyrConverter(int p, int gyr, int curve, double amin, double amid, double amax)
-        {
-             setConverter(fGyr, p, gyr, curve, amin, amid, amax);
-        }
-    
-        /**
+    void setGyrConverter(int p, int gyr, int curve, double amin, double amid, double amax)
+    {
+        setConverter(fGyr, p, gyr, curve, amin, amid, amax);
+    }
+
+    /**
          * Used to edit accelerometer curves and mapping. Get curve and related mapping for a given UI parameter.
          *
          * @param p - the UI parameter index
@@ -1465,12 +1487,13 @@ class APIUI : public PathBuilder, public Meta, public UI
          * @param amax - the amax value to be retrieved
          *
          */
-        void getAccConverter(int p, int& acc, int& curve, double& amin, double& amid, double& amax)
-        {
-            getConverter(fAcc, p, acc, curve, amin, amid, amax);
-        }
+    void getAccConverter(int p, int& acc, int& curve, double& amin, double& amid,
+                         double& amax)
+    {
+        getConverter(fAcc, p, acc, curve, amin, amid, amax);
+    }
 
-        /**
+    /**
          * Used to edit gyroscope curves and mapping. Get curve and related mapping for a given UI parameter.
          *
          * @param p - the UI parameter index
@@ -1481,63 +1504,55 @@ class APIUI : public PathBuilder, public Meta, public UI
          * @param amax - the amax value to be retrieved
          *
          */
-        void getGyrConverter(int p, int& gyr, int& curve, double& amin, double& amid, double& amax)
-        {
-            getConverter(fGyr, p, gyr, curve, amin, amid, amax);
-        }
-    
-        /**
+    void getGyrConverter(int p, int& gyr, int& curve, double& amin, double& amid,
+                         double& amax)
+    {
+        getConverter(fGyr, p, gyr, curve, amin, amid, amax);
+    }
+
+    /**
          * Set a new value coming from an gyroscope, propagate it to all relevant FAUSTFLOAT* zones.
          *
          * @param gyr - 0 for X gyroscope, 1 for Y gyroscope, 2 for Z gyroscope
          * @param value - the new value
          *
          */
-        void propagateGyr(int gyr, double value)
-        {
-            for (size_t i = 0; i < fGyr[gyr].size(); i++) {
-                fGyr[gyr][i]->update(value);
-            }
-        }
-    
-        /**
+    void propagateGyr(int gyr, double value)
+    {
+        for (size_t i = 0; i < fGyr[gyr].size(); i++) { fGyr[gyr][i]->update(value); }
+    }
+
+    /**
          * Get the number of FAUSTFLOAT* zones controlled with the accelerometer
          *
          * @param acc - 0 for X accelerometer, 1 for Y accelerometer, 2 for Z accelerometer
          * @return the number of zones
          *
          */
-        int getAccCount(int acc)
-        {
-            return (acc >= 0 && acc < 3) ? int(fAcc[acc].size()) : 0;
-        }
-    
-        /**
+    int getAccCount(int acc) { return (acc >= 0 && acc < 3) ? int(fAcc[acc].size()) : 0; }
+
+    /**
          * Get the number of FAUSTFLOAT* zones controlled with the gyroscope
          *
          * @param gyr - 0 for X gyroscope, 1 for Y gyroscope, 2 for Z gyroscope
          * @param the number of zones
          *
          */
-        int getGyrCount(int gyr)
-        {
-            return (gyr >= 0 && gyr < 3) ? int(fGyr[gyr].size()) : 0;
+    int getGyrCount(int gyr) { return (gyr >= 0 && gyr < 3) ? int(fGyr[gyr].size()) : 0; }
+
+    // getScreenColor() : -1 means no screen color control (no screencolor metadata found)
+    // otherwise return 0x00RRGGBB a ready to use color
+    int getScreenColor()
+    {
+        if (fHasScreenControl) {
+            int r = (fRedReader) ? fRedReader->getValue() : 0;
+            int g = (fGreenReader) ? fGreenReader->getValue() : 0;
+            int b = (fBlueReader) ? fBlueReader->getValue() : 0;
+            return (r << 16) | (g << 8) | b;
+        } else {
+            return -1;
         }
-   
-        // getScreenColor() : -1 means no screen color control (no screencolor metadata found)
-        // otherwise return 0x00RRGGBB a ready to use color
-        int getScreenColor()
-        {
-            if (fHasScreenControl) {
-                int r = (fRedReader) ? fRedReader->getValue() : 0;
-                int g = (fGreenReader) ? fGreenReader->getValue() : 0;
-                int b = (fBlueReader) ? fBlueReader->getValue() : 0;
-                return (r<<16) | (g<<8) | b;
-            } else {
-                return -1;
-            }
-        }
- 
+    }
 };
 
 #endif
@@ -1550,605 +1565,500 @@ class APIUI : public PathBuilder, public Meta, public UI
 //  FAUST Generated Code
 //----------------------------------------------------------------------------
 
-
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
+
+#include <math.h>
 
 #include <algorithm>
 #include <cmath>
-#include <math.h>
 
-
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS freeverbmonodsp
 #endif
 
-#ifdef __APPLE__ 
+#ifdef __APPLE__
 #define exp10f __exp10f
-#define exp10 __exp10
+#define exp10  __exp10
 #endif
 
-class freeverbmonodsp : public dsp {
-	
- private:
-	
-	FAUSTFLOAT fVslider0;
-	int fSampleRate;
-	float fConst0;
-	float fConst1;
-	FAUSTFLOAT fVslider1;
-	float fConst2;
-	FAUSTFLOAT fVslider2;
-	float fRec9[2];
-	int IOTA;
-	float fVec0[8192];
-	int iConst3;
-	float fConst4;
-	FAUSTFLOAT fVslider3;
-	float fRec8[2];
-	float fRec11[2];
-	float fVec1[8192];
-	int iConst5;
-	float fRec10[2];
-	float fRec13[2];
-	float fVec2[8192];
-	int iConst6;
-	float fRec12[2];
-	float fRec15[2];
-	float fVec3[8192];
-	int iConst7;
-	float fRec14[2];
-	float fRec17[2];
-	float fVec4[8192];
-	int iConst8;
-	float fRec16[2];
-	float fRec19[2];
-	float fVec5[8192];
-	int iConst9;
-	float fRec18[2];
-	float fRec21[2];
-	float fVec6[8192];
-	int iConst10;
-	float fRec20[2];
-	float fRec23[2];
-	float fVec7[8192];
-	int iConst11;
-	float fRec22[2];
-	float fVec8[2048];
-	int iConst12;
-	float fRec6[2];
-	float fVec9[2048];
-	int iConst13;
-	float fRec4[2];
-	float fVec10[2048];
-	int iConst14;
-	float fRec2[2];
-	float fVec11[2048];
-	int iConst15;
-	float fRec0[2];
-	float fRec33[2];
-	float fVec12[8192];
-	float fRec32[2];
-	float fRec35[2];
-	float fVec13[8192];
-	float fRec34[2];
-	float fRec37[2];
-	float fVec14[8192];
-	float fRec36[2];
-	float fRec39[2];
-	float fVec15[8192];
-	float fRec38[2];
-	float fRec41[2];
-	float fVec16[8192];
-	float fRec40[2];
-	float fRec43[2];
-	float fVec17[8192];
-	float fRec42[2];
-	float fRec45[2];
-	float fVec18[8192];
-	float fRec44[2];
-	float fRec47[2];
-	float fVec19[8192];
-	float fRec46[2];
-	float fVec20[2048];
-	int iConst16;
-	float fRec30[2];
-	float fVec21[2048];
-	int iConst17;
-	float fRec28[2];
-	float fVec22[2048];
-	int iConst18;
-	float fRec26[2];
-	float fVec23[1024];
-	int iConst19;
-	float fRec24[2];
-	
- public:
-	
-	void metadata(Meta* m) { 
-		m->declare("delays.lib/name", "Faust Delay Library");
-		m->declare("delays.lib/version", "0.1");
-		m->declare("filename", "freeverbmonodsp.dsp");
-		m->declare("filters.lib/allpass_comb:author", "Julius O. Smith III");
-		m->declare("filters.lib/allpass_comb:copyright", "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
-		m->declare("filters.lib/allpass_comb:license", "MIT-style STK-4.3 license");
-		m->declare("filters.lib/lowpass0_highpass1", "MIT-style STK-4.3 license");
-		m->declare("filters.lib/name", "Faust Filters Library");
-		m->declare("freeverbdsp.dsp/author", "Romain Michon");
-		m->declare("freeverbdsp.dsp/description", "Freeverb implementation in Faust, from the Faust Library's dm.freeverb_demo in demos.lib");
-		m->declare("freeverbdsp.dsp/license", "LGPL");
-		m->declare("freeverbdsp.dsp/name", "freeverb");
-		m->declare("freeverbdsp.dsp/version", "0.0");
-		m->declare("maths.lib/author", "GRAME");
-		m->declare("maths.lib/copyright", "GRAME");
-		m->declare("maths.lib/license", "LGPL with exception");
-		m->declare("maths.lib/name", "Faust Math Library");
-		m->declare("maths.lib/version", "2.3");
-		m->declare("name", "freeverbmonodsp");
-		m->declare("platform.lib/name", "Generic Platform Library");
-		m->declare("platform.lib/version", "0.1");
-		m->declare("reverbs.lib/name", "Faust Reverb Library");
-		m->declare("reverbs.lib/version", "0.0");
-	}
+class freeverbmonodsp : public dsp
+{
+   private:
+    FAUSTFLOAT fVslider0;
+    int fSampleRate;
+    float fConst0;
+    float fConst1;
+    FAUSTFLOAT fVslider1;
+    float fConst2;
+    FAUSTFLOAT fVslider2;
+    float fRec9[2];
+    int IOTA;
+    float fVec0[8192];
+    int iConst3;
+    float fConst4;
+    FAUSTFLOAT fVslider3;
+    float fRec8[2];
+    float fRec11[2];
+    float fVec1[8192];
+    int iConst5;
+    float fRec10[2];
+    float fRec13[2];
+    float fVec2[8192];
+    int iConst6;
+    float fRec12[2];
+    float fRec15[2];
+    float fVec3[8192];
+    int iConst7;
+    float fRec14[2];
+    float fRec17[2];
+    float fVec4[8192];
+    int iConst8;
+    float fRec16[2];
+    float fRec19[2];
+    float fVec5[8192];
+    int iConst9;
+    float fRec18[2];
+    float fRec21[2];
+    float fVec6[8192];
+    int iConst10;
+    float fRec20[2];
+    float fRec23[2];
+    float fVec7[8192];
+    int iConst11;
+    float fRec22[2];
+    float fVec8[2048];
+    int iConst12;
+    float fRec6[2];
+    float fVec9[2048];
+    int iConst13;
+    float fRec4[2];
+    float fVec10[2048];
+    int iConst14;
+    float fRec2[2];
+    float fVec11[2048];
+    int iConst15;
+    float fRec0[2];
+    float fRec33[2];
+    float fVec12[8192];
+    float fRec32[2];
+    float fRec35[2];
+    float fVec13[8192];
+    float fRec34[2];
+    float fRec37[2];
+    float fVec14[8192];
+    float fRec36[2];
+    float fRec39[2];
+    float fVec15[8192];
+    float fRec38[2];
+    float fRec41[2];
+    float fVec16[8192];
+    float fRec40[2];
+    float fRec43[2];
+    float fVec17[8192];
+    float fRec42[2];
+    float fRec45[2];
+    float fVec18[8192];
+    float fRec44[2];
+    float fRec47[2];
+    float fVec19[8192];
+    float fRec46[2];
+    float fVec20[2048];
+    int iConst16;
+    float fRec30[2];
+    float fVec21[2048];
+    int iConst17;
+    float fRec28[2];
+    float fVec22[2048];
+    int iConst18;
+    float fRec26[2];
+    float fVec23[1024];
+    int iConst19;
+    float fRec24[2];
 
-	virtual int getNumInputs() {
-		return 1;
-	}
-	virtual int getNumOutputs() {
-		return 1;
-	}
-	virtual int getInputRate(int channel) {
-		int rate;
-		switch ((channel)) {
-			case 0: {
-				rate = 1;
-				break;
-			}
-			default: {
-				rate = -1;
-				break;
-			}
-		}
-		return rate;
-	}
-	virtual int getOutputRate(int channel) {
-		int rate;
-		switch ((channel)) {
-			case 0: {
-				rate = 1;
-				break;
-			}
-			default: {
-				rate = -1;
-				break;
-			}
-		}
-		return rate;
-	}
-	
-	static void classInit(int sample_rate) {
-	}
-	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = std::min<float>(192000.0f, std::max<float>(1.0f, float(fSampleRate)));
-		fConst1 = (12348.0f / fConst0);
-		fConst2 = (17640.0f / fConst0);
-		iConst3 = int((0.0253061224f * fConst0));
-		fConst4 = (0.00104308384f * fConst0);
-		iConst5 = int((0.0269387756f * fConst0));
-		iConst6 = int((0.0289569162f * fConst0));
-		iConst7 = int((0.0307482984f * fConst0));
-		iConst8 = int((0.0322448984f * fConst0));
-		iConst9 = int((0.033809524f * fConst0));
-		iConst10 = int((0.0353061222f * fConst0));
-		iConst11 = int((0.0366666652f * fConst0));
-		iConst12 = int((0.0126077095f * fConst0));
-		iConst13 = int((0.00999999978f * fConst0));
-		iConst14 = int((0.00773242628f * fConst0));
-		iConst15 = int((0.00510204071f * fConst0));
-		iConst16 = std::min<int>(1024, std::max<int>(0, (iConst12 + -1)));
-		iConst17 = std::min<int>(1024, std::max<int>(0, (iConst13 + -1)));
-		iConst18 = std::min<int>(1024, std::max<int>(0, (iConst14 + -1)));
-		iConst19 = std::min<int>(1024, std::max<int>(0, (iConst15 + -1)));
-	}
-	
-	virtual void instanceResetUserInterface() {
-		fVslider0 = FAUSTFLOAT(0.10000000000000001f);
-		fVslider1 = FAUSTFLOAT(0.10000000000000001f);
-		fVslider2 = FAUSTFLOAT(0.5f);
-		fVslider3 = FAUSTFLOAT(0.5f);
-	}
-	
-	virtual void instanceClear() {
-		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
-			fRec9[l0] = 0.0f;
-		}
-		IOTA = 0;
-		for (int l1 = 0; (l1 < 8192); l1 = (l1 + 1)) {
-			fVec0[l1] = 0.0f;
-		}
-		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
-			fRec8[l2] = 0.0f;
-		}
-		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
-			fRec11[l3] = 0.0f;
-		}
-		for (int l4 = 0; (l4 < 8192); l4 = (l4 + 1)) {
-			fVec1[l4] = 0.0f;
-		}
-		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
-			fRec10[l5] = 0.0f;
-		}
-		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
-			fRec13[l6] = 0.0f;
-		}
-		for (int l7 = 0; (l7 < 8192); l7 = (l7 + 1)) {
-			fVec2[l7] = 0.0f;
-		}
-		for (int l8 = 0; (l8 < 2); l8 = (l8 + 1)) {
-			fRec12[l8] = 0.0f;
-		}
-		for (int l9 = 0; (l9 < 2); l9 = (l9 + 1)) {
-			fRec15[l9] = 0.0f;
-		}
-		for (int l10 = 0; (l10 < 8192); l10 = (l10 + 1)) {
-			fVec3[l10] = 0.0f;
-		}
-		for (int l11 = 0; (l11 < 2); l11 = (l11 + 1)) {
-			fRec14[l11] = 0.0f;
-		}
-		for (int l12 = 0; (l12 < 2); l12 = (l12 + 1)) {
-			fRec17[l12] = 0.0f;
-		}
-		for (int l13 = 0; (l13 < 8192); l13 = (l13 + 1)) {
-			fVec4[l13] = 0.0f;
-		}
-		for (int l14 = 0; (l14 < 2); l14 = (l14 + 1)) {
-			fRec16[l14] = 0.0f;
-		}
-		for (int l15 = 0; (l15 < 2); l15 = (l15 + 1)) {
-			fRec19[l15] = 0.0f;
-		}
-		for (int l16 = 0; (l16 < 8192); l16 = (l16 + 1)) {
-			fVec5[l16] = 0.0f;
-		}
-		for (int l17 = 0; (l17 < 2); l17 = (l17 + 1)) {
-			fRec18[l17] = 0.0f;
-		}
-		for (int l18 = 0; (l18 < 2); l18 = (l18 + 1)) {
-			fRec21[l18] = 0.0f;
-		}
-		for (int l19 = 0; (l19 < 8192); l19 = (l19 + 1)) {
-			fVec6[l19] = 0.0f;
-		}
-		for (int l20 = 0; (l20 < 2); l20 = (l20 + 1)) {
-			fRec20[l20] = 0.0f;
-		}
-		for (int l21 = 0; (l21 < 2); l21 = (l21 + 1)) {
-			fRec23[l21] = 0.0f;
-		}
-		for (int l22 = 0; (l22 < 8192); l22 = (l22 + 1)) {
-			fVec7[l22] = 0.0f;
-		}
-		for (int l23 = 0; (l23 < 2); l23 = (l23 + 1)) {
-			fRec22[l23] = 0.0f;
-		}
-		for (int l24 = 0; (l24 < 2048); l24 = (l24 + 1)) {
-			fVec8[l24] = 0.0f;
-		}
-		for (int l25 = 0; (l25 < 2); l25 = (l25 + 1)) {
-			fRec6[l25] = 0.0f;
-		}
-		for (int l26 = 0; (l26 < 2048); l26 = (l26 + 1)) {
-			fVec9[l26] = 0.0f;
-		}
-		for (int l27 = 0; (l27 < 2); l27 = (l27 + 1)) {
-			fRec4[l27] = 0.0f;
-		}
-		for (int l28 = 0; (l28 < 2048); l28 = (l28 + 1)) {
-			fVec10[l28] = 0.0f;
-		}
-		for (int l29 = 0; (l29 < 2); l29 = (l29 + 1)) {
-			fRec2[l29] = 0.0f;
-		}
-		for (int l30 = 0; (l30 < 2048); l30 = (l30 + 1)) {
-			fVec11[l30] = 0.0f;
-		}
-		for (int l31 = 0; (l31 < 2); l31 = (l31 + 1)) {
-			fRec0[l31] = 0.0f;
-		}
-		for (int l32 = 0; (l32 < 2); l32 = (l32 + 1)) {
-			fRec33[l32] = 0.0f;
-		}
-		for (int l33 = 0; (l33 < 8192); l33 = (l33 + 1)) {
-			fVec12[l33] = 0.0f;
-		}
-		for (int l34 = 0; (l34 < 2); l34 = (l34 + 1)) {
-			fRec32[l34] = 0.0f;
-		}
-		for (int l35 = 0; (l35 < 2); l35 = (l35 + 1)) {
-			fRec35[l35] = 0.0f;
-		}
-		for (int l36 = 0; (l36 < 8192); l36 = (l36 + 1)) {
-			fVec13[l36] = 0.0f;
-		}
-		for (int l37 = 0; (l37 < 2); l37 = (l37 + 1)) {
-			fRec34[l37] = 0.0f;
-		}
-		for (int l38 = 0; (l38 < 2); l38 = (l38 + 1)) {
-			fRec37[l38] = 0.0f;
-		}
-		for (int l39 = 0; (l39 < 8192); l39 = (l39 + 1)) {
-			fVec14[l39] = 0.0f;
-		}
-		for (int l40 = 0; (l40 < 2); l40 = (l40 + 1)) {
-			fRec36[l40] = 0.0f;
-		}
-		for (int l41 = 0; (l41 < 2); l41 = (l41 + 1)) {
-			fRec39[l41] = 0.0f;
-		}
-		for (int l42 = 0; (l42 < 8192); l42 = (l42 + 1)) {
-			fVec15[l42] = 0.0f;
-		}
-		for (int l43 = 0; (l43 < 2); l43 = (l43 + 1)) {
-			fRec38[l43] = 0.0f;
-		}
-		for (int l44 = 0; (l44 < 2); l44 = (l44 + 1)) {
-			fRec41[l44] = 0.0f;
-		}
-		for (int l45 = 0; (l45 < 8192); l45 = (l45 + 1)) {
-			fVec16[l45] = 0.0f;
-		}
-		for (int l46 = 0; (l46 < 2); l46 = (l46 + 1)) {
-			fRec40[l46] = 0.0f;
-		}
-		for (int l47 = 0; (l47 < 2); l47 = (l47 + 1)) {
-			fRec43[l47] = 0.0f;
-		}
-		for (int l48 = 0; (l48 < 8192); l48 = (l48 + 1)) {
-			fVec17[l48] = 0.0f;
-		}
-		for (int l49 = 0; (l49 < 2); l49 = (l49 + 1)) {
-			fRec42[l49] = 0.0f;
-		}
-		for (int l50 = 0; (l50 < 2); l50 = (l50 + 1)) {
-			fRec45[l50] = 0.0f;
-		}
-		for (int l51 = 0; (l51 < 8192); l51 = (l51 + 1)) {
-			fVec18[l51] = 0.0f;
-		}
-		for (int l52 = 0; (l52 < 2); l52 = (l52 + 1)) {
-			fRec44[l52] = 0.0f;
-		}
-		for (int l53 = 0; (l53 < 2); l53 = (l53 + 1)) {
-			fRec47[l53] = 0.0f;
-		}
-		for (int l54 = 0; (l54 < 8192); l54 = (l54 + 1)) {
-			fVec19[l54] = 0.0f;
-		}
-		for (int l55 = 0; (l55 < 2); l55 = (l55 + 1)) {
-			fRec46[l55] = 0.0f;
-		}
-		for (int l56 = 0; (l56 < 2048); l56 = (l56 + 1)) {
-			fVec20[l56] = 0.0f;
-		}
-		for (int l57 = 0; (l57 < 2); l57 = (l57 + 1)) {
-			fRec30[l57] = 0.0f;
-		}
-		for (int l58 = 0; (l58 < 2048); l58 = (l58 + 1)) {
-			fVec21[l58] = 0.0f;
-		}
-		for (int l59 = 0; (l59 < 2); l59 = (l59 + 1)) {
-			fRec28[l59] = 0.0f;
-		}
-		for (int l60 = 0; (l60 < 2048); l60 = (l60 + 1)) {
-			fVec22[l60] = 0.0f;
-		}
-		for (int l61 = 0; (l61 < 2); l61 = (l61 + 1)) {
-			fRec26[l61] = 0.0f;
-		}
-		for (int l62 = 0; (l62 < 1024); l62 = (l62 + 1)) {
-			fVec23[l62] = 0.0f;
-		}
-		for (int l63 = 0; (l63 < 2); l63 = (l63 + 1)) {
-			fRec24[l63] = 0.0f;
-		}
-	}
-	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
-	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
-		instanceResetUserInterface();
-		instanceClear();
-	}
-	
-	virtual freeverbmonodsp* clone() {
-		return new freeverbmonodsp();
-	}
-	
-	virtual int getSampleRate() {
-		return fSampleRate;
-	}
-	
-	virtual void buildUserInterface(UI* ui_interface) {
-		ui_interface->openHorizontalBox("Freeverb");
-		ui_interface->declare(0, "0", "");
-		ui_interface->openVerticalBox("0x00");
-		ui_interface->declare(&fVslider2, "0", "");
-		ui_interface->declare(&fVslider2, "style", "knob");
-		ui_interface->declare(&fVslider2, "tooltip", "Somehow control the   density of the reverb.");
-		ui_interface->addVerticalSlider("Damp", &fVslider2, 0.5f, 0.0f, 1.0f, 0.0250000004f);
-		ui_interface->declare(&fVslider1, "1", "");
-		ui_interface->declare(&fVslider1, "style", "knob");
-		ui_interface->declare(&fVslider1, "tooltip", "The room size   between 0 and 1 with 1 for the largest room.");
-		ui_interface->addVerticalSlider("RoomSize", &fVslider1, 0.100000001f, 0.0f, 1.0f, 0.0250000004f);
-		ui_interface->declare(&fVslider3, "2", "");
-		ui_interface->declare(&fVslider3, "style", "knob");
-		ui_interface->declare(&fVslider3, "tooltip", "Spatial   spread between 0 and 1 with 1 for maximum spread.");
-		ui_interface->addVerticalSlider("Stereo Spread", &fVslider3, 0.5f, 0.0f, 1.0f, 0.00999999978f);
-		ui_interface->closeBox();
-		ui_interface->declare(&fVslider0, "1", "");
-		ui_interface->declare(&fVslider0, "tooltip", "The amount of reverb applied to the signal   between 0 and 1 with 1 for the maximum amount of reverb.");
-		ui_interface->addVerticalSlider("Wet", &fVslider0, 0.100000001f, 0.0f, 1.0f, 0.0250000004f);
-		ui_interface->closeBox();
-	}
-	
-	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
-		FAUSTFLOAT* input0 = inputs[0];
-		FAUSTFLOAT* output0 = outputs[0];
-		float fSlow0 = float(fVslider0);
-		float fSlow1 = (0.200000003f * fSlow0);
-		float fSlow2 = ((fConst1 * float(fVslider1)) + 0.699999988f);
-		float fSlow3 = (fConst2 * float(fVslider2));
-		float fSlow4 = (1.0f - fSlow3);
-		int iSlow5 = int((fConst4 * float(fVslider3)));
-		int iSlow6 = (iConst3 + iSlow5);
-		int iSlow7 = (iConst5 + iSlow5);
-		int iSlow8 = (iConst6 + iSlow5);
-		int iSlow9 = (iConst7 + iSlow5);
-		int iSlow10 = (iConst8 + iSlow5);
-		int iSlow11 = (iConst9 + iSlow5);
-		int iSlow12 = (iConst10 + iSlow5);
-		int iSlow13 = (iConst11 + iSlow5);
-		int iSlow14 = (iSlow5 + -1);
-		int iSlow15 = std::min<int>(1024, std::max<int>(0, (iConst12 + iSlow14)));
-		int iSlow16 = std::min<int>(1024, std::max<int>(0, (iConst13 + iSlow14)));
-		int iSlow17 = std::min<int>(1024, std::max<int>(0, (iConst14 + iSlow14)));
-		int iSlow18 = std::min<int>(1024, std::max<int>(0, (iConst15 + iSlow14)));
-		float fSlow19 = (2.0f * (1.0f - fSlow0));
-		for (int i = 0; (i < count); i = (i + 1)) {
-			float fTemp0 = float(input0[i]);
-			float fTemp1 = (fSlow1 * fTemp0);
-			fRec9[0] = ((fSlow3 * fRec9[1]) + (fSlow4 * fRec8[1]));
-			fVec0[(IOTA & 8191)] = (fTemp1 + (fSlow2 * fRec9[0]));
-			fRec8[0] = fVec0[((IOTA - iSlow6) & 8191)];
-			fRec11[0] = ((fSlow3 * fRec11[1]) + (fSlow4 * fRec10[1]));
-			fVec1[(IOTA & 8191)] = (fTemp1 + (fSlow2 * fRec11[0]));
-			fRec10[0] = fVec1[((IOTA - iSlow7) & 8191)];
-			fRec13[0] = ((fSlow3 * fRec13[1]) + (fSlow4 * fRec12[1]));
-			fVec2[(IOTA & 8191)] = (fTemp1 + (fSlow2 * fRec13[0]));
-			fRec12[0] = fVec2[((IOTA - iSlow8) & 8191)];
-			fRec15[0] = ((fSlow3 * fRec15[1]) + (fSlow4 * fRec14[1]));
-			fVec3[(IOTA & 8191)] = (fTemp1 + (fSlow2 * fRec15[0]));
-			fRec14[0] = fVec3[((IOTA - iSlow9) & 8191)];
-			fRec17[0] = ((fSlow3 * fRec17[1]) + (fSlow4 * fRec16[1]));
-			fVec4[(IOTA & 8191)] = (fTemp1 + (fSlow2 * fRec17[0]));
-			fRec16[0] = fVec4[((IOTA - iSlow10) & 8191)];
-			fRec19[0] = ((fSlow3 * fRec19[1]) + (fSlow4 * fRec18[1]));
-			fVec5[(IOTA & 8191)] = (fTemp1 + (fSlow2 * fRec19[0]));
-			fRec18[0] = fVec5[((IOTA - iSlow11) & 8191)];
-			fRec21[0] = ((fSlow3 * fRec21[1]) + (fSlow4 * fRec20[1]));
-			fVec6[(IOTA & 8191)] = (fTemp1 + (fSlow2 * fRec21[0]));
-			fRec20[0] = fVec6[((IOTA - iSlow12) & 8191)];
-			fRec23[0] = ((fSlow3 * fRec23[1]) + (fSlow4 * fRec22[1]));
-			fVec7[(IOTA & 8191)] = (fTemp1 + (fSlow2 * fRec23[0]));
-			fRec22[0] = fVec7[((IOTA - iSlow13) & 8191)];
-			float fTemp2 = ((((((((fRec8[0] + fRec10[0]) + fRec12[0]) + fRec14[0]) + fRec16[0]) + fRec18[0]) + fRec20[0]) + fRec22[0]) + (0.5f * fRec6[1]));
-			fVec8[(IOTA & 2047)] = fTemp2;
-			fRec6[0] = fVec8[((IOTA - iSlow15) & 2047)];
-			float fRec7 = (0.0f - (0.5f * fTemp2));
-			float fTemp3 = (fRec6[1] + (fRec7 + (0.5f * fRec4[1])));
-			fVec9[(IOTA & 2047)] = fTemp3;
-			fRec4[0] = fVec9[((IOTA - iSlow16) & 2047)];
-			float fRec5 = (0.0f - (0.5f * fTemp3));
-			float fTemp4 = (fRec4[1] + (fRec5 + (0.5f * fRec2[1])));
-			fVec10[(IOTA & 2047)] = fTemp4;
-			fRec2[0] = fVec10[((IOTA - iSlow17) & 2047)];
-			float fRec3 = (0.0f - (0.5f * fTemp4));
-			float fTemp5 = (fRec2[1] + (fRec3 + (0.5f * fRec0[1])));
-			fVec11[(IOTA & 2047)] = fTemp5;
-			fRec0[0] = fVec11[((IOTA - iSlow18) & 2047)];
-			float fRec1 = (0.0f - (0.5f * fTemp5));
-			fRec33[0] = ((fSlow3 * fRec33[1]) + (fSlow4 * fRec32[1]));
-			fVec12[(IOTA & 8191)] = ((fSlow2 * fRec33[0]) + fTemp1);
-			fRec32[0] = fVec12[((IOTA - iConst3) & 8191)];
-			fRec35[0] = ((fSlow3 * fRec35[1]) + (fSlow4 * fRec34[1]));
-			fVec13[(IOTA & 8191)] = (fTemp1 + (fSlow2 * fRec35[0]));
-			fRec34[0] = fVec13[((IOTA - iConst5) & 8191)];
-			fRec37[0] = ((fSlow3 * fRec37[1]) + (fSlow4 * fRec36[1]));
-			fVec14[(IOTA & 8191)] = (fTemp1 + (fSlow2 * fRec37[0]));
-			fRec36[0] = fVec14[((IOTA - iConst6) & 8191)];
-			fRec39[0] = ((fSlow3 * fRec39[1]) + (fSlow4 * fRec38[1]));
-			fVec15[(IOTA & 8191)] = (fTemp1 + (fSlow2 * fRec39[0]));
-			fRec38[0] = fVec15[((IOTA - iConst7) & 8191)];
-			fRec41[0] = ((fSlow3 * fRec41[1]) + (fSlow4 * fRec40[1]));
-			fVec16[(IOTA & 8191)] = (fTemp1 + (fSlow2 * fRec41[0]));
-			fRec40[0] = fVec16[((IOTA - iConst8) & 8191)];
-			fRec43[0] = ((fSlow3 * fRec43[1]) + (fSlow4 * fRec42[1]));
-			fVec17[(IOTA & 8191)] = (fTemp1 + (fSlow2 * fRec43[0]));
-			fRec42[0] = fVec17[((IOTA - iConst9) & 8191)];
-			fRec45[0] = ((fSlow3 * fRec45[1]) + (fSlow4 * fRec44[1]));
-			fVec18[(IOTA & 8191)] = (fTemp1 + (fSlow2 * fRec45[0]));
-			fRec44[0] = fVec18[((IOTA - iConst10) & 8191)];
-			fRec47[0] = ((fSlow3 * fRec47[1]) + (fSlow4 * fRec46[1]));
-			fVec19[(IOTA & 8191)] = (fTemp1 + (fSlow2 * fRec47[0]));
-			fRec46[0] = fVec19[((IOTA - iConst11) & 8191)];
-			float fTemp6 = ((((((((fRec32[0] + fRec34[0]) + fRec36[0]) + fRec38[0]) + fRec40[0]) + fRec42[0]) + fRec44[0]) + fRec46[0]) + (0.5f * fRec30[1]));
-			fVec20[(IOTA & 2047)] = fTemp6;
-			fRec30[0] = fVec20[((IOTA - iConst16) & 2047)];
-			float fRec31 = (0.0f - (0.5f * fTemp6));
-			float fTemp7 = (fRec30[1] + (fRec31 + (0.5f * fRec28[1])));
-			fVec21[(IOTA & 2047)] = fTemp7;
-			fRec28[0] = fVec21[((IOTA - iConst17) & 2047)];
-			float fRec29 = (0.0f - (0.5f * fTemp7));
-			float fTemp8 = (fRec28[1] + (fRec29 + (0.5f * fRec26[1])));
-			fVec22[(IOTA & 2047)] = fTemp8;
-			fRec26[0] = fVec22[((IOTA - iConst18) & 2047)];
-			float fRec27 = (0.0f - (0.5f * fTemp8));
-			float fTemp9 = (fRec26[1] + (fRec27 + (0.5f * fRec24[1])));
-			fVec23[(IOTA & 1023)] = fTemp9;
-			fRec24[0] = fVec23[((IOTA - iConst19) & 1023)];
-			float fRec25 = (0.0f - (0.5f * fTemp9));
-			output0[i] = FAUSTFLOAT((fRec0[1] + ((fRec24[1] + (fRec25 + fRec1)) + (fSlow19 * fTemp0))));
-			fRec9[1] = fRec9[0];
-			IOTA = (IOTA + 1);
-			fRec8[1] = fRec8[0];
-			fRec11[1] = fRec11[0];
-			fRec10[1] = fRec10[0];
-			fRec13[1] = fRec13[0];
-			fRec12[1] = fRec12[0];
-			fRec15[1] = fRec15[0];
-			fRec14[1] = fRec14[0];
-			fRec17[1] = fRec17[0];
-			fRec16[1] = fRec16[0];
-			fRec19[1] = fRec19[0];
-			fRec18[1] = fRec18[0];
-			fRec21[1] = fRec21[0];
-			fRec20[1] = fRec20[0];
-			fRec23[1] = fRec23[0];
-			fRec22[1] = fRec22[0];
-			fRec6[1] = fRec6[0];
-			fRec4[1] = fRec4[0];
-			fRec2[1] = fRec2[0];
-			fRec0[1] = fRec0[0];
-			fRec33[1] = fRec33[0];
-			fRec32[1] = fRec32[0];
-			fRec35[1] = fRec35[0];
-			fRec34[1] = fRec34[0];
-			fRec37[1] = fRec37[0];
-			fRec36[1] = fRec36[0];
-			fRec39[1] = fRec39[0];
-			fRec38[1] = fRec38[0];
-			fRec41[1] = fRec41[0];
-			fRec40[1] = fRec40[0];
-			fRec43[1] = fRec43[0];
-			fRec42[1] = fRec42[0];
-			fRec45[1] = fRec45[0];
-			fRec44[1] = fRec44[0];
-			fRec47[1] = fRec47[0];
-			fRec46[1] = fRec46[0];
-			fRec30[1] = fRec30[0];
-			fRec28[1] = fRec28[0];
-			fRec26[1] = fRec26[0];
-			fRec24[1] = fRec24[0];
-		}
-	}
+   public:
+    void metadata(Meta* m)
+    {
+        m->declare("delays.lib/name", "Faust Delay Library");
+        m->declare("delays.lib/version", "0.1");
+        m->declare("filename", "freeverbmonodsp.dsp");
+        m->declare("filters.lib/allpass_comb:author", "Julius O. Smith III");
+        m->declare(
+            "filters.lib/allpass_comb:copyright",
+            "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
+        m->declare("filters.lib/allpass_comb:license", "MIT-style STK-4.3 license");
+        m->declare("filters.lib/lowpass0_highpass1", "MIT-style STK-4.3 license");
+        m->declare("filters.lib/name", "Faust Filters Library");
+        m->declare("freeverbdsp.dsp/author", "Romain Michon");
+        m->declare("freeverbdsp.dsp/description",
+                   "Freeverb implementation in Faust, from the Faust Library's "
+                   "dm.freeverb_demo in demos.lib");
+        m->declare("freeverbdsp.dsp/license", "LGPL");
+        m->declare("freeverbdsp.dsp/name", "freeverb");
+        m->declare("freeverbdsp.dsp/version", "0.0");
+        m->declare("maths.lib/author", "GRAME");
+        m->declare("maths.lib/copyright", "GRAME");
+        m->declare("maths.lib/license", "LGPL with exception");
+        m->declare("maths.lib/name", "Faust Math Library");
+        m->declare("maths.lib/version", "2.3");
+        m->declare("name", "freeverbmonodsp");
+        m->declare("platform.lib/name", "Generic Platform Library");
+        m->declare("platform.lib/version", "0.1");
+        m->declare("reverbs.lib/name", "Faust Reverb Library");
+        m->declare("reverbs.lib/version", "0.0");
+    }
 
+    virtual int getNumInputs() { return 1; }
+    virtual int getNumOutputs() { return 1; }
+    virtual int getInputRate(int channel)
+    {
+        int rate;
+        switch ((channel)) {
+        case 0: {
+            rate = 1;
+            break;
+        }
+        default: {
+            rate = -1;
+            break;
+        }
+        }
+        return rate;
+    }
+    virtual int getOutputRate(int channel)
+    {
+        int rate;
+        switch ((channel)) {
+        case 0: {
+            rate = 1;
+            break;
+        }
+        default: {
+            rate = -1;
+            break;
+        }
+        }
+        return rate;
+    }
+
+    static void classInit(int sample_rate) {}
+
+    virtual void instanceConstants(int sample_rate)
+    {
+        fSampleRate = sample_rate;
+        fConst0  = std::min<float>(192000.0f, std::max<float>(1.0f, float(fSampleRate)));
+        fConst1  = (12348.0f / fConst0);
+        fConst2  = (17640.0f / fConst0);
+        iConst3  = int((0.0253061224f * fConst0));
+        fConst4  = (0.00104308384f * fConst0);
+        iConst5  = int((0.0269387756f * fConst0));
+        iConst6  = int((0.0289569162f * fConst0));
+        iConst7  = int((0.0307482984f * fConst0));
+        iConst8  = int((0.0322448984f * fConst0));
+        iConst9  = int((0.033809524f * fConst0));
+        iConst10 = int((0.0353061222f * fConst0));
+        iConst11 = int((0.0366666652f * fConst0));
+        iConst12 = int((0.0126077095f * fConst0));
+        iConst13 = int((0.00999999978f * fConst0));
+        iConst14 = int((0.00773242628f * fConst0));
+        iConst15 = int((0.00510204071f * fConst0));
+        iConst16 = std::min<int>(1024, std::max<int>(0, (iConst12 + -1)));
+        iConst17 = std::min<int>(1024, std::max<int>(0, (iConst13 + -1)));
+        iConst18 = std::min<int>(1024, std::max<int>(0, (iConst14 + -1)));
+        iConst19 = std::min<int>(1024, std::max<int>(0, (iConst15 + -1)));
+    }
+
+    virtual void instanceResetUserInterface()
+    {
+        fVslider0 = FAUSTFLOAT(0.10000000000000001f);
+        fVslider1 = FAUSTFLOAT(0.10000000000000001f);
+        fVslider2 = FAUSTFLOAT(0.5f);
+        fVslider3 = FAUSTFLOAT(0.5f);
+    }
+
+    virtual void instanceClear()
+    {
+        for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) { fRec9[l0] = 0.0f; }
+        IOTA = 0;
+        for (int l1 = 0; (l1 < 8192); l1 = (l1 + 1)) { fVec0[l1] = 0.0f; }
+        for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) { fRec8[l2] = 0.0f; }
+        for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) { fRec11[l3] = 0.0f; }
+        for (int l4 = 0; (l4 < 8192); l4 = (l4 + 1)) { fVec1[l4] = 0.0f; }
+        for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) { fRec10[l5] = 0.0f; }
+        for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) { fRec13[l6] = 0.0f; }
+        for (int l7 = 0; (l7 < 8192); l7 = (l7 + 1)) { fVec2[l7] = 0.0f; }
+        for (int l8 = 0; (l8 < 2); l8 = (l8 + 1)) { fRec12[l8] = 0.0f; }
+        for (int l9 = 0; (l9 < 2); l9 = (l9 + 1)) { fRec15[l9] = 0.0f; }
+        for (int l10 = 0; (l10 < 8192); l10 = (l10 + 1)) { fVec3[l10] = 0.0f; }
+        for (int l11 = 0; (l11 < 2); l11 = (l11 + 1)) { fRec14[l11] = 0.0f; }
+        for (int l12 = 0; (l12 < 2); l12 = (l12 + 1)) { fRec17[l12] = 0.0f; }
+        for (int l13 = 0; (l13 < 8192); l13 = (l13 + 1)) { fVec4[l13] = 0.0f; }
+        for (int l14 = 0; (l14 < 2); l14 = (l14 + 1)) { fRec16[l14] = 0.0f; }
+        for (int l15 = 0; (l15 < 2); l15 = (l15 + 1)) { fRec19[l15] = 0.0f; }
+        for (int l16 = 0; (l16 < 8192); l16 = (l16 + 1)) { fVec5[l16] = 0.0f; }
+        for (int l17 = 0; (l17 < 2); l17 = (l17 + 1)) { fRec18[l17] = 0.0f; }
+        for (int l18 = 0; (l18 < 2); l18 = (l18 + 1)) { fRec21[l18] = 0.0f; }
+        for (int l19 = 0; (l19 < 8192); l19 = (l19 + 1)) { fVec6[l19] = 0.0f; }
+        for (int l20 = 0; (l20 < 2); l20 = (l20 + 1)) { fRec20[l20] = 0.0f; }
+        for (int l21 = 0; (l21 < 2); l21 = (l21 + 1)) { fRec23[l21] = 0.0f; }
+        for (int l22 = 0; (l22 < 8192); l22 = (l22 + 1)) { fVec7[l22] = 0.0f; }
+        for (int l23 = 0; (l23 < 2); l23 = (l23 + 1)) { fRec22[l23] = 0.0f; }
+        for (int l24 = 0; (l24 < 2048); l24 = (l24 + 1)) { fVec8[l24] = 0.0f; }
+        for (int l25 = 0; (l25 < 2); l25 = (l25 + 1)) { fRec6[l25] = 0.0f; }
+        for (int l26 = 0; (l26 < 2048); l26 = (l26 + 1)) { fVec9[l26] = 0.0f; }
+        for (int l27 = 0; (l27 < 2); l27 = (l27 + 1)) { fRec4[l27] = 0.0f; }
+        for (int l28 = 0; (l28 < 2048); l28 = (l28 + 1)) { fVec10[l28] = 0.0f; }
+        for (int l29 = 0; (l29 < 2); l29 = (l29 + 1)) { fRec2[l29] = 0.0f; }
+        for (int l30 = 0; (l30 < 2048); l30 = (l30 + 1)) { fVec11[l30] = 0.0f; }
+        for (int l31 = 0; (l31 < 2); l31 = (l31 + 1)) { fRec0[l31] = 0.0f; }
+        for (int l32 = 0; (l32 < 2); l32 = (l32 + 1)) { fRec33[l32] = 0.0f; }
+        for (int l33 = 0; (l33 < 8192); l33 = (l33 + 1)) { fVec12[l33] = 0.0f; }
+        for (int l34 = 0; (l34 < 2); l34 = (l34 + 1)) { fRec32[l34] = 0.0f; }
+        for (int l35 = 0; (l35 < 2); l35 = (l35 + 1)) { fRec35[l35] = 0.0f; }
+        for (int l36 = 0; (l36 < 8192); l36 = (l36 + 1)) { fVec13[l36] = 0.0f; }
+        for (int l37 = 0; (l37 < 2); l37 = (l37 + 1)) { fRec34[l37] = 0.0f; }
+        for (int l38 = 0; (l38 < 2); l38 = (l38 + 1)) { fRec37[l38] = 0.0f; }
+        for (int l39 = 0; (l39 < 8192); l39 = (l39 + 1)) { fVec14[l39] = 0.0f; }
+        for (int l40 = 0; (l40 < 2); l40 = (l40 + 1)) { fRec36[l40] = 0.0f; }
+        for (int l41 = 0; (l41 < 2); l41 = (l41 + 1)) { fRec39[l41] = 0.0f; }
+        for (int l42 = 0; (l42 < 8192); l42 = (l42 + 1)) { fVec15[l42] = 0.0f; }
+        for (int l43 = 0; (l43 < 2); l43 = (l43 + 1)) { fRec38[l43] = 0.0f; }
+        for (int l44 = 0; (l44 < 2); l44 = (l44 + 1)) { fRec41[l44] = 0.0f; }
+        for (int l45 = 0; (l45 < 8192); l45 = (l45 + 1)) { fVec16[l45] = 0.0f; }
+        for (int l46 = 0; (l46 < 2); l46 = (l46 + 1)) { fRec40[l46] = 0.0f; }
+        for (int l47 = 0; (l47 < 2); l47 = (l47 + 1)) { fRec43[l47] = 0.0f; }
+        for (int l48 = 0; (l48 < 8192); l48 = (l48 + 1)) { fVec17[l48] = 0.0f; }
+        for (int l49 = 0; (l49 < 2); l49 = (l49 + 1)) { fRec42[l49] = 0.0f; }
+        for (int l50 = 0; (l50 < 2); l50 = (l50 + 1)) { fRec45[l50] = 0.0f; }
+        for (int l51 = 0; (l51 < 8192); l51 = (l51 + 1)) { fVec18[l51] = 0.0f; }
+        for (int l52 = 0; (l52 < 2); l52 = (l52 + 1)) { fRec44[l52] = 0.0f; }
+        for (int l53 = 0; (l53 < 2); l53 = (l53 + 1)) { fRec47[l53] = 0.0f; }
+        for (int l54 = 0; (l54 < 8192); l54 = (l54 + 1)) { fVec19[l54] = 0.0f; }
+        for (int l55 = 0; (l55 < 2); l55 = (l55 + 1)) { fRec46[l55] = 0.0f; }
+        for (int l56 = 0; (l56 < 2048); l56 = (l56 + 1)) { fVec20[l56] = 0.0f; }
+        for (int l57 = 0; (l57 < 2); l57 = (l57 + 1)) { fRec30[l57] = 0.0f; }
+        for (int l58 = 0; (l58 < 2048); l58 = (l58 + 1)) { fVec21[l58] = 0.0f; }
+        for (int l59 = 0; (l59 < 2); l59 = (l59 + 1)) { fRec28[l59] = 0.0f; }
+        for (int l60 = 0; (l60 < 2048); l60 = (l60 + 1)) { fVec22[l60] = 0.0f; }
+        for (int l61 = 0; (l61 < 2); l61 = (l61 + 1)) { fRec26[l61] = 0.0f; }
+        for (int l62 = 0; (l62 < 1024); l62 = (l62 + 1)) { fVec23[l62] = 0.0f; }
+        for (int l63 = 0; (l63 < 2); l63 = (l63 + 1)) { fRec24[l63] = 0.0f; }
+    }
+
+    virtual void init(int sample_rate)
+    {
+        classInit(sample_rate);
+        instanceInit(sample_rate);
+    }
+    virtual void instanceInit(int sample_rate)
+    {
+        instanceConstants(sample_rate);
+        instanceResetUserInterface();
+        instanceClear();
+    }
+
+    virtual freeverbmonodsp* clone() { return new freeverbmonodsp(); }
+
+    virtual int getSampleRate() { return fSampleRate; }
+
+    virtual void buildUserInterface(UI* ui_interface)
+    {
+        ui_interface->openHorizontalBox("Freeverb");
+        ui_interface->declare(0, "0", "");
+        ui_interface->openVerticalBox("0x00");
+        ui_interface->declare(&fVslider2, "0", "");
+        ui_interface->declare(&fVslider2, "style", "knob");
+        ui_interface->declare(&fVslider2, "tooltip",
+                              "Somehow control the   density of the reverb.");
+        ui_interface->addVerticalSlider("Damp", &fVslider2, 0.5f, 0.0f, 1.0f,
+                                        0.0250000004f);
+        ui_interface->declare(&fVslider1, "1", "");
+        ui_interface->declare(&fVslider1, "style", "knob");
+        ui_interface->declare(
+            &fVslider1, "tooltip",
+            "The room size   between 0 and 1 with 1 for the largest room.");
+        ui_interface->addVerticalSlider("RoomSize", &fVslider1, 0.100000001f, 0.0f, 1.0f,
+                                        0.0250000004f);
+        ui_interface->declare(&fVslider3, "2", "");
+        ui_interface->declare(&fVslider3, "style", "knob");
+        ui_interface->declare(
+            &fVslider3, "tooltip",
+            "Spatial   spread between 0 and 1 with 1 for maximum spread.");
+        ui_interface->addVerticalSlider("Stereo Spread", &fVslider3, 0.5f, 0.0f, 1.0f,
+                                        0.00999999978f);
+        ui_interface->closeBox();
+        ui_interface->declare(&fVslider0, "1", "");
+        ui_interface->declare(&fVslider0, "tooltip",
+                              "The amount of reverb applied to the signal   between 0 "
+                              "and 1 with 1 for the maximum amount of reverb.");
+        ui_interface->addVerticalSlider("Wet", &fVslider0, 0.100000001f, 0.0f, 1.0f,
+                                        0.0250000004f);
+        ui_interface->closeBox();
+    }
+
+    virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+    {
+        FAUSTFLOAT* input0  = inputs[0];
+        FAUSTFLOAT* output0 = outputs[0];
+        float fSlow0        = float(fVslider0);
+        float fSlow1        = (0.200000003f * fSlow0);
+        float fSlow2        = ((fConst1 * float(fVslider1)) + 0.699999988f);
+        float fSlow3        = (fConst2 * float(fVslider2));
+        float fSlow4        = (1.0f - fSlow3);
+        int iSlow5          = int((fConst4 * float(fVslider3)));
+        int iSlow6          = (iConst3 + iSlow5);
+        int iSlow7          = (iConst5 + iSlow5);
+        int iSlow8          = (iConst6 + iSlow5);
+        int iSlow9          = (iConst7 + iSlow5);
+        int iSlow10         = (iConst8 + iSlow5);
+        int iSlow11         = (iConst9 + iSlow5);
+        int iSlow12         = (iConst10 + iSlow5);
+        int iSlow13         = (iConst11 + iSlow5);
+        int iSlow14         = (iSlow5 + -1);
+        int iSlow15         = std::min<int>(1024, std::max<int>(0, (iConst12 + iSlow14)));
+        int iSlow16         = std::min<int>(1024, std::max<int>(0, (iConst13 + iSlow14)));
+        int iSlow17         = std::min<int>(1024, std::max<int>(0, (iConst14 + iSlow14)));
+        int iSlow18         = std::min<int>(1024, std::max<int>(0, (iConst15 + iSlow14)));
+        float fSlow19       = (2.0f * (1.0f - fSlow0));
+        for (int i = 0; (i < count); i = (i + 1)) {
+            float fTemp0         = float(input0[i]);
+            float fTemp1         = (fSlow1 * fTemp0);
+            fRec9[0]             = ((fSlow3 * fRec9[1]) + (fSlow4 * fRec8[1]));
+            fVec0[(IOTA & 8191)] = (fTemp1 + (fSlow2 * fRec9[0]));
+            fRec8[0]             = fVec0[((IOTA - iSlow6) & 8191)];
+            fRec11[0]            = ((fSlow3 * fRec11[1]) + (fSlow4 * fRec10[1]));
+            fVec1[(IOTA & 8191)] = (fTemp1 + (fSlow2 * fRec11[0]));
+            fRec10[0]            = fVec1[((IOTA - iSlow7) & 8191)];
+            fRec13[0]            = ((fSlow3 * fRec13[1]) + (fSlow4 * fRec12[1]));
+            fVec2[(IOTA & 8191)] = (fTemp1 + (fSlow2 * fRec13[0]));
+            fRec12[0]            = fVec2[((IOTA - iSlow8) & 8191)];
+            fRec15[0]            = ((fSlow3 * fRec15[1]) + (fSlow4 * fRec14[1]));
+            fVec3[(IOTA & 8191)] = (fTemp1 + (fSlow2 * fRec15[0]));
+            fRec14[0]            = fVec3[((IOTA - iSlow9) & 8191)];
+            fRec17[0]            = ((fSlow3 * fRec17[1]) + (fSlow4 * fRec16[1]));
+            fVec4[(IOTA & 8191)] = (fTemp1 + (fSlow2 * fRec17[0]));
+            fRec16[0]            = fVec4[((IOTA - iSlow10) & 8191)];
+            fRec19[0]            = ((fSlow3 * fRec19[1]) + (fSlow4 * fRec18[1]));
+            fVec5[(IOTA & 8191)] = (fTemp1 + (fSlow2 * fRec19[0]));
+            fRec18[0]            = fVec5[((IOTA - iSlow11) & 8191)];
+            fRec21[0]            = ((fSlow3 * fRec21[1]) + (fSlow4 * fRec20[1]));
+            fVec6[(IOTA & 8191)] = (fTemp1 + (fSlow2 * fRec21[0]));
+            fRec20[0]            = fVec6[((IOTA - iSlow12) & 8191)];
+            fRec23[0]            = ((fSlow3 * fRec23[1]) + (fSlow4 * fRec22[1]));
+            fVec7[(IOTA & 8191)] = (fTemp1 + (fSlow2 * fRec23[0]));
+            fRec22[0]            = fVec7[((IOTA - iSlow13) & 8191)];
+            float fTemp2 =
+                ((((((((fRec8[0] + fRec10[0]) + fRec12[0]) + fRec14[0]) + fRec16[0])
+                    + fRec18[0])
+                   + fRec20[0])
+                  + fRec22[0])
+                 + (0.5f * fRec6[1]));
+            fVec8[(IOTA & 2047)]  = fTemp2;
+            fRec6[0]              = fVec8[((IOTA - iSlow15) & 2047)];
+            float fRec7           = (0.0f - (0.5f * fTemp2));
+            float fTemp3          = (fRec6[1] + (fRec7 + (0.5f * fRec4[1])));
+            fVec9[(IOTA & 2047)]  = fTemp3;
+            fRec4[0]              = fVec9[((IOTA - iSlow16) & 2047)];
+            float fRec5           = (0.0f - (0.5f * fTemp3));
+            float fTemp4          = (fRec4[1] + (fRec5 + (0.5f * fRec2[1])));
+            fVec10[(IOTA & 2047)] = fTemp4;
+            fRec2[0]              = fVec10[((IOTA - iSlow17) & 2047)];
+            float fRec3           = (0.0f - (0.5f * fTemp4));
+            float fTemp5          = (fRec2[1] + (fRec3 + (0.5f * fRec0[1])));
+            fVec11[(IOTA & 2047)] = fTemp5;
+            fRec0[0]              = fVec11[((IOTA - iSlow18) & 2047)];
+            float fRec1           = (0.0f - (0.5f * fTemp5));
+            fRec33[0]             = ((fSlow3 * fRec33[1]) + (fSlow4 * fRec32[1]));
+            fVec12[(IOTA & 8191)] = ((fSlow2 * fRec33[0]) + fTemp1);
+            fRec32[0]             = fVec12[((IOTA - iConst3) & 8191)];
+            fRec35[0]             = ((fSlow3 * fRec35[1]) + (fSlow4 * fRec34[1]));
+            fVec13[(IOTA & 8191)] = (fTemp1 + (fSlow2 * fRec35[0]));
+            fRec34[0]             = fVec13[((IOTA - iConst5) & 8191)];
+            fRec37[0]             = ((fSlow3 * fRec37[1]) + (fSlow4 * fRec36[1]));
+            fVec14[(IOTA & 8191)] = (fTemp1 + (fSlow2 * fRec37[0]));
+            fRec36[0]             = fVec14[((IOTA - iConst6) & 8191)];
+            fRec39[0]             = ((fSlow3 * fRec39[1]) + (fSlow4 * fRec38[1]));
+            fVec15[(IOTA & 8191)] = (fTemp1 + (fSlow2 * fRec39[0]));
+            fRec38[0]             = fVec15[((IOTA - iConst7) & 8191)];
+            fRec41[0]             = ((fSlow3 * fRec41[1]) + (fSlow4 * fRec40[1]));
+            fVec16[(IOTA & 8191)] = (fTemp1 + (fSlow2 * fRec41[0]));
+            fRec40[0]             = fVec16[((IOTA - iConst8) & 8191)];
+            fRec43[0]             = ((fSlow3 * fRec43[1]) + (fSlow4 * fRec42[1]));
+            fVec17[(IOTA & 8191)] = (fTemp1 + (fSlow2 * fRec43[0]));
+            fRec42[0]             = fVec17[((IOTA - iConst9) & 8191)];
+            fRec45[0]             = ((fSlow3 * fRec45[1]) + (fSlow4 * fRec44[1]));
+            fVec18[(IOTA & 8191)] = (fTemp1 + (fSlow2 * fRec45[0]));
+            fRec44[0]             = fVec18[((IOTA - iConst10) & 8191)];
+            fRec47[0]             = ((fSlow3 * fRec47[1]) + (fSlow4 * fRec46[1]));
+            fVec19[(IOTA & 8191)] = (fTemp1 + (fSlow2 * fRec47[0]));
+            fRec46[0]             = fVec19[((IOTA - iConst11) & 8191)];
+            float fTemp6 =
+                ((((((((fRec32[0] + fRec34[0]) + fRec36[0]) + fRec38[0]) + fRec40[0])
+                    + fRec42[0])
+                   + fRec44[0])
+                  + fRec46[0])
+                 + (0.5f * fRec30[1]));
+            fVec20[(IOTA & 2047)] = fTemp6;
+            fRec30[0]             = fVec20[((IOTA - iConst16) & 2047)];
+            float fRec31          = (0.0f - (0.5f * fTemp6));
+            float fTemp7          = (fRec30[1] + (fRec31 + (0.5f * fRec28[1])));
+            fVec21[(IOTA & 2047)] = fTemp7;
+            fRec28[0]             = fVec21[((IOTA - iConst17) & 2047)];
+            float fRec29          = (0.0f - (0.5f * fTemp7));
+            float fTemp8          = (fRec28[1] + (fRec29 + (0.5f * fRec26[1])));
+            fVec22[(IOTA & 2047)] = fTemp8;
+            fRec26[0]             = fVec22[((IOTA - iConst18) & 2047)];
+            float fRec27          = (0.0f - (0.5f * fTemp8));
+            float fTemp9          = (fRec26[1] + (fRec27 + (0.5f * fRec24[1])));
+            fVec23[(IOTA & 1023)] = fTemp9;
+            fRec24[0]             = fVec23[((IOTA - iConst19) & 1023)];
+            float fRec25          = (0.0f - (0.5f * fTemp9));
+            output0[i]            = FAUSTFLOAT(
+                (fRec0[1] + ((fRec24[1] + (fRec25 + fRec1)) + (fSlow19 * fTemp0))));
+            fRec9[1]  = fRec9[0];
+            IOTA      = (IOTA + 1);
+            fRec8[1]  = fRec8[0];
+            fRec11[1] = fRec11[0];
+            fRec10[1] = fRec10[0];
+            fRec13[1] = fRec13[0];
+            fRec12[1] = fRec12[0];
+            fRec15[1] = fRec15[0];
+            fRec14[1] = fRec14[0];
+            fRec17[1] = fRec17[0];
+            fRec16[1] = fRec16[0];
+            fRec19[1] = fRec19[0];
+            fRec18[1] = fRec18[0];
+            fRec21[1] = fRec21[0];
+            fRec20[1] = fRec20[0];
+            fRec23[1] = fRec23[0];
+            fRec22[1] = fRec22[0];
+            fRec6[1]  = fRec6[0];
+            fRec4[1]  = fRec4[0];
+            fRec2[1]  = fRec2[0];
+            fRec0[1]  = fRec0[0];
+            fRec33[1] = fRec33[0];
+            fRec32[1] = fRec32[0];
+            fRec35[1] = fRec35[0];
+            fRec34[1] = fRec34[0];
+            fRec37[1] = fRec37[0];
+            fRec36[1] = fRec36[0];
+            fRec39[1] = fRec39[0];
+            fRec38[1] = fRec38[0];
+            fRec41[1] = fRec41[0];
+            fRec40[1] = fRec40[0];
+            fRec43[1] = fRec43[0];
+            fRec42[1] = fRec42[0];
+            fRec45[1] = fRec45[0];
+            fRec44[1] = fRec44[0];
+            fRec47[1] = fRec47[0];
+            fRec46[1] = fRec46[0];
+            fRec30[1] = fRec30[0];
+            fRec28[1] = fRec28[0];
+            fRec26[1] = fRec26[0];
+            fRec24[1] = fRec24[0];
+        }
+    }
 };
 
 #endif

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -49,13 +49,13 @@ const char* const gVersion = "1.3.0"; ///< JackTrip version
 //*******************************************************************************
 /// \name Default Values
 //@{
-const int gDefaultNumInChannels = 2;
+const int gDefaultNumInChannels  = 2;
 const int gDefaultNumOutChannels = 2;
 
-#define PROTOCOL_STACK QHostAddress::AnyIPv4 // as opposed to Any
+#define PROTOCOL_STACK QHostAddress::AnyIPv4  // as opposed to Any
 // #define WAIR_AUDIO_NAME "JackTrip" // for jack connection
-const QString WAIR_AUDIO_NAME = QString("JackTrip"); // keep legacy for WAIR
-const int gMAX_WAIRS = 128; // FIXME, should agree with maxThreadCount
+const QString WAIR_AUDIO_NAME = QString("JackTrip");  // keep legacy for WAIR
+const int gMAX_WAIRS          = 128;  // FIXME, should agree with maxThreadCount
 // jmess revision needed for string parse if > 1 digit
 
 // hubpatch = 3 for TUB ensemble patching
@@ -66,75 +66,70 @@ const int gMAX_WAIRS = 128; // FIXME, should agree with maxThreadCount
 //const int gMAX_TUB = 245; // highest client address
 ///////////////////////////////
 // test Riviera as server
- const QString gDOMAIN_TRIPLE = QString("192.168.0"); // for TUB multiclient hub
- const int gMIN_TUB = 11; // lowest client address
- const int gMAX_TUB = 20; // highest client address
+const QString gDOMAIN_TRIPLE = QString("192.168.0");  // for TUB multiclient hub
+const int gMIN_TUB           = 11;                    // lowest client address
+const int gMAX_TUB           = 20;                    // highest client address
 
-#ifdef WAIR // wair
+#ifdef WAIR  // wair
 // uses hub mode
 // hard wire the number of netrev (comb filter) channels
-  #define NUMNETREVCHANSbecauseNOTINRECEIVEDheader 16 // for jacktripworker, jmess
-  const int gDefaultNumNetRevChannels = NUMNETREVCHANSbecauseNOTINRECEIVEDheader;
-  const int gDefaultAddCombFilterLength = 0;
-  const int gDefaultCombFilterFeedback = 0;
-#endif // endwhere
+#define NUMNETREVCHANSbecauseNOTINRECEIVEDheader 16  // for jacktripworker, jmess
+const int gDefaultNumNetRevChannels   = NUMNETREVCHANSbecauseNOTINRECEIVEDheader;
+const int gDefaultAddCombFilterLength = 0;
+const int gDefaultCombFilterFeedback  = 0;
+#endif  // endwhere
 
 //const JackAudioInterface::audioBitResolutionT gDefaultBitResolutionMode =
 //    JackAudioInterface::BIT16;
 const AudioInterface::audioBitResolutionT gDefaultBitResolutionMode =
-        AudioInterface::BIT16;
-const int gDefaultQueueLength = 4;
-const int gDefaultOutputQueueLength = 4;
-const uint32_t gDefaultSampleRate = 48000;
-const uint32_t gDefaultDeviceID = 0;
+    AudioInterface::BIT16;
+const int gDefaultQueueLength              = 4;
+const int gDefaultOutputQueueLength        = 4;
+const uint32_t gDefaultSampleRate          = 48000;
+const uint32_t gDefaultDeviceID            = 0;
 const uint32_t gDefaultBufferSizeInSamples = 128;
-const QString gDefaultLocalAddress = QString();
-const int gDefaultRedundancy = 1;
-const int gTimeOutMultiThreadedServer = 10000; // seconds
-const int gWaitCounter = 60;
+const QString gDefaultLocalAddress         = QString();
+const int gDefaultRedundancy               = 1;
+const int gTimeOutMultiThreadedServer      = 10000;  // seconds
+const int gWaitCounter                     = 60;
 //@}
-
 
 //*******************************************************************************
 /// \name Network related ports
 //@{
-const int gDefaultPort = 4464; ///< Default JackTrip Port
-const int gBindPortLow = 3464; ///< lowest Bindport
-const int gBindPortHigh = 5464; ///< highest Bindport
+const int gDefaultPort  = 4464;  ///< Default JackTrip Port
+const int gBindPortLow  = 3464;  ///< lowest Bindport
+const int gBindPortHigh = 5464;  ///< highest Bindport
 //const int gInputPort_0 = 4464; ///< Input base port
 //const int gOutputPort_0 = 4465; ///< Output base port
 //const int gDefaultSendPort = 4464; ///< Default for to use to send packet
 //@}
 
-
 //*******************************************************************************
 /// \name Separator for terminal printing
 //@{
-const char* const gPrintSeparator = "---------------------------------------------------------";
+const char* const gPrintSeparator =
+    "---------------------------------------------------------";
 //@}
-
 
 //*******************************************************************************
 /// \name Global flags
 //@{
-extern int gVerboseFlag; ///< Verbose mode flag declaration
+extern int gVerboseFlag;  ///< Verbose mode flag declaration
 //@}
-
 
 //*******************************************************************************
 /// \name JackAudio
 //@{
-const int gJackBitResolution = 32; ///< Audio Bit Resolution of the Jack Server
+const int gJackBitResolution         = 32;  ///< Audio Bit Resolution of the Jack Server
 const QString gJackDefaultClientName = "JackTrip";
-const int gMaxRemoteNameLength = 64;
+const int gMaxRemoteNameLength       = 64;
 //@}
-
 
 //*******************************************************************************
 /// \name Global Functions
 
 void setRealtimeProcessPriority();
-
 
 //*******************************************************************************
 /// \name JackTrip Server parameters
@@ -145,6 +140,5 @@ const int gMaxThreads = 1024;
 /// Public well-known UDP port to where the clients will connect
 const int gServerUdpPort = 4464;
 //@}
-
 
 #endif

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -44,7 +44,7 @@
 /// \todo Add this namespace
 //namespace JackTrip
 
-const char* const gVersion = "1.3.0"; ///< JackTrip version
+const char* const gVersion = "1.3.0";  ///< JackTrip version
 
 //*******************************************************************************
 /// \name Default Values

--- a/src/jacktrip_tests.cpp
+++ b/src/jacktrip_tests.cpp
@@ -35,35 +35,29 @@
  * \date September 2008
  */
 
-#include <iostream>
-
 #include <QVector>
+#include <iostream>
 
 #include "JackTripThread.h"
 
-using std::cout; using std::endl;
+using std::cout;
+using std::endl;
 
 const int num_jacktrips = 5;
-const int base_port = 4464;
-
+const int base_port     = 4464;
 
 void main_tests(int argc, char** argv);
 void test_threads_server();
 void test_threads_client(const char* peer_address);
 
-
 void main_tests(int /*argc*/, char** argv)
 {
-    if (argv[1][0] == 's' )
-    {
+    if (argv[1][0] == 's') {
         test_threads_server();
-    }
-    else if (argv[1][0] == 'c' )
-    {
+    } else if (argv[1][0] == 'c') {
         test_threads_client("171.64.197.209");
     }
 }
-
 
 // Test many servers running at the same time
 void test_threads_server()
@@ -71,9 +65,8 @@ void test_threads_server()
     QVector<JackTripThread*> jacktrips;
     jacktrips.resize(num_jacktrips);
     int port_num;
-    for (int i = 0; i < num_jacktrips; i++)
-    {
-        port_num = base_port + i*10;
+    for (int i = 0; i < num_jacktrips; i++) {
+        port_num = base_port + i * 10;
         cout << "Port Number: " << port_num << endl;
         jacktrips[i] = new JackTripThread(JackTrip::SERVER);
         jacktrips[i]->setPort(port_num);
@@ -82,16 +75,14 @@ void test_threads_server()
     }
 }
 
-
 // Test many servers running at the same time
 void test_threads_client(const char* peer_address)
 {
     QVector<JackTripThread*> jacktrips;
     jacktrips.resize(num_jacktrips);
     int port_num;
-    for (int i = 0; i < num_jacktrips; i++)
-    {
-        port_num = base_port + i*10;
+    for (int i = 0; i < num_jacktrips; i++) {
+        port_num = base_port + i * 10;
         cout << "Port Number: " << port_num << endl;
         jacktrips[i] = new JackTripThread(JackTrip::CLIENT);
         jacktrips[i]->setPort(port_num);

--- a/src/jacktrip_types.h
+++ b/src/jacktrip_types.h
@@ -35,55 +35,53 @@
  * \date June 2008
  */
 
-
 #ifndef __JACKTRIP_TYPES_H__
 #define __JACKTRIP_TYPES_H__
 
 //#include <jack/types.h>
-#include <QtGlobal> //For QT4 types
+#include <QtGlobal>  //For QT4 types
 
 //namespace JackTripNamespace
 //{
 
-  //-------------------------------------------------------------------------------
-  /** \name Audio typedefs
+//-------------------------------------------------------------------------------
+/** \name Audio typedefs
  *
  */
-  //-------------------------------------------------------------------------------
-  //@{
-  /// Audio sample type
-  //typedef jack_default_audio_sample_t sample_t;
-  typedef float sample_t;
-  //@}
+//-------------------------------------------------------------------------------
+//@{
+/// Audio sample type
+//typedef jack_default_audio_sample_t sample_t;
+typedef float sample_t;
+//@}
 
-
-  //-------------------------------------------------------------------------------
-  /** \name Typedefs that guaranty some specific bit length
+//-------------------------------------------------------------------------------
+/** \name Typedefs that guaranty some specific bit length
  *
  * It uses the QT4 types. This can be changed in the future, keeping
  * compatibility for the rest of the code.
  */
-  //-------------------------------------------------------------------------------
-  //@{
-  /// Typedef for <tt>unsigned char</tt>. This type is guaranteed to be 8-bit.
-  typedef quint8 uint8_t;
-  /// Typedef for <tt>unsigned short</tt>. This type is guaranteed to be 16-bit.
-  typedef quint16 uint16_t;
-  /// Typedef for <tt>unsigned int</tt>. This type is guaranteed to be 32-bit.
-  typedef quint32 uint32_t;
-  /// \brief Typedef for <tt>unsigned long long int</tt>. This type is guaranteed to
-  /// be 64-bit.
-  //typedef quint64 uint64_t;
-  /// Typedef for <tt>signed char</tt>. This type is guaranteed to be 8-bit.
-  typedef qint8 int8_t;
-  /// Typedef for <tt>signed short</tt>. This type is guaranteed to be 16-bit.
-  typedef qint16 int16_t;
-  /// Typedef for <tt>signed int</tt>. This type is guaranteed to be 32-bit.
-  typedef qint32 int32_t;
-  /// \brief Typedef for <tt>long long int</tt>. This type is guaranteed to
-  /// be 64-bit.
-  //typedef qint64 int64_t;
-  //@}
+//-------------------------------------------------------------------------------
+//@{
+/// Typedef for <tt>unsigned char</tt>. This type is guaranteed to be 8-bit.
+typedef quint8 uint8_t;
+/// Typedef for <tt>unsigned short</tt>. This type is guaranteed to be 16-bit.
+typedef quint16 uint16_t;
+/// Typedef for <tt>unsigned int</tt>. This type is guaranteed to be 32-bit.
+typedef quint32 uint32_t;
+/// \brief Typedef for <tt>unsigned long long int</tt>. This type is guaranteed to
+/// be 64-bit.
+//typedef quint64 uint64_t;
+/// Typedef for <tt>signed char</tt>. This type is guaranteed to be 8-bit.
+typedef qint8 int8_t;
+/// Typedef for <tt>signed short</tt>. This type is guaranteed to be 16-bit.
+typedef qint16 int16_t;
+/// Typedef for <tt>signed int</tt>. This type is guaranteed to be 32-bit.
+typedef qint32 int32_t;
+/// \brief Typedef for <tt>long long int</tt>. This type is guaranteed to
+/// be 64-bit.
+//typedef qint64 int64_t;
+//@}
 //} // end of namespace JackTripNamespace
 
 #endif

--- a/src/limiterdsp.h
+++ b/src/limiterdsp.h
@@ -4,8 +4,8 @@ Code generated with Faust 2.28.6 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -scal -ftz 0
 ------------------------------------------------------------ */
 
-#ifndef  __limiterdsp_H__
-#define  __limiterdsp_H__
+#ifndef __limiterdsp_H__
+#define __limiterdsp_H__
 
 // NOTE: ANY INCLUDE-GUARD HERE MUST BE DERIVED FROM THE CLASS NAME
 //
@@ -56,86 +56,83 @@ struct Meta;
  */
 
 struct dsp_memory_manager {
-    
     virtual ~dsp_memory_manager() {}
-    
+
     virtual void* allocate(size_t size) = 0;
-    virtual void destroy(void* ptr) = 0;
-    
+    virtual void destroy(void* ptr)     = 0;
 };
 
 /**
 * Signal processor definition.
 */
 
-class dsp {
+class dsp
+{
+   public:
+    dsp() {}
+    virtual ~dsp() {}
 
-    public:
+    /* Return instance number of audio inputs */
+    virtual int getNumInputs() = 0;
 
-        dsp() {}
-        virtual ~dsp() {}
+    /* Return instance number of audio outputs */
+    virtual int getNumOutputs() = 0;
 
-        /* Return instance number of audio inputs */
-        virtual int getNumInputs() = 0;
-    
-        /* Return instance number of audio outputs */
-        virtual int getNumOutputs() = 0;
-    
-        /**
+    /**
          * Trigger the ui_interface parameter with instance specific calls
          * to 'openTabBox', 'addButton', 'addVerticalSlider'... in order to build the UI.
          *
          * @param ui_interface - the user interface builder
          */
-        virtual void buildUserInterface(UI* ui_interface) = 0;
-    
-        /* Returns the sample rate currently used by the instance */
-        virtual int getSampleRate() = 0;
-    
-        /**
+    virtual void buildUserInterface(UI* ui_interface) = 0;
+
+    /* Returns the sample rate currently used by the instance */
+    virtual int getSampleRate() = 0;
+
+    /**
          * Global init, calls the following methods:
          * - static class 'classInit': static tables initialization
          * - 'instanceInit': constants and instance state initialization
          *
          * @param sample_rate - the sampling rate in Hertz
          */
-        virtual void init(int sample_rate) = 0;
+    virtual void init(int sample_rate) = 0;
 
-        /**
+    /**
          * Init instance state
          *
          * @param sample_rate - the sampling rate in Hertz
          */
-        virtual void instanceInit(int sample_rate) = 0;
+    virtual void instanceInit(int sample_rate) = 0;
 
-        /**
+    /**
          * Init instance constant state
          *
          * @param sample_rate - the sampling rate in Hertz
          */
-        virtual void instanceConstants(int sample_rate) = 0;
-    
-        /* Init default control parameters values */
-        virtual void instanceResetUserInterface() = 0;
-    
-        /* Init instance state (delay lines...) */
-        virtual void instanceClear() = 0;
- 
-        /**
+    virtual void instanceConstants(int sample_rate) = 0;
+
+    /* Init default control parameters values */
+    virtual void instanceResetUserInterface() = 0;
+
+    /* Init instance state (delay lines...) */
+    virtual void instanceClear() = 0;
+
+    /**
          * Return a clone of the instance.
          *
          * @return a copy of the instance on success, otherwise a null pointer.
          */
-        virtual dsp* clone() = 0;
-    
-        /**
+    virtual dsp* clone() = 0;
+
+    /**
          * Trigger the Meta* parameter with instance specific calls to 'declare' (key, value) metadata.
          *
          * @param m - the Meta* meta user
          */
-        virtual void metadata(Meta* m) = 0;
-    
-        /**
+    virtual void metadata(Meta* m) = 0;
+
+    /**
          * DSP instance computation, to be called with successive in/out audio buffers.
          *
          * @param count - the number of frames to compute
@@ -143,9 +140,9 @@ class dsp {
          * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
          *
          */
-        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
-    
-        /**
+    virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
+
+    /**
          * DSP instance computation: alternative method to be used by subclasses.
          *
          * @param date_usec - the timestamp in microsec given by audio driver.
@@ -154,67 +151,77 @@ class dsp {
          * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (either float, double or quad)
          *
          */
-        virtual void compute(double /*date_usec*/, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
-       
+    virtual void compute(double /*date_usec*/, int count, FAUSTFLOAT** inputs,
+                         FAUSTFLOAT** outputs)
+    {
+        compute(count, inputs, outputs);
+    }
 };
 
 /**
  * Generic DSP decorator.
  */
 
-class decorator_dsp : public dsp {
+class decorator_dsp : public dsp
+{
+   protected:
+    dsp* fDSP;
 
-    protected:
+   public:
+    decorator_dsp(dsp* dsp = nullptr) : fDSP(dsp) {}
+    virtual ~decorator_dsp() { delete fDSP; }
 
-        dsp* fDSP;
-
-    public:
-
-        decorator_dsp(dsp* dsp = nullptr):fDSP(dsp) {}
-        virtual ~decorator_dsp() { delete fDSP; }
-
-        virtual int getNumInputs() { return fDSP->getNumInputs(); }
-        virtual int getNumOutputs() { return fDSP->getNumOutputs(); }
-        virtual void buildUserInterface(UI* ui_interface) { fDSP->buildUserInterface(ui_interface); }
-        virtual int getSampleRate() { return fDSP->getSampleRate(); }
-        virtual void init(int sample_rate) { fDSP->init(sample_rate); }
-        virtual void instanceInit(int sample_rate) { fDSP->instanceInit(sample_rate); }
-        virtual void instanceConstants(int sample_rate) { fDSP->instanceConstants(sample_rate); }
-        virtual void instanceResetUserInterface() { fDSP->instanceResetUserInterface(); }
-        virtual void instanceClear() { fDSP->instanceClear(); }
-        virtual decorator_dsp* clone() { return new decorator_dsp(fDSP->clone()); }
-        virtual void metadata(Meta* m) { fDSP->metadata(m); }
-        // Beware: subclasses usually have to overload the two 'compute' methods
-        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(count, inputs, outputs); }
-        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(date_usec, count, inputs, outputs); }
-    
+    virtual int getNumInputs() { return fDSP->getNumInputs(); }
+    virtual int getNumOutputs() { return fDSP->getNumOutputs(); }
+    virtual void buildUserInterface(UI* ui_interface)
+    {
+        fDSP->buildUserInterface(ui_interface);
+    }
+    virtual int getSampleRate() { return fDSP->getSampleRate(); }
+    virtual void init(int sample_rate) { fDSP->init(sample_rate); }
+    virtual void instanceInit(int sample_rate) { fDSP->instanceInit(sample_rate); }
+    virtual void instanceConstants(int sample_rate)
+    {
+        fDSP->instanceConstants(sample_rate);
+    }
+    virtual void instanceResetUserInterface() { fDSP->instanceResetUserInterface(); }
+    virtual void instanceClear() { fDSP->instanceClear(); }
+    virtual decorator_dsp* clone() { return new decorator_dsp(fDSP->clone()); }
+    virtual void metadata(Meta* m) { fDSP->metadata(m); }
+    // Beware: subclasses usually have to overload the two 'compute' methods
+    virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+    {
+        fDSP->compute(count, inputs, outputs);
+    }
+    virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs,
+                         FAUSTFLOAT** outputs)
+    {
+        fDSP->compute(date_usec, count, inputs, outputs);
+    }
 };
 
 /**
  * DSP factory class.
  */
 
-class dsp_factory {
-    
-    protected:
-    
-        // So that to force sub-classes to use deleteDSPFactory(dsp_factory* factory);
-        virtual ~dsp_factory() {}
-    
-    public:
-    
-        virtual std::string getName() = 0;
-        virtual std::string getSHAKey() = 0;
-        virtual std::string getDSPCode() = 0;
-        virtual std::string getCompileOptions() = 0;
-        virtual std::vector<std::string> getLibraryList() = 0;
-        virtual std::vector<std::string> getIncludePathnames() = 0;
-    
-        virtual dsp* createDSPInstance() = 0;
-    
-        virtual void setMemoryManager(dsp_memory_manager* manager) = 0;
-        virtual dsp_memory_manager* getMemoryManager() = 0;
-    
+class dsp_factory
+{
+   protected:
+    // So that to force sub-classes to use deleteDSPFactory(dsp_factory* factory);
+    virtual ~dsp_factory() {}
+
+   public:
+    virtual std::string getName()                          = 0;
+    virtual std::string getSHAKey()                        = 0;
+    virtual std::string getDSPCode()                       = 0;
+    virtual std::string getCompileOptions()                = 0;
+    virtual std::vector<std::string> getLibraryList()      = 0;
+    virtual std::vector<std::string> getIncludePathnames() = 0;
+
+    virtual dsp* createDSPInstance() = 0;
+
+    virtual void setMemoryManager(dsp_memory_manager* manager) = 0;
+    virtual dsp_memory_manager* getMemoryManager()             = 0;
 };
 
 /**
@@ -223,14 +230,14 @@ class dsp_factory {
  */
 
 #ifdef __SSE__
-    #include <xmmintrin.h>
-    #ifdef __SSE2__
-        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8040)
-    #else
-        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8000)
-    #endif
+#include <xmmintrin.h>
+#ifdef __SSE2__
+#define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8040)
 #else
-    #define AVOIDDENORMALS
+#define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8000)
+#endif
+#else
+#define AVOIDDENORMALS
 #endif
 
 #endif
@@ -263,11 +270,11 @@ class dsp_factory {
 #ifndef API_UI_H
 #define API_UI_H
 
+#include <iostream>
+#include <map>
 #include <sstream>
 #include <string>
 #include <vector>
-#include <iostream>
-#include <map>
 
 /************************** BEGIN meta.h **************************/
 /************************************************************************
@@ -296,11 +303,9 @@ class dsp_factory {
 #ifndef __meta__
 #define __meta__
 
-struct Meta
-{
-    virtual ~Meta() {};
+struct Meta {
+    virtual ~Meta(){};
     virtual void declare(const char* key, const char* value) = 0;
-    
 };
 
 #endif
@@ -345,43 +350,47 @@ struct Meta
 
 struct Soundfile;
 
-template <typename REAL>
-struct UIReal
-{
+template<typename REAL>
+struct UIReal {
     UIReal() {}
     virtual ~UIReal() {}
-    
+
     // -- widget's layouts
-    
-    virtual void openTabBox(const char* label) = 0;
+
+    virtual void openTabBox(const char* label)        = 0;
     virtual void openHorizontalBox(const char* label) = 0;
-    virtual void openVerticalBox(const char* label) = 0;
-    virtual void closeBox() = 0;
-    
+    virtual void openVerticalBox(const char* label)   = 0;
+    virtual void closeBox()                           = 0;
+
     // -- active widgets
-    
-    virtual void addButton(const char* label, REAL* zone) = 0;
+
+    virtual void addButton(const char* label, REAL* zone)      = 0;
     virtual void addCheckButton(const char* label, REAL* zone) = 0;
-    virtual void addVerticalSlider(const char* label, REAL* zone, REAL init, REAL min, REAL max, REAL step) = 0;
-    virtual void addHorizontalSlider(const char* label, REAL* zone, REAL init, REAL min, REAL max, REAL step) = 0;
-    virtual void addNumEntry(const char* label, REAL* zone, REAL init, REAL min, REAL max, REAL step) = 0;
-    
+    virtual void addVerticalSlider(const char* label, REAL* zone, REAL init, REAL min,
+                                   REAL max, REAL step)        = 0;
+    virtual void addHorizontalSlider(const char* label, REAL* zone, REAL init, REAL min,
+                                     REAL max, REAL step)      = 0;
+    virtual void addNumEntry(const char* label, REAL* zone, REAL init, REAL min, REAL max,
+                             REAL step)                        = 0;
+
     // -- passive widgets
-    
-    virtual void addHorizontalBargraph(const char* label, REAL* zone, REAL min, REAL max) = 0;
-    virtual void addVerticalBargraph(const char* label, REAL* zone, REAL min, REAL max) = 0;
-    
+
+    virtual void addHorizontalBargraph(const char* label, REAL* zone, REAL min,
+                                       REAL max) = 0;
+    virtual void addVerticalBargraph(const char* label, REAL* zone, REAL min,
+                                     REAL max)   = 0;
+
     // -- soundfiles
-    
-    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) = 0;
-    
+
+    virtual void addSoundfile(const char* label, const char* filename,
+                              Soundfile** sf_zone) = 0;
+
     // -- metadata declarations
-    
+
     virtual void declare(REAL* zone, const char* key, const char* val) {}
 };
 
-struct UI : public UIReal<FAUSTFLOAT>
-{
+struct UI : public UIReal<FAUSTFLOAT> {
     UI() {}
     virtual ~UI() {}
 };
@@ -415,9 +424,9 @@ struct UI : public UIReal<FAUSTFLOAT>
 #ifndef FAUST_PATHBUILDER_H
 #define FAUST_PATHBUILDER_H
 
-#include <vector>
-#include <string>
 #include <algorithm>
+#include <string>
+#include <vector>
 
 /*******************************************************************************
  * PathBuilder : Faust User Interface
@@ -426,37 +435,33 @@ struct UI : public UIReal<FAUSTFLOAT>
 
 class PathBuilder
 {
+   protected:
+    std::vector<std::string> fControlsLevel;
 
-    protected:
-    
-        std::vector<std::string> fControlsLevel;
-       
-    public:
-    
-        PathBuilder() {}
-        virtual ~PathBuilder() {}
-    
-        std::string buildPath(const std::string& label) 
-        {
-            std::string res = "/";
-            for (size_t i = 0; i < fControlsLevel.size(); i++) {
-                res += fControlsLevel[i];
-                res += "/";
-            }
-            res += label;
-            std::replace(res.begin(), res.end(), ' ', '_');
-            return res;
+   public:
+    PathBuilder() {}
+    virtual ~PathBuilder() {}
+
+    std::string buildPath(const std::string& label)
+    {
+        std::string res = "/";
+        for (size_t i = 0; i < fControlsLevel.size(); i++) {
+            res += fControlsLevel[i];
+            res += "/";
         }
-    
-        std::string buildLabel(std::string label)
-        {
-            std::replace(label.begin(), label.end(), ' ', '_');
-            return label;
-        }
-    
-        void pushLabel(const std::string& label) { fControlsLevel.push_back(label); }
-        void popLabel() { fControlsLevel.pop_back(); }
-    
+        res += label;
+        std::replace(res.begin(), res.end(), ' ', '_');
+        return res;
+    }
+
+    std::string buildLabel(std::string label)
+    {
+        std::replace(label.begin(), label.end(), ' ', '_');
+        return label;
+    }
+
+    void pushLabel(const std::string& label) { fControlsLevel.push_back(label); }
+    void popLabel() { fControlsLevel.pop_back(); }
 };
 
 #endif  // FAUST_PATHBUILDER_H
@@ -531,11 +536,12 @@ ZoneReader(zone, valueConverter) : a zone with a data converter
 
 ****************************************************************************************/
 
+#include <assert.h>
 #include <float.h>
-#include <algorithm>    // std::max
+
+#include <algorithm>  // std::max
 #include <cmath>
 #include <vector>
-#include <assert.h>
 
 //--------------------------------------------------------------------------------------
 // Interpolator(lo,hi,v1,v2)
@@ -548,50 +554,49 @@ ZoneReader(zone, valueConverter) : a zone with a data converter
 //--------------------------------------------------------------------------------------
 class Interpolator
 {
-    private:
+   private:
+    //--------------------------------------------------------------------------------------
+    // Range(lo,hi) clip a value between lo and hi
+    //--------------------------------------------------------------------------------------
+    struct Range {
+        double fLo;
+        double fHi;
 
-        //--------------------------------------------------------------------------------------
-        // Range(lo,hi) clip a value between lo and hi
-        //--------------------------------------------------------------------------------------
-        struct Range
+        Range(double x, double y)
+            : fLo(std::min<double>(x, y)), fHi(std::max<double>(x, y))
         {
-            double fLo;
-            double fHi;
-
-            Range(double x, double y) : fLo(std::min<double>(x,y)), fHi(std::max<double>(x,y)) {}
-            double operator()(double x) { return (x<fLo) ? fLo : (x>fHi) ? fHi : x; }
-        };
-
-
-        Range fRange;
-        double fCoef;
-        double fOffset;
-
-    public:
-
-        Interpolator(double lo, double hi, double v1, double v2) : fRange(lo,hi)
-        {
-            if (hi != lo) {
-                // regular case
-                fCoef = (v2-v1)/(hi-lo);
-                fOffset = v1 - lo*fCoef;
-            } else {
-                // degenerate case, avoids division by zero
-                fCoef = 0;
-                fOffset = (v1+v2)/2;
-            }
         }
-        double operator()(double v)
-        {
-            double x = fRange(v);
-            return  fOffset + x*fCoef;
-        }
+        double operator()(double x) { return (x < fLo) ? fLo : (x > fHi) ? fHi : x; }
+    };
 
-        void getLowHigh(double& amin, double& amax)
-        {
-            amin = fRange.fLo;
-            amax = fRange.fHi;
+    Range fRange;
+    double fCoef;
+    double fOffset;
+
+   public:
+    Interpolator(double lo, double hi, double v1, double v2) : fRange(lo, hi)
+    {
+        if (hi != lo) {
+            // regular case
+            fCoef   = (v2 - v1) / (hi - lo);
+            fOffset = v1 - lo * fCoef;
+        } else {
+            // degenerate case, avoids division by zero
+            fCoef   = 0;
+            fOffset = (v1 + v2) / 2;
         }
+    }
+    double operator()(double v)
+    {
+        double x = fRange(v);
+        return fOffset + x * fCoef;
+    }
+
+    void getLowHigh(double& amin, double& amax)
+    {
+        amin = fRange.fLo;
+        amax = fRange.fHi;
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -600,26 +605,23 @@ class Interpolator
 //--------------------------------------------------------------------------------------
 class Interpolator3pt
 {
+   private:
+    Interpolator fSegment1;
+    Interpolator fSegment2;
+    double fMid;
 
-    private:
+   public:
+    Interpolator3pt(double lo, double mi, double hi, double v1, double vm, double v2)
+        : fSegment1(lo, mi, v1, vm), fSegment2(mi, hi, vm, v2), fMid(mi)
+    {
+    }
+    double operator()(double x) { return (x < fMid) ? fSegment1(x) : fSegment2(x); }
 
-        Interpolator fSegment1;
-        Interpolator fSegment2;
-        double fMid;
-
-    public:
-
-        Interpolator3pt(double lo, double mi, double hi, double v1, double vm, double v2) :
-            fSegment1(lo, mi, v1, vm),
-            fSegment2(mi, hi, vm, v2),
-            fMid(mi) {}
-        double operator()(double x) { return  (x < fMid) ? fSegment1(x) : fSegment2(x); }
-
-        void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fSegment1.getLowHigh(amin, amid);
-            fSegment2.getLowHigh(amid, amax);
-        }
+    void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fSegment1.getLowHigh(amin, amid);
+        fSegment2.getLowHigh(amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -627,62 +629,51 @@ class Interpolator3pt
 //--------------------------------------------------------------------------------------
 class ValueConverter
 {
-
-    public:
-
-        virtual ~ValueConverter() {}
-        virtual double ui2faust(double x) = 0;
-        virtual double faust2ui(double x) = 0;
+   public:
+    virtual ~ValueConverter() {}
+    virtual double ui2faust(double x) = 0;
+    virtual double faust2ui(double x) = 0;
 };
 
 //--------------------------------------------------------------------------------------
 // A converter than can be updated
 //--------------------------------------------------------------------------------------
 
-class UpdatableValueConverter : public ValueConverter {
-    
-    protected:
-        
-        bool fActive;
-        
-    public:
-        
-        UpdatableValueConverter():fActive(true)
-        {}
-        virtual ~UpdatableValueConverter()
-        {}
-        
-        virtual void setMappingValues(double amin, double amid, double amax, double min, double init, double max) = 0;
-        virtual void getMappingValues(double& amin, double& amid, double& amax) = 0;
-        
-        void setActive(bool on_off) { fActive = on_off; }
-        bool getActive() { return fActive; }
-    
-};
+class UpdatableValueConverter : public ValueConverter
+{
+   protected:
+    bool fActive;
 
+   public:
+    UpdatableValueConverter() : fActive(true) {}
+    virtual ~UpdatableValueConverter() {}
+
+    virtual void setMappingValues(double amin, double amid, double amax, double min,
+                                  double init, double max)                  = 0;
+    virtual void getMappingValues(double& amin, double& amid, double& amax) = 0;
+
+    void setActive(bool on_off) { fActive = on_off; }
+    bool getActive() { return fActive; }
+};
 
 //--------------------------------------------------------------------------------------
 // Linear conversion between ui and Faust values
 //--------------------------------------------------------------------------------------
 class LinearValueConverter : public ValueConverter
 {
-    
-    private:
-        
-        Interpolator fUI2F;
-        Interpolator fF2UI;
-        
-    public:
-        
-        LinearValueConverter(double umin, double umax, double fmin, double fmax) :
-            fUI2F(umin,umax,fmin,fmax), fF2UI(fmin,fmax,umin,umax)
-        {}
-        
-        LinearValueConverter() : fUI2F(0.,0.,0.,0.), fF2UI(0.,0.,0.,0.)
-        {}
-        virtual double ui2faust(double x) { return fUI2F(x); }
-        virtual double faust2ui(double x) { return fF2UI(x); }
-    
+   private:
+    Interpolator fUI2F;
+    Interpolator fF2UI;
+
+   public:
+    LinearValueConverter(double umin, double umax, double fmin, double fmax)
+        : fUI2F(umin, umax, fmin, fmax), fF2UI(fmin, fmax, umin, umax)
+    {
+    }
+
+    LinearValueConverter() : fUI2F(0., 0., 0., 0.), fF2UI(0., 0., 0., 0.) {}
+    virtual double ui2faust(double x) { return fUI2F(x); }
+    virtual double faust2ui(double x) { return fF2UI(x); }
 };
 
 //--------------------------------------------------------------------------------------
@@ -690,35 +681,35 @@ class LinearValueConverter : public ValueConverter
 //--------------------------------------------------------------------------------------
 class LinearValueConverter2 : public UpdatableValueConverter
 {
-    
-    private:
-    
-        Interpolator3pt fUI2F;
-        Interpolator3pt fF2UI;
-        
-    public:
-    
-        LinearValueConverter2(double amin, double amid, double amax, double min, double init, double max) :
-            fUI2F(amin, amid, amax, min, init, max), fF2UI(min, init, max, amin, amid, amax)
-        {}
-        
-        LinearValueConverter2() : fUI2F(0.,0.,0.,0.,0.,0.), fF2UI(0.,0.,0.,0.,0.,0.)
-        {}
-    
-        virtual double ui2faust(double x) { return fUI2F(x); }
-        virtual double faust2ui(double x) { return fF2UI(x); }
-    
-        virtual void setMappingValues(double amin, double amid, double amax, double min, double init, double max)
-        {
-            fUI2F = Interpolator3pt(amin, amid, amax, min, init, max);
-            fF2UI = Interpolator3pt(min, init, max, amin, amid, amax);
-        }
+   private:
+    Interpolator3pt fUI2F;
+    Interpolator3pt fF2UI;
 
-        virtual void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fUI2F.getMappingValues(amin, amid, amax);
-        }
-    
+   public:
+    LinearValueConverter2(double amin, double amid, double amax, double min, double init,
+                          double max)
+        : fUI2F(amin, amid, amax, min, init, max), fF2UI(min, init, max, amin, amid, amax)
+    {
+    }
+
+    LinearValueConverter2() : fUI2F(0., 0., 0., 0., 0., 0.), fF2UI(0., 0., 0., 0., 0., 0.)
+    {
+    }
+
+    virtual double ui2faust(double x) { return fUI2F(x); }
+    virtual double faust2ui(double x) { return fF2UI(x); }
+
+    virtual void setMappingValues(double amin, double amid, double amax, double min,
+                                  double init, double max)
+    {
+        fUI2F = Interpolator3pt(amin, amid, amax, min, init, max);
+        fF2UI = Interpolator3pt(min, init, max, amin, amid, amax);
+    }
+
+    virtual void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fUI2F.getMappingValues(amin, amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -726,16 +717,21 @@ class LinearValueConverter2 : public UpdatableValueConverter
 //--------------------------------------------------------------------------------------
 class LogValueConverter : public LinearValueConverter
 {
+   public:
+    LogValueConverter(double umin, double umax, double fmin, double fmax)
+        : LinearValueConverter(umin, umax, std::log(std::max<double>(DBL_MIN, fmin)),
+                               std::log(std::max<double>(DBL_MIN, fmax)))
+    {
+    }
 
-    public:
-
-        LogValueConverter(double umin, double umax, double fmin, double fmax) :
-            LinearValueConverter(umin, umax, std::log(std::max<double>(DBL_MIN, fmin)), std::log(std::max<double>(DBL_MIN, fmax)))
-        {}
-
-        virtual double ui2faust(double x) { return std::exp(LinearValueConverter::ui2faust(x)); }
-        virtual double faust2ui(double x) { return LinearValueConverter::faust2ui(std::log(std::max<double>(x, DBL_MIN))); }
-
+    virtual double ui2faust(double x)
+    {
+        return std::exp(LinearValueConverter::ui2faust(x));
+    }
+    virtual double faust2ui(double x)
+    {
+        return LinearValueConverter::faust2ui(std::log(std::max<double>(x, DBL_MIN)));
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -743,16 +739,21 @@ class LogValueConverter : public LinearValueConverter
 //--------------------------------------------------------------------------------------
 class ExpValueConverter : public LinearValueConverter
 {
+   public:
+    ExpValueConverter(double umin, double umax, double fmin, double fmax)
+        : LinearValueConverter(umin, umax, std::min<double>(DBL_MAX, std::exp(fmin)),
+                               std::min<double>(DBL_MAX, std::exp(fmax)))
+    {
+    }
 
-    public:
-
-        ExpValueConverter(double umin, double umax, double fmin, double fmax) :
-            LinearValueConverter(umin, umax, std::min<double>(DBL_MAX, std::exp(fmin)), std::min<double>(DBL_MAX, std::exp(fmax)))
-        {}
-
-        virtual double ui2faust(double x) { return std::log(LinearValueConverter::ui2faust(x)); }
-        virtual double faust2ui(double x) { return LinearValueConverter::faust2ui(std::min<double>(DBL_MAX, std::exp(x))); }
-
+    virtual double ui2faust(double x)
+    {
+        return std::log(LinearValueConverter::ui2faust(x));
+    }
+    virtual double faust2ui(double x)
+    {
+        return LinearValueConverter::faust2ui(std::min<double>(DBL_MAX, std::exp(x)));
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -761,34 +762,33 @@ class ExpValueConverter : public LinearValueConverter
 //--------------------------------------------------------------------------------------
 class AccUpConverter : public UpdatableValueConverter
 {
+   private:
+    Interpolator3pt fA2F;
+    Interpolator3pt fF2A;
 
-    private:
+   public:
+    AccUpConverter(double amin, double amid, double amax, double fmin, double fmid,
+                   double fmax)
+        : fA2F(amin, amid, amax, fmin, fmid, fmax)
+        , fF2A(fmin, fmid, fmax, amin, amid, amax)
+    {
+    }
 
-        Interpolator3pt fA2F;
-        Interpolator3pt fF2A;
+    virtual double ui2faust(double x) { return fA2F(x); }
+    virtual double faust2ui(double x) { return fF2A(x); }
 
-    public:
+    virtual void setMappingValues(double amin, double amid, double amax, double fmin,
+                                  double fmid, double fmax)
+    {
+        //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccUpConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
+        fA2F = Interpolator3pt(amin, amid, amax, fmin, fmid, fmax);
+        fF2A = Interpolator3pt(fmin, fmid, fmax, amin, amid, amax);
+    }
 
-        AccUpConverter(double amin, double amid, double amax, double fmin, double fmid, double fmax) :
-            fA2F(amin,amid,amax,fmin,fmid,fmax),
-            fF2A(fmin,fmid,fmax,amin,amid,amax)
-        {}
-
-        virtual double ui2faust(double x) { return fA2F(x); }
-        virtual double faust2ui(double x) { return fF2A(x); }
-
-        virtual void setMappingValues(double amin, double amid, double amax, double fmin, double fmid, double fmax)
-        {
-            //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccUpConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
-            fA2F = Interpolator3pt(amin, amid, amax, fmin, fmid, fmax);
-            fF2A = Interpolator3pt(fmin, fmid, fmax, amin, amid, amax);
-        }
-
-        virtual void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fA2F.getMappingValues(amin, amid, amax);
-        }
-
+    virtual void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fA2F.getMappingValues(amin, amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -797,33 +797,33 @@ class AccUpConverter : public UpdatableValueConverter
 //--------------------------------------------------------------------------------------
 class AccDownConverter : public UpdatableValueConverter
 {
+   private:
+    Interpolator3pt fA2F;
+    Interpolator3pt fF2A;
 
-    private:
+   public:
+    AccDownConverter(double amin, double amid, double amax, double fmin, double fmid,
+                     double fmax)
+        : fA2F(amin, amid, amax, fmax, fmid, fmin)
+        , fF2A(fmin, fmid, fmax, amax, amid, amin)
+    {
+    }
 
-        Interpolator3pt	fA2F;
-        Interpolator3pt	fF2A;
+    virtual double ui2faust(double x) { return fA2F(x); }
+    virtual double faust2ui(double x) { return fF2A(x); }
 
-    public:
+    virtual void setMappingValues(double amin, double amid, double amax, double fmin,
+                                  double fmid, double fmax)
+    {
+        //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccDownConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
+        fA2F = Interpolator3pt(amin, amid, amax, fmax, fmid, fmin);
+        fF2A = Interpolator3pt(fmin, fmid, fmax, amax, amid, amin);
+    }
 
-        AccDownConverter(double amin, double amid, double amax, double fmin, double fmid, double fmax) :
-            fA2F(amin,amid,amax,fmax,fmid,fmin),
-            fF2A(fmin,fmid,fmax,amax,amid,amin)
-        {}
-
-        virtual double ui2faust(double x) { return fA2F(x); }
-        virtual double faust2ui(double x) { return fF2A(x); }
-
-        virtual void setMappingValues(double amin, double amid, double amax, double fmin, double fmid, double fmax)
-        {
-             //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccDownConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
-            fA2F = Interpolator3pt(amin, amid, amax, fmax, fmid, fmin);
-            fF2A = Interpolator3pt(fmin, fmid, fmax, amax, amid, amin);
-        }
-
-        virtual void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fA2F.getMappingValues(amin, amid, amax);
-        }
+    virtual void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fA2F.getMappingValues(amin, amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -832,33 +832,34 @@ class AccDownConverter : public UpdatableValueConverter
 //--------------------------------------------------------------------------------------
 class AccUpDownConverter : public UpdatableValueConverter
 {
+   private:
+    Interpolator3pt fA2F;
+    Interpolator fF2A;
 
-    private:
+   public:
+    AccUpDownConverter(double amin, double amid, double amax, double fmin, double fmid,
+                       double fmax)
+        : fA2F(amin, amid, amax, fmin, fmax, fmin)
+        , fF2A(fmin, fmax, amin,
+               amax)  // Special, pseudo inverse of a non monotonic function
+    {
+    }
 
-        Interpolator3pt	fA2F;
-        Interpolator fF2A;
+    virtual double ui2faust(double x) { return fA2F(x); }
+    virtual double faust2ui(double x) { return fF2A(x); }
 
-    public:
+    virtual void setMappingValues(double amin, double amid, double amax, double fmin,
+                                  double fmid, double fmax)
+    {
+        //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccUpDownConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
+        fA2F = Interpolator3pt(amin, amid, amax, fmin, fmax, fmin);
+        fF2A = Interpolator(fmin, fmax, amin, amax);
+    }
 
-        AccUpDownConverter(double amin, double amid, double amax, double fmin, double fmid, double fmax) :
-            fA2F(amin,amid,amax,fmin,fmax,fmin),
-            fF2A(fmin,fmax,amin,amax)				// Special, pseudo inverse of a non monotonic function
-        {}
-
-        virtual double ui2faust(double x) { return fA2F(x); }
-        virtual double faust2ui(double x) { return fF2A(x); }
-
-        virtual void setMappingValues(double amin, double amid, double amax, double fmin, double fmid, double fmax)
-        {
-            //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccUpDownConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
-            fA2F = Interpolator3pt(amin, amid, amax, fmin, fmax, fmin);
-            fF2A = Interpolator(fmin, fmax, amin, amax);
-        }
-
-        virtual void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fA2F.getMappingValues(amin, amid, amax);
-        }
+    virtual void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fA2F.getMappingValues(amin, amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -867,33 +868,34 @@ class AccUpDownConverter : public UpdatableValueConverter
 //--------------------------------------------------------------------------------------
 class AccDownUpConverter : public UpdatableValueConverter
 {
+   private:
+    Interpolator3pt fA2F;
+    Interpolator fF2A;
 
-    private:
+   public:
+    AccDownUpConverter(double amin, double amid, double amax, double fmin, double fmid,
+                       double fmax)
+        : fA2F(amin, amid, amax, fmax, fmin, fmax)
+        , fF2A(fmin, fmax, amin,
+               amax)  // Special, pseudo inverse of a non monotonic function
+    {
+    }
 
-        Interpolator3pt	fA2F;
-        Interpolator fF2A;
+    virtual double ui2faust(double x) { return fA2F(x); }
+    virtual double faust2ui(double x) { return fF2A(x); }
 
-    public:
+    virtual void setMappingValues(double amin, double amid, double amax, double fmin,
+                                  double fmid, double fmax)
+    {
+        //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccDownUpConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
+        fA2F = Interpolator3pt(amin, amid, amax, fmax, fmin, fmax);
+        fF2A = Interpolator(fmin, fmax, amin, amax);
+    }
 
-        AccDownUpConverter(double amin, double amid, double amax, double fmin, double fmid, double fmax) :
-            fA2F(amin,amid,amax,fmax,fmin,fmax),
-            fF2A(fmin,fmax,amin,amax)				// Special, pseudo inverse of a non monotonic function
-        {}
-
-        virtual double ui2faust(double x) { return fA2F(x); }
-        virtual double faust2ui(double x) { return fF2A(x); }
-
-        virtual void setMappingValues(double amin, double amid, double amax, double fmin, double fmid, double fmax)
-        {
-            //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccDownUpConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
-            fA2F = Interpolator3pt(amin, amid, amax, fmax, fmin, fmax);
-            fF2A = Interpolator(fmin, fmax, amin, amax);
-        }
-
-        virtual void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fA2F.getMappingValues(amin, amid, amax);
-        }
+    virtual void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fA2F.getMappingValues(amin, amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -901,28 +903,27 @@ class AccDownUpConverter : public UpdatableValueConverter
 //--------------------------------------------------------------------------------------
 class ZoneControl
 {
+   protected:
+    FAUSTFLOAT* fZone;
 
-    protected:
+   public:
+    ZoneControl(FAUSTFLOAT* zone) : fZone(zone) {}
+    virtual ~ZoneControl() {}
 
-        FAUSTFLOAT*	fZone;
+    virtual void update(double v) const {}
 
-    public:
+    virtual void setMappingValues(int curve, double amin, double amid, double amax,
+                                  double min, double init, double max)
+    {
+    }
+    virtual void getMappingValues(double& amin, double& amid, double& amax) {}
 
-        ZoneControl(FAUSTFLOAT* zone) : fZone(zone) {}
-        virtual ~ZoneControl() {}
+    FAUSTFLOAT* getZone() { return fZone; }
 
-        virtual void update(double v) const {}
+    virtual void setActive(bool on_off) {}
+    virtual bool getActive() { return false; }
 
-        virtual void setMappingValues(int curve, double amin, double amid, double amax, double min, double init, double max) {}
-        virtual void getMappingValues(double& amin, double& amid, double& amax) {}
-
-        FAUSTFLOAT* getZone() { return fZone; }
-
-        virtual void setActive(bool on_off) {}
-        virtual bool getActive() { return false; }
-
-        virtual int getCurve() { return -1; }
-
+    virtual int getCurve() { return -1; }
 };
 
 //--------------------------------------------------------------------------------------
@@ -930,20 +931,22 @@ class ZoneControl
 //--------------------------------------------------------------------------------------
 class ConverterZoneControl : public ZoneControl
 {
+   protected:
+    ValueConverter* fValueConverter;
 
-    protected:
+   public:
+    ConverterZoneControl(FAUSTFLOAT* zone, ValueConverter* converter)
+        : ZoneControl(zone), fValueConverter(converter)
+    {
+    }
+    virtual ~ConverterZoneControl()
+    {
+        delete fValueConverter;
+    }  // Assuming fValueConverter is not kept elsewhere...
 
-        ValueConverter* fValueConverter;
+    virtual void update(double v) const { *fZone = fValueConverter->ui2faust(v); }
 
-    public:
-
-        ConverterZoneControl(FAUSTFLOAT* zone, ValueConverter* converter) : ZoneControl(zone), fValueConverter(converter) {}
-        virtual ~ConverterZoneControl() { delete fValueConverter; } // Assuming fValueConverter is not kept elsewhere...
-
-        virtual void update(double v) const { *fZone = fValueConverter->ui2faust(v); }
-
-        ValueConverter* getConverter() { return fValueConverter; }
-
+    ValueConverter* getConverter() { return fValueConverter; }
 };
 
 //--------------------------------------------------------------------------------------
@@ -952,477 +955,496 @@ class ConverterZoneControl : public ZoneControl
 //--------------------------------------------------------------------------------------
 class CurveZoneControl : public ZoneControl
 {
+   private:
+    std::vector<UpdatableValueConverter*> fValueConverters;
+    int fCurve;
 
-    private:
-
-        std::vector<UpdatableValueConverter*> fValueConverters;
-        int fCurve;
-
-    public:
-
-        CurveZoneControl(FAUSTFLOAT* zone, int curve, double amin, double amid, double amax, double min, double init, double max) : ZoneControl(zone), fCurve(0)
-        {
-            assert(curve >= 0 && curve <= 3);
-            fValueConverters.push_back(new AccUpConverter(amin, amid, amax, min, init, max));
-            fValueConverters.push_back(new AccDownConverter(amin, amid, amax, min, init, max));
-            fValueConverters.push_back(new AccUpDownConverter(amin, amid, amax, min, init, max));
-            fValueConverters.push_back(new AccDownUpConverter(amin, amid, amax, min, init, max));
-            fCurve = curve;
+   public:
+    CurveZoneControl(FAUSTFLOAT* zone, int curve, double amin, double amid, double amax,
+                     double min, double init, double max)
+        : ZoneControl(zone), fCurve(0)
+    {
+        assert(curve >= 0 && curve <= 3);
+        fValueConverters.push_back(new AccUpConverter(amin, amid, amax, min, init, max));
+        fValueConverters.push_back(
+            new AccDownConverter(amin, amid, amax, min, init, max));
+        fValueConverters.push_back(
+            new AccUpDownConverter(amin, amid, amax, min, init, max));
+        fValueConverters.push_back(
+            new AccDownUpConverter(amin, amid, amax, min, init, max));
+        fCurve = curve;
+    }
+    virtual ~CurveZoneControl()
+    {
+        std::vector<UpdatableValueConverter*>::iterator it;
+        for (it = fValueConverters.begin(); it != fValueConverters.end(); it++) {
+            delete (*it);
         }
-        virtual ~CurveZoneControl()
-        {
-            std::vector<UpdatableValueConverter*>::iterator it;
-            for (it = fValueConverters.begin(); it != fValueConverters.end(); it++) {
-                delete(*it);
-            }
-        }
-        void update(double v) const { if (fValueConverters[fCurve]->getActive()) *fZone = fValueConverters[fCurve]->ui2faust(v); }
+    }
+    void update(double v) const
+    {
+        if (fValueConverters[fCurve]->getActive())
+            *fZone = fValueConverters[fCurve]->ui2faust(v);
+    }
 
-        void setMappingValues(int curve, double amin, double amid, double amax, double min, double init, double max)
-        {
-            fValueConverters[curve]->setMappingValues(amin, amid, amax, min, init, max);
-            fCurve = curve;
-        }
+    void setMappingValues(int curve, double amin, double amid, double amax, double min,
+                          double init, double max)
+    {
+        fValueConverters[curve]->setMappingValues(amin, amid, amax, min, init, max);
+        fCurve = curve;
+    }
 
-        void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fValueConverters[fCurve]->getMappingValues(amin, amid, amax);
-        }
+    void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fValueConverters[fCurve]->getMappingValues(amin, amid, amax);
+    }
 
-        void setActive(bool on_off)
-        {
-            std::vector<UpdatableValueConverter*>::iterator it;
-            for (it = fValueConverters.begin(); it != fValueConverters.end(); it++) {
-                (*it)->setActive(on_off);
-            }
+    void setActive(bool on_off)
+    {
+        std::vector<UpdatableValueConverter*>::iterator it;
+        for (it = fValueConverters.begin(); it != fValueConverters.end(); it++) {
+            (*it)->setActive(on_off);
         }
+    }
 
-        int getCurve() { return fCurve; }
+    int getCurve() { return fCurve; }
 };
 
 class ZoneReader
 {
+   private:
+    FAUSTFLOAT* fZone;
+    Interpolator fInterpolator;
 
-    private:
+   public:
+    ZoneReader(FAUSTFLOAT* zone, double lo, double hi)
+        : fZone(zone), fInterpolator(lo, hi, 0, 255)
+    {
+    }
 
-        FAUSTFLOAT* fZone;
-        Interpolator fInterpolator;
+    virtual ~ZoneReader() {}
 
-    public:
-
-        ZoneReader(FAUSTFLOAT* zone, double lo, double hi) : fZone(zone), fInterpolator(lo, hi, 0, 255) {}
-
-        virtual ~ZoneReader() {}
-
-        int getValue()
-        {
-            return (fZone != nullptr) ? int(fInterpolator(*fZone)) : 127;
-        }
-
+    int getValue() { return (fZone != nullptr) ? int(fInterpolator(*fZone)) : 127; }
 };
 
 #endif
 /**************************  END  ValueConverter.h **************************/
 
-class APIUI : public PathBuilder, public Meta, public UI
+class APIUI
+    : public PathBuilder
+    , public Meta
+    , public UI
 {
-    public:
-    
-        enum ItemType { kButton = 0, kCheckButton, kVSlider, kHSlider, kNumEntry, kHBargraph, kVBargraph };
-  
-    protected:
-    
-        enum { kLin = 0, kLog = 1, kExp = 2 };
-    
-        int fNumParameters;
-        std::vector<std::string> fPaths;
-        std::vector<std::string> fLabels;
-        std::map<std::string, int> fPathMap;
-        std::map<std::string, int> fLabelMap;
-        std::vector<ValueConverter*> fConversion;
-        std::vector<FAUSTFLOAT*> fZone;
-        std::vector<FAUSTFLOAT> fInit;
-        std::vector<FAUSTFLOAT> fMin;
-        std::vector<FAUSTFLOAT> fMax;
-        std::vector<FAUSTFLOAT> fStep;
-        std::vector<ItemType> fItemType;
-        std::vector<std::map<std::string, std::string> > fMetaData;
-        std::vector<ZoneControl*> fAcc[3];
-        std::vector<ZoneControl*> fGyr[3];
+   public:
+    enum ItemType {
+        kButton = 0,
+        kCheckButton,
+        kVSlider,
+        kHSlider,
+        kNumEntry,
+        kHBargraph,
+        kVBargraph
+    };
 
-        // Screen color control
-        // "...[screencolor:red]..." etc.
-        bool fHasScreenControl;      // true if control screen color metadata
-        ZoneReader* fRedReader;
-        ZoneReader* fGreenReader;
-        ZoneReader* fBlueReader;
+   protected:
+    enum { kLin = 0, kLog = 1, kExp = 2 };
 
-        // Current values controlled by metadata
-        std::string fCurrentUnit;
-        int fCurrentScale;
-        std::string fCurrentAcc;
-        std::string fCurrentGyr;
-        std::string fCurrentColor;
-        std::string fCurrentTooltip;
-        std::map<std::string, std::string> fCurrentMetadata;
-    
-        // Add a generic parameter
-        virtual void addParameter(const char* label,
-                                FAUSTFLOAT* zone,
-                                FAUSTFLOAT init,
-                                FAUSTFLOAT min,
-                                FAUSTFLOAT max,
-                                FAUSTFLOAT step,
-                                ItemType type)
-        {
-            std::string path = buildPath(label);
-            fPathMap[path] = fLabelMap[label] = fNumParameters++;
-            fPaths.push_back(path);
-            fLabels.push_back(label);
-            fZone.push_back(zone);
-            fInit.push_back(init);
-            fMin.push_back(min);
-            fMax.push_back(max);
-            fStep.push_back(step);
-            fItemType.push_back(type);
-            
-            // handle scale metadata
-            switch (fCurrentScale) {
-                case kLin:
-                    fConversion.push_back(new LinearValueConverter(0, 1, min, max));
-                    break;
-                case kLog:
-                    fConversion.push_back(new LogValueConverter(0, 1, min, max));
-                    break;
-                case kExp: fConversion.push_back(new ExpValueConverter(0, 1, min, max));
-                    break;
-            }
-            fCurrentScale = kLin;
-            
-            if (fCurrentAcc.size() > 0 && fCurrentGyr.size() > 0) {
-                std::cerr << "warning : 'acc' and 'gyr' metadata used for the same " << label << " parameter !!\n";
-            }
+    int fNumParameters;
+    std::vector<std::string> fPaths;
+    std::vector<std::string> fLabels;
+    std::map<std::string, int> fPathMap;
+    std::map<std::string, int> fLabelMap;
+    std::vector<ValueConverter*> fConversion;
+    std::vector<FAUSTFLOAT*> fZone;
+    std::vector<FAUSTFLOAT> fInit;
+    std::vector<FAUSTFLOAT> fMin;
+    std::vector<FAUSTFLOAT> fMax;
+    std::vector<FAUSTFLOAT> fStep;
+    std::vector<ItemType> fItemType;
+    std::vector<std::map<std::string, std::string> > fMetaData;
+    std::vector<ZoneControl*> fAcc[3];
+    std::vector<ZoneControl*> fGyr[3];
 
-            // handle acc metadata "...[acc : <axe> <curve> <amin> <amid> <amax>]..."
-            if (fCurrentAcc.size() > 0) {
-                std::istringstream iss(fCurrentAcc);
-                int axe, curve;
-                double amin, amid, amax;
-                iss >> axe >> curve >> amin >> amid >> amax;
+    // Screen color control
+    // "...[screencolor:red]..." etc.
+    bool fHasScreenControl;  // true if control screen color metadata
+    ZoneReader* fRedReader;
+    ZoneReader* fGreenReader;
+    ZoneReader* fBlueReader;
 
-                if ((0 <= axe) && (axe < 3) &&
-                    (0 <= curve) && (curve < 4) &&
-                    (amin < amax) && (amin <= amid) && (amid <= amax))
-                {
-                    fAcc[axe].push_back(new CurveZoneControl(zone, curve, amin, amid, amax, min, init, max));
-                } else {
-                    std::cerr << "incorrect acc metadata : " << fCurrentAcc << std::endl;
-                }
-                fCurrentAcc = "";
-            }
-       
-            // handle gyr metadata "...[gyr : <axe> <curve> <amin> <amid> <amax>]..."
-            if (fCurrentGyr.size() > 0) {
-                std::istringstream iss(fCurrentGyr);
-                int axe, curve;
-                double amin, amid, amax;
-                iss >> axe >> curve >> amin >> amid >> amax;
+    // Current values controlled by metadata
+    std::string fCurrentUnit;
+    int fCurrentScale;
+    std::string fCurrentAcc;
+    std::string fCurrentGyr;
+    std::string fCurrentColor;
+    std::string fCurrentTooltip;
+    std::map<std::string, std::string> fCurrentMetadata;
 
-                if ((0 <= axe) && (axe < 3) &&
-                    (0 <= curve) && (curve < 4) &&
-                    (amin < amax) && (amin <= amid) && (amid <= amax))
-                {
-                    fGyr[axe].push_back(new CurveZoneControl(zone, curve, amin, amid, amax, min, init, max));
-                } else {
-                    std::cerr << "incorrect gyr metadata : " << fCurrentGyr << std::endl;
-                }
-                fCurrentGyr = "";
-            }
-        
-            // handle screencolor metadata "...[screencolor:red|green|blue|white]..."
-            if (fCurrentColor.size() > 0) {
-                if ((fCurrentColor == "red") && (fRedReader == 0)) {
-                    fRedReader = new ZoneReader(zone, min, max);
-                    fHasScreenControl = true;
-                } else if ((fCurrentColor == "green") && (fGreenReader == 0)) {
-                    fGreenReader = new ZoneReader(zone, min, max);
-                    fHasScreenControl = true;
-                } else if ((fCurrentColor == "blue") && (fBlueReader == 0)) {
-                    fBlueReader = new ZoneReader(zone, min, max);
-                    fHasScreenControl = true;
-                } else if ((fCurrentColor == "white") && (fRedReader == 0) && (fGreenReader == 0) && (fBlueReader == 0)) {
-                    fRedReader = new ZoneReader(zone, min, max);
-                    fGreenReader = new ZoneReader(zone, min, max);
-                    fBlueReader = new ZoneReader(zone, min, max);
-                    fHasScreenControl = true;
-                } else {
-                    std::cerr << "incorrect screencolor metadata : " << fCurrentColor << std::endl;
-                }
-            }
-            fCurrentColor = "";
-            
-            fMetaData.push_back(fCurrentMetadata);
-            fCurrentMetadata.clear();
+    // Add a generic parameter
+    virtual void addParameter(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init,
+                              FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step,
+                              ItemType type)
+    {
+        std::string path = buildPath(label);
+        fPathMap[path] = fLabelMap[label] = fNumParameters++;
+        fPaths.push_back(path);
+        fLabels.push_back(label);
+        fZone.push_back(zone);
+        fInit.push_back(init);
+        fMin.push_back(min);
+        fMax.push_back(max);
+        fStep.push_back(step);
+        fItemType.push_back(type);
+
+        // handle scale metadata
+        switch (fCurrentScale) {
+        case kLin:
+            fConversion.push_back(new LinearValueConverter(0, 1, min, max));
+            break;
+        case kLog:
+            fConversion.push_back(new LogValueConverter(0, 1, min, max));
+            break;
+        case kExp:
+            fConversion.push_back(new ExpValueConverter(0, 1, min, max));
+            break;
+        }
+        fCurrentScale = kLin;
+
+        if (fCurrentAcc.size() > 0 && fCurrentGyr.size() > 0) {
+            std::cerr << "warning : 'acc' and 'gyr' metadata used for the same " << label
+                      << " parameter !!\n";
         }
 
-        int getZoneIndex(std::vector<ZoneControl*>* table, int p, int val)
-        {
-            FAUSTFLOAT* zone = fZone[p];
-            for (size_t i = 0; i < table[val].size(); i++) {
-                if (zone == table[val][i]->getZone()) return int(i);
+        // handle acc metadata "...[acc : <axe> <curve> <amin> <amid> <amax>]..."
+        if (fCurrentAcc.size() > 0) {
+            std::istringstream iss(fCurrentAcc);
+            int axe, curve;
+            double amin, amid, amax;
+            iss >> axe >> curve >> amin >> amid >> amax;
+
+            if ((0 <= axe) && (axe < 3) && (0 <= curve) && (curve < 4) && (amin < amax)
+                && (amin <= amid) && (amid <= amax)) {
+                fAcc[axe].push_back(
+                    new CurveZoneControl(zone, curve, amin, amid, amax, min, init, max));
+            } else {
+                std::cerr << "incorrect acc metadata : " << fCurrentAcc << std::endl;
             }
+            fCurrentAcc = "";
+        }
+
+        // handle gyr metadata "...[gyr : <axe> <curve> <amin> <amid> <amax>]..."
+        if (fCurrentGyr.size() > 0) {
+            std::istringstream iss(fCurrentGyr);
+            int axe, curve;
+            double amin, amid, amax;
+            iss >> axe >> curve >> amin >> amid >> amax;
+
+            if ((0 <= axe) && (axe < 3) && (0 <= curve) && (curve < 4) && (amin < amax)
+                && (amin <= amid) && (amid <= amax)) {
+                fGyr[axe].push_back(
+                    new CurveZoneControl(zone, curve, amin, amid, amax, min, init, max));
+            } else {
+                std::cerr << "incorrect gyr metadata : " << fCurrentGyr << std::endl;
+            }
+            fCurrentGyr = "";
+        }
+
+        // handle screencolor metadata "...[screencolor:red|green|blue|white]..."
+        if (fCurrentColor.size() > 0) {
+            if ((fCurrentColor == "red") && (fRedReader == 0)) {
+                fRedReader        = new ZoneReader(zone, min, max);
+                fHasScreenControl = true;
+            } else if ((fCurrentColor == "green") && (fGreenReader == 0)) {
+                fGreenReader      = new ZoneReader(zone, min, max);
+                fHasScreenControl = true;
+            } else if ((fCurrentColor == "blue") && (fBlueReader == 0)) {
+                fBlueReader       = new ZoneReader(zone, min, max);
+                fHasScreenControl = true;
+            } else if ((fCurrentColor == "white") && (fRedReader == 0)
+                       && (fGreenReader == 0) && (fBlueReader == 0)) {
+                fRedReader        = new ZoneReader(zone, min, max);
+                fGreenReader      = new ZoneReader(zone, min, max);
+                fBlueReader       = new ZoneReader(zone, min, max);
+                fHasScreenControl = true;
+            } else {
+                std::cerr << "incorrect screencolor metadata : " << fCurrentColor
+                          << std::endl;
+            }
+        }
+        fCurrentColor = "";
+
+        fMetaData.push_back(fCurrentMetadata);
+        fCurrentMetadata.clear();
+    }
+
+    int getZoneIndex(std::vector<ZoneControl*>* table, int p, int val)
+    {
+        FAUSTFLOAT* zone = fZone[p];
+        for (size_t i = 0; i < table[val].size(); i++) {
+            if (zone == table[val][i]->getZone()) return int(i);
+        }
+        return -1;
+    }
+
+    void setConverter(std::vector<ZoneControl*>* table, int p, int val, int curve,
+                      double amin, double amid, double amax)
+    {
+        int id1 = getZoneIndex(table, p, 0);
+        int id2 = getZoneIndex(table, p, 1);
+        int id3 = getZoneIndex(table, p, 2);
+
+        // Deactivates everywhere..
+        if (id1 != -1) table[0][id1]->setActive(false);
+        if (id2 != -1) table[1][id2]->setActive(false);
+        if (id3 != -1) table[2][id3]->setActive(false);
+
+        if (val == -1) {  // Means: no more mapping...
+            // So stay all deactivated...
+        } else {
+            int id4 = getZoneIndex(table, p, val);
+            if (id4 != -1) {
+                // Reactivate the one we edit...
+                table[val][id4]->setMappingValues(curve, amin, amid, amax, fMin[p],
+                                                  fInit[p], fMax[p]);
+                table[val][id4]->setActive(true);
+            } else {
+                // Allocate a new CurveZoneControl which is 'active' by default
+                FAUSTFLOAT* zone = fZone[p];
+                table[val].push_back(new CurveZoneControl(zone, curve, amin, amid, amax,
+                                                          fMin[p], fInit[p], fMax[p]));
+            }
+        }
+    }
+
+    void getConverter(std::vector<ZoneControl*>* table, int p, int& val, int& curve,
+                      double& amin, double& amid, double& amax)
+    {
+        int id1 = getZoneIndex(table, p, 0);
+        int id2 = getZoneIndex(table, p, 1);
+        int id3 = getZoneIndex(table, p, 2);
+
+        if (id1 != -1) {
+            val   = 0;
+            curve = table[val][id1]->getCurve();
+            table[val][id1]->getMappingValues(amin, amid, amax);
+        } else if (id2 != -1) {
+            val   = 1;
+            curve = table[val][id2]->getCurve();
+            table[val][id2]->getMappingValues(amin, amid, amax);
+        } else if (id3 != -1) {
+            val   = 2;
+            curve = table[val][id3]->getCurve();
+            table[val][id3]->getMappingValues(amin, amid, amax);
+        } else {
+            val   = -1;  // No mapping
+            curve = 0;
+            amin  = -100.;
+            amid  = 0.;
+            amax  = 100.;
+        }
+    }
+
+   public:
+    enum Type { kAcc = 0, kGyr = 1, kNoType };
+
+    APIUI()
+        : fNumParameters(0)
+        , fHasScreenControl(false)
+        , fRedReader(0)
+        , fGreenReader(0)
+        , fBlueReader(0)
+        , fCurrentScale(kLin)
+    {
+    }
+
+    virtual ~APIUI()
+    {
+        for (auto& it : fConversion) delete it;
+        for (int i = 0; i < 3; i++) {
+            for (auto& it : fAcc[i]) delete it;
+            for (auto& it : fGyr[i]) delete it;
+        }
+        delete fRedReader;
+        delete fGreenReader;
+        delete fBlueReader;
+    }
+
+    // -- widget's layouts
+
+    virtual void openTabBox(const char* label) { pushLabel(label); }
+    virtual void openHorizontalBox(const char* label) { pushLabel(label); }
+    virtual void openVerticalBox(const char* label) { pushLabel(label); }
+    virtual void closeBox() { popLabel(); }
+
+    // -- active widgets
+
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    {
+        addParameter(label, zone, 0, 0, 1, 1, kButton);
+    }
+
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    {
+        addParameter(label, zone, 0, 0, 1, 1, kCheckButton);
+    }
+
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init,
+                                   FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addParameter(label, zone, init, min, max, step, kVSlider);
+    }
+
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init,
+                                     FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addParameter(label, zone, init, min, max, step, kHSlider);
+    }
+
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init,
+                             FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addParameter(label, zone, init, min, max, step, kNumEntry);
+    }
+
+    // -- passive widgets
+
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone,
+                                       FAUSTFLOAT min, FAUSTFLOAT max)
+    {
+        addParameter(label, zone, min, min, max, (max - min) / 1000.0, kHBargraph);
+    }
+
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min,
+                                     FAUSTFLOAT max)
+    {
+        addParameter(label, zone, min, min, max, (max - min) / 1000.0, kVBargraph);
+    }
+
+    // -- soundfiles
+
+    virtual void addSoundfile(const char* label, const char* filename,
+                              Soundfile** sf_zone)
+    {
+    }
+
+    // -- metadata declarations
+
+    virtual void declare(FAUSTFLOAT* zone, const char* key, const char* val)
+    {
+        // Keep metadata
+        fCurrentMetadata[key] = val;
+
+        if (strcmp(key, "scale") == 0) {
+            if (strcmp(val, "log") == 0) {
+                fCurrentScale = kLog;
+            } else if (strcmp(val, "exp") == 0) {
+                fCurrentScale = kExp;
+            } else {
+                fCurrentScale = kLin;
+            }
+        } else if (strcmp(key, "unit") == 0) {
+            fCurrentUnit = val;
+        } else if (strcmp(key, "acc") == 0) {
+            fCurrentAcc = val;
+        } else if (strcmp(key, "gyr") == 0) {
+            fCurrentGyr = val;
+        } else if (strcmp(key, "screencolor") == 0) {
+            fCurrentColor = val;  // val = "red", "green", "blue" or "white"
+        } else if (strcmp(key, "tooltip") == 0) {
+            fCurrentTooltip = val;
+        }
+    }
+
+    virtual void declare(const char* key, const char* val) {}
+
+    //-------------------------------------------------------------------------------
+    // Simple API part
+    //-------------------------------------------------------------------------------
+    int getParamsCount() { return fNumParameters; }
+    int getParamIndex(const char* path)
+    {
+        if (fPathMap.find(path) != fPathMap.end()) {
+            return fPathMap[path];
+        } else if (fLabelMap.find(path) != fLabelMap.end()) {
+            return fLabelMap[path];
+        } else {
             return -1;
         }
-    
-        void setConverter(std::vector<ZoneControl*>* table, int p, int val, int curve, double amin, double amid, double amax)
-        {
-            int id1 = getZoneIndex(table, p, 0);
-            int id2 = getZoneIndex(table, p, 1);
-            int id3 = getZoneIndex(table, p, 2);
-            
-            // Deactivates everywhere..
-            if (id1 != -1) table[0][id1]->setActive(false);
-            if (id2 != -1) table[1][id2]->setActive(false);
-            if (id3 != -1) table[2][id3]->setActive(false);
-            
-            if (val == -1) { // Means: no more mapping...
-                // So stay all deactivated...
-            } else {
-                int id4 = getZoneIndex(table, p, val);
-                if (id4 != -1) {
-                    // Reactivate the one we edit...
-                    table[val][id4]->setMappingValues(curve, amin, amid, amax, fMin[p], fInit[p], fMax[p]);
-                    table[val][id4]->setActive(true);
-                } else {
-                    // Allocate a new CurveZoneControl which is 'active' by default
-                    FAUSTFLOAT* zone = fZone[p];
-                    table[val].push_back(new CurveZoneControl(zone, curve, amin, amid, amax, fMin[p], fInit[p], fMax[p]));
-                }
-            }
-        }
-    
-        void getConverter(std::vector<ZoneControl*>* table, int p, int& val, int& curve, double& amin, double& amid, double& amax)
-        {
-            int id1 = getZoneIndex(table, p, 0);
-            int id2 = getZoneIndex(table, p, 1);
-            int id3 = getZoneIndex(table, p, 2);
-            
-            if (id1 != -1) {
-                val = 0;
-                curve = table[val][id1]->getCurve();
-                table[val][id1]->getMappingValues(amin, amid, amax);
-            } else if (id2 != -1) {
-                val = 1;
-                curve = table[val][id2]->getCurve();
-                table[val][id2]->getMappingValues(amin, amid, amax);
-            } else if (id3 != -1) {
-                val = 2;
-                curve = table[val][id3]->getCurve();
-                table[val][id3]->getMappingValues(amin, amid, amax);
-            } else {
-                val = -1; // No mapping
-                curve = 0;
-                amin = -100.;
-                amid = 0.;
-                amax = 100.;
-            }
-        }
+    }
+    const char* getParamAddress(int p) { return fPaths[p].c_str(); }
+    const char* getParamLabel(int p) { return fLabels[p].c_str(); }
+    std::map<const char*, const char*> getMetadata(int p)
+    {
+        std::map<const char*, const char*> res;
+        std::map<std::string, std::string> metadata = fMetaData[p];
+        for (auto it : metadata) { res[it.first.c_str()] = it.second.c_str(); }
+        return res;
+    }
 
-     public:
-    
-        enum Type { kAcc = 0, kGyr = 1, kNoType };
-   
-        APIUI() : fNumParameters(0), fHasScreenControl(false), fRedReader(0), fGreenReader(0), fBlueReader(0), fCurrentScale(kLin)
-        {}
+    const char* getMetadata(int p, const char* key)
+    {
+        return (fMetaData[p].find(key) != fMetaData[p].end()) ? fMetaData[p][key].c_str()
+                                                              : "";
+    }
+    FAUSTFLOAT getParamMin(int p) { return fMin[p]; }
+    FAUSTFLOAT getParamMax(int p) { return fMax[p]; }
+    FAUSTFLOAT getParamStep(int p) { return fStep[p]; }
+    FAUSTFLOAT getParamInit(int p) { return fInit[p]; }
 
-        virtual ~APIUI()
-        {
-            for (auto& it : fConversion) delete it;
-            for (int i = 0; i < 3; i++) {
-                for (auto& it : fAcc[i]) delete it;
-                for (auto& it : fGyr[i]) delete it;
-            }
-            delete fRedReader;
-            delete fGreenReader;
-            delete fBlueReader;
-        }
-    
-        // -- widget's layouts
+    FAUSTFLOAT* getParamZone(int p) { return fZone[p]; }
+    FAUSTFLOAT getParamValue(int p) { return *fZone[p]; }
+    void setParamValue(int p, FAUSTFLOAT v) { *fZone[p] = v; }
 
-        virtual void openTabBox(const char* label) { pushLabel(label); }
-        virtual void openHorizontalBox(const char* label) { pushLabel(label); }
-        virtual void openVerticalBox(const char* label) { pushLabel(label); }
-        virtual void closeBox() { popLabel(); }
+    double getParamRatio(int p) { return fConversion[p]->faust2ui(*fZone[p]); }
+    void setParamRatio(int p, double r) { *fZone[p] = fConversion[p]->ui2faust(r); }
 
-        // -- active widgets
+    double value2ratio(int p, double r) { return fConversion[p]->faust2ui(r); }
+    double ratio2value(int p, double r) { return fConversion[p]->ui2faust(r); }
 
-        virtual void addButton(const char* label, FAUSTFLOAT* zone)
-        {
-            addParameter(label, zone, 0, 0, 1, 1, kButton);
-        }
-
-        virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
-        {
-            addParameter(label, zone, 0, 0, 1, 1, kCheckButton);
-        }
-
-        virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
-        {
-            addParameter(label, zone, init, min, max, step, kVSlider);
-        }
-
-        virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
-        {
-            addParameter(label, zone, init, min, max, step, kHSlider);
-        }
-
-        virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
-        {
-            addParameter(label, zone, init, min, max, step, kNumEntry);
-        }
-
-        // -- passive widgets
-
-        virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
-        {
-            addParameter(label, zone, min, min, max, (max-min)/1000.0, kHBargraph);
-        }
-
-        virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
-        {
-            addParameter(label, zone, min, min, max, (max-min)/1000.0, kVBargraph);
-        }
-    
-        // -- soundfiles
-    
-        virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
-
-        // -- metadata declarations
-
-        virtual void declare(FAUSTFLOAT* zone, const char* key, const char* val)
-        {
-            // Keep metadata
-            fCurrentMetadata[key] = val;
-            
-            if (strcmp(key, "scale") == 0) {
-                if (strcmp(val, "log") == 0) {
-                    fCurrentScale = kLog;
-                } else if (strcmp(val, "exp") == 0) {
-                    fCurrentScale = kExp;
-                } else {
-                    fCurrentScale = kLin;
-                }
-            } else if (strcmp(key, "unit") == 0) {
-                fCurrentUnit = val;
-            } else if (strcmp(key, "acc") == 0) {
-                fCurrentAcc = val;
-            } else if (strcmp(key, "gyr") == 0) {
-                fCurrentGyr = val;
-            } else if (strcmp(key, "screencolor") == 0) {
-                fCurrentColor = val; // val = "red", "green", "blue" or "white"
-            } else if (strcmp(key, "tooltip") == 0) {
-                fCurrentTooltip = val;
-            }
-        }
-
-        virtual void declare(const char* key, const char* val)
-        {}
-
-		//-------------------------------------------------------------------------------
-		// Simple API part
-		//-------------------------------------------------------------------------------
-		int getParamsCount() { return fNumParameters; }
-        int getParamIndex(const char* path)
-        {
-            if (fPathMap.find(path) != fPathMap.end()) {
-                return fPathMap[path];
-            } else if (fLabelMap.find(path) != fLabelMap.end()) {
-                return fLabelMap[path];
-            } else {
-                return -1;
-            }
-        }
-        const char* getParamAddress(int p) { return fPaths[p].c_str(); }
-        const char* getParamLabel(int p) { return fLabels[p].c_str(); }
-        std::map<const char*, const char*> getMetadata(int p)
-        {
-            std::map<const char*, const char*> res;
-            std::map<std::string, std::string> metadata = fMetaData[p];
-            for (auto it : metadata) {
-                res[it.first.c_str()] = it.second.c_str();
-            }
-            return res;
-        }
-
-        const char* getMetadata(int p, const char* key)
-        {
-            return (fMetaData[p].find(key) != fMetaData[p].end()) ? fMetaData[p][key].c_str() : "";
-        }
-        FAUSTFLOAT getParamMin(int p) { return fMin[p]; }
-        FAUSTFLOAT getParamMax(int p) { return fMax[p]; }
-        FAUSTFLOAT getParamStep(int p) { return fStep[p]; }
-        FAUSTFLOAT getParamInit(int p) { return fInit[p]; }
-
-        FAUSTFLOAT* getParamZone(int p) { return fZone[p]; }
-        FAUSTFLOAT getParamValue(int p) { return *fZone[p]; }
-        void setParamValue(int p, FAUSTFLOAT v) { *fZone[p] = v; }
-
-        double getParamRatio(int p) { return fConversion[p]->faust2ui(*fZone[p]); }
-        void setParamRatio(int p, double r) { *fZone[p] = fConversion[p]->ui2faust(r); }
-
-        double value2ratio(int p, double r)	{ return fConversion[p]->faust2ui(r); }
-        double ratio2value(int p, double r)	{ return fConversion[p]->ui2faust(r); }
-    
-        /**
+    /**
          * Return the control type (kAcc, kGyr, or -1) for a given parameter
          *
          * @param p - the UI parameter index
          *
          * @return the type
          */
-        Type getParamType(int p)
-        {
-            if (p >= 0) {
-                if (getZoneIndex(fAcc, p, 0) != -1
-                    || getZoneIndex(fAcc, p, 1) != -1
-                    || getZoneIndex(fAcc, p, 2) != -1) {
-                    return kAcc;
-                } else if (getZoneIndex(fGyr, p, 0) != -1
-                           || getZoneIndex(fGyr, p, 1) != -1
-                           || getZoneIndex(fGyr, p, 2) != -1) {
-                    return kGyr;
-                }
+    Type getParamType(int p)
+    {
+        if (p >= 0) {
+            if (getZoneIndex(fAcc, p, 0) != -1 || getZoneIndex(fAcc, p, 1) != -1
+                || getZoneIndex(fAcc, p, 2) != -1) {
+                return kAcc;
+            } else if (getZoneIndex(fGyr, p, 0) != -1 || getZoneIndex(fGyr, p, 1) != -1
+                       || getZoneIndex(fGyr, p, 2) != -1) {
+                return kGyr;
             }
-            return kNoType;
         }
-    
-        /**
+        return kNoType;
+    }
+
+    /**
          * Return the Item type (kButton = 0, kCheckButton, kVSlider, kHSlider, kNumEntry, kHBargraph, kVBargraph) for a given parameter
          *
          * @param p - the UI parameter index
          *
          * @return the Item type
          */
-        ItemType getParamItemType(int p)
-        {
-            return fItemType[p];
-        }
-   
-        /**
+    ItemType getParamItemType(int p) { return fItemType[p]; }
+
+    /**
          * Set a new value coming from an accelerometer, propagate it to all relevant FAUSTFLOAT* zones.
          *
          * @param acc - 0 for X accelerometer, 1 for Y accelerometer, 2 for Z accelerometer
          * @param value - the new value
          *
          */
-        void propagateAcc(int acc, double value)
-        {
-            for (size_t i = 0; i < fAcc[acc].size(); i++) {
-                fAcc[acc][i]->update(value);
-            }
-        }
-    
-        /**
+    void propagateAcc(int acc, double value)
+    {
+        for (size_t i = 0; i < fAcc[acc].size(); i++) { fAcc[acc][i]->update(value); }
+    }
+
+    /**
          * Used to edit accelerometer curves and mapping. Set curve and related mapping for a given UI parameter.
          *
          * @param p - the UI parameter index
@@ -1433,12 +1455,12 @@ class APIUI : public PathBuilder, public Meta, public UI
          * @param amax - mapping 'max' point
          *
          */
-        void setAccConverter(int p, int acc, int curve, double amin, double amid, double amax)
-        {
-            setConverter(fAcc, p, acc, curve, amin, amid, amax);
-        }
-    
-        /**
+    void setAccConverter(int p, int acc, int curve, double amin, double amid, double amax)
+    {
+        setConverter(fAcc, p, acc, curve, amin, amid, amax);
+    }
+
+    /**
          * Used to edit gyroscope curves and mapping. Set curve and related mapping for a given UI parameter.
          *
          * @param p - the UI parameter index
@@ -1449,12 +1471,12 @@ class APIUI : public PathBuilder, public Meta, public UI
          * @param amax - mapping 'max' point
          *
          */
-        void setGyrConverter(int p, int gyr, int curve, double amin, double amid, double amax)
-        {
-             setConverter(fGyr, p, gyr, curve, amin, amid, amax);
-        }
-    
-        /**
+    void setGyrConverter(int p, int gyr, int curve, double amin, double amid, double amax)
+    {
+        setConverter(fGyr, p, gyr, curve, amin, amid, amax);
+    }
+
+    /**
          * Used to edit accelerometer curves and mapping. Get curve and related mapping for a given UI parameter.
          *
          * @param p - the UI parameter index
@@ -1465,12 +1487,13 @@ class APIUI : public PathBuilder, public Meta, public UI
          * @param amax - the amax value to be retrieved
          *
          */
-        void getAccConverter(int p, int& acc, int& curve, double& amin, double& amid, double& amax)
-        {
-            getConverter(fAcc, p, acc, curve, amin, amid, amax);
-        }
+    void getAccConverter(int p, int& acc, int& curve, double& amin, double& amid,
+                         double& amax)
+    {
+        getConverter(fAcc, p, acc, curve, amin, amid, amax);
+    }
 
-        /**
+    /**
          * Used to edit gyroscope curves and mapping. Get curve and related mapping for a given UI parameter.
          *
          * @param p - the UI parameter index
@@ -1481,63 +1504,55 @@ class APIUI : public PathBuilder, public Meta, public UI
          * @param amax - the amax value to be retrieved
          *
          */
-        void getGyrConverter(int p, int& gyr, int& curve, double& amin, double& amid, double& amax)
-        {
-            getConverter(fGyr, p, gyr, curve, amin, amid, amax);
-        }
-    
-        /**
+    void getGyrConverter(int p, int& gyr, int& curve, double& amin, double& amid,
+                         double& amax)
+    {
+        getConverter(fGyr, p, gyr, curve, amin, amid, amax);
+    }
+
+    /**
          * Set a new value coming from an gyroscope, propagate it to all relevant FAUSTFLOAT* zones.
          *
          * @param gyr - 0 for X gyroscope, 1 for Y gyroscope, 2 for Z gyroscope
          * @param value - the new value
          *
          */
-        void propagateGyr(int gyr, double value)
-        {
-            for (size_t i = 0; i < fGyr[gyr].size(); i++) {
-                fGyr[gyr][i]->update(value);
-            }
-        }
-    
-        /**
+    void propagateGyr(int gyr, double value)
+    {
+        for (size_t i = 0; i < fGyr[gyr].size(); i++) { fGyr[gyr][i]->update(value); }
+    }
+
+    /**
          * Get the number of FAUSTFLOAT* zones controlled with the accelerometer
          *
          * @param acc - 0 for X accelerometer, 1 for Y accelerometer, 2 for Z accelerometer
          * @return the number of zones
          *
          */
-        int getAccCount(int acc)
-        {
-            return (acc >= 0 && acc < 3) ? int(fAcc[acc].size()) : 0;
-        }
-    
-        /**
+    int getAccCount(int acc) { return (acc >= 0 && acc < 3) ? int(fAcc[acc].size()) : 0; }
+
+    /**
          * Get the number of FAUSTFLOAT* zones controlled with the gyroscope
          *
          * @param gyr - 0 for X gyroscope, 1 for Y gyroscope, 2 for Z gyroscope
          * @param the number of zones
          *
          */
-        int getGyrCount(int gyr)
-        {
-            return (gyr >= 0 && gyr < 3) ? int(fGyr[gyr].size()) : 0;
+    int getGyrCount(int gyr) { return (gyr >= 0 && gyr < 3) ? int(fGyr[gyr].size()) : 0; }
+
+    // getScreenColor() : -1 means no screen color control (no screencolor metadata found)
+    // otherwise return 0x00RRGGBB a ready to use color
+    int getScreenColor()
+    {
+        if (fHasScreenControl) {
+            int r = (fRedReader) ? fRedReader->getValue() : 0;
+            int g = (fGreenReader) ? fGreenReader->getValue() : 0;
+            int b = (fBlueReader) ? fBlueReader->getValue() : 0;
+            return (r << 16) | (g << 8) | b;
+        } else {
+            return -1;
         }
-   
-        // getScreenColor() : -1 means no screen color control (no screencolor metadata found)
-        // otherwise return 0x00RRGGBB a ready to use color
-        int getScreenColor()
-        {
-            if (fHasScreenControl) {
-                int r = (fRedReader) ? fRedReader->getValue() : 0;
-                int g = (fGreenReader) ? fGreenReader->getValue() : 0;
-                int b = (fBlueReader) ? fBlueReader->getValue() : 0;
-                return (r<<16) | (g<<8) | b;
-            } else {
-                return -1;
-            }
-        }
- 
+    }
 };
 
 #endif
@@ -1550,202 +1565,193 @@ class APIUI : public PathBuilder, public Meta, public UI
 //  FAUST Generated Code
 //----------------------------------------------------------------------------
 
-
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
+
+#include <math.h>
 
 #include <algorithm>
 #include <cmath>
-#include <math.h>
 
-
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS limiterdsp
 #endif
 
-#ifdef __APPLE__ 
+#ifdef __APPLE__
 #define exp10f __exp10f
-#define exp10 __exp10
+#define exp10  __exp10
 #endif
 
-class limiterdsp : public dsp {
-	
- private:
-	
-	int fSampleRate;
-	float fConst0;
-	float fConst1;
-	float fConst2;
-	float fConst3;
-	int iRec5[2];
-	FAUSTFLOAT fHslider0;
-	int IOTA;
-	float fVec0[32];
-	float fRec4[2];
-	int iRec2[2];
-	float fRec1[2];
-	float fConst4;
-	float fConst5;
-	float fRec0[2];
-	int iConst6;
-	
- public:
-	
-	void metadata(Meta* m) { 
-		m->declare("analyzers.lib/name", "Faust Analyzer Library");
-		m->declare("analyzers.lib/version", "0.1");
-		m->declare("basics.lib/name", "Faust Basic Element Library");
-		m->declare("basics.lib/version", "0.1");
-		m->declare("compressors.lib/limiter_lad_N:author", "Dario Sanfilippo");
-		m->declare("compressors.lib/limiter_lad_N:copyright", "Copyright (C) 2020 Dario Sanfilippo       <sanfilippo.dario@gmail.com>");
-		m->declare("compressors.lib/limiter_lad_N:license", "GPLv3 license");
-		m->declare("compressors.lib/limiter_lad_mono:author", "Dario Sanfilippo");
-		m->declare("compressors.lib/limiter_lad_mono:copyright", "Copyright (C) 2020 Dario Sanfilippo       <sanfilippo.dario@gmail.com>");
-		m->declare("compressors.lib/limiter_lad_mono:license", "GPLv3 license");
-		m->declare("compressors.lib/name", "Faust Compressor Effect Library");
-		m->declare("compressors.lib/version", "0.0");
-		m->declare("filename", "limiterdsp.dsp");
-		m->declare("maths.lib/author", "GRAME");
-		m->declare("maths.lib/copyright", "GRAME");
-		m->declare("maths.lib/license", "LGPL with exception");
-		m->declare("maths.lib/name", "Faust Math Library");
-		m->declare("maths.lib/version", "2.3");
-		m->declare("name", "limiterdsp");
-		m->declare("platform.lib/name", "Generic Platform Library");
-		m->declare("platform.lib/version", "0.1");
-		m->declare("routes.lib/name", "Faust Signal Routing Library");
-		m->declare("routes.lib/version", "0.2");
-		m->declare("signals.lib/name", "Faust Signal Routing Library");
-		m->declare("signals.lib/version", "0.0");
-	}
+class limiterdsp : public dsp
+{
+   private:
+    int fSampleRate;
+    float fConst0;
+    float fConst1;
+    float fConst2;
+    float fConst3;
+    int iRec5[2];
+    FAUSTFLOAT fHslider0;
+    int IOTA;
+    float fVec0[32];
+    float fRec4[2];
+    int iRec2[2];
+    float fRec1[2];
+    float fConst4;
+    float fConst5;
+    float fRec0[2];
+    int iConst6;
 
-	virtual int getNumInputs() {
-		return 1;
-	}
-	virtual int getNumOutputs() {
-		return 1;
-	}
-	virtual int getInputRate(int channel) {
-		int rate;
-		switch ((channel)) {
-			case 0: {
-				rate = 1;
-				break;
-			}
-			default: {
-				rate = -1;
-				break;
-			}
-		}
-		return rate;
-	}
-	virtual int getOutputRate(int channel) {
-		int rate;
-		switch ((channel)) {
-			case 0: {
-				rate = 1;
-				break;
-			}
-			default: {
-				rate = -1;
-				break;
-			}
-		}
-		return rate;
-	}
-	
-	static void classInit(int sample_rate) {
-	}
-	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = std::min<float>(192000.0f, std::max<float>(1.0f, float(fSampleRate)));
-		fConst1 = std::exp((0.0f - (100000.0f / fConst0)));
-		fConst2 = (1.0f - fConst1);
-		fConst3 = (0.100000001f * fConst0);
-		fConst4 = std::exp((0.0f - (4.0f / fConst0)));
-		fConst5 = (1.0f - fConst4);
-		iConst6 = int((9.99999975e-05f * fConst0));
-	}
-	
-	virtual void instanceResetUserInterface() {
-		fHslider0 = FAUSTFLOAT(2.0f);
-	}
-	
-	virtual void instanceClear() {
-		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
-			iRec5[l0] = 0;
-		}
-		IOTA = 0;
-		for (int l1 = 0; (l1 < 32); l1 = (l1 + 1)) {
-			fVec0[l1] = 0.0f;
-		}
-		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
-			fRec4[l2] = 0.0f;
-		}
-		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
-			iRec2[l3] = 0;
-		}
-		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
-			fRec1[l4] = 0.0f;
-		}
-		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
-			fRec0[l5] = 0.0f;
-		}
-	}
-	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
-	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
-		instanceResetUserInterface();
-		instanceClear();
-	}
-	
-	virtual limiterdsp* clone() {
-		return new limiterdsp();
-	}
-	
-	virtual int getSampleRate() {
-		return fSampleRate;
-	}
-	
-	virtual void buildUserInterface(UI* ui_interface) {
-		ui_interface->openVerticalBox("limiterdsp");
-		ui_interface->declare(&fHslider0, "0", "");
-		ui_interface->addHorizontalSlider("NumClientsAssumed", &fHslider0, 2.0f, 1.0f, 64.0f, 1.0f);
-		ui_interface->closeBox();
-	}
-	
-	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
-		FAUSTFLOAT* input0 = inputs[0];
-		FAUSTFLOAT* output0 = outputs[0];
-		float fSlow0 = (1.0f / std::sqrt(float(fHslider0)));
-		for (int i = 0; (i < count); i = (i + 1)) {
-			float fTemp0 = float(input0[i]);
-			iRec5[0] = ((iRec5[1] + 1) % int(std::max<float>(1.0f, (fConst3 * float(iRec2[1])))));
-			float fTemp1 = (fSlow0 * fTemp0);
-			fVec0[(IOTA & 31)] = fTemp1;
-			float fTemp2 = std::fabs(fTemp1);
-			fRec4[0] = std::max<float>((float((iRec5[0] > 0)) * fRec4[1]), fTemp2);
-			iRec2[0] = (fRec4[0] >= fTemp2);
-			float fRec3 = fRec4[0];
-			fRec1[0] = ((fConst1 * fRec1[1]) + (fConst2 * fRec3));
-			float fTemp3 = std::fabs(fRec1[0]);
-			fRec0[0] = std::max<float>(fTemp3, ((fConst4 * fRec0[1]) + (fConst5 * fTemp3)));
-			output0[i] = FAUSTFLOAT((std::min<float>(1.0f, (0.5f / std::max<float>(fRec0[0], 1.1920929e-07f))) * fVec0[((IOTA - iConst6) & 31)]));
-			iRec5[1] = iRec5[0];
-			IOTA = (IOTA + 1);
-			fRec4[1] = fRec4[0];
-			iRec2[1] = iRec2[0];
-			fRec1[1] = fRec1[0];
-			fRec0[1] = fRec0[0];
-		}
-	}
+   public:
+    void metadata(Meta* m)
+    {
+        m->declare("analyzers.lib/name", "Faust Analyzer Library");
+        m->declare("analyzers.lib/version", "0.1");
+        m->declare("basics.lib/name", "Faust Basic Element Library");
+        m->declare("basics.lib/version", "0.1");
+        m->declare("compressors.lib/limiter_lad_N:author", "Dario Sanfilippo");
+        m->declare(
+            "compressors.lib/limiter_lad_N:copyright",
+            "Copyright (C) 2020 Dario Sanfilippo       <sanfilippo.dario@gmail.com>");
+        m->declare("compressors.lib/limiter_lad_N:license", "GPLv3 license");
+        m->declare("compressors.lib/limiter_lad_mono:author", "Dario Sanfilippo");
+        m->declare(
+            "compressors.lib/limiter_lad_mono:copyright",
+            "Copyright (C) 2020 Dario Sanfilippo       <sanfilippo.dario@gmail.com>");
+        m->declare("compressors.lib/limiter_lad_mono:license", "GPLv3 license");
+        m->declare("compressors.lib/name", "Faust Compressor Effect Library");
+        m->declare("compressors.lib/version", "0.0");
+        m->declare("filename", "limiterdsp.dsp");
+        m->declare("maths.lib/author", "GRAME");
+        m->declare("maths.lib/copyright", "GRAME");
+        m->declare("maths.lib/license", "LGPL with exception");
+        m->declare("maths.lib/name", "Faust Math Library");
+        m->declare("maths.lib/version", "2.3");
+        m->declare("name", "limiterdsp");
+        m->declare("platform.lib/name", "Generic Platform Library");
+        m->declare("platform.lib/version", "0.1");
+        m->declare("routes.lib/name", "Faust Signal Routing Library");
+        m->declare("routes.lib/version", "0.2");
+        m->declare("signals.lib/name", "Faust Signal Routing Library");
+        m->declare("signals.lib/version", "0.0");
+    }
 
+    virtual int getNumInputs() { return 1; }
+    virtual int getNumOutputs() { return 1; }
+    virtual int getInputRate(int channel)
+    {
+        int rate;
+        switch ((channel)) {
+        case 0: {
+            rate = 1;
+            break;
+        }
+        default: {
+            rate = -1;
+            break;
+        }
+        }
+        return rate;
+    }
+    virtual int getOutputRate(int channel)
+    {
+        int rate;
+        switch ((channel)) {
+        case 0: {
+            rate = 1;
+            break;
+        }
+        default: {
+            rate = -1;
+            break;
+        }
+        }
+        return rate;
+    }
+
+    static void classInit(int sample_rate) {}
+
+    virtual void instanceConstants(int sample_rate)
+    {
+        fSampleRate = sample_rate;
+        fConst0 = std::min<float>(192000.0f, std::max<float>(1.0f, float(fSampleRate)));
+        fConst1 = std::exp((0.0f - (100000.0f / fConst0)));
+        fConst2 = (1.0f - fConst1);
+        fConst3 = (0.100000001f * fConst0);
+        fConst4 = std::exp((0.0f - (4.0f / fConst0)));
+        fConst5 = (1.0f - fConst4);
+        iConst6 = int((9.99999975e-05f * fConst0));
+    }
+
+    virtual void instanceResetUserInterface() { fHslider0 = FAUSTFLOAT(2.0f); }
+
+    virtual void instanceClear()
+    {
+        for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) { iRec5[l0] = 0; }
+        IOTA = 0;
+        for (int l1 = 0; (l1 < 32); l1 = (l1 + 1)) { fVec0[l1] = 0.0f; }
+        for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) { fRec4[l2] = 0.0f; }
+        for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) { iRec2[l3] = 0; }
+        for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) { fRec1[l4] = 0.0f; }
+        for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) { fRec0[l5] = 0.0f; }
+    }
+
+    virtual void init(int sample_rate)
+    {
+        classInit(sample_rate);
+        instanceInit(sample_rate);
+    }
+    virtual void instanceInit(int sample_rate)
+    {
+        instanceConstants(sample_rate);
+        instanceResetUserInterface();
+        instanceClear();
+    }
+
+    virtual limiterdsp* clone() { return new limiterdsp(); }
+
+    virtual int getSampleRate() { return fSampleRate; }
+
+    virtual void buildUserInterface(UI* ui_interface)
+    {
+        ui_interface->openVerticalBox("limiterdsp");
+        ui_interface->declare(&fHslider0, "0", "");
+        ui_interface->addHorizontalSlider("NumClientsAssumed", &fHslider0, 2.0f, 1.0f,
+                                          64.0f, 1.0f);
+        ui_interface->closeBox();
+    }
+
+    virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+    {
+        FAUSTFLOAT* input0  = inputs[0];
+        FAUSTFLOAT* output0 = outputs[0];
+        float fSlow0        = (1.0f / std::sqrt(float(fHslider0)));
+        for (int i = 0; (i < count); i = (i + 1)) {
+            float fTemp0       = float(input0[i]);
+            iRec5[0]           = ((iRec5[1] + 1)
+                        % int(std::max<float>(1.0f, (fConst3 * float(iRec2[1])))));
+            float fTemp1       = (fSlow0 * fTemp0);
+            fVec0[(IOTA & 31)] = fTemp1;
+            float fTemp2       = std::fabs(fTemp1);
+            fRec4[0]     = std::max<float>((float((iRec5[0] > 0)) * fRec4[1]), fTemp2);
+            iRec2[0]     = (fRec4[0] >= fTemp2);
+            float fRec3  = fRec4[0];
+            fRec1[0]     = ((fConst1 * fRec1[1]) + (fConst2 * fRec3));
+            float fTemp3 = std::fabs(fRec1[0]);
+            fRec0[0] =
+                std::max<float>(fTemp3, ((fConst4 * fRec0[1]) + (fConst5 * fTemp3)));
+            output0[i] = FAUSTFLOAT(
+                (std::min<float>(1.0f, (0.5f / std::max<float>(fRec0[0], 1.1920929e-07f)))
+                 * fVec0[((IOTA - iConst6) & 31)]));
+            iRec5[1] = iRec5[0];
+            IOTA     = (IOTA + 1);
+            fRec4[1] = fRec4[0];
+            iRec2[1] = iRec2[0];
+            fRec1[1] = fRec1[0];
+            fRec0[1] = fRec0[0];
+        }
+    }
 };
 
 #endif

--- a/src/zitarevdsp.h
+++ b/src/zitarevdsp.h
@@ -4,8 +4,8 @@ Code generated with Faust 2.28.6 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -scal -ftz 0
 ------------------------------------------------------------ */
 
-#ifndef  __zitarevdsp_H__
-#define  __zitarevdsp_H__
+#ifndef __zitarevdsp_H__
+#define __zitarevdsp_H__
 
 // NOTE: ANY INCLUDE-GUARD HERE MUST BE DERIVED FROM THE CLASS NAME
 //
@@ -56,86 +56,83 @@ struct Meta;
  */
 
 struct dsp_memory_manager {
-    
     virtual ~dsp_memory_manager() {}
-    
+
     virtual void* allocate(size_t size) = 0;
-    virtual void destroy(void* ptr) = 0;
-    
+    virtual void destroy(void* ptr)     = 0;
 };
 
 /**
 * Signal processor definition.
 */
 
-class dsp {
+class dsp
+{
+   public:
+    dsp() {}
+    virtual ~dsp() {}
 
-    public:
+    /* Return instance number of audio inputs */
+    virtual int getNumInputs() = 0;
 
-        dsp() {}
-        virtual ~dsp() {}
+    /* Return instance number of audio outputs */
+    virtual int getNumOutputs() = 0;
 
-        /* Return instance number of audio inputs */
-        virtual int getNumInputs() = 0;
-    
-        /* Return instance number of audio outputs */
-        virtual int getNumOutputs() = 0;
-    
-        /**
+    /**
          * Trigger the ui_interface parameter with instance specific calls
          * to 'openTabBox', 'addButton', 'addVerticalSlider'... in order to build the UI.
          *
          * @param ui_interface - the user interface builder
          */
-        virtual void buildUserInterface(UI* ui_interface) = 0;
-    
-        /* Returns the sample rate currently used by the instance */
-        virtual int getSampleRate() = 0;
-    
-        /**
+    virtual void buildUserInterface(UI* ui_interface) = 0;
+
+    /* Returns the sample rate currently used by the instance */
+    virtual int getSampleRate() = 0;
+
+    /**
          * Global init, calls the following methods:
          * - static class 'classInit': static tables initialization
          * - 'instanceInit': constants and instance state initialization
          *
          * @param sample_rate - the sampling rate in Hertz
          */
-        virtual void init(int sample_rate) = 0;
+    virtual void init(int sample_rate) = 0;
 
-        /**
+    /**
          * Init instance state
          *
          * @param sample_rate - the sampling rate in Hertz
          */
-        virtual void instanceInit(int sample_rate) = 0;
+    virtual void instanceInit(int sample_rate) = 0;
 
-        /**
+    /**
          * Init instance constant state
          *
          * @param sample_rate - the sampling rate in Hertz
          */
-        virtual void instanceConstants(int sample_rate) = 0;
-    
-        /* Init default control parameters values */
-        virtual void instanceResetUserInterface() = 0;
-    
-        /* Init instance state (delay lines...) */
-        virtual void instanceClear() = 0;
- 
-        /**
+    virtual void instanceConstants(int sample_rate) = 0;
+
+    /* Init default control parameters values */
+    virtual void instanceResetUserInterface() = 0;
+
+    /* Init instance state (delay lines...) */
+    virtual void instanceClear() = 0;
+
+    /**
          * Return a clone of the instance.
          *
          * @return a copy of the instance on success, otherwise a null pointer.
          */
-        virtual dsp* clone() = 0;
-    
-        /**
+    virtual dsp* clone() = 0;
+
+    /**
          * Trigger the Meta* parameter with instance specific calls to 'declare' (key, value) metadata.
          *
          * @param m - the Meta* meta user
          */
-        virtual void metadata(Meta* m) = 0;
-    
-        /**
+    virtual void metadata(Meta* m) = 0;
+
+    /**
          * DSP instance computation, to be called with successive in/out audio buffers.
          *
          * @param count - the number of frames to compute
@@ -143,9 +140,9 @@ class dsp {
          * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
          *
          */
-        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
-    
-        /**
+    virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
+
+    /**
          * DSP instance computation: alternative method to be used by subclasses.
          *
          * @param date_usec - the timestamp in microsec given by audio driver.
@@ -154,67 +151,77 @@ class dsp {
          * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (either float, double or quad)
          *
          */
-        virtual void compute(double /*date_usec*/, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
-       
+    virtual void compute(double /*date_usec*/, int count, FAUSTFLOAT** inputs,
+                         FAUSTFLOAT** outputs)
+    {
+        compute(count, inputs, outputs);
+    }
 };
 
 /**
  * Generic DSP decorator.
  */
 
-class decorator_dsp : public dsp {
+class decorator_dsp : public dsp
+{
+   protected:
+    dsp* fDSP;
 
-    protected:
+   public:
+    decorator_dsp(dsp* dsp = nullptr) : fDSP(dsp) {}
+    virtual ~decorator_dsp() { delete fDSP; }
 
-        dsp* fDSP;
-
-    public:
-
-        decorator_dsp(dsp* dsp = nullptr):fDSP(dsp) {}
-        virtual ~decorator_dsp() { delete fDSP; }
-
-        virtual int getNumInputs() { return fDSP->getNumInputs(); }
-        virtual int getNumOutputs() { return fDSP->getNumOutputs(); }
-        virtual void buildUserInterface(UI* ui_interface) { fDSP->buildUserInterface(ui_interface); }
-        virtual int getSampleRate() { return fDSP->getSampleRate(); }
-        virtual void init(int sample_rate) { fDSP->init(sample_rate); }
-        virtual void instanceInit(int sample_rate) { fDSP->instanceInit(sample_rate); }
-        virtual void instanceConstants(int sample_rate) { fDSP->instanceConstants(sample_rate); }
-        virtual void instanceResetUserInterface() { fDSP->instanceResetUserInterface(); }
-        virtual void instanceClear() { fDSP->instanceClear(); }
-        virtual decorator_dsp* clone() { return new decorator_dsp(fDSP->clone()); }
-        virtual void metadata(Meta* m) { fDSP->metadata(m); }
-        // Beware: subclasses usually have to overload the two 'compute' methods
-        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(count, inputs, outputs); }
-        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(date_usec, count, inputs, outputs); }
-    
+    virtual int getNumInputs() { return fDSP->getNumInputs(); }
+    virtual int getNumOutputs() { return fDSP->getNumOutputs(); }
+    virtual void buildUserInterface(UI* ui_interface)
+    {
+        fDSP->buildUserInterface(ui_interface);
+    }
+    virtual int getSampleRate() { return fDSP->getSampleRate(); }
+    virtual void init(int sample_rate) { fDSP->init(sample_rate); }
+    virtual void instanceInit(int sample_rate) { fDSP->instanceInit(sample_rate); }
+    virtual void instanceConstants(int sample_rate)
+    {
+        fDSP->instanceConstants(sample_rate);
+    }
+    virtual void instanceResetUserInterface() { fDSP->instanceResetUserInterface(); }
+    virtual void instanceClear() { fDSP->instanceClear(); }
+    virtual decorator_dsp* clone() { return new decorator_dsp(fDSP->clone()); }
+    virtual void metadata(Meta* m) { fDSP->metadata(m); }
+    // Beware: subclasses usually have to overload the two 'compute' methods
+    virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+    {
+        fDSP->compute(count, inputs, outputs);
+    }
+    virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs,
+                         FAUSTFLOAT** outputs)
+    {
+        fDSP->compute(date_usec, count, inputs, outputs);
+    }
 };
 
 /**
  * DSP factory class.
  */
 
-class dsp_factory {
-    
-    protected:
-    
-        // So that to force sub-classes to use deleteDSPFactory(dsp_factory* factory);
-        virtual ~dsp_factory() {}
-    
-    public:
-    
-        virtual std::string getName() = 0;
-        virtual std::string getSHAKey() = 0;
-        virtual std::string getDSPCode() = 0;
-        virtual std::string getCompileOptions() = 0;
-        virtual std::vector<std::string> getLibraryList() = 0;
-        virtual std::vector<std::string> getIncludePathnames() = 0;
-    
-        virtual dsp* createDSPInstance() = 0;
-    
-        virtual void setMemoryManager(dsp_memory_manager* manager) = 0;
-        virtual dsp_memory_manager* getMemoryManager() = 0;
-    
+class dsp_factory
+{
+   protected:
+    // So that to force sub-classes to use deleteDSPFactory(dsp_factory* factory);
+    virtual ~dsp_factory() {}
+
+   public:
+    virtual std::string getName()                          = 0;
+    virtual std::string getSHAKey()                        = 0;
+    virtual std::string getDSPCode()                       = 0;
+    virtual std::string getCompileOptions()                = 0;
+    virtual std::vector<std::string> getLibraryList()      = 0;
+    virtual std::vector<std::string> getIncludePathnames() = 0;
+
+    virtual dsp* createDSPInstance() = 0;
+
+    virtual void setMemoryManager(dsp_memory_manager* manager) = 0;
+    virtual dsp_memory_manager* getMemoryManager()             = 0;
 };
 
 /**
@@ -223,14 +230,14 @@ class dsp_factory {
  */
 
 #ifdef __SSE__
-    #include <xmmintrin.h>
-    #ifdef __SSE2__
-        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8040)
-    #else
-        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8000)
-    #endif
+#include <xmmintrin.h>
+#ifdef __SSE2__
+#define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8040)
 #else
-    #define AVOIDDENORMALS
+#define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8000)
+#endif
+#else
+#define AVOIDDENORMALS
 #endif
 
 #endif
@@ -263,11 +270,11 @@ class dsp_factory {
 #ifndef API_UI_H
 #define API_UI_H
 
+#include <iostream>
+#include <map>
 #include <sstream>
 #include <string>
 #include <vector>
-#include <iostream>
-#include <map>
 
 /************************** BEGIN meta.h **************************/
 /************************************************************************
@@ -296,11 +303,9 @@ class dsp_factory {
 #ifndef __meta__
 #define __meta__
 
-struct Meta
-{
-    virtual ~Meta() {};
+struct Meta {
+    virtual ~Meta(){};
     virtual void declare(const char* key, const char* value) = 0;
-    
 };
 
 #endif
@@ -345,43 +350,47 @@ struct Meta
 
 struct Soundfile;
 
-template <typename REAL>
-struct UIReal
-{
+template<typename REAL>
+struct UIReal {
     UIReal() {}
     virtual ~UIReal() {}
-    
+
     // -- widget's layouts
-    
-    virtual void openTabBox(const char* label) = 0;
+
+    virtual void openTabBox(const char* label)        = 0;
     virtual void openHorizontalBox(const char* label) = 0;
-    virtual void openVerticalBox(const char* label) = 0;
-    virtual void closeBox() = 0;
-    
+    virtual void openVerticalBox(const char* label)   = 0;
+    virtual void closeBox()                           = 0;
+
     // -- active widgets
-    
-    virtual void addButton(const char* label, REAL* zone) = 0;
+
+    virtual void addButton(const char* label, REAL* zone)      = 0;
     virtual void addCheckButton(const char* label, REAL* zone) = 0;
-    virtual void addVerticalSlider(const char* label, REAL* zone, REAL init, REAL min, REAL max, REAL step) = 0;
-    virtual void addHorizontalSlider(const char* label, REAL* zone, REAL init, REAL min, REAL max, REAL step) = 0;
-    virtual void addNumEntry(const char* label, REAL* zone, REAL init, REAL min, REAL max, REAL step) = 0;
-    
+    virtual void addVerticalSlider(const char* label, REAL* zone, REAL init, REAL min,
+                                   REAL max, REAL step)        = 0;
+    virtual void addHorizontalSlider(const char* label, REAL* zone, REAL init, REAL min,
+                                     REAL max, REAL step)      = 0;
+    virtual void addNumEntry(const char* label, REAL* zone, REAL init, REAL min, REAL max,
+                             REAL step)                        = 0;
+
     // -- passive widgets
-    
-    virtual void addHorizontalBargraph(const char* label, REAL* zone, REAL min, REAL max) = 0;
-    virtual void addVerticalBargraph(const char* label, REAL* zone, REAL min, REAL max) = 0;
-    
+
+    virtual void addHorizontalBargraph(const char* label, REAL* zone, REAL min,
+                                       REAL max) = 0;
+    virtual void addVerticalBargraph(const char* label, REAL* zone, REAL min,
+                                     REAL max)   = 0;
+
     // -- soundfiles
-    
-    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) = 0;
-    
+
+    virtual void addSoundfile(const char* label, const char* filename,
+                              Soundfile** sf_zone) = 0;
+
     // -- metadata declarations
-    
+
     virtual void declare(REAL* zone, const char* key, const char* val) {}
 };
 
-struct UI : public UIReal<FAUSTFLOAT>
-{
+struct UI : public UIReal<FAUSTFLOAT> {
     UI() {}
     virtual ~UI() {}
 };
@@ -415,9 +424,9 @@ struct UI : public UIReal<FAUSTFLOAT>
 #ifndef FAUST_PATHBUILDER_H
 #define FAUST_PATHBUILDER_H
 
-#include <vector>
-#include <string>
 #include <algorithm>
+#include <string>
+#include <vector>
 
 /*******************************************************************************
  * PathBuilder : Faust User Interface
@@ -426,37 +435,33 @@ struct UI : public UIReal<FAUSTFLOAT>
 
 class PathBuilder
 {
+   protected:
+    std::vector<std::string> fControlsLevel;
 
-    protected:
-    
-        std::vector<std::string> fControlsLevel;
-       
-    public:
-    
-        PathBuilder() {}
-        virtual ~PathBuilder() {}
-    
-        std::string buildPath(const std::string& label) 
-        {
-            std::string res = "/";
-            for (size_t i = 0; i < fControlsLevel.size(); i++) {
-                res += fControlsLevel[i];
-                res += "/";
-            }
-            res += label;
-            std::replace(res.begin(), res.end(), ' ', '_');
-            return res;
+   public:
+    PathBuilder() {}
+    virtual ~PathBuilder() {}
+
+    std::string buildPath(const std::string& label)
+    {
+        std::string res = "/";
+        for (size_t i = 0; i < fControlsLevel.size(); i++) {
+            res += fControlsLevel[i];
+            res += "/";
         }
-    
-        std::string buildLabel(std::string label)
-        {
-            std::replace(label.begin(), label.end(), ' ', '_');
-            return label;
-        }
-    
-        void pushLabel(const std::string& label) { fControlsLevel.push_back(label); }
-        void popLabel() { fControlsLevel.pop_back(); }
-    
+        res += label;
+        std::replace(res.begin(), res.end(), ' ', '_');
+        return res;
+    }
+
+    std::string buildLabel(std::string label)
+    {
+        std::replace(label.begin(), label.end(), ' ', '_');
+        return label;
+    }
+
+    void pushLabel(const std::string& label) { fControlsLevel.push_back(label); }
+    void popLabel() { fControlsLevel.pop_back(); }
 };
 
 #endif  // FAUST_PATHBUILDER_H
@@ -531,11 +536,12 @@ ZoneReader(zone, valueConverter) : a zone with a data converter
 
 ****************************************************************************************/
 
+#include <assert.h>
 #include <float.h>
-#include <algorithm>    // std::max
+
+#include <algorithm>  // std::max
 #include <cmath>
 #include <vector>
-#include <assert.h>
 
 //--------------------------------------------------------------------------------------
 // Interpolator(lo,hi,v1,v2)
@@ -548,50 +554,49 @@ ZoneReader(zone, valueConverter) : a zone with a data converter
 //--------------------------------------------------------------------------------------
 class Interpolator
 {
-    private:
+   private:
+    //--------------------------------------------------------------------------------------
+    // Range(lo,hi) clip a value between lo and hi
+    //--------------------------------------------------------------------------------------
+    struct Range {
+        double fLo;
+        double fHi;
 
-        //--------------------------------------------------------------------------------------
-        // Range(lo,hi) clip a value between lo and hi
-        //--------------------------------------------------------------------------------------
-        struct Range
+        Range(double x, double y)
+            : fLo(std::min<double>(x, y)), fHi(std::max<double>(x, y))
         {
-            double fLo;
-            double fHi;
-
-            Range(double x, double y) : fLo(std::min<double>(x,y)), fHi(std::max<double>(x,y)) {}
-            double operator()(double x) { return (x<fLo) ? fLo : (x>fHi) ? fHi : x; }
-        };
-
-
-        Range fRange;
-        double fCoef;
-        double fOffset;
-
-    public:
-
-        Interpolator(double lo, double hi, double v1, double v2) : fRange(lo,hi)
-        {
-            if (hi != lo) {
-                // regular case
-                fCoef = (v2-v1)/(hi-lo);
-                fOffset = v1 - lo*fCoef;
-            } else {
-                // degenerate case, avoids division by zero
-                fCoef = 0;
-                fOffset = (v1+v2)/2;
-            }
         }
-        double operator()(double v)
-        {
-            double x = fRange(v);
-            return  fOffset + x*fCoef;
-        }
+        double operator()(double x) { return (x < fLo) ? fLo : (x > fHi) ? fHi : x; }
+    };
 
-        void getLowHigh(double& amin, double& amax)
-        {
-            amin = fRange.fLo;
-            amax = fRange.fHi;
+    Range fRange;
+    double fCoef;
+    double fOffset;
+
+   public:
+    Interpolator(double lo, double hi, double v1, double v2) : fRange(lo, hi)
+    {
+        if (hi != lo) {
+            // regular case
+            fCoef   = (v2 - v1) / (hi - lo);
+            fOffset = v1 - lo * fCoef;
+        } else {
+            // degenerate case, avoids division by zero
+            fCoef   = 0;
+            fOffset = (v1 + v2) / 2;
         }
+    }
+    double operator()(double v)
+    {
+        double x = fRange(v);
+        return fOffset + x * fCoef;
+    }
+
+    void getLowHigh(double& amin, double& amax)
+    {
+        amin = fRange.fLo;
+        amax = fRange.fHi;
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -600,26 +605,23 @@ class Interpolator
 //--------------------------------------------------------------------------------------
 class Interpolator3pt
 {
+   private:
+    Interpolator fSegment1;
+    Interpolator fSegment2;
+    double fMid;
 
-    private:
+   public:
+    Interpolator3pt(double lo, double mi, double hi, double v1, double vm, double v2)
+        : fSegment1(lo, mi, v1, vm), fSegment2(mi, hi, vm, v2), fMid(mi)
+    {
+    }
+    double operator()(double x) { return (x < fMid) ? fSegment1(x) : fSegment2(x); }
 
-        Interpolator fSegment1;
-        Interpolator fSegment2;
-        double fMid;
-
-    public:
-
-        Interpolator3pt(double lo, double mi, double hi, double v1, double vm, double v2) :
-            fSegment1(lo, mi, v1, vm),
-            fSegment2(mi, hi, vm, v2),
-            fMid(mi) {}
-        double operator()(double x) { return  (x < fMid) ? fSegment1(x) : fSegment2(x); }
-
-        void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fSegment1.getLowHigh(amin, amid);
-            fSegment2.getLowHigh(amid, amax);
-        }
+    void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fSegment1.getLowHigh(amin, amid);
+        fSegment2.getLowHigh(amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -627,62 +629,51 @@ class Interpolator3pt
 //--------------------------------------------------------------------------------------
 class ValueConverter
 {
-
-    public:
-
-        virtual ~ValueConverter() {}
-        virtual double ui2faust(double x) = 0;
-        virtual double faust2ui(double x) = 0;
+   public:
+    virtual ~ValueConverter() {}
+    virtual double ui2faust(double x) = 0;
+    virtual double faust2ui(double x) = 0;
 };
 
 //--------------------------------------------------------------------------------------
 // A converter than can be updated
 //--------------------------------------------------------------------------------------
 
-class UpdatableValueConverter : public ValueConverter {
-    
-    protected:
-        
-        bool fActive;
-        
-    public:
-        
-        UpdatableValueConverter():fActive(true)
-        {}
-        virtual ~UpdatableValueConverter()
-        {}
-        
-        virtual void setMappingValues(double amin, double amid, double amax, double min, double init, double max) = 0;
-        virtual void getMappingValues(double& amin, double& amid, double& amax) = 0;
-        
-        void setActive(bool on_off) { fActive = on_off; }
-        bool getActive() { return fActive; }
-    
-};
+class UpdatableValueConverter : public ValueConverter
+{
+   protected:
+    bool fActive;
 
+   public:
+    UpdatableValueConverter() : fActive(true) {}
+    virtual ~UpdatableValueConverter() {}
+
+    virtual void setMappingValues(double amin, double amid, double amax, double min,
+                                  double init, double max)                  = 0;
+    virtual void getMappingValues(double& amin, double& amid, double& amax) = 0;
+
+    void setActive(bool on_off) { fActive = on_off; }
+    bool getActive() { return fActive; }
+};
 
 //--------------------------------------------------------------------------------------
 // Linear conversion between ui and Faust values
 //--------------------------------------------------------------------------------------
 class LinearValueConverter : public ValueConverter
 {
-    
-    private:
-        
-        Interpolator fUI2F;
-        Interpolator fF2UI;
-        
-    public:
-        
-        LinearValueConverter(double umin, double umax, double fmin, double fmax) :
-            fUI2F(umin,umax,fmin,fmax), fF2UI(fmin,fmax,umin,umax)
-        {}
-        
-        LinearValueConverter() : fUI2F(0.,0.,0.,0.), fF2UI(0.,0.,0.,0.)
-        {}
-        virtual double ui2faust(double x) { return fUI2F(x); }
-        virtual double faust2ui(double x) { return fF2UI(x); }
-    
+   private:
+    Interpolator fUI2F;
+    Interpolator fF2UI;
+
+   public:
+    LinearValueConverter(double umin, double umax, double fmin, double fmax)
+        : fUI2F(umin, umax, fmin, fmax), fF2UI(fmin, fmax, umin, umax)
+    {
+    }
+
+    LinearValueConverter() : fUI2F(0., 0., 0., 0.), fF2UI(0., 0., 0., 0.) {}
+    virtual double ui2faust(double x) { return fUI2F(x); }
+    virtual double faust2ui(double x) { return fF2UI(x); }
 };
 
 //--------------------------------------------------------------------------------------
@@ -690,35 +681,35 @@ class LinearValueConverter : public ValueConverter
 //--------------------------------------------------------------------------------------
 class LinearValueConverter2 : public UpdatableValueConverter
 {
-    
-    private:
-    
-        Interpolator3pt fUI2F;
-        Interpolator3pt fF2UI;
-        
-    public:
-    
-        LinearValueConverter2(double amin, double amid, double amax, double min, double init, double max) :
-            fUI2F(amin, amid, amax, min, init, max), fF2UI(min, init, max, amin, amid, amax)
-        {}
-        
-        LinearValueConverter2() : fUI2F(0.,0.,0.,0.,0.,0.), fF2UI(0.,0.,0.,0.,0.,0.)
-        {}
-    
-        virtual double ui2faust(double x) { return fUI2F(x); }
-        virtual double faust2ui(double x) { return fF2UI(x); }
-    
-        virtual void setMappingValues(double amin, double amid, double amax, double min, double init, double max)
-        {
-            fUI2F = Interpolator3pt(amin, amid, amax, min, init, max);
-            fF2UI = Interpolator3pt(min, init, max, amin, amid, amax);
-        }
+   private:
+    Interpolator3pt fUI2F;
+    Interpolator3pt fF2UI;
 
-        virtual void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fUI2F.getMappingValues(amin, amid, amax);
-        }
-    
+   public:
+    LinearValueConverter2(double amin, double amid, double amax, double min, double init,
+                          double max)
+        : fUI2F(amin, amid, amax, min, init, max), fF2UI(min, init, max, amin, amid, amax)
+    {
+    }
+
+    LinearValueConverter2() : fUI2F(0., 0., 0., 0., 0., 0.), fF2UI(0., 0., 0., 0., 0., 0.)
+    {
+    }
+
+    virtual double ui2faust(double x) { return fUI2F(x); }
+    virtual double faust2ui(double x) { return fF2UI(x); }
+
+    virtual void setMappingValues(double amin, double amid, double amax, double min,
+                                  double init, double max)
+    {
+        fUI2F = Interpolator3pt(amin, amid, amax, min, init, max);
+        fF2UI = Interpolator3pt(min, init, max, amin, amid, amax);
+    }
+
+    virtual void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fUI2F.getMappingValues(amin, amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -726,16 +717,21 @@ class LinearValueConverter2 : public UpdatableValueConverter
 //--------------------------------------------------------------------------------------
 class LogValueConverter : public LinearValueConverter
 {
+   public:
+    LogValueConverter(double umin, double umax, double fmin, double fmax)
+        : LinearValueConverter(umin, umax, std::log(std::max<double>(DBL_MIN, fmin)),
+                               std::log(std::max<double>(DBL_MIN, fmax)))
+    {
+    }
 
-    public:
-
-        LogValueConverter(double umin, double umax, double fmin, double fmax) :
-            LinearValueConverter(umin, umax, std::log(std::max<double>(DBL_MIN, fmin)), std::log(std::max<double>(DBL_MIN, fmax)))
-        {}
-
-        virtual double ui2faust(double x) { return std::exp(LinearValueConverter::ui2faust(x)); }
-        virtual double faust2ui(double x) { return LinearValueConverter::faust2ui(std::log(std::max<double>(x, DBL_MIN))); }
-
+    virtual double ui2faust(double x)
+    {
+        return std::exp(LinearValueConverter::ui2faust(x));
+    }
+    virtual double faust2ui(double x)
+    {
+        return LinearValueConverter::faust2ui(std::log(std::max<double>(x, DBL_MIN)));
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -743,16 +739,21 @@ class LogValueConverter : public LinearValueConverter
 //--------------------------------------------------------------------------------------
 class ExpValueConverter : public LinearValueConverter
 {
+   public:
+    ExpValueConverter(double umin, double umax, double fmin, double fmax)
+        : LinearValueConverter(umin, umax, std::min<double>(DBL_MAX, std::exp(fmin)),
+                               std::min<double>(DBL_MAX, std::exp(fmax)))
+    {
+    }
 
-    public:
-
-        ExpValueConverter(double umin, double umax, double fmin, double fmax) :
-            LinearValueConverter(umin, umax, std::min<double>(DBL_MAX, std::exp(fmin)), std::min<double>(DBL_MAX, std::exp(fmax)))
-        {}
-
-        virtual double ui2faust(double x) { return std::log(LinearValueConverter::ui2faust(x)); }
-        virtual double faust2ui(double x) { return LinearValueConverter::faust2ui(std::min<double>(DBL_MAX, std::exp(x))); }
-
+    virtual double ui2faust(double x)
+    {
+        return std::log(LinearValueConverter::ui2faust(x));
+    }
+    virtual double faust2ui(double x)
+    {
+        return LinearValueConverter::faust2ui(std::min<double>(DBL_MAX, std::exp(x)));
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -761,34 +762,33 @@ class ExpValueConverter : public LinearValueConverter
 //--------------------------------------------------------------------------------------
 class AccUpConverter : public UpdatableValueConverter
 {
+   private:
+    Interpolator3pt fA2F;
+    Interpolator3pt fF2A;
 
-    private:
+   public:
+    AccUpConverter(double amin, double amid, double amax, double fmin, double fmid,
+                   double fmax)
+        : fA2F(amin, amid, amax, fmin, fmid, fmax)
+        , fF2A(fmin, fmid, fmax, amin, amid, amax)
+    {
+    }
 
-        Interpolator3pt fA2F;
-        Interpolator3pt fF2A;
+    virtual double ui2faust(double x) { return fA2F(x); }
+    virtual double faust2ui(double x) { return fF2A(x); }
 
-    public:
+    virtual void setMappingValues(double amin, double amid, double amax, double fmin,
+                                  double fmid, double fmax)
+    {
+        //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccUpConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
+        fA2F = Interpolator3pt(amin, amid, amax, fmin, fmid, fmax);
+        fF2A = Interpolator3pt(fmin, fmid, fmax, amin, amid, amax);
+    }
 
-        AccUpConverter(double amin, double amid, double amax, double fmin, double fmid, double fmax) :
-            fA2F(amin,amid,amax,fmin,fmid,fmax),
-            fF2A(fmin,fmid,fmax,amin,amid,amax)
-        {}
-
-        virtual double ui2faust(double x) { return fA2F(x); }
-        virtual double faust2ui(double x) { return fF2A(x); }
-
-        virtual void setMappingValues(double amin, double amid, double amax, double fmin, double fmid, double fmax)
-        {
-            //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccUpConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
-            fA2F = Interpolator3pt(amin, amid, amax, fmin, fmid, fmax);
-            fF2A = Interpolator3pt(fmin, fmid, fmax, amin, amid, amax);
-        }
-
-        virtual void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fA2F.getMappingValues(amin, amid, amax);
-        }
-
+    virtual void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fA2F.getMappingValues(amin, amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -797,33 +797,33 @@ class AccUpConverter : public UpdatableValueConverter
 //--------------------------------------------------------------------------------------
 class AccDownConverter : public UpdatableValueConverter
 {
+   private:
+    Interpolator3pt fA2F;
+    Interpolator3pt fF2A;
 
-    private:
+   public:
+    AccDownConverter(double amin, double amid, double amax, double fmin, double fmid,
+                     double fmax)
+        : fA2F(amin, amid, amax, fmax, fmid, fmin)
+        , fF2A(fmin, fmid, fmax, amax, amid, amin)
+    {
+    }
 
-        Interpolator3pt	fA2F;
-        Interpolator3pt	fF2A;
+    virtual double ui2faust(double x) { return fA2F(x); }
+    virtual double faust2ui(double x) { return fF2A(x); }
 
-    public:
+    virtual void setMappingValues(double amin, double amid, double amax, double fmin,
+                                  double fmid, double fmax)
+    {
+        //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccDownConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
+        fA2F = Interpolator3pt(amin, amid, amax, fmax, fmid, fmin);
+        fF2A = Interpolator3pt(fmin, fmid, fmax, amax, amid, amin);
+    }
 
-        AccDownConverter(double amin, double amid, double amax, double fmin, double fmid, double fmax) :
-            fA2F(amin,amid,amax,fmax,fmid,fmin),
-            fF2A(fmin,fmid,fmax,amax,amid,amin)
-        {}
-
-        virtual double ui2faust(double x) { return fA2F(x); }
-        virtual double faust2ui(double x) { return fF2A(x); }
-
-        virtual void setMappingValues(double amin, double amid, double amax, double fmin, double fmid, double fmax)
-        {
-             //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccDownConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
-            fA2F = Interpolator3pt(amin, amid, amax, fmax, fmid, fmin);
-            fF2A = Interpolator3pt(fmin, fmid, fmax, amax, amid, amin);
-        }
-
-        virtual void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fA2F.getMappingValues(amin, amid, amax);
-        }
+    virtual void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fA2F.getMappingValues(amin, amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -832,33 +832,34 @@ class AccDownConverter : public UpdatableValueConverter
 //--------------------------------------------------------------------------------------
 class AccUpDownConverter : public UpdatableValueConverter
 {
+   private:
+    Interpolator3pt fA2F;
+    Interpolator fF2A;
 
-    private:
+   public:
+    AccUpDownConverter(double amin, double amid, double amax, double fmin, double fmid,
+                       double fmax)
+        : fA2F(amin, amid, amax, fmin, fmax, fmin)
+        , fF2A(fmin, fmax, amin,
+               amax)  // Special, pseudo inverse of a non monotonic function
+    {
+    }
 
-        Interpolator3pt	fA2F;
-        Interpolator fF2A;
+    virtual double ui2faust(double x) { return fA2F(x); }
+    virtual double faust2ui(double x) { return fF2A(x); }
 
-    public:
+    virtual void setMappingValues(double amin, double amid, double amax, double fmin,
+                                  double fmid, double fmax)
+    {
+        //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccUpDownConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
+        fA2F = Interpolator3pt(amin, amid, amax, fmin, fmax, fmin);
+        fF2A = Interpolator(fmin, fmax, amin, amax);
+    }
 
-        AccUpDownConverter(double amin, double amid, double amax, double fmin, double fmid, double fmax) :
-            fA2F(amin,amid,amax,fmin,fmax,fmin),
-            fF2A(fmin,fmax,amin,amax)				// Special, pseudo inverse of a non monotonic function
-        {}
-
-        virtual double ui2faust(double x) { return fA2F(x); }
-        virtual double faust2ui(double x) { return fF2A(x); }
-
-        virtual void setMappingValues(double amin, double amid, double amax, double fmin, double fmid, double fmax)
-        {
-            //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccUpDownConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
-            fA2F = Interpolator3pt(amin, amid, amax, fmin, fmax, fmin);
-            fF2A = Interpolator(fmin, fmax, amin, amax);
-        }
-
-        virtual void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fA2F.getMappingValues(amin, amid, amax);
-        }
+    virtual void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fA2F.getMappingValues(amin, amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -867,33 +868,34 @@ class AccUpDownConverter : public UpdatableValueConverter
 //--------------------------------------------------------------------------------------
 class AccDownUpConverter : public UpdatableValueConverter
 {
+   private:
+    Interpolator3pt fA2F;
+    Interpolator fF2A;
 
-    private:
+   public:
+    AccDownUpConverter(double amin, double amid, double amax, double fmin, double fmid,
+                       double fmax)
+        : fA2F(amin, amid, amax, fmax, fmin, fmax)
+        , fF2A(fmin, fmax, amin,
+               amax)  // Special, pseudo inverse of a non monotonic function
+    {
+    }
 
-        Interpolator3pt	fA2F;
-        Interpolator fF2A;
+    virtual double ui2faust(double x) { return fA2F(x); }
+    virtual double faust2ui(double x) { return fF2A(x); }
 
-    public:
+    virtual void setMappingValues(double amin, double amid, double amax, double fmin,
+                                  double fmid, double fmax)
+    {
+        //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccDownUpConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
+        fA2F = Interpolator3pt(amin, amid, amax, fmax, fmin, fmax);
+        fF2A = Interpolator(fmin, fmax, amin, amax);
+    }
 
-        AccDownUpConverter(double amin, double amid, double amax, double fmin, double fmid, double fmax) :
-            fA2F(amin,amid,amax,fmax,fmin,fmax),
-            fF2A(fmin,fmax,amin,amax)				// Special, pseudo inverse of a non monotonic function
-        {}
-
-        virtual double ui2faust(double x) { return fA2F(x); }
-        virtual double faust2ui(double x) { return fF2A(x); }
-
-        virtual void setMappingValues(double amin, double amid, double amax, double fmin, double fmid, double fmax)
-        {
-            //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccDownUpConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
-            fA2F = Interpolator3pt(amin, amid, amax, fmax, fmin, fmax);
-            fF2A = Interpolator(fmin, fmax, amin, amax);
-        }
-
-        virtual void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fA2F.getMappingValues(amin, amid, amax);
-        }
+    virtual void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fA2F.getMappingValues(amin, amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -901,28 +903,27 @@ class AccDownUpConverter : public UpdatableValueConverter
 //--------------------------------------------------------------------------------------
 class ZoneControl
 {
+   protected:
+    FAUSTFLOAT* fZone;
 
-    protected:
+   public:
+    ZoneControl(FAUSTFLOAT* zone) : fZone(zone) {}
+    virtual ~ZoneControl() {}
 
-        FAUSTFLOAT*	fZone;
+    virtual void update(double v) const {}
 
-    public:
+    virtual void setMappingValues(int curve, double amin, double amid, double amax,
+                                  double min, double init, double max)
+    {
+    }
+    virtual void getMappingValues(double& amin, double& amid, double& amax) {}
 
-        ZoneControl(FAUSTFLOAT* zone) : fZone(zone) {}
-        virtual ~ZoneControl() {}
+    FAUSTFLOAT* getZone() { return fZone; }
 
-        virtual void update(double v) const {}
+    virtual void setActive(bool on_off) {}
+    virtual bool getActive() { return false; }
 
-        virtual void setMappingValues(int curve, double amin, double amid, double amax, double min, double init, double max) {}
-        virtual void getMappingValues(double& amin, double& amid, double& amax) {}
-
-        FAUSTFLOAT* getZone() { return fZone; }
-
-        virtual void setActive(bool on_off) {}
-        virtual bool getActive() { return false; }
-
-        virtual int getCurve() { return -1; }
-
+    virtual int getCurve() { return -1; }
 };
 
 //--------------------------------------------------------------------------------------
@@ -930,20 +931,22 @@ class ZoneControl
 //--------------------------------------------------------------------------------------
 class ConverterZoneControl : public ZoneControl
 {
+   protected:
+    ValueConverter* fValueConverter;
 
-    protected:
+   public:
+    ConverterZoneControl(FAUSTFLOAT* zone, ValueConverter* converter)
+        : ZoneControl(zone), fValueConverter(converter)
+    {
+    }
+    virtual ~ConverterZoneControl()
+    {
+        delete fValueConverter;
+    }  // Assuming fValueConverter is not kept elsewhere...
 
-        ValueConverter* fValueConverter;
+    virtual void update(double v) const { *fZone = fValueConverter->ui2faust(v); }
 
-    public:
-
-        ConverterZoneControl(FAUSTFLOAT* zone, ValueConverter* converter) : ZoneControl(zone), fValueConverter(converter) {}
-        virtual ~ConverterZoneControl() { delete fValueConverter; } // Assuming fValueConverter is not kept elsewhere...
-
-        virtual void update(double v) const { *fZone = fValueConverter->ui2faust(v); }
-
-        ValueConverter* getConverter() { return fValueConverter; }
-
+    ValueConverter* getConverter() { return fValueConverter; }
 };
 
 //--------------------------------------------------------------------------------------
@@ -952,477 +955,496 @@ class ConverterZoneControl : public ZoneControl
 //--------------------------------------------------------------------------------------
 class CurveZoneControl : public ZoneControl
 {
+   private:
+    std::vector<UpdatableValueConverter*> fValueConverters;
+    int fCurve;
 
-    private:
-
-        std::vector<UpdatableValueConverter*> fValueConverters;
-        int fCurve;
-
-    public:
-
-        CurveZoneControl(FAUSTFLOAT* zone, int curve, double amin, double amid, double amax, double min, double init, double max) : ZoneControl(zone), fCurve(0)
-        {
-            assert(curve >= 0 && curve <= 3);
-            fValueConverters.push_back(new AccUpConverter(amin, amid, amax, min, init, max));
-            fValueConverters.push_back(new AccDownConverter(amin, amid, amax, min, init, max));
-            fValueConverters.push_back(new AccUpDownConverter(amin, amid, amax, min, init, max));
-            fValueConverters.push_back(new AccDownUpConverter(amin, amid, amax, min, init, max));
-            fCurve = curve;
+   public:
+    CurveZoneControl(FAUSTFLOAT* zone, int curve, double amin, double amid, double amax,
+                     double min, double init, double max)
+        : ZoneControl(zone), fCurve(0)
+    {
+        assert(curve >= 0 && curve <= 3);
+        fValueConverters.push_back(new AccUpConverter(amin, amid, amax, min, init, max));
+        fValueConverters.push_back(
+            new AccDownConverter(amin, amid, amax, min, init, max));
+        fValueConverters.push_back(
+            new AccUpDownConverter(amin, amid, amax, min, init, max));
+        fValueConverters.push_back(
+            new AccDownUpConverter(amin, amid, amax, min, init, max));
+        fCurve = curve;
+    }
+    virtual ~CurveZoneControl()
+    {
+        std::vector<UpdatableValueConverter*>::iterator it;
+        for (it = fValueConverters.begin(); it != fValueConverters.end(); it++) {
+            delete (*it);
         }
-        virtual ~CurveZoneControl()
-        {
-            std::vector<UpdatableValueConverter*>::iterator it;
-            for (it = fValueConverters.begin(); it != fValueConverters.end(); it++) {
-                delete(*it);
-            }
-        }
-        void update(double v) const { if (fValueConverters[fCurve]->getActive()) *fZone = fValueConverters[fCurve]->ui2faust(v); }
+    }
+    void update(double v) const
+    {
+        if (fValueConverters[fCurve]->getActive())
+            *fZone = fValueConverters[fCurve]->ui2faust(v);
+    }
 
-        void setMappingValues(int curve, double amin, double amid, double amax, double min, double init, double max)
-        {
-            fValueConverters[curve]->setMappingValues(amin, amid, amax, min, init, max);
-            fCurve = curve;
-        }
+    void setMappingValues(int curve, double amin, double amid, double amax, double min,
+                          double init, double max)
+    {
+        fValueConverters[curve]->setMappingValues(amin, amid, amax, min, init, max);
+        fCurve = curve;
+    }
 
-        void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fValueConverters[fCurve]->getMappingValues(amin, amid, amax);
-        }
+    void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fValueConverters[fCurve]->getMappingValues(amin, amid, amax);
+    }
 
-        void setActive(bool on_off)
-        {
-            std::vector<UpdatableValueConverter*>::iterator it;
-            for (it = fValueConverters.begin(); it != fValueConverters.end(); it++) {
-                (*it)->setActive(on_off);
-            }
+    void setActive(bool on_off)
+    {
+        std::vector<UpdatableValueConverter*>::iterator it;
+        for (it = fValueConverters.begin(); it != fValueConverters.end(); it++) {
+            (*it)->setActive(on_off);
         }
+    }
 
-        int getCurve() { return fCurve; }
+    int getCurve() { return fCurve; }
 };
 
 class ZoneReader
 {
+   private:
+    FAUSTFLOAT* fZone;
+    Interpolator fInterpolator;
 
-    private:
+   public:
+    ZoneReader(FAUSTFLOAT* zone, double lo, double hi)
+        : fZone(zone), fInterpolator(lo, hi, 0, 255)
+    {
+    }
 
-        FAUSTFLOAT* fZone;
-        Interpolator fInterpolator;
+    virtual ~ZoneReader() {}
 
-    public:
-
-        ZoneReader(FAUSTFLOAT* zone, double lo, double hi) : fZone(zone), fInterpolator(lo, hi, 0, 255) {}
-
-        virtual ~ZoneReader() {}
-
-        int getValue()
-        {
-            return (fZone != nullptr) ? int(fInterpolator(*fZone)) : 127;
-        }
-
+    int getValue() { return (fZone != nullptr) ? int(fInterpolator(*fZone)) : 127; }
 };
 
 #endif
 /**************************  END  ValueConverter.h **************************/
 
-class APIUI : public PathBuilder, public Meta, public UI
+class APIUI
+    : public PathBuilder
+    , public Meta
+    , public UI
 {
-    public:
-    
-        enum ItemType { kButton = 0, kCheckButton, kVSlider, kHSlider, kNumEntry, kHBargraph, kVBargraph };
-  
-    protected:
-    
-        enum { kLin = 0, kLog = 1, kExp = 2 };
-    
-        int fNumParameters;
-        std::vector<std::string> fPaths;
-        std::vector<std::string> fLabels;
-        std::map<std::string, int> fPathMap;
-        std::map<std::string, int> fLabelMap;
-        std::vector<ValueConverter*> fConversion;
-        std::vector<FAUSTFLOAT*> fZone;
-        std::vector<FAUSTFLOAT> fInit;
-        std::vector<FAUSTFLOAT> fMin;
-        std::vector<FAUSTFLOAT> fMax;
-        std::vector<FAUSTFLOAT> fStep;
-        std::vector<ItemType> fItemType;
-        std::vector<std::map<std::string, std::string> > fMetaData;
-        std::vector<ZoneControl*> fAcc[3];
-        std::vector<ZoneControl*> fGyr[3];
+   public:
+    enum ItemType {
+        kButton = 0,
+        kCheckButton,
+        kVSlider,
+        kHSlider,
+        kNumEntry,
+        kHBargraph,
+        kVBargraph
+    };
 
-        // Screen color control
-        // "...[screencolor:red]..." etc.
-        bool fHasScreenControl;      // true if control screen color metadata
-        ZoneReader* fRedReader;
-        ZoneReader* fGreenReader;
-        ZoneReader* fBlueReader;
+   protected:
+    enum { kLin = 0, kLog = 1, kExp = 2 };
 
-        // Current values controlled by metadata
-        std::string fCurrentUnit;
-        int fCurrentScale;
-        std::string fCurrentAcc;
-        std::string fCurrentGyr;
-        std::string fCurrentColor;
-        std::string fCurrentTooltip;
-        std::map<std::string, std::string> fCurrentMetadata;
-    
-        // Add a generic parameter
-        virtual void addParameter(const char* label,
-                                FAUSTFLOAT* zone,
-                                FAUSTFLOAT init,
-                                FAUSTFLOAT min,
-                                FAUSTFLOAT max,
-                                FAUSTFLOAT step,
-                                ItemType type)
-        {
-            std::string path = buildPath(label);
-            fPathMap[path] = fLabelMap[label] = fNumParameters++;
-            fPaths.push_back(path);
-            fLabels.push_back(label);
-            fZone.push_back(zone);
-            fInit.push_back(init);
-            fMin.push_back(min);
-            fMax.push_back(max);
-            fStep.push_back(step);
-            fItemType.push_back(type);
-            
-            // handle scale metadata
-            switch (fCurrentScale) {
-                case kLin:
-                    fConversion.push_back(new LinearValueConverter(0, 1, min, max));
-                    break;
-                case kLog:
-                    fConversion.push_back(new LogValueConverter(0, 1, min, max));
-                    break;
-                case kExp: fConversion.push_back(new ExpValueConverter(0, 1, min, max));
-                    break;
-            }
-            fCurrentScale = kLin;
-            
-            if (fCurrentAcc.size() > 0 && fCurrentGyr.size() > 0) {
-                std::cerr << "warning : 'acc' and 'gyr' metadata used for the same " << label << " parameter !!\n";
-            }
+    int fNumParameters;
+    std::vector<std::string> fPaths;
+    std::vector<std::string> fLabels;
+    std::map<std::string, int> fPathMap;
+    std::map<std::string, int> fLabelMap;
+    std::vector<ValueConverter*> fConversion;
+    std::vector<FAUSTFLOAT*> fZone;
+    std::vector<FAUSTFLOAT> fInit;
+    std::vector<FAUSTFLOAT> fMin;
+    std::vector<FAUSTFLOAT> fMax;
+    std::vector<FAUSTFLOAT> fStep;
+    std::vector<ItemType> fItemType;
+    std::vector<std::map<std::string, std::string> > fMetaData;
+    std::vector<ZoneControl*> fAcc[3];
+    std::vector<ZoneControl*> fGyr[3];
 
-            // handle acc metadata "...[acc : <axe> <curve> <amin> <amid> <amax>]..."
-            if (fCurrentAcc.size() > 0) {
-                std::istringstream iss(fCurrentAcc);
-                int axe, curve;
-                double amin, amid, amax;
-                iss >> axe >> curve >> amin >> amid >> amax;
+    // Screen color control
+    // "...[screencolor:red]..." etc.
+    bool fHasScreenControl;  // true if control screen color metadata
+    ZoneReader* fRedReader;
+    ZoneReader* fGreenReader;
+    ZoneReader* fBlueReader;
 
-                if ((0 <= axe) && (axe < 3) &&
-                    (0 <= curve) && (curve < 4) &&
-                    (amin < amax) && (amin <= amid) && (amid <= amax))
-                {
-                    fAcc[axe].push_back(new CurveZoneControl(zone, curve, amin, amid, amax, min, init, max));
-                } else {
-                    std::cerr << "incorrect acc metadata : " << fCurrentAcc << std::endl;
-                }
-                fCurrentAcc = "";
-            }
-       
-            // handle gyr metadata "...[gyr : <axe> <curve> <amin> <amid> <amax>]..."
-            if (fCurrentGyr.size() > 0) {
-                std::istringstream iss(fCurrentGyr);
-                int axe, curve;
-                double amin, amid, amax;
-                iss >> axe >> curve >> amin >> amid >> amax;
+    // Current values controlled by metadata
+    std::string fCurrentUnit;
+    int fCurrentScale;
+    std::string fCurrentAcc;
+    std::string fCurrentGyr;
+    std::string fCurrentColor;
+    std::string fCurrentTooltip;
+    std::map<std::string, std::string> fCurrentMetadata;
 
-                if ((0 <= axe) && (axe < 3) &&
-                    (0 <= curve) && (curve < 4) &&
-                    (amin < amax) && (amin <= amid) && (amid <= amax))
-                {
-                    fGyr[axe].push_back(new CurveZoneControl(zone, curve, amin, amid, amax, min, init, max));
-                } else {
-                    std::cerr << "incorrect gyr metadata : " << fCurrentGyr << std::endl;
-                }
-                fCurrentGyr = "";
-            }
-        
-            // handle screencolor metadata "...[screencolor:red|green|blue|white]..."
-            if (fCurrentColor.size() > 0) {
-                if ((fCurrentColor == "red") && (fRedReader == 0)) {
-                    fRedReader = new ZoneReader(zone, min, max);
-                    fHasScreenControl = true;
-                } else if ((fCurrentColor == "green") && (fGreenReader == 0)) {
-                    fGreenReader = new ZoneReader(zone, min, max);
-                    fHasScreenControl = true;
-                } else if ((fCurrentColor == "blue") && (fBlueReader == 0)) {
-                    fBlueReader = new ZoneReader(zone, min, max);
-                    fHasScreenControl = true;
-                } else if ((fCurrentColor == "white") && (fRedReader == 0) && (fGreenReader == 0) && (fBlueReader == 0)) {
-                    fRedReader = new ZoneReader(zone, min, max);
-                    fGreenReader = new ZoneReader(zone, min, max);
-                    fBlueReader = new ZoneReader(zone, min, max);
-                    fHasScreenControl = true;
-                } else {
-                    std::cerr << "incorrect screencolor metadata : " << fCurrentColor << std::endl;
-                }
-            }
-            fCurrentColor = "";
-            
-            fMetaData.push_back(fCurrentMetadata);
-            fCurrentMetadata.clear();
+    // Add a generic parameter
+    virtual void addParameter(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init,
+                              FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step,
+                              ItemType type)
+    {
+        std::string path = buildPath(label);
+        fPathMap[path] = fLabelMap[label] = fNumParameters++;
+        fPaths.push_back(path);
+        fLabels.push_back(label);
+        fZone.push_back(zone);
+        fInit.push_back(init);
+        fMin.push_back(min);
+        fMax.push_back(max);
+        fStep.push_back(step);
+        fItemType.push_back(type);
+
+        // handle scale metadata
+        switch (fCurrentScale) {
+        case kLin:
+            fConversion.push_back(new LinearValueConverter(0, 1, min, max));
+            break;
+        case kLog:
+            fConversion.push_back(new LogValueConverter(0, 1, min, max));
+            break;
+        case kExp:
+            fConversion.push_back(new ExpValueConverter(0, 1, min, max));
+            break;
+        }
+        fCurrentScale = kLin;
+
+        if (fCurrentAcc.size() > 0 && fCurrentGyr.size() > 0) {
+            std::cerr << "warning : 'acc' and 'gyr' metadata used for the same " << label
+                      << " parameter !!\n";
         }
 
-        int getZoneIndex(std::vector<ZoneControl*>* table, int p, int val)
-        {
-            FAUSTFLOAT* zone = fZone[p];
-            for (size_t i = 0; i < table[val].size(); i++) {
-                if (zone == table[val][i]->getZone()) return int(i);
+        // handle acc metadata "...[acc : <axe> <curve> <amin> <amid> <amax>]..."
+        if (fCurrentAcc.size() > 0) {
+            std::istringstream iss(fCurrentAcc);
+            int axe, curve;
+            double amin, amid, amax;
+            iss >> axe >> curve >> amin >> amid >> amax;
+
+            if ((0 <= axe) && (axe < 3) && (0 <= curve) && (curve < 4) && (amin < amax)
+                && (amin <= amid) && (amid <= amax)) {
+                fAcc[axe].push_back(
+                    new CurveZoneControl(zone, curve, amin, amid, amax, min, init, max));
+            } else {
+                std::cerr << "incorrect acc metadata : " << fCurrentAcc << std::endl;
             }
+            fCurrentAcc = "";
+        }
+
+        // handle gyr metadata "...[gyr : <axe> <curve> <amin> <amid> <amax>]..."
+        if (fCurrentGyr.size() > 0) {
+            std::istringstream iss(fCurrentGyr);
+            int axe, curve;
+            double amin, amid, amax;
+            iss >> axe >> curve >> amin >> amid >> amax;
+
+            if ((0 <= axe) && (axe < 3) && (0 <= curve) && (curve < 4) && (amin < amax)
+                && (amin <= amid) && (amid <= amax)) {
+                fGyr[axe].push_back(
+                    new CurveZoneControl(zone, curve, amin, amid, amax, min, init, max));
+            } else {
+                std::cerr << "incorrect gyr metadata : " << fCurrentGyr << std::endl;
+            }
+            fCurrentGyr = "";
+        }
+
+        // handle screencolor metadata "...[screencolor:red|green|blue|white]..."
+        if (fCurrentColor.size() > 0) {
+            if ((fCurrentColor == "red") && (fRedReader == 0)) {
+                fRedReader        = new ZoneReader(zone, min, max);
+                fHasScreenControl = true;
+            } else if ((fCurrentColor == "green") && (fGreenReader == 0)) {
+                fGreenReader      = new ZoneReader(zone, min, max);
+                fHasScreenControl = true;
+            } else if ((fCurrentColor == "blue") && (fBlueReader == 0)) {
+                fBlueReader       = new ZoneReader(zone, min, max);
+                fHasScreenControl = true;
+            } else if ((fCurrentColor == "white") && (fRedReader == 0)
+                       && (fGreenReader == 0) && (fBlueReader == 0)) {
+                fRedReader        = new ZoneReader(zone, min, max);
+                fGreenReader      = new ZoneReader(zone, min, max);
+                fBlueReader       = new ZoneReader(zone, min, max);
+                fHasScreenControl = true;
+            } else {
+                std::cerr << "incorrect screencolor metadata : " << fCurrentColor
+                          << std::endl;
+            }
+        }
+        fCurrentColor = "";
+
+        fMetaData.push_back(fCurrentMetadata);
+        fCurrentMetadata.clear();
+    }
+
+    int getZoneIndex(std::vector<ZoneControl*>* table, int p, int val)
+    {
+        FAUSTFLOAT* zone = fZone[p];
+        for (size_t i = 0; i < table[val].size(); i++) {
+            if (zone == table[val][i]->getZone()) return int(i);
+        }
+        return -1;
+    }
+
+    void setConverter(std::vector<ZoneControl*>* table, int p, int val, int curve,
+                      double amin, double amid, double amax)
+    {
+        int id1 = getZoneIndex(table, p, 0);
+        int id2 = getZoneIndex(table, p, 1);
+        int id3 = getZoneIndex(table, p, 2);
+
+        // Deactivates everywhere..
+        if (id1 != -1) table[0][id1]->setActive(false);
+        if (id2 != -1) table[1][id2]->setActive(false);
+        if (id3 != -1) table[2][id3]->setActive(false);
+
+        if (val == -1) {  // Means: no more mapping...
+            // So stay all deactivated...
+        } else {
+            int id4 = getZoneIndex(table, p, val);
+            if (id4 != -1) {
+                // Reactivate the one we edit...
+                table[val][id4]->setMappingValues(curve, amin, amid, amax, fMin[p],
+                                                  fInit[p], fMax[p]);
+                table[val][id4]->setActive(true);
+            } else {
+                // Allocate a new CurveZoneControl which is 'active' by default
+                FAUSTFLOAT* zone = fZone[p];
+                table[val].push_back(new CurveZoneControl(zone, curve, amin, amid, amax,
+                                                          fMin[p], fInit[p], fMax[p]));
+            }
+        }
+    }
+
+    void getConverter(std::vector<ZoneControl*>* table, int p, int& val, int& curve,
+                      double& amin, double& amid, double& amax)
+    {
+        int id1 = getZoneIndex(table, p, 0);
+        int id2 = getZoneIndex(table, p, 1);
+        int id3 = getZoneIndex(table, p, 2);
+
+        if (id1 != -1) {
+            val   = 0;
+            curve = table[val][id1]->getCurve();
+            table[val][id1]->getMappingValues(amin, amid, amax);
+        } else if (id2 != -1) {
+            val   = 1;
+            curve = table[val][id2]->getCurve();
+            table[val][id2]->getMappingValues(amin, amid, amax);
+        } else if (id3 != -1) {
+            val   = 2;
+            curve = table[val][id3]->getCurve();
+            table[val][id3]->getMappingValues(amin, amid, amax);
+        } else {
+            val   = -1;  // No mapping
+            curve = 0;
+            amin  = -100.;
+            amid  = 0.;
+            amax  = 100.;
+        }
+    }
+
+   public:
+    enum Type { kAcc = 0, kGyr = 1, kNoType };
+
+    APIUI()
+        : fNumParameters(0)
+        , fHasScreenControl(false)
+        , fRedReader(0)
+        , fGreenReader(0)
+        , fBlueReader(0)
+        , fCurrentScale(kLin)
+    {
+    }
+
+    virtual ~APIUI()
+    {
+        for (auto& it : fConversion) delete it;
+        for (int i = 0; i < 3; i++) {
+            for (auto& it : fAcc[i]) delete it;
+            for (auto& it : fGyr[i]) delete it;
+        }
+        delete fRedReader;
+        delete fGreenReader;
+        delete fBlueReader;
+    }
+
+    // -- widget's layouts
+
+    virtual void openTabBox(const char* label) { pushLabel(label); }
+    virtual void openHorizontalBox(const char* label) { pushLabel(label); }
+    virtual void openVerticalBox(const char* label) { pushLabel(label); }
+    virtual void closeBox() { popLabel(); }
+
+    // -- active widgets
+
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    {
+        addParameter(label, zone, 0, 0, 1, 1, kButton);
+    }
+
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    {
+        addParameter(label, zone, 0, 0, 1, 1, kCheckButton);
+    }
+
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init,
+                                   FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addParameter(label, zone, init, min, max, step, kVSlider);
+    }
+
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init,
+                                     FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addParameter(label, zone, init, min, max, step, kHSlider);
+    }
+
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init,
+                             FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addParameter(label, zone, init, min, max, step, kNumEntry);
+    }
+
+    // -- passive widgets
+
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone,
+                                       FAUSTFLOAT min, FAUSTFLOAT max)
+    {
+        addParameter(label, zone, min, min, max, (max - min) / 1000.0, kHBargraph);
+    }
+
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min,
+                                     FAUSTFLOAT max)
+    {
+        addParameter(label, zone, min, min, max, (max - min) / 1000.0, kVBargraph);
+    }
+
+    // -- soundfiles
+
+    virtual void addSoundfile(const char* label, const char* filename,
+                              Soundfile** sf_zone)
+    {
+    }
+
+    // -- metadata declarations
+
+    virtual void declare(FAUSTFLOAT* zone, const char* key, const char* val)
+    {
+        // Keep metadata
+        fCurrentMetadata[key] = val;
+
+        if (strcmp(key, "scale") == 0) {
+            if (strcmp(val, "log") == 0) {
+                fCurrentScale = kLog;
+            } else if (strcmp(val, "exp") == 0) {
+                fCurrentScale = kExp;
+            } else {
+                fCurrentScale = kLin;
+            }
+        } else if (strcmp(key, "unit") == 0) {
+            fCurrentUnit = val;
+        } else if (strcmp(key, "acc") == 0) {
+            fCurrentAcc = val;
+        } else if (strcmp(key, "gyr") == 0) {
+            fCurrentGyr = val;
+        } else if (strcmp(key, "screencolor") == 0) {
+            fCurrentColor = val;  // val = "red", "green", "blue" or "white"
+        } else if (strcmp(key, "tooltip") == 0) {
+            fCurrentTooltip = val;
+        }
+    }
+
+    virtual void declare(const char* key, const char* val) {}
+
+    //-------------------------------------------------------------------------------
+    // Simple API part
+    //-------------------------------------------------------------------------------
+    int getParamsCount() { return fNumParameters; }
+    int getParamIndex(const char* path)
+    {
+        if (fPathMap.find(path) != fPathMap.end()) {
+            return fPathMap[path];
+        } else if (fLabelMap.find(path) != fLabelMap.end()) {
+            return fLabelMap[path];
+        } else {
             return -1;
         }
-    
-        void setConverter(std::vector<ZoneControl*>* table, int p, int val, int curve, double amin, double amid, double amax)
-        {
-            int id1 = getZoneIndex(table, p, 0);
-            int id2 = getZoneIndex(table, p, 1);
-            int id3 = getZoneIndex(table, p, 2);
-            
-            // Deactivates everywhere..
-            if (id1 != -1) table[0][id1]->setActive(false);
-            if (id2 != -1) table[1][id2]->setActive(false);
-            if (id3 != -1) table[2][id3]->setActive(false);
-            
-            if (val == -1) { // Means: no more mapping...
-                // So stay all deactivated...
-            } else {
-                int id4 = getZoneIndex(table, p, val);
-                if (id4 != -1) {
-                    // Reactivate the one we edit...
-                    table[val][id4]->setMappingValues(curve, amin, amid, amax, fMin[p], fInit[p], fMax[p]);
-                    table[val][id4]->setActive(true);
-                } else {
-                    // Allocate a new CurveZoneControl which is 'active' by default
-                    FAUSTFLOAT* zone = fZone[p];
-                    table[val].push_back(new CurveZoneControl(zone, curve, amin, amid, amax, fMin[p], fInit[p], fMax[p]));
-                }
-            }
-        }
-    
-        void getConverter(std::vector<ZoneControl*>* table, int p, int& val, int& curve, double& amin, double& amid, double& amax)
-        {
-            int id1 = getZoneIndex(table, p, 0);
-            int id2 = getZoneIndex(table, p, 1);
-            int id3 = getZoneIndex(table, p, 2);
-            
-            if (id1 != -1) {
-                val = 0;
-                curve = table[val][id1]->getCurve();
-                table[val][id1]->getMappingValues(amin, amid, amax);
-            } else if (id2 != -1) {
-                val = 1;
-                curve = table[val][id2]->getCurve();
-                table[val][id2]->getMappingValues(amin, amid, amax);
-            } else if (id3 != -1) {
-                val = 2;
-                curve = table[val][id3]->getCurve();
-                table[val][id3]->getMappingValues(amin, amid, amax);
-            } else {
-                val = -1; // No mapping
-                curve = 0;
-                amin = -100.;
-                amid = 0.;
-                amax = 100.;
-            }
-        }
+    }
+    const char* getParamAddress(int p) { return fPaths[p].c_str(); }
+    const char* getParamLabel(int p) { return fLabels[p].c_str(); }
+    std::map<const char*, const char*> getMetadata(int p)
+    {
+        std::map<const char*, const char*> res;
+        std::map<std::string, std::string> metadata = fMetaData[p];
+        for (auto it : metadata) { res[it.first.c_str()] = it.second.c_str(); }
+        return res;
+    }
 
-     public:
-    
-        enum Type { kAcc = 0, kGyr = 1, kNoType };
-   
-        APIUI() : fNumParameters(0), fHasScreenControl(false), fRedReader(0), fGreenReader(0), fBlueReader(0), fCurrentScale(kLin)
-        {}
+    const char* getMetadata(int p, const char* key)
+    {
+        return (fMetaData[p].find(key) != fMetaData[p].end()) ? fMetaData[p][key].c_str()
+                                                              : "";
+    }
+    FAUSTFLOAT getParamMin(int p) { return fMin[p]; }
+    FAUSTFLOAT getParamMax(int p) { return fMax[p]; }
+    FAUSTFLOAT getParamStep(int p) { return fStep[p]; }
+    FAUSTFLOAT getParamInit(int p) { return fInit[p]; }
 
-        virtual ~APIUI()
-        {
-            for (auto& it : fConversion) delete it;
-            for (int i = 0; i < 3; i++) {
-                for (auto& it : fAcc[i]) delete it;
-                for (auto& it : fGyr[i]) delete it;
-            }
-            delete fRedReader;
-            delete fGreenReader;
-            delete fBlueReader;
-        }
-    
-        // -- widget's layouts
+    FAUSTFLOAT* getParamZone(int p) { return fZone[p]; }
+    FAUSTFLOAT getParamValue(int p) { return *fZone[p]; }
+    void setParamValue(int p, FAUSTFLOAT v) { *fZone[p] = v; }
 
-        virtual void openTabBox(const char* label) { pushLabel(label); }
-        virtual void openHorizontalBox(const char* label) { pushLabel(label); }
-        virtual void openVerticalBox(const char* label) { pushLabel(label); }
-        virtual void closeBox() { popLabel(); }
+    double getParamRatio(int p) { return fConversion[p]->faust2ui(*fZone[p]); }
+    void setParamRatio(int p, double r) { *fZone[p] = fConversion[p]->ui2faust(r); }
 
-        // -- active widgets
+    double value2ratio(int p, double r) { return fConversion[p]->faust2ui(r); }
+    double ratio2value(int p, double r) { return fConversion[p]->ui2faust(r); }
 
-        virtual void addButton(const char* label, FAUSTFLOAT* zone)
-        {
-            addParameter(label, zone, 0, 0, 1, 1, kButton);
-        }
-
-        virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
-        {
-            addParameter(label, zone, 0, 0, 1, 1, kCheckButton);
-        }
-
-        virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
-        {
-            addParameter(label, zone, init, min, max, step, kVSlider);
-        }
-
-        virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
-        {
-            addParameter(label, zone, init, min, max, step, kHSlider);
-        }
-
-        virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
-        {
-            addParameter(label, zone, init, min, max, step, kNumEntry);
-        }
-
-        // -- passive widgets
-
-        virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
-        {
-            addParameter(label, zone, min, min, max, (max-min)/1000.0, kHBargraph);
-        }
-
-        virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
-        {
-            addParameter(label, zone, min, min, max, (max-min)/1000.0, kVBargraph);
-        }
-    
-        // -- soundfiles
-    
-        virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
-
-        // -- metadata declarations
-
-        virtual void declare(FAUSTFLOAT* zone, const char* key, const char* val)
-        {
-            // Keep metadata
-            fCurrentMetadata[key] = val;
-            
-            if (strcmp(key, "scale") == 0) {
-                if (strcmp(val, "log") == 0) {
-                    fCurrentScale = kLog;
-                } else if (strcmp(val, "exp") == 0) {
-                    fCurrentScale = kExp;
-                } else {
-                    fCurrentScale = kLin;
-                }
-            } else if (strcmp(key, "unit") == 0) {
-                fCurrentUnit = val;
-            } else if (strcmp(key, "acc") == 0) {
-                fCurrentAcc = val;
-            } else if (strcmp(key, "gyr") == 0) {
-                fCurrentGyr = val;
-            } else if (strcmp(key, "screencolor") == 0) {
-                fCurrentColor = val; // val = "red", "green", "blue" or "white"
-            } else if (strcmp(key, "tooltip") == 0) {
-                fCurrentTooltip = val;
-            }
-        }
-
-        virtual void declare(const char* key, const char* val)
-        {}
-
-		//-------------------------------------------------------------------------------
-		// Simple API part
-		//-------------------------------------------------------------------------------
-		int getParamsCount() { return fNumParameters; }
-        int getParamIndex(const char* path)
-        {
-            if (fPathMap.find(path) != fPathMap.end()) {
-                return fPathMap[path];
-            } else if (fLabelMap.find(path) != fLabelMap.end()) {
-                return fLabelMap[path];
-            } else {
-                return -1;
-            }
-        }
-        const char* getParamAddress(int p) { return fPaths[p].c_str(); }
-        const char* getParamLabel(int p) { return fLabels[p].c_str(); }
-        std::map<const char*, const char*> getMetadata(int p)
-        {
-            std::map<const char*, const char*> res;
-            std::map<std::string, std::string> metadata = fMetaData[p];
-            for (auto it : metadata) {
-                res[it.first.c_str()] = it.second.c_str();
-            }
-            return res;
-        }
-
-        const char* getMetadata(int p, const char* key)
-        {
-            return (fMetaData[p].find(key) != fMetaData[p].end()) ? fMetaData[p][key].c_str() : "";
-        }
-        FAUSTFLOAT getParamMin(int p) { return fMin[p]; }
-        FAUSTFLOAT getParamMax(int p) { return fMax[p]; }
-        FAUSTFLOAT getParamStep(int p) { return fStep[p]; }
-        FAUSTFLOAT getParamInit(int p) { return fInit[p]; }
-
-        FAUSTFLOAT* getParamZone(int p) { return fZone[p]; }
-        FAUSTFLOAT getParamValue(int p) { return *fZone[p]; }
-        void setParamValue(int p, FAUSTFLOAT v) { *fZone[p] = v; }
-
-        double getParamRatio(int p) { return fConversion[p]->faust2ui(*fZone[p]); }
-        void setParamRatio(int p, double r) { *fZone[p] = fConversion[p]->ui2faust(r); }
-
-        double value2ratio(int p, double r)	{ return fConversion[p]->faust2ui(r); }
-        double ratio2value(int p, double r)	{ return fConversion[p]->ui2faust(r); }
-    
-        /**
+    /**
          * Return the control type (kAcc, kGyr, or -1) for a given parameter
          *
          * @param p - the UI parameter index
          *
          * @return the type
          */
-        Type getParamType(int p)
-        {
-            if (p >= 0) {
-                if (getZoneIndex(fAcc, p, 0) != -1
-                    || getZoneIndex(fAcc, p, 1) != -1
-                    || getZoneIndex(fAcc, p, 2) != -1) {
-                    return kAcc;
-                } else if (getZoneIndex(fGyr, p, 0) != -1
-                           || getZoneIndex(fGyr, p, 1) != -1
-                           || getZoneIndex(fGyr, p, 2) != -1) {
-                    return kGyr;
-                }
+    Type getParamType(int p)
+    {
+        if (p >= 0) {
+            if (getZoneIndex(fAcc, p, 0) != -1 || getZoneIndex(fAcc, p, 1) != -1
+                || getZoneIndex(fAcc, p, 2) != -1) {
+                return kAcc;
+            } else if (getZoneIndex(fGyr, p, 0) != -1 || getZoneIndex(fGyr, p, 1) != -1
+                       || getZoneIndex(fGyr, p, 2) != -1) {
+                return kGyr;
             }
-            return kNoType;
         }
-    
-        /**
+        return kNoType;
+    }
+
+    /**
          * Return the Item type (kButton = 0, kCheckButton, kVSlider, kHSlider, kNumEntry, kHBargraph, kVBargraph) for a given parameter
          *
          * @param p - the UI parameter index
          *
          * @return the Item type
          */
-        ItemType getParamItemType(int p)
-        {
-            return fItemType[p];
-        }
-   
-        /**
+    ItemType getParamItemType(int p) { return fItemType[p]; }
+
+    /**
          * Set a new value coming from an accelerometer, propagate it to all relevant FAUSTFLOAT* zones.
          *
          * @param acc - 0 for X accelerometer, 1 for Y accelerometer, 2 for Z accelerometer
          * @param value - the new value
          *
          */
-        void propagateAcc(int acc, double value)
-        {
-            for (size_t i = 0; i < fAcc[acc].size(); i++) {
-                fAcc[acc][i]->update(value);
-            }
-        }
-    
-        /**
+    void propagateAcc(int acc, double value)
+    {
+        for (size_t i = 0; i < fAcc[acc].size(); i++) { fAcc[acc][i]->update(value); }
+    }
+
+    /**
          * Used to edit accelerometer curves and mapping. Set curve and related mapping for a given UI parameter.
          *
          * @param p - the UI parameter index
@@ -1433,12 +1455,12 @@ class APIUI : public PathBuilder, public Meta, public UI
          * @param amax - mapping 'max' point
          *
          */
-        void setAccConverter(int p, int acc, int curve, double amin, double amid, double amax)
-        {
-            setConverter(fAcc, p, acc, curve, amin, amid, amax);
-        }
-    
-        /**
+    void setAccConverter(int p, int acc, int curve, double amin, double amid, double amax)
+    {
+        setConverter(fAcc, p, acc, curve, amin, amid, amax);
+    }
+
+    /**
          * Used to edit gyroscope curves and mapping. Set curve and related mapping for a given UI parameter.
          *
          * @param p - the UI parameter index
@@ -1449,12 +1471,12 @@ class APIUI : public PathBuilder, public Meta, public UI
          * @param amax - mapping 'max' point
          *
          */
-        void setGyrConverter(int p, int gyr, int curve, double amin, double amid, double amax)
-        {
-             setConverter(fGyr, p, gyr, curve, amin, amid, amax);
-        }
-    
-        /**
+    void setGyrConverter(int p, int gyr, int curve, double amin, double amid, double amax)
+    {
+        setConverter(fGyr, p, gyr, curve, amin, amid, amax);
+    }
+
+    /**
          * Used to edit accelerometer curves and mapping. Get curve and related mapping for a given UI parameter.
          *
          * @param p - the UI parameter index
@@ -1465,12 +1487,13 @@ class APIUI : public PathBuilder, public Meta, public UI
          * @param amax - the amax value to be retrieved
          *
          */
-        void getAccConverter(int p, int& acc, int& curve, double& amin, double& amid, double& amax)
-        {
-            getConverter(fAcc, p, acc, curve, amin, amid, amax);
-        }
+    void getAccConverter(int p, int& acc, int& curve, double& amin, double& amid,
+                         double& amax)
+    {
+        getConverter(fAcc, p, acc, curve, amin, amid, amax);
+    }
 
-        /**
+    /**
          * Used to edit gyroscope curves and mapping. Get curve and related mapping for a given UI parameter.
          *
          * @param p - the UI parameter index
@@ -1481,63 +1504,55 @@ class APIUI : public PathBuilder, public Meta, public UI
          * @param amax - the amax value to be retrieved
          *
          */
-        void getGyrConverter(int p, int& gyr, int& curve, double& amin, double& amid, double& amax)
-        {
-            getConverter(fGyr, p, gyr, curve, amin, amid, amax);
-        }
-    
-        /**
+    void getGyrConverter(int p, int& gyr, int& curve, double& amin, double& amid,
+                         double& amax)
+    {
+        getConverter(fGyr, p, gyr, curve, amin, amid, amax);
+    }
+
+    /**
          * Set a new value coming from an gyroscope, propagate it to all relevant FAUSTFLOAT* zones.
          *
          * @param gyr - 0 for X gyroscope, 1 for Y gyroscope, 2 for Z gyroscope
          * @param value - the new value
          *
          */
-        void propagateGyr(int gyr, double value)
-        {
-            for (size_t i = 0; i < fGyr[gyr].size(); i++) {
-                fGyr[gyr][i]->update(value);
-            }
-        }
-    
-        /**
+    void propagateGyr(int gyr, double value)
+    {
+        for (size_t i = 0; i < fGyr[gyr].size(); i++) { fGyr[gyr][i]->update(value); }
+    }
+
+    /**
          * Get the number of FAUSTFLOAT* zones controlled with the accelerometer
          *
          * @param acc - 0 for X accelerometer, 1 for Y accelerometer, 2 for Z accelerometer
          * @return the number of zones
          *
          */
-        int getAccCount(int acc)
-        {
-            return (acc >= 0 && acc < 3) ? int(fAcc[acc].size()) : 0;
-        }
-    
-        /**
+    int getAccCount(int acc) { return (acc >= 0 && acc < 3) ? int(fAcc[acc].size()) : 0; }
+
+    /**
          * Get the number of FAUSTFLOAT* zones controlled with the gyroscope
          *
          * @param gyr - 0 for X gyroscope, 1 for Y gyroscope, 2 for Z gyroscope
          * @param the number of zones
          *
          */
-        int getGyrCount(int gyr)
-        {
-            return (gyr >= 0 && gyr < 3) ? int(fGyr[gyr].size()) : 0;
+    int getGyrCount(int gyr) { return (gyr >= 0 && gyr < 3) ? int(fGyr[gyr].size()) : 0; }
+
+    // getScreenColor() : -1 means no screen color control (no screencolor metadata found)
+    // otherwise return 0x00RRGGBB a ready to use color
+    int getScreenColor()
+    {
+        if (fHasScreenControl) {
+            int r = (fRedReader) ? fRedReader->getValue() : 0;
+            int g = (fGreenReader) ? fGreenReader->getValue() : 0;
+            int b = (fBlueReader) ? fBlueReader->getValue() : 0;
+            return (r << 16) | (g << 8) | b;
+        } else {
+            return -1;
         }
-   
-        // getScreenColor() : -1 means no screen color control (no screencolor metadata found)
-        // otherwise return 0x00RRGGBB a ready to use color
-        int getScreenColor()
-        {
-            if (fHasScreenControl) {
-                int r = (fRedReader) ? fRedReader->getValue() : 0;
-                int g = (fGreenReader) ? fGreenReader->getValue() : 0;
-                int b = (fBlueReader) ? fBlueReader->getValue() : 0;
-                return (r<<16) | (g<<8) | b;
-            } else {
-                return -1;
-            }
-        }
- 
+    }
 };
 
 #endif
@@ -1550,826 +1565,885 @@ class APIUI : public PathBuilder, public Meta, public UI
 //  FAUST Generated Code
 //----------------------------------------------------------------------------
 
-
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
+
+#include <math.h>
 
 #include <algorithm>
 #include <cmath>
-#include <math.h>
 
-static float zitarevdsp_faustpower2_f(float value) {
-	return (value * value);
-}
+static float zitarevdsp_faustpower2_f(float value) { return (value * value); }
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS zitarevdsp
 #endif
 
-#ifdef __APPLE__ 
+#ifdef __APPLE__
 #define exp10f __exp10f
-#define exp10 __exp10
+#define exp10  __exp10
 #endif
 
-class zitarevdsp : public dsp {
-	
- private:
-	
-	int IOTA;
-	float fVec0[16384];
-	float fVec1[16384];
-	FAUSTFLOAT fVslider0;
-	float fRec0[2];
-	FAUSTFLOAT fVslider1;
-	float fRec1[2];
-	int fSampleRate;
-	float fConst0;
-	float fConst1;
-	FAUSTFLOAT fVslider2;
-	FAUSTFLOAT fVslider3;
-	FAUSTFLOAT fVslider4;
-	FAUSTFLOAT fVslider5;
-	float fConst2;
-	float fConst3;
-	FAUSTFLOAT fVslider6;
-	FAUSTFLOAT fVslider7;
-	FAUSTFLOAT fVslider8;
-	float fConst4;
-	FAUSTFLOAT fVslider9;
-	float fRec15[2];
-	float fRec14[2];
-	float fVec2[32768];
-	float fConst5;
-	int iConst6;
-	float fConst7;
-	FAUSTFLOAT fVslider10;
-	float fVec3[2048];
-	int iConst8;
-	float fRec12[2];
-	float fConst9;
-	float fConst10;
-	float fRec19[2];
-	float fRec18[2];
-	float fVec4[32768];
-	float fConst11;
-	int iConst12;
-	float fVec5[4096];
-	int iConst13;
-	float fRec16[2];
-	float fConst14;
-	float fConst15;
-	float fRec23[2];
-	float fRec22[2];
-	float fVec6[16384];
-	float fConst16;
-	int iConst17;
-	float fVec7[4096];
-	int iConst18;
-	float fRec20[2];
-	float fConst19;
-	float fConst20;
-	float fRec27[2];
-	float fRec26[2];
-	float fVec8[32768];
-	float fConst21;
-	int iConst22;
-	float fVec9[4096];
-	int iConst23;
-	float fRec24[2];
-	float fConst24;
-	float fConst25;
-	float fRec31[2];
-	float fRec30[2];
-	float fVec10[16384];
-	float fConst26;
-	int iConst27;
-	float fVec11[2048];
-	int iConst28;
-	float fRec28[2];
-	float fConst29;
-	float fConst30;
-	float fRec35[2];
-	float fRec34[2];
-	float fVec12[16384];
-	float fConst31;
-	int iConst32;
-	float fVec13[4096];
-	int iConst33;
-	float fRec32[2];
-	float fConst34;
-	float fConst35;
-	float fRec39[2];
-	float fRec38[2];
-	float fVec14[16384];
-	float fConst36;
-	int iConst37;
-	float fVec15[4096];
-	int iConst38;
-	float fRec36[2];
-	float fConst39;
-	float fConst40;
-	float fRec43[2];
-	float fRec42[2];
-	float fVec16[16384];
-	float fConst41;
-	int iConst42;
-	float fVec17[2048];
-	int iConst43;
-	float fRec40[2];
-	float fRec4[3];
-	float fRec5[3];
-	float fRec6[3];
-	float fRec7[3];
-	float fRec8[3];
-	float fRec9[3];
-	float fRec10[3];
-	float fRec11[3];
-	float fRec3[3];
-	float fRec2[3];
-	float fRec45[3];
-	float fRec44[3];
-	
- public:
-	
-	void metadata(Meta* m) { 
-		m->declare("basics.lib/name", "Faust Basic Element Library");
-		m->declare("basics.lib/version", "0.1");
-		m->declare("delays.lib/name", "Faust Delay Library");
-		m->declare("delays.lib/version", "0.1");
-		m->declare("filename", "zitarevdsp.dsp");
-		m->declare("filters.lib/allpass_comb:author", "Julius O. Smith III");
-		m->declare("filters.lib/allpass_comb:copyright", "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
-		m->declare("filters.lib/allpass_comb:license", "MIT-style STK-4.3 license");
-		m->declare("filters.lib/fir:author", "Julius O. Smith III");
-		m->declare("filters.lib/fir:copyright", "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
-		m->declare("filters.lib/fir:license", "MIT-style STK-4.3 license");
-		m->declare("filters.lib/iir:author", "Julius O. Smith III");
-		m->declare("filters.lib/iir:copyright", "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
-		m->declare("filters.lib/iir:license", "MIT-style STK-4.3 license");
-		m->declare("filters.lib/lowpass0_highpass1", "MIT-style STK-4.3 license");
-		m->declare("filters.lib/lowpass0_highpass1:author", "Julius O. Smith III");
-		m->declare("filters.lib/lowpass:author", "Julius O. Smith III");
-		m->declare("filters.lib/lowpass:copyright", "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
-		m->declare("filters.lib/lowpass:license", "MIT-style STK-4.3 license");
-		m->declare("filters.lib/name", "Faust Filters Library");
-		m->declare("filters.lib/peak_eq_rm:author", "Julius O. Smith III");
-		m->declare("filters.lib/peak_eq_rm:copyright", "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
-		m->declare("filters.lib/peak_eq_rm:license", "MIT-style STK-4.3 license");
-		m->declare("filters.lib/tf1:author", "Julius O. Smith III");
-		m->declare("filters.lib/tf1:copyright", "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
-		m->declare("filters.lib/tf1:license", "MIT-style STK-4.3 license");
-		m->declare("filters.lib/tf1s:author", "Julius O. Smith III");
-		m->declare("filters.lib/tf1s:copyright", "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
-		m->declare("filters.lib/tf1s:license", "MIT-style STK-4.3 license");
-		m->declare("filters.lib/tf2:author", "Julius O. Smith III");
-		m->declare("filters.lib/tf2:copyright", "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
-		m->declare("filters.lib/tf2:license", "MIT-style STK-4.3 license");
-		m->declare("maths.lib/author", "GRAME");
-		m->declare("maths.lib/copyright", "GRAME");
-		m->declare("maths.lib/license", "LGPL with exception");
-		m->declare("maths.lib/name", "Faust Math Library");
-		m->declare("maths.lib/version", "2.3");
-		m->declare("name", "zitarevdsp");
-		m->declare("platform.lib/name", "Generic Platform Library");
-		m->declare("platform.lib/version", "0.1");
-		m->declare("reverbs.lib/name", "Faust Reverb Library");
-		m->declare("reverbs.lib/version", "0.0");
-		m->declare("routes.lib/name", "Faust Signal Routing Library");
-		m->declare("routes.lib/version", "0.2");
-		m->declare("signals.lib/name", "Faust Signal Routing Library");
-		m->declare("signals.lib/version", "0.0");
-	}
+class zitarevdsp : public dsp
+{
+   private:
+    int IOTA;
+    float fVec0[16384];
+    float fVec1[16384];
+    FAUSTFLOAT fVslider0;
+    float fRec0[2];
+    FAUSTFLOAT fVslider1;
+    float fRec1[2];
+    int fSampleRate;
+    float fConst0;
+    float fConst1;
+    FAUSTFLOAT fVslider2;
+    FAUSTFLOAT fVslider3;
+    FAUSTFLOAT fVslider4;
+    FAUSTFLOAT fVslider5;
+    float fConst2;
+    float fConst3;
+    FAUSTFLOAT fVslider6;
+    FAUSTFLOAT fVslider7;
+    FAUSTFLOAT fVslider8;
+    float fConst4;
+    FAUSTFLOAT fVslider9;
+    float fRec15[2];
+    float fRec14[2];
+    float fVec2[32768];
+    float fConst5;
+    int iConst6;
+    float fConst7;
+    FAUSTFLOAT fVslider10;
+    float fVec3[2048];
+    int iConst8;
+    float fRec12[2];
+    float fConst9;
+    float fConst10;
+    float fRec19[2];
+    float fRec18[2];
+    float fVec4[32768];
+    float fConst11;
+    int iConst12;
+    float fVec5[4096];
+    int iConst13;
+    float fRec16[2];
+    float fConst14;
+    float fConst15;
+    float fRec23[2];
+    float fRec22[2];
+    float fVec6[16384];
+    float fConst16;
+    int iConst17;
+    float fVec7[4096];
+    int iConst18;
+    float fRec20[2];
+    float fConst19;
+    float fConst20;
+    float fRec27[2];
+    float fRec26[2];
+    float fVec8[32768];
+    float fConst21;
+    int iConst22;
+    float fVec9[4096];
+    int iConst23;
+    float fRec24[2];
+    float fConst24;
+    float fConst25;
+    float fRec31[2];
+    float fRec30[2];
+    float fVec10[16384];
+    float fConst26;
+    int iConst27;
+    float fVec11[2048];
+    int iConst28;
+    float fRec28[2];
+    float fConst29;
+    float fConst30;
+    float fRec35[2];
+    float fRec34[2];
+    float fVec12[16384];
+    float fConst31;
+    int iConst32;
+    float fVec13[4096];
+    int iConst33;
+    float fRec32[2];
+    float fConst34;
+    float fConst35;
+    float fRec39[2];
+    float fRec38[2];
+    float fVec14[16384];
+    float fConst36;
+    int iConst37;
+    float fVec15[4096];
+    int iConst38;
+    float fRec36[2];
+    float fConst39;
+    float fConst40;
+    float fRec43[2];
+    float fRec42[2];
+    float fVec16[16384];
+    float fConst41;
+    int iConst42;
+    float fVec17[2048];
+    int iConst43;
+    float fRec40[2];
+    float fRec4[3];
+    float fRec5[3];
+    float fRec6[3];
+    float fRec7[3];
+    float fRec8[3];
+    float fRec9[3];
+    float fRec10[3];
+    float fRec11[3];
+    float fRec3[3];
+    float fRec2[3];
+    float fRec45[3];
+    float fRec44[3];
 
-	virtual int getNumInputs() {
-		return 2;
-	}
-	virtual int getNumOutputs() {
-		return 2;
-	}
-	virtual int getInputRate(int channel) {
-		int rate;
-		switch ((channel)) {
-			case 0: {
-				rate = 1;
-				break;
-			}
-			case 1: {
-				rate = 1;
-				break;
-			}
-			default: {
-				rate = -1;
-				break;
-			}
-		}
-		return rate;
-	}
-	virtual int getOutputRate(int channel) {
-		int rate;
-		switch ((channel)) {
-			case 0: {
-				rate = 1;
-				break;
-			}
-			case 1: {
-				rate = 1;
-				break;
-			}
-			default: {
-				rate = -1;
-				break;
-			}
-		}
-		return rate;
-	}
-	
-	static void classInit(int sample_rate) {
-	}
-	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = std::min<float>(192000.0f, std::max<float>(1.0f, float(fSampleRate)));
-		fConst1 = (6.28318548f / fConst0);
-		fConst2 = std::floor(((0.219990999f * fConst0) + 0.5f));
-		fConst3 = ((0.0f - (6.90775537f * fConst2)) / fConst0);
-		fConst4 = (3.14159274f / fConst0);
-		fConst5 = std::floor(((0.0191229992f * fConst0) + 0.5f));
-		iConst6 = int(std::min<float>(16384.0f, std::max<float>(0.0f, (fConst2 - fConst5))));
-		fConst7 = (0.00100000005f * fConst0);
-		iConst8 = int(std::min<float>(1024.0f, std::max<float>(0.0f, (fConst5 + -1.0f))));
-		fConst9 = std::floor(((0.256891012f * fConst0) + 0.5f));
-		fConst10 = ((0.0f - (6.90775537f * fConst9)) / fConst0);
-		fConst11 = std::floor(((0.0273330007f * fConst0) + 0.5f));
-		iConst12 = int(std::min<float>(16384.0f, std::max<float>(0.0f, (fConst9 - fConst11))));
-		iConst13 = int(std::min<float>(2048.0f, std::max<float>(0.0f, (fConst11 + -1.0f))));
-		fConst14 = std::floor(((0.192303002f * fConst0) + 0.5f));
-		fConst15 = ((0.0f - (6.90775537f * fConst14)) / fConst0);
-		fConst16 = std::floor(((0.0292910002f * fConst0) + 0.5f));
-		iConst17 = int(std::min<float>(8192.0f, std::max<float>(0.0f, (fConst14 - fConst16))));
-		iConst18 = int(std::min<float>(2048.0f, std::max<float>(0.0f, (fConst16 + -1.0f))));
-		fConst19 = std::floor(((0.210389003f * fConst0) + 0.5f));
-		fConst20 = ((0.0f - (6.90775537f * fConst19)) / fConst0);
-		fConst21 = std::floor(((0.0244210009f * fConst0) + 0.5f));
-		iConst22 = int(std::min<float>(16384.0f, std::max<float>(0.0f, (fConst19 - fConst21))));
-		iConst23 = int(std::min<float>(2048.0f, std::max<float>(0.0f, (fConst21 + -1.0f))));
-		fConst24 = std::floor(((0.125f * fConst0) + 0.5f));
-		fConst25 = ((0.0f - (6.90775537f * fConst24)) / fConst0);
-		fConst26 = std::floor(((0.0134579996f * fConst0) + 0.5f));
-		iConst27 = int(std::min<float>(8192.0f, std::max<float>(0.0f, (fConst24 - fConst26))));
-		iConst28 = int(std::min<float>(1024.0f, std::max<float>(0.0f, (fConst26 + -1.0f))));
-		fConst29 = std::floor(((0.127837002f * fConst0) + 0.5f));
-		fConst30 = ((0.0f - (6.90775537f * fConst29)) / fConst0);
-		fConst31 = std::floor(((0.0316039994f * fConst0) + 0.5f));
-		iConst32 = int(std::min<float>(8192.0f, std::max<float>(0.0f, (fConst29 - fConst31))));
-		iConst33 = int(std::min<float>(2048.0f, std::max<float>(0.0f, (fConst31 + -1.0f))));
-		fConst34 = std::floor(((0.174713001f * fConst0) + 0.5f));
-		fConst35 = ((0.0f - (6.90775537f * fConst34)) / fConst0);
-		fConst36 = std::floor(((0.0229039993f * fConst0) + 0.5f));
-		iConst37 = int(std::min<float>(8192.0f, std::max<float>(0.0f, (fConst34 - fConst36))));
-		iConst38 = int(std::min<float>(2048.0f, std::max<float>(0.0f, (fConst36 + -1.0f))));
-		fConst39 = std::floor(((0.153128996f * fConst0) + 0.5f));
-		fConst40 = ((0.0f - (6.90775537f * fConst39)) / fConst0);
-		fConst41 = std::floor(((0.0203460008f * fConst0) + 0.5f));
-		iConst42 = int(std::min<float>(8192.0f, std::max<float>(0.0f, (fConst39 - fConst41))));
-		iConst43 = int(std::min<float>(1024.0f, std::max<float>(0.0f, (fConst41 + -1.0f))));
-	}
-	
-	virtual void instanceResetUserInterface() {
-		fVslider0 = FAUSTFLOAT(-3.0f);
-		fVslider1 = FAUSTFLOAT(0.0f);
-		fVslider2 = FAUSTFLOAT(1500.0f);
-		fVslider3 = FAUSTFLOAT(0.0f);
-		fVslider4 = FAUSTFLOAT(315.0f);
-		fVslider5 = FAUSTFLOAT(0.0f);
-		fVslider6 = FAUSTFLOAT(2.0f);
-		fVslider7 = FAUSTFLOAT(6000.0f);
-		fVslider8 = FAUSTFLOAT(3.0f);
-		fVslider9 = FAUSTFLOAT(200.0f);
-		fVslider10 = FAUSTFLOAT(60.0f);
-	}
-	
-	virtual void instanceClear() {
-		IOTA = 0;
-		for (int l0 = 0; (l0 < 16384); l0 = (l0 + 1)) {
-			fVec0[l0] = 0.0f;
-		}
-		for (int l1 = 0; (l1 < 16384); l1 = (l1 + 1)) {
-			fVec1[l1] = 0.0f;
-		}
-		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
-			fRec0[l2] = 0.0f;
-		}
-		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
-			fRec1[l3] = 0.0f;
-		}
-		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
-			fRec15[l4] = 0.0f;
-		}
-		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
-			fRec14[l5] = 0.0f;
-		}
-		for (int l6 = 0; (l6 < 32768); l6 = (l6 + 1)) {
-			fVec2[l6] = 0.0f;
-		}
-		for (int l7 = 0; (l7 < 2048); l7 = (l7 + 1)) {
-			fVec3[l7] = 0.0f;
-		}
-		for (int l8 = 0; (l8 < 2); l8 = (l8 + 1)) {
-			fRec12[l8] = 0.0f;
-		}
-		for (int l9 = 0; (l9 < 2); l9 = (l9 + 1)) {
-			fRec19[l9] = 0.0f;
-		}
-		for (int l10 = 0; (l10 < 2); l10 = (l10 + 1)) {
-			fRec18[l10] = 0.0f;
-		}
-		for (int l11 = 0; (l11 < 32768); l11 = (l11 + 1)) {
-			fVec4[l11] = 0.0f;
-		}
-		for (int l12 = 0; (l12 < 4096); l12 = (l12 + 1)) {
-			fVec5[l12] = 0.0f;
-		}
-		for (int l13 = 0; (l13 < 2); l13 = (l13 + 1)) {
-			fRec16[l13] = 0.0f;
-		}
-		for (int l14 = 0; (l14 < 2); l14 = (l14 + 1)) {
-			fRec23[l14] = 0.0f;
-		}
-		for (int l15 = 0; (l15 < 2); l15 = (l15 + 1)) {
-			fRec22[l15] = 0.0f;
-		}
-		for (int l16 = 0; (l16 < 16384); l16 = (l16 + 1)) {
-			fVec6[l16] = 0.0f;
-		}
-		for (int l17 = 0; (l17 < 4096); l17 = (l17 + 1)) {
-			fVec7[l17] = 0.0f;
-		}
-		for (int l18 = 0; (l18 < 2); l18 = (l18 + 1)) {
-			fRec20[l18] = 0.0f;
-		}
-		for (int l19 = 0; (l19 < 2); l19 = (l19 + 1)) {
-			fRec27[l19] = 0.0f;
-		}
-		for (int l20 = 0; (l20 < 2); l20 = (l20 + 1)) {
-			fRec26[l20] = 0.0f;
-		}
-		for (int l21 = 0; (l21 < 32768); l21 = (l21 + 1)) {
-			fVec8[l21] = 0.0f;
-		}
-		for (int l22 = 0; (l22 < 4096); l22 = (l22 + 1)) {
-			fVec9[l22] = 0.0f;
-		}
-		for (int l23 = 0; (l23 < 2); l23 = (l23 + 1)) {
-			fRec24[l23] = 0.0f;
-		}
-		for (int l24 = 0; (l24 < 2); l24 = (l24 + 1)) {
-			fRec31[l24] = 0.0f;
-		}
-		for (int l25 = 0; (l25 < 2); l25 = (l25 + 1)) {
-			fRec30[l25] = 0.0f;
-		}
-		for (int l26 = 0; (l26 < 16384); l26 = (l26 + 1)) {
-			fVec10[l26] = 0.0f;
-		}
-		for (int l27 = 0; (l27 < 2048); l27 = (l27 + 1)) {
-			fVec11[l27] = 0.0f;
-		}
-		for (int l28 = 0; (l28 < 2); l28 = (l28 + 1)) {
-			fRec28[l28] = 0.0f;
-		}
-		for (int l29 = 0; (l29 < 2); l29 = (l29 + 1)) {
-			fRec35[l29] = 0.0f;
-		}
-		for (int l30 = 0; (l30 < 2); l30 = (l30 + 1)) {
-			fRec34[l30] = 0.0f;
-		}
-		for (int l31 = 0; (l31 < 16384); l31 = (l31 + 1)) {
-			fVec12[l31] = 0.0f;
-		}
-		for (int l32 = 0; (l32 < 4096); l32 = (l32 + 1)) {
-			fVec13[l32] = 0.0f;
-		}
-		for (int l33 = 0; (l33 < 2); l33 = (l33 + 1)) {
-			fRec32[l33] = 0.0f;
-		}
-		for (int l34 = 0; (l34 < 2); l34 = (l34 + 1)) {
-			fRec39[l34] = 0.0f;
-		}
-		for (int l35 = 0; (l35 < 2); l35 = (l35 + 1)) {
-			fRec38[l35] = 0.0f;
-		}
-		for (int l36 = 0; (l36 < 16384); l36 = (l36 + 1)) {
-			fVec14[l36] = 0.0f;
-		}
-		for (int l37 = 0; (l37 < 4096); l37 = (l37 + 1)) {
-			fVec15[l37] = 0.0f;
-		}
-		for (int l38 = 0; (l38 < 2); l38 = (l38 + 1)) {
-			fRec36[l38] = 0.0f;
-		}
-		for (int l39 = 0; (l39 < 2); l39 = (l39 + 1)) {
-			fRec43[l39] = 0.0f;
-		}
-		for (int l40 = 0; (l40 < 2); l40 = (l40 + 1)) {
-			fRec42[l40] = 0.0f;
-		}
-		for (int l41 = 0; (l41 < 16384); l41 = (l41 + 1)) {
-			fVec16[l41] = 0.0f;
-		}
-		for (int l42 = 0; (l42 < 2048); l42 = (l42 + 1)) {
-			fVec17[l42] = 0.0f;
-		}
-		for (int l43 = 0; (l43 < 2); l43 = (l43 + 1)) {
-			fRec40[l43] = 0.0f;
-		}
-		for (int l44 = 0; (l44 < 3); l44 = (l44 + 1)) {
-			fRec4[l44] = 0.0f;
-		}
-		for (int l45 = 0; (l45 < 3); l45 = (l45 + 1)) {
-			fRec5[l45] = 0.0f;
-		}
-		for (int l46 = 0; (l46 < 3); l46 = (l46 + 1)) {
-			fRec6[l46] = 0.0f;
-		}
-		for (int l47 = 0; (l47 < 3); l47 = (l47 + 1)) {
-			fRec7[l47] = 0.0f;
-		}
-		for (int l48 = 0; (l48 < 3); l48 = (l48 + 1)) {
-			fRec8[l48] = 0.0f;
-		}
-		for (int l49 = 0; (l49 < 3); l49 = (l49 + 1)) {
-			fRec9[l49] = 0.0f;
-		}
-		for (int l50 = 0; (l50 < 3); l50 = (l50 + 1)) {
-			fRec10[l50] = 0.0f;
-		}
-		for (int l51 = 0; (l51 < 3); l51 = (l51 + 1)) {
-			fRec11[l51] = 0.0f;
-		}
-		for (int l52 = 0; (l52 < 3); l52 = (l52 + 1)) {
-			fRec3[l52] = 0.0f;
-		}
-		for (int l53 = 0; (l53 < 3); l53 = (l53 + 1)) {
-			fRec2[l53] = 0.0f;
-		}
-		for (int l54 = 0; (l54 < 3); l54 = (l54 + 1)) {
-			fRec45[l54] = 0.0f;
-		}
-		for (int l55 = 0; (l55 < 3); l55 = (l55 + 1)) {
-			fRec44[l55] = 0.0f;
-		}
-	}
-	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
-	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
-		instanceResetUserInterface();
-		instanceClear();
-	}
-	
-	virtual zitarevdsp* clone() {
-		return new zitarevdsp();
-	}
-	
-	virtual int getSampleRate() {
-		return fSampleRate;
-	}
-	
-	virtual void buildUserInterface(UI* ui_interface) {
-		ui_interface->declare(0, "0", "");
-		ui_interface->declare(0, "tooltip", "~ ZITA REV1 FEEDBACK DELAY NETWORK (FDN) & SCHROEDER  ALLPASS-COMB REVERBERATOR (8x8). See Faust's reverbs.lib for documentation and  references");
-		ui_interface->openHorizontalBox("Zita_Rev1");
-		ui_interface->declare(0, "1", "");
-		ui_interface->openHorizontalBox("Input");
-		ui_interface->declare(&fVslider10, "1", "");
-		ui_interface->declare(&fVslider10, "style", "knob");
-		ui_interface->declare(&fVslider10, "tooltip", "Delay in ms   before reverberation begins");
-		ui_interface->declare(&fVslider10, "unit", "ms");
-		ui_interface->addVerticalSlider("In Delay", &fVslider10, 60.0f, 20.0f, 100.0f, 1.0f);
-		ui_interface->closeBox();
-		ui_interface->declare(0, "2", "");
-		ui_interface->openHorizontalBox("Decay Times in Bands (see tooltips)");
-		ui_interface->declare(&fVslider9, "1", "");
-		ui_interface->declare(&fVslider9, "scale", "log");
-		ui_interface->declare(&fVslider9, "style", "knob");
-		ui_interface->declare(&fVslider9, "tooltip", "Crossover frequency (Hz) separating low and middle frequencies");
-		ui_interface->declare(&fVslider9, "unit", "Hz");
-		ui_interface->addVerticalSlider("LF X", &fVslider9, 200.0f, 50.0f, 1000.0f, 1.0f);
-		ui_interface->declare(&fVslider8, "2", "");
-		ui_interface->declare(&fVslider8, "scale", "log");
-		ui_interface->declare(&fVslider8, "style", "knob");
-		ui_interface->declare(&fVslider8, "tooltip", "T60 = time (in seconds) to decay 60dB in low-frequency band");
-		ui_interface->declare(&fVslider8, "unit", "s");
-		ui_interface->addVerticalSlider("Low RT60", &fVslider8, 3.0f, 1.0f, 8.0f, 0.100000001f);
-		ui_interface->declare(&fVslider6, "3", "");
-		ui_interface->declare(&fVslider6, "scale", "log");
-		ui_interface->declare(&fVslider6, "style", "knob");
-		ui_interface->declare(&fVslider6, "tooltip", "T60 = time (in seconds) to decay 60dB in middle band");
-		ui_interface->declare(&fVslider6, "unit", "s");
-		ui_interface->addVerticalSlider("Mid RT60", &fVslider6, 2.0f, 1.0f, 8.0f, 0.100000001f);
-		ui_interface->declare(&fVslider7, "4", "");
-		ui_interface->declare(&fVslider7, "scale", "log");
-		ui_interface->declare(&fVslider7, "style", "knob");
-		ui_interface->declare(&fVslider7, "tooltip", "Frequency (Hz) at which the high-frequency T60 is half the middle-band's T60");
-		ui_interface->declare(&fVslider7, "unit", "Hz");
-		ui_interface->addVerticalSlider("HF Damping", &fVslider7, 6000.0f, 1500.0f, 23520.0f, 1.0f);
-		ui_interface->closeBox();
-		ui_interface->declare(0, "3", "");
-		ui_interface->openHorizontalBox("RM Peaking Equalizer 1");
-		ui_interface->declare(&fVslider4, "1", "");
-		ui_interface->declare(&fVslider4, "scale", "log");
-		ui_interface->declare(&fVslider4, "style", "knob");
-		ui_interface->declare(&fVslider4, "tooltip", "Center-frequency of second-order Regalia-Mitra peaking equalizer section 1");
-		ui_interface->declare(&fVslider4, "unit", "Hz");
-		ui_interface->addVerticalSlider("Eq1 Freq", &fVslider4, 315.0f, 40.0f, 2500.0f, 1.0f);
-		ui_interface->declare(&fVslider5, "2", "");
-		ui_interface->declare(&fVslider5, "style", "knob");
-		ui_interface->declare(&fVslider5, "tooltip", "Peak level   in dB of second-order Regalia-Mitra peaking equalizer section 1");
-		ui_interface->declare(&fVslider5, "unit", "dB");
-		ui_interface->addVerticalSlider("Eq1 Level", &fVslider5, 0.0f, -15.0f, 15.0f, 0.100000001f);
-		ui_interface->closeBox();
-		ui_interface->declare(0, "4", "");
-		ui_interface->openHorizontalBox("RM Peaking Equalizer 2");
-		ui_interface->declare(&fVslider2, "1", "");
-		ui_interface->declare(&fVslider2, "scale", "log");
-		ui_interface->declare(&fVslider2, "style", "knob");
-		ui_interface->declare(&fVslider2, "tooltip", "Center-frequency of second-order Regalia-Mitra peaking equalizer section 2");
-		ui_interface->declare(&fVslider2, "unit", "Hz");
-		ui_interface->addVerticalSlider("Eq2 Freq", &fVslider2, 1500.0f, 160.0f, 10000.0f, 1.0f);
-		ui_interface->declare(&fVslider3, "2", "");
-		ui_interface->declare(&fVslider3, "style", "knob");
-		ui_interface->declare(&fVslider3, "tooltip", "Peak level   in dB of second-order Regalia-Mitra peaking equalizer section 2");
-		ui_interface->declare(&fVslider3, "unit", "dB");
-		ui_interface->addVerticalSlider("Eq2 Level", &fVslider3, 0.0f, -15.0f, 15.0f, 0.100000001f);
-		ui_interface->closeBox();
-		ui_interface->declare(0, "5", "");
-		ui_interface->openHorizontalBox("Output");
-		ui_interface->declare(&fVslider1, "1", "");
-		ui_interface->declare(&fVslider1, "style", "knob");
-		ui_interface->declare(&fVslider1, "tooltip", "Dry/Wet Mix: 0 = dry, 1 = wet");
-		ui_interface->addVerticalSlider("Wet", &fVslider1, 0.0f, 0.0f, 1.0f, 0.00999999978f);
-		ui_interface->declare(&fVslider0, "2", "");
-		ui_interface->declare(&fVslider0, "style", "knob");
-		ui_interface->declare(&fVslider0, "tooltip", "Output scale   factor");
-		ui_interface->declare(&fVslider0, "unit", "dB");
-		ui_interface->addVerticalSlider("Level", &fVslider0, -3.0f, -70.0f, 20.0f, 0.100000001f);
-		ui_interface->closeBox();
-		ui_interface->closeBox();
-	}
-	
-	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
-		FAUSTFLOAT* input0 = inputs[0];
-		FAUSTFLOAT* input1 = inputs[1];
-		FAUSTFLOAT* output0 = outputs[0];
-		FAUSTFLOAT* output1 = outputs[1];
-		float fSlow0 = (0.00100000005f * std::pow(10.0f, (0.0500000007f * float(fVslider0))));
-		float fSlow1 = (0.00100000005f * float(fVslider1));
-		float fSlow2 = float(fVslider2);
-		float fSlow3 = std::pow(10.0f, (0.0500000007f * float(fVslider3)));
-		float fSlow4 = (fConst1 * (fSlow2 / std::sqrt(std::max<float>(0.0f, fSlow3))));
-		float fSlow5 = ((1.0f - fSlow4) / (fSlow4 + 1.0f));
-		float fSlow6 = float(fVslider4);
-		float fSlow7 = std::pow(10.0f, (0.0500000007f * float(fVslider5)));
-		float fSlow8 = (fConst1 * (fSlow6 / std::sqrt(std::max<float>(0.0f, fSlow7))));
-		float fSlow9 = ((1.0f - fSlow8) / (fSlow8 + 1.0f));
-		float fSlow10 = float(fVslider6);
-		float fSlow11 = std::exp((fConst3 / fSlow10));
-		float fSlow12 = zitarevdsp_faustpower2_f(fSlow11);
-		float fSlow13 = std::cos((fConst1 * float(fVslider7)));
-		float fSlow14 = (1.0f - (fSlow12 * fSlow13));
-		float fSlow15 = (1.0f - fSlow12);
-		float fSlow16 = (fSlow14 / fSlow15);
-		float fSlow17 = std::sqrt(std::max<float>(0.0f, ((zitarevdsp_faustpower2_f(fSlow14) / zitarevdsp_faustpower2_f(fSlow15)) + -1.0f)));
-		float fSlow18 = (fSlow16 - fSlow17);
-		float fSlow19 = (fSlow11 * (fSlow17 + (1.0f - fSlow16)));
-		float fSlow20 = float(fVslider8);
-		float fSlow21 = ((std::exp((fConst3 / fSlow20)) / fSlow11) + -1.0f);
-		float fSlow22 = (1.0f / std::tan((fConst4 * float(fVslider9))));
-		float fSlow23 = (1.0f / (fSlow22 + 1.0f));
-		float fSlow24 = (1.0f - fSlow22);
-		int iSlow25 = int(std::min<float>(8192.0f, std::max<float>(0.0f, (fConst7 * float(fVslider10)))));
-		float fSlow26 = std::exp((fConst10 / fSlow10));
-		float fSlow27 = zitarevdsp_faustpower2_f(fSlow26);
-		float fSlow28 = (1.0f - (fSlow27 * fSlow13));
-		float fSlow29 = (1.0f - fSlow27);
-		float fSlow30 = (fSlow28 / fSlow29);
-		float fSlow31 = std::sqrt(std::max<float>(0.0f, ((zitarevdsp_faustpower2_f(fSlow28) / zitarevdsp_faustpower2_f(fSlow29)) + -1.0f)));
-		float fSlow32 = (fSlow30 - fSlow31);
-		float fSlow33 = (fSlow26 * (fSlow31 + (1.0f - fSlow30)));
-		float fSlow34 = ((std::exp((fConst10 / fSlow20)) / fSlow26) + -1.0f);
-		float fSlow35 = std::exp((fConst15 / fSlow10));
-		float fSlow36 = zitarevdsp_faustpower2_f(fSlow35);
-		float fSlow37 = (1.0f - (fSlow36 * fSlow13));
-		float fSlow38 = (1.0f - fSlow36);
-		float fSlow39 = (fSlow37 / fSlow38);
-		float fSlow40 = std::sqrt(std::max<float>(0.0f, ((zitarevdsp_faustpower2_f(fSlow37) / zitarevdsp_faustpower2_f(fSlow38)) + -1.0f)));
-		float fSlow41 = (fSlow39 - fSlow40);
-		float fSlow42 = (fSlow35 * (fSlow40 + (1.0f - fSlow39)));
-		float fSlow43 = ((std::exp((fConst15 / fSlow20)) / fSlow35) + -1.0f);
-		float fSlow44 = std::exp((fConst20 / fSlow10));
-		float fSlow45 = zitarevdsp_faustpower2_f(fSlow44);
-		float fSlow46 = (1.0f - (fSlow45 * fSlow13));
-		float fSlow47 = (1.0f - fSlow45);
-		float fSlow48 = (fSlow46 / fSlow47);
-		float fSlow49 = std::sqrt(std::max<float>(0.0f, ((zitarevdsp_faustpower2_f(fSlow46) / zitarevdsp_faustpower2_f(fSlow47)) + -1.0f)));
-		float fSlow50 = (fSlow48 - fSlow49);
-		float fSlow51 = (fSlow44 * (fSlow49 + (1.0f - fSlow48)));
-		float fSlow52 = ((std::exp((fConst20 / fSlow20)) / fSlow44) + -1.0f);
-		float fSlow53 = std::exp((fConst25 / fSlow10));
-		float fSlow54 = zitarevdsp_faustpower2_f(fSlow53);
-		float fSlow55 = (1.0f - (fSlow54 * fSlow13));
-		float fSlow56 = (1.0f - fSlow54);
-		float fSlow57 = (fSlow55 / fSlow56);
-		float fSlow58 = std::sqrt(std::max<float>(0.0f, ((zitarevdsp_faustpower2_f(fSlow55) / zitarevdsp_faustpower2_f(fSlow56)) + -1.0f)));
-		float fSlow59 = (fSlow57 - fSlow58);
-		float fSlow60 = (fSlow53 * (fSlow58 + (1.0f - fSlow57)));
-		float fSlow61 = ((std::exp((fConst25 / fSlow20)) / fSlow53) + -1.0f);
-		float fSlow62 = std::exp((fConst30 / fSlow10));
-		float fSlow63 = zitarevdsp_faustpower2_f(fSlow62);
-		float fSlow64 = (1.0f - (fSlow63 * fSlow13));
-		float fSlow65 = (1.0f - fSlow63);
-		float fSlow66 = (fSlow64 / fSlow65);
-		float fSlow67 = std::sqrt(std::max<float>(0.0f, ((zitarevdsp_faustpower2_f(fSlow64) / zitarevdsp_faustpower2_f(fSlow65)) + -1.0f)));
-		float fSlow68 = (fSlow66 - fSlow67);
-		float fSlow69 = (fSlow62 * (fSlow67 + (1.0f - fSlow66)));
-		float fSlow70 = ((std::exp((fConst30 / fSlow20)) / fSlow62) + -1.0f);
-		float fSlow71 = std::exp((fConst35 / fSlow10));
-		float fSlow72 = zitarevdsp_faustpower2_f(fSlow71);
-		float fSlow73 = (1.0f - (fSlow72 * fSlow13));
-		float fSlow74 = (1.0f - fSlow72);
-		float fSlow75 = (fSlow73 / fSlow74);
-		float fSlow76 = std::sqrt(std::max<float>(0.0f, ((zitarevdsp_faustpower2_f(fSlow73) / zitarevdsp_faustpower2_f(fSlow74)) + -1.0f)));
-		float fSlow77 = (fSlow75 - fSlow76);
-		float fSlow78 = (fSlow71 * (fSlow76 + (1.0f - fSlow75)));
-		float fSlow79 = ((std::exp((fConst35 / fSlow20)) / fSlow71) + -1.0f);
-		float fSlow80 = std::exp((fConst40 / fSlow10));
-		float fSlow81 = zitarevdsp_faustpower2_f(fSlow80);
-		float fSlow82 = (1.0f - (fSlow81 * fSlow13));
-		float fSlow83 = (1.0f - fSlow81);
-		float fSlow84 = (fSlow82 / fSlow83);
-		float fSlow85 = std::sqrt(std::max<float>(0.0f, ((zitarevdsp_faustpower2_f(fSlow82) / zitarevdsp_faustpower2_f(fSlow83)) + -1.0f)));
-		float fSlow86 = (fSlow84 - fSlow85);
-		float fSlow87 = (fSlow80 * (fSlow85 + (1.0f - fSlow84)));
-		float fSlow88 = ((std::exp((fConst40 / fSlow20)) / fSlow80) + -1.0f);
-		float fSlow89 = (0.0f - (std::cos((fConst1 * fSlow6)) * (fSlow9 + 1.0f)));
-		float fSlow90 = (0.0f - (std::cos((fConst1 * fSlow2)) * (fSlow5 + 1.0f)));
-		for (int i = 0; (i < count); i = (i + 1)) {
-			float fTemp0 = float(input0[i]);
-			fVec0[(IOTA & 16383)] = fTemp0;
-			float fTemp1 = float(input1[i]);
-			fVec1[(IOTA & 16383)] = fTemp1;
-			fRec0[0] = (fSlow0 + (0.999000013f * fRec0[1]));
-			fRec1[0] = (fSlow1 + (0.999000013f * fRec1[1]));
-			fRec15[0] = (0.0f - (fSlow23 * ((fSlow24 * fRec15[1]) - (fRec11[1] + fRec11[2]))));
-			fRec14[0] = ((fSlow18 * fRec14[1]) + (fSlow19 * (fRec11[1] + (fSlow21 * fRec15[0]))));
-			fVec2[(IOTA & 32767)] = ((0.353553385f * fRec14[0]) + 9.99999968e-21f);
-			float fTemp2 = (0.300000012f * fVec1[((IOTA - iSlow25) & 16383)]);
-			float fTemp3 = (((0.600000024f * fRec12[1]) + fVec2[((IOTA - iConst6) & 32767)]) - fTemp2);
-			fVec3[(IOTA & 2047)] = fTemp3;
-			fRec12[0] = fVec3[((IOTA - iConst8) & 2047)];
-			float fRec13 = (0.0f - (0.600000024f * fTemp3));
-			fRec19[0] = (0.0f - (fSlow23 * ((fSlow24 * fRec19[1]) - (fRec7[1] + fRec7[2]))));
-			fRec18[0] = ((fSlow32 * fRec18[1]) + (fSlow33 * (fRec7[1] + (fSlow34 * fRec19[0]))));
-			fVec4[(IOTA & 32767)] = ((0.353553385f * fRec18[0]) + 9.99999968e-21f);
-			float fTemp4 = (((0.600000024f * fRec16[1]) + fVec4[((IOTA - iConst12) & 32767)]) - fTemp2);
-			fVec5[(IOTA & 4095)] = fTemp4;
-			fRec16[0] = fVec5[((IOTA - iConst13) & 4095)];
-			float fRec17 = (0.0f - (0.600000024f * fTemp4));
-			fRec23[0] = (0.0f - (fSlow23 * ((fSlow24 * fRec23[1]) - (fRec9[1] + fRec9[2]))));
-			fRec22[0] = ((fSlow41 * fRec22[1]) + (fSlow42 * (fRec9[1] + (fSlow43 * fRec23[0]))));
-			fVec6[(IOTA & 16383)] = ((0.353553385f * fRec22[0]) + 9.99999968e-21f);
-			float fTemp5 = (fVec6[((IOTA - iConst17) & 16383)] + (fTemp2 + (0.600000024f * fRec20[1])));
-			fVec7[(IOTA & 4095)] = fTemp5;
-			fRec20[0] = fVec7[((IOTA - iConst18) & 4095)];
-			float fRec21 = (0.0f - (0.600000024f * fTemp5));
-			fRec27[0] = (0.0f - (fSlow23 * ((fSlow24 * fRec27[1]) - (fRec5[1] + fRec5[2]))));
-			fRec26[0] = ((fSlow50 * fRec26[1]) + (fSlow51 * (fRec5[1] + (fSlow52 * fRec27[0]))));
-			fVec8[(IOTA & 32767)] = ((0.353553385f * fRec26[0]) + 9.99999968e-21f);
-			float fTemp6 = (fTemp2 + ((0.600000024f * fRec24[1]) + fVec8[((IOTA - iConst22) & 32767)]));
-			fVec9[(IOTA & 4095)] = fTemp6;
-			fRec24[0] = fVec9[((IOTA - iConst23) & 4095)];
-			float fRec25 = (0.0f - (0.600000024f * fTemp6));
-			fRec31[0] = (0.0f - (fSlow23 * ((fSlow24 * fRec31[1]) - (fRec10[1] + fRec10[2]))));
-			fRec30[0] = ((fSlow59 * fRec30[1]) + (fSlow60 * (fRec10[1] + (fSlow61 * fRec31[0]))));
-			fVec10[(IOTA & 16383)] = ((0.353553385f * fRec30[0]) + 9.99999968e-21f);
-			float fTemp7 = (0.300000012f * fVec0[((IOTA - iSlow25) & 16383)]);
-			float fTemp8 = (fVec10[((IOTA - iConst27) & 16383)] - (fTemp7 + (0.600000024f * fRec28[1])));
-			fVec11[(IOTA & 2047)] = fTemp8;
-			fRec28[0] = fVec11[((IOTA - iConst28) & 2047)];
-			float fRec29 = (0.600000024f * fTemp8);
-			fRec35[0] = (0.0f - (fSlow23 * ((fSlow24 * fRec35[1]) - (fRec6[1] + fRec6[2]))));
-			fRec34[0] = ((fSlow68 * fRec34[1]) + (fSlow69 * (fRec6[1] + (fSlow70 * fRec35[0]))));
-			fVec12[(IOTA & 16383)] = ((0.353553385f * fRec34[0]) + 9.99999968e-21f);
-			float fTemp9 = (fVec12[((IOTA - iConst32) & 16383)] - (fTemp7 + (0.600000024f * fRec32[1])));
-			fVec13[(IOTA & 4095)] = fTemp9;
-			fRec32[0] = fVec13[((IOTA - iConst33) & 4095)];
-			float fRec33 = (0.600000024f * fTemp9);
-			fRec39[0] = (0.0f - (fSlow23 * ((fSlow24 * fRec39[1]) - (fRec8[1] + fRec8[2]))));
-			fRec38[0] = ((fSlow77 * fRec38[1]) + (fSlow78 * (fRec8[1] + (fSlow79 * fRec39[0]))));
-			fVec14[(IOTA & 16383)] = ((0.353553385f * fRec38[0]) + 9.99999968e-21f);
-			float fTemp10 = ((fTemp7 + fVec14[((IOTA - iConst37) & 16383)]) - (0.600000024f * fRec36[1]));
-			fVec15[(IOTA & 4095)] = fTemp10;
-			fRec36[0] = fVec15[((IOTA - iConst38) & 4095)];
-			float fRec37 = (0.600000024f * fTemp10);
-			fRec43[0] = (0.0f - (fSlow23 * ((fSlow24 * fRec43[1]) - (fRec4[1] + fRec4[2]))));
-			fRec42[0] = ((fSlow86 * fRec42[1]) + (fSlow87 * (fRec4[1] + (fSlow88 * fRec43[0]))));
-			fVec16[(IOTA & 16383)] = ((0.353553385f * fRec42[0]) + 9.99999968e-21f);
-			float fTemp11 = ((fVec16[((IOTA - iConst42) & 16383)] + fTemp7) - (0.600000024f * fRec40[1]));
-			fVec17[(IOTA & 2047)] = fTemp11;
-			fRec40[0] = fVec17[((IOTA - iConst43) & 2047)];
-			float fRec41 = (0.600000024f * fTemp11);
-			float fTemp12 = (fRec41 + fRec37);
-			float fTemp13 = (fRec29 + (fRec33 + fTemp12));
-			fRec4[0] = (fRec12[1] + (fRec16[1] + (fRec20[1] + (fRec24[1] + (fRec28[1] + (fRec32[1] + (fRec36[1] + (fRec40[1] + (fRec13 + (fRec17 + (fRec21 + (fRec25 + fTemp13))))))))))));
-			fRec5[0] = ((fRec28[1] + (fRec32[1] + (fRec36[1] + (fRec40[1] + fTemp13)))) - (fRec12[1] + (fRec16[1] + (fRec20[1] + (fRec24[1] + (fRec13 + (fRec17 + (fRec25 + fRec21))))))));
-			float fTemp14 = (fRec33 + fRec29);
-			fRec6[0] = ((fRec20[1] + (fRec24[1] + (fRec36[1] + (fRec40[1] + (fRec21 + (fRec25 + fTemp12)))))) - (fRec12[1] + (fRec16[1] + (fRec28[1] + (fRec32[1] + (fRec13 + (fRec17 + fTemp14)))))));
-			fRec7[0] = ((fRec12[1] + (fRec16[1] + (fRec36[1] + (fRec40[1] + (fRec13 + (fRec17 + fTemp12)))))) - (fRec20[1] + (fRec24[1] + (fRec28[1] + (fRec32[1] + (fRec21 + (fRec25 + fTemp14)))))));
-			float fTemp15 = (fRec41 + fRec33);
-			float fTemp16 = (fRec37 + fRec29);
-			fRec8[0] = ((fRec16[1] + (fRec24[1] + (fRec32[1] + (fRec40[1] + (fRec17 + (fRec25 + fTemp15)))))) - (fRec12[1] + (fRec20[1] + (fRec28[1] + (fRec36[1] + (fRec13 + (fRec21 + fTemp16)))))));
-			fRec9[0] = ((fRec12[1] + (fRec20[1] + (fRec32[1] + (fRec40[1] + (fRec13 + (fRec21 + fTemp15)))))) - (fRec16[1] + (fRec24[1] + (fRec28[1] + (fRec36[1] + (fRec17 + (fRec25 + fTemp16)))))));
-			float fTemp17 = (fRec41 + fRec29);
-			float fTemp18 = (fRec37 + fRec33);
-			fRec10[0] = ((fRec12[1] + (fRec24[1] + (fRec28[1] + (fRec40[1] + (fRec13 + (fRec25 + fTemp17)))))) - (fRec16[1] + (fRec20[1] + (fRec32[1] + (fRec36[1] + (fRec17 + (fRec21 + fTemp18)))))));
-			fRec11[0] = ((fRec16[1] + (fRec20[1] + (fRec28[1] + (fRec40[1] + (fRec17 + (fRec21 + fTemp17)))))) - (fRec12[1] + (fRec24[1] + (fRec32[1] + (fRec36[1] + (fRec13 + (fRec25 + fTemp18)))))));
-			float fTemp19 = (0.370000005f * (fRec5[0] + fRec6[0]));
-			float fTemp20 = (fSlow89 * fRec3[1]);
-			fRec3[0] = (fTemp19 - (fTemp20 + (fSlow9 * fRec3[2])));
-			float fTemp21 = (fSlow9 * fRec3[0]);
-			float fTemp22 = (0.5f * ((fTemp21 + (fRec3[2] + (fTemp19 + fTemp20))) + (fSlow7 * ((fTemp21 + (fTemp20 + fRec3[2])) - fTemp19))));
-			float fTemp23 = (fSlow90 * fRec2[1]);
-			fRec2[0] = (fTemp22 - (fTemp23 + (fSlow5 * fRec2[2])));
-			float fTemp24 = (fSlow5 * fRec2[0]);
-			float fTemp25 = (1.0f - fRec1[0]);
-			output0[i] = FAUSTFLOAT((fRec0[0] * ((0.5f * (fRec1[0] * ((fTemp24 + (fRec2[2] + (fTemp22 + fTemp23))) + (fSlow3 * ((fTemp24 + (fTemp23 + fRec2[2])) - fTemp22))))) + (fTemp0 * fTemp25))));
-			float fTemp26 = (0.370000005f * (fRec5[0] - fRec6[0]));
-			float fTemp27 = (fSlow89 * fRec45[1]);
-			fRec45[0] = (fTemp26 - (fTemp27 + (fSlow9 * fRec45[2])));
-			float fTemp28 = (fSlow9 * fRec45[0]);
-			float fTemp29 = (0.5f * ((fTemp28 + (fRec45[2] + (fTemp26 + fTemp27))) + (fSlow7 * ((fTemp28 + (fTemp27 + fRec45[2])) - fTemp26))));
-			float fTemp30 = (fSlow90 * fRec44[1]);
-			fRec44[0] = (fTemp29 - (fTemp30 + (fSlow5 * fRec44[2])));
-			float fTemp31 = (fSlow5 * fRec44[0]);
-			output1[i] = FAUSTFLOAT((fRec0[0] * ((0.5f * (fRec1[0] * ((fTemp31 + (fRec44[2] + (fTemp29 + fTemp30))) + (fSlow3 * ((fTemp31 + (fTemp30 + fRec44[2])) - fTemp29))))) + (fTemp1 * fTemp25))));
-			IOTA = (IOTA + 1);
-			fRec0[1] = fRec0[0];
-			fRec1[1] = fRec1[0];
-			fRec15[1] = fRec15[0];
-			fRec14[1] = fRec14[0];
-			fRec12[1] = fRec12[0];
-			fRec19[1] = fRec19[0];
-			fRec18[1] = fRec18[0];
-			fRec16[1] = fRec16[0];
-			fRec23[1] = fRec23[0];
-			fRec22[1] = fRec22[0];
-			fRec20[1] = fRec20[0];
-			fRec27[1] = fRec27[0];
-			fRec26[1] = fRec26[0];
-			fRec24[1] = fRec24[0];
-			fRec31[1] = fRec31[0];
-			fRec30[1] = fRec30[0];
-			fRec28[1] = fRec28[0];
-			fRec35[1] = fRec35[0];
-			fRec34[1] = fRec34[0];
-			fRec32[1] = fRec32[0];
-			fRec39[1] = fRec39[0];
-			fRec38[1] = fRec38[0];
-			fRec36[1] = fRec36[0];
-			fRec43[1] = fRec43[0];
-			fRec42[1] = fRec42[0];
-			fRec40[1] = fRec40[0];
-			fRec4[2] = fRec4[1];
-			fRec4[1] = fRec4[0];
-			fRec5[2] = fRec5[1];
-			fRec5[1] = fRec5[0];
-			fRec6[2] = fRec6[1];
-			fRec6[1] = fRec6[0];
-			fRec7[2] = fRec7[1];
-			fRec7[1] = fRec7[0];
-			fRec8[2] = fRec8[1];
-			fRec8[1] = fRec8[0];
-			fRec9[2] = fRec9[1];
-			fRec9[1] = fRec9[0];
-			fRec10[2] = fRec10[1];
-			fRec10[1] = fRec10[0];
-			fRec11[2] = fRec11[1];
-			fRec11[1] = fRec11[0];
-			fRec3[2] = fRec3[1];
-			fRec3[1] = fRec3[0];
-			fRec2[2] = fRec2[1];
-			fRec2[1] = fRec2[0];
-			fRec45[2] = fRec45[1];
-			fRec45[1] = fRec45[0];
-			fRec44[2] = fRec44[1];
-			fRec44[1] = fRec44[0];
-		}
-	}
+   public:
+    void metadata(Meta* m)
+    {
+        m->declare("basics.lib/name", "Faust Basic Element Library");
+        m->declare("basics.lib/version", "0.1");
+        m->declare("delays.lib/name", "Faust Delay Library");
+        m->declare("delays.lib/version", "0.1");
+        m->declare("filename", "zitarevdsp.dsp");
+        m->declare("filters.lib/allpass_comb:author", "Julius O. Smith III");
+        m->declare(
+            "filters.lib/allpass_comb:copyright",
+            "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
+        m->declare("filters.lib/allpass_comb:license", "MIT-style STK-4.3 license");
+        m->declare("filters.lib/fir:author", "Julius O. Smith III");
+        m->declare(
+            "filters.lib/fir:copyright",
+            "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
+        m->declare("filters.lib/fir:license", "MIT-style STK-4.3 license");
+        m->declare("filters.lib/iir:author", "Julius O. Smith III");
+        m->declare(
+            "filters.lib/iir:copyright",
+            "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
+        m->declare("filters.lib/iir:license", "MIT-style STK-4.3 license");
+        m->declare("filters.lib/lowpass0_highpass1", "MIT-style STK-4.3 license");
+        m->declare("filters.lib/lowpass0_highpass1:author", "Julius O. Smith III");
+        m->declare("filters.lib/lowpass:author", "Julius O. Smith III");
+        m->declare(
+            "filters.lib/lowpass:copyright",
+            "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
+        m->declare("filters.lib/lowpass:license", "MIT-style STK-4.3 license");
+        m->declare("filters.lib/name", "Faust Filters Library");
+        m->declare("filters.lib/peak_eq_rm:author", "Julius O. Smith III");
+        m->declare(
+            "filters.lib/peak_eq_rm:copyright",
+            "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
+        m->declare("filters.lib/peak_eq_rm:license", "MIT-style STK-4.3 license");
+        m->declare("filters.lib/tf1:author", "Julius O. Smith III");
+        m->declare(
+            "filters.lib/tf1:copyright",
+            "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
+        m->declare("filters.lib/tf1:license", "MIT-style STK-4.3 license");
+        m->declare("filters.lib/tf1s:author", "Julius O. Smith III");
+        m->declare(
+            "filters.lib/tf1s:copyright",
+            "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
+        m->declare("filters.lib/tf1s:license", "MIT-style STK-4.3 license");
+        m->declare("filters.lib/tf2:author", "Julius O. Smith III");
+        m->declare(
+            "filters.lib/tf2:copyright",
+            "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
+        m->declare("filters.lib/tf2:license", "MIT-style STK-4.3 license");
+        m->declare("maths.lib/author", "GRAME");
+        m->declare("maths.lib/copyright", "GRAME");
+        m->declare("maths.lib/license", "LGPL with exception");
+        m->declare("maths.lib/name", "Faust Math Library");
+        m->declare("maths.lib/version", "2.3");
+        m->declare("name", "zitarevdsp");
+        m->declare("platform.lib/name", "Generic Platform Library");
+        m->declare("platform.lib/version", "0.1");
+        m->declare("reverbs.lib/name", "Faust Reverb Library");
+        m->declare("reverbs.lib/version", "0.0");
+        m->declare("routes.lib/name", "Faust Signal Routing Library");
+        m->declare("routes.lib/version", "0.2");
+        m->declare("signals.lib/name", "Faust Signal Routing Library");
+        m->declare("signals.lib/version", "0.0");
+    }
 
+    virtual int getNumInputs() { return 2; }
+    virtual int getNumOutputs() { return 2; }
+    virtual int getInputRate(int channel)
+    {
+        int rate;
+        switch ((channel)) {
+        case 0: {
+            rate = 1;
+            break;
+        }
+        case 1: {
+            rate = 1;
+            break;
+        }
+        default: {
+            rate = -1;
+            break;
+        }
+        }
+        return rate;
+    }
+    virtual int getOutputRate(int channel)
+    {
+        int rate;
+        switch ((channel)) {
+        case 0: {
+            rate = 1;
+            break;
+        }
+        case 1: {
+            rate = 1;
+            break;
+        }
+        default: {
+            rate = -1;
+            break;
+        }
+        }
+        return rate;
+    }
+
+    static void classInit(int sample_rate) {}
+
+    virtual void instanceConstants(int sample_rate)
+    {
+        fSampleRate = sample_rate;
+        fConst0 = std::min<float>(192000.0f, std::max<float>(1.0f, float(fSampleRate)));
+        fConst1 = (6.28318548f / fConst0);
+        fConst2 = std::floor(((0.219990999f * fConst0) + 0.5f));
+        fConst3 = ((0.0f - (6.90775537f * fConst2)) / fConst0);
+        fConst4 = (3.14159274f / fConst0);
+        fConst5 = std::floor(((0.0191229992f * fConst0) + 0.5f));
+        iConst6 =
+            int(std::min<float>(16384.0f, std::max<float>(0.0f, (fConst2 - fConst5))));
+        fConst7 = (0.00100000005f * fConst0);
+        iConst8 = int(std::min<float>(1024.0f, std::max<float>(0.0f, (fConst5 + -1.0f))));
+        fConst9 = std::floor(((0.256891012f * fConst0) + 0.5f));
+        fConst10 = ((0.0f - (6.90775537f * fConst9)) / fConst0);
+        fConst11 = std::floor(((0.0273330007f * fConst0) + 0.5f));
+        iConst12 =
+            int(std::min<float>(16384.0f, std::max<float>(0.0f, (fConst9 - fConst11))));
+        iConst13 =
+            int(std::min<float>(2048.0f, std::max<float>(0.0f, (fConst11 + -1.0f))));
+        fConst14 = std::floor(((0.192303002f * fConst0) + 0.5f));
+        fConst15 = ((0.0f - (6.90775537f * fConst14)) / fConst0);
+        fConst16 = std::floor(((0.0292910002f * fConst0) + 0.5f));
+        iConst17 =
+            int(std::min<float>(8192.0f, std::max<float>(0.0f, (fConst14 - fConst16))));
+        iConst18 =
+            int(std::min<float>(2048.0f, std::max<float>(0.0f, (fConst16 + -1.0f))));
+        fConst19 = std::floor(((0.210389003f * fConst0) + 0.5f));
+        fConst20 = ((0.0f - (6.90775537f * fConst19)) / fConst0);
+        fConst21 = std::floor(((0.0244210009f * fConst0) + 0.5f));
+        iConst22 =
+            int(std::min<float>(16384.0f, std::max<float>(0.0f, (fConst19 - fConst21))));
+        iConst23 =
+            int(std::min<float>(2048.0f, std::max<float>(0.0f, (fConst21 + -1.0f))));
+        fConst24 = std::floor(((0.125f * fConst0) + 0.5f));
+        fConst25 = ((0.0f - (6.90775537f * fConst24)) / fConst0);
+        fConst26 = std::floor(((0.0134579996f * fConst0) + 0.5f));
+        iConst27 =
+            int(std::min<float>(8192.0f, std::max<float>(0.0f, (fConst24 - fConst26))));
+        iConst28 =
+            int(std::min<float>(1024.0f, std::max<float>(0.0f, (fConst26 + -1.0f))));
+        fConst29 = std::floor(((0.127837002f * fConst0) + 0.5f));
+        fConst30 = ((0.0f - (6.90775537f * fConst29)) / fConst0);
+        fConst31 = std::floor(((0.0316039994f * fConst0) + 0.5f));
+        iConst32 =
+            int(std::min<float>(8192.0f, std::max<float>(0.0f, (fConst29 - fConst31))));
+        iConst33 =
+            int(std::min<float>(2048.0f, std::max<float>(0.0f, (fConst31 + -1.0f))));
+        fConst34 = std::floor(((0.174713001f * fConst0) + 0.5f));
+        fConst35 = ((0.0f - (6.90775537f * fConst34)) / fConst0);
+        fConst36 = std::floor(((0.0229039993f * fConst0) + 0.5f));
+        iConst37 =
+            int(std::min<float>(8192.0f, std::max<float>(0.0f, (fConst34 - fConst36))));
+        iConst38 =
+            int(std::min<float>(2048.0f, std::max<float>(0.0f, (fConst36 + -1.0f))));
+        fConst39 = std::floor(((0.153128996f * fConst0) + 0.5f));
+        fConst40 = ((0.0f - (6.90775537f * fConst39)) / fConst0);
+        fConst41 = std::floor(((0.0203460008f * fConst0) + 0.5f));
+        iConst42 =
+            int(std::min<float>(8192.0f, std::max<float>(0.0f, (fConst39 - fConst41))));
+        iConst43 =
+            int(std::min<float>(1024.0f, std::max<float>(0.0f, (fConst41 + -1.0f))));
+    }
+
+    virtual void instanceResetUserInterface()
+    {
+        fVslider0  = FAUSTFLOAT(-3.0f);
+        fVslider1  = FAUSTFLOAT(0.0f);
+        fVslider2  = FAUSTFLOAT(1500.0f);
+        fVslider3  = FAUSTFLOAT(0.0f);
+        fVslider4  = FAUSTFLOAT(315.0f);
+        fVslider5  = FAUSTFLOAT(0.0f);
+        fVslider6  = FAUSTFLOAT(2.0f);
+        fVslider7  = FAUSTFLOAT(6000.0f);
+        fVslider8  = FAUSTFLOAT(3.0f);
+        fVslider9  = FAUSTFLOAT(200.0f);
+        fVslider10 = FAUSTFLOAT(60.0f);
+    }
+
+    virtual void instanceClear()
+    {
+        IOTA = 0;
+        for (int l0 = 0; (l0 < 16384); l0 = (l0 + 1)) { fVec0[l0] = 0.0f; }
+        for (int l1 = 0; (l1 < 16384); l1 = (l1 + 1)) { fVec1[l1] = 0.0f; }
+        for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) { fRec0[l2] = 0.0f; }
+        for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) { fRec1[l3] = 0.0f; }
+        for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) { fRec15[l4] = 0.0f; }
+        for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) { fRec14[l5] = 0.0f; }
+        for (int l6 = 0; (l6 < 32768); l6 = (l6 + 1)) { fVec2[l6] = 0.0f; }
+        for (int l7 = 0; (l7 < 2048); l7 = (l7 + 1)) { fVec3[l7] = 0.0f; }
+        for (int l8 = 0; (l8 < 2); l8 = (l8 + 1)) { fRec12[l8] = 0.0f; }
+        for (int l9 = 0; (l9 < 2); l9 = (l9 + 1)) { fRec19[l9] = 0.0f; }
+        for (int l10 = 0; (l10 < 2); l10 = (l10 + 1)) { fRec18[l10] = 0.0f; }
+        for (int l11 = 0; (l11 < 32768); l11 = (l11 + 1)) { fVec4[l11] = 0.0f; }
+        for (int l12 = 0; (l12 < 4096); l12 = (l12 + 1)) { fVec5[l12] = 0.0f; }
+        for (int l13 = 0; (l13 < 2); l13 = (l13 + 1)) { fRec16[l13] = 0.0f; }
+        for (int l14 = 0; (l14 < 2); l14 = (l14 + 1)) { fRec23[l14] = 0.0f; }
+        for (int l15 = 0; (l15 < 2); l15 = (l15 + 1)) { fRec22[l15] = 0.0f; }
+        for (int l16 = 0; (l16 < 16384); l16 = (l16 + 1)) { fVec6[l16] = 0.0f; }
+        for (int l17 = 0; (l17 < 4096); l17 = (l17 + 1)) { fVec7[l17] = 0.0f; }
+        for (int l18 = 0; (l18 < 2); l18 = (l18 + 1)) { fRec20[l18] = 0.0f; }
+        for (int l19 = 0; (l19 < 2); l19 = (l19 + 1)) { fRec27[l19] = 0.0f; }
+        for (int l20 = 0; (l20 < 2); l20 = (l20 + 1)) { fRec26[l20] = 0.0f; }
+        for (int l21 = 0; (l21 < 32768); l21 = (l21 + 1)) { fVec8[l21] = 0.0f; }
+        for (int l22 = 0; (l22 < 4096); l22 = (l22 + 1)) { fVec9[l22] = 0.0f; }
+        for (int l23 = 0; (l23 < 2); l23 = (l23 + 1)) { fRec24[l23] = 0.0f; }
+        for (int l24 = 0; (l24 < 2); l24 = (l24 + 1)) { fRec31[l24] = 0.0f; }
+        for (int l25 = 0; (l25 < 2); l25 = (l25 + 1)) { fRec30[l25] = 0.0f; }
+        for (int l26 = 0; (l26 < 16384); l26 = (l26 + 1)) { fVec10[l26] = 0.0f; }
+        for (int l27 = 0; (l27 < 2048); l27 = (l27 + 1)) { fVec11[l27] = 0.0f; }
+        for (int l28 = 0; (l28 < 2); l28 = (l28 + 1)) { fRec28[l28] = 0.0f; }
+        for (int l29 = 0; (l29 < 2); l29 = (l29 + 1)) { fRec35[l29] = 0.0f; }
+        for (int l30 = 0; (l30 < 2); l30 = (l30 + 1)) { fRec34[l30] = 0.0f; }
+        for (int l31 = 0; (l31 < 16384); l31 = (l31 + 1)) { fVec12[l31] = 0.0f; }
+        for (int l32 = 0; (l32 < 4096); l32 = (l32 + 1)) { fVec13[l32] = 0.0f; }
+        for (int l33 = 0; (l33 < 2); l33 = (l33 + 1)) { fRec32[l33] = 0.0f; }
+        for (int l34 = 0; (l34 < 2); l34 = (l34 + 1)) { fRec39[l34] = 0.0f; }
+        for (int l35 = 0; (l35 < 2); l35 = (l35 + 1)) { fRec38[l35] = 0.0f; }
+        for (int l36 = 0; (l36 < 16384); l36 = (l36 + 1)) { fVec14[l36] = 0.0f; }
+        for (int l37 = 0; (l37 < 4096); l37 = (l37 + 1)) { fVec15[l37] = 0.0f; }
+        for (int l38 = 0; (l38 < 2); l38 = (l38 + 1)) { fRec36[l38] = 0.0f; }
+        for (int l39 = 0; (l39 < 2); l39 = (l39 + 1)) { fRec43[l39] = 0.0f; }
+        for (int l40 = 0; (l40 < 2); l40 = (l40 + 1)) { fRec42[l40] = 0.0f; }
+        for (int l41 = 0; (l41 < 16384); l41 = (l41 + 1)) { fVec16[l41] = 0.0f; }
+        for (int l42 = 0; (l42 < 2048); l42 = (l42 + 1)) { fVec17[l42] = 0.0f; }
+        for (int l43 = 0; (l43 < 2); l43 = (l43 + 1)) { fRec40[l43] = 0.0f; }
+        for (int l44 = 0; (l44 < 3); l44 = (l44 + 1)) { fRec4[l44] = 0.0f; }
+        for (int l45 = 0; (l45 < 3); l45 = (l45 + 1)) { fRec5[l45] = 0.0f; }
+        for (int l46 = 0; (l46 < 3); l46 = (l46 + 1)) { fRec6[l46] = 0.0f; }
+        for (int l47 = 0; (l47 < 3); l47 = (l47 + 1)) { fRec7[l47] = 0.0f; }
+        for (int l48 = 0; (l48 < 3); l48 = (l48 + 1)) { fRec8[l48] = 0.0f; }
+        for (int l49 = 0; (l49 < 3); l49 = (l49 + 1)) { fRec9[l49] = 0.0f; }
+        for (int l50 = 0; (l50 < 3); l50 = (l50 + 1)) { fRec10[l50] = 0.0f; }
+        for (int l51 = 0; (l51 < 3); l51 = (l51 + 1)) { fRec11[l51] = 0.0f; }
+        for (int l52 = 0; (l52 < 3); l52 = (l52 + 1)) { fRec3[l52] = 0.0f; }
+        for (int l53 = 0; (l53 < 3); l53 = (l53 + 1)) { fRec2[l53] = 0.0f; }
+        for (int l54 = 0; (l54 < 3); l54 = (l54 + 1)) { fRec45[l54] = 0.0f; }
+        for (int l55 = 0; (l55 < 3); l55 = (l55 + 1)) { fRec44[l55] = 0.0f; }
+    }
+
+    virtual void init(int sample_rate)
+    {
+        classInit(sample_rate);
+        instanceInit(sample_rate);
+    }
+    virtual void instanceInit(int sample_rate)
+    {
+        instanceConstants(sample_rate);
+        instanceResetUserInterface();
+        instanceClear();
+    }
+
+    virtual zitarevdsp* clone() { return new zitarevdsp(); }
+
+    virtual int getSampleRate() { return fSampleRate; }
+
+    virtual void buildUserInterface(UI* ui_interface)
+    {
+        ui_interface->declare(0, "0", "");
+        ui_interface->declare(0, "tooltip",
+                              "~ ZITA REV1 FEEDBACK DELAY NETWORK (FDN) & SCHROEDER  "
+                              "ALLPASS-COMB REVERBERATOR (8x8). See Faust's reverbs.lib "
+                              "for documentation and  references");
+        ui_interface->openHorizontalBox("Zita_Rev1");
+        ui_interface->declare(0, "1", "");
+        ui_interface->openHorizontalBox("Input");
+        ui_interface->declare(&fVslider10, "1", "");
+        ui_interface->declare(&fVslider10, "style", "knob");
+        ui_interface->declare(&fVslider10, "tooltip",
+                              "Delay in ms   before reverberation begins");
+        ui_interface->declare(&fVslider10, "unit", "ms");
+        ui_interface->addVerticalSlider("In Delay", &fVslider10, 60.0f, 20.0f, 100.0f,
+                                        1.0f);
+        ui_interface->closeBox();
+        ui_interface->declare(0, "2", "");
+        ui_interface->openHorizontalBox("Decay Times in Bands (see tooltips)");
+        ui_interface->declare(&fVslider9, "1", "");
+        ui_interface->declare(&fVslider9, "scale", "log");
+        ui_interface->declare(&fVslider9, "style", "knob");
+        ui_interface->declare(
+            &fVslider9, "tooltip",
+            "Crossover frequency (Hz) separating low and middle frequencies");
+        ui_interface->declare(&fVslider9, "unit", "Hz");
+        ui_interface->addVerticalSlider("LF X", &fVslider9, 200.0f, 50.0f, 1000.0f, 1.0f);
+        ui_interface->declare(&fVslider8, "2", "");
+        ui_interface->declare(&fVslider8, "scale", "log");
+        ui_interface->declare(&fVslider8, "style", "knob");
+        ui_interface->declare(
+            &fVslider8, "tooltip",
+            "T60 = time (in seconds) to decay 60dB in low-frequency band");
+        ui_interface->declare(&fVslider8, "unit", "s");
+        ui_interface->addVerticalSlider("Low RT60", &fVslider8, 3.0f, 1.0f, 8.0f,
+                                        0.100000001f);
+        ui_interface->declare(&fVslider6, "3", "");
+        ui_interface->declare(&fVslider6, "scale", "log");
+        ui_interface->declare(&fVslider6, "style", "knob");
+        ui_interface->declare(&fVslider6, "tooltip",
+                              "T60 = time (in seconds) to decay 60dB in middle band");
+        ui_interface->declare(&fVslider6, "unit", "s");
+        ui_interface->addVerticalSlider("Mid RT60", &fVslider6, 2.0f, 1.0f, 8.0f,
+                                        0.100000001f);
+        ui_interface->declare(&fVslider7, "4", "");
+        ui_interface->declare(&fVslider7, "scale", "log");
+        ui_interface->declare(&fVslider7, "style", "knob");
+        ui_interface->declare(&fVslider7, "tooltip",
+                              "Frequency (Hz) at which the high-frequency T60 is half "
+                              "the middle-band's T60");
+        ui_interface->declare(&fVslider7, "unit", "Hz");
+        ui_interface->addVerticalSlider("HF Damping", &fVslider7, 6000.0f, 1500.0f,
+                                        23520.0f, 1.0f);
+        ui_interface->closeBox();
+        ui_interface->declare(0, "3", "");
+        ui_interface->openHorizontalBox("RM Peaking Equalizer 1");
+        ui_interface->declare(&fVslider4, "1", "");
+        ui_interface->declare(&fVslider4, "scale", "log");
+        ui_interface->declare(&fVslider4, "style", "knob");
+        ui_interface->declare(
+            &fVslider4, "tooltip",
+            "Center-frequency of second-order Regalia-Mitra peaking equalizer section 1");
+        ui_interface->declare(&fVslider4, "unit", "Hz");
+        ui_interface->addVerticalSlider("Eq1 Freq", &fVslider4, 315.0f, 40.0f, 2500.0f,
+                                        1.0f);
+        ui_interface->declare(&fVslider5, "2", "");
+        ui_interface->declare(&fVslider5, "style", "knob");
+        ui_interface->declare(&fVslider5, "tooltip",
+                              "Peak level   in dB of second-order Regalia-Mitra peaking "
+                              "equalizer section 1");
+        ui_interface->declare(&fVslider5, "unit", "dB");
+        ui_interface->addVerticalSlider("Eq1 Level", &fVslider5, 0.0f, -15.0f, 15.0f,
+                                        0.100000001f);
+        ui_interface->closeBox();
+        ui_interface->declare(0, "4", "");
+        ui_interface->openHorizontalBox("RM Peaking Equalizer 2");
+        ui_interface->declare(&fVslider2, "1", "");
+        ui_interface->declare(&fVslider2, "scale", "log");
+        ui_interface->declare(&fVslider2, "style", "knob");
+        ui_interface->declare(
+            &fVslider2, "tooltip",
+            "Center-frequency of second-order Regalia-Mitra peaking equalizer section 2");
+        ui_interface->declare(&fVslider2, "unit", "Hz");
+        ui_interface->addVerticalSlider("Eq2 Freq", &fVslider2, 1500.0f, 160.0f, 10000.0f,
+                                        1.0f);
+        ui_interface->declare(&fVslider3, "2", "");
+        ui_interface->declare(&fVslider3, "style", "knob");
+        ui_interface->declare(&fVslider3, "tooltip",
+                              "Peak level   in dB of second-order Regalia-Mitra peaking "
+                              "equalizer section 2");
+        ui_interface->declare(&fVslider3, "unit", "dB");
+        ui_interface->addVerticalSlider("Eq2 Level", &fVslider3, 0.0f, -15.0f, 15.0f,
+                                        0.100000001f);
+        ui_interface->closeBox();
+        ui_interface->declare(0, "5", "");
+        ui_interface->openHorizontalBox("Output");
+        ui_interface->declare(&fVslider1, "1", "");
+        ui_interface->declare(&fVslider1, "style", "knob");
+        ui_interface->declare(&fVslider1, "tooltip", "Dry/Wet Mix: 0 = dry, 1 = wet");
+        ui_interface->addVerticalSlider("Wet", &fVslider1, 0.0f, 0.0f, 1.0f,
+                                        0.00999999978f);
+        ui_interface->declare(&fVslider0, "2", "");
+        ui_interface->declare(&fVslider0, "style", "knob");
+        ui_interface->declare(&fVslider0, "tooltip", "Output scale   factor");
+        ui_interface->declare(&fVslider0, "unit", "dB");
+        ui_interface->addVerticalSlider("Level", &fVslider0, -3.0f, -70.0f, 20.0f,
+                                        0.100000001f);
+        ui_interface->closeBox();
+        ui_interface->closeBox();
+    }
+
+    virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+    {
+        FAUSTFLOAT* input0  = inputs[0];
+        FAUSTFLOAT* input1  = inputs[1];
+        FAUSTFLOAT* output0 = outputs[0];
+        FAUSTFLOAT* output1 = outputs[1];
+        float fSlow0 =
+            (0.00100000005f * std::pow(10.0f, (0.0500000007f * float(fVslider0))));
+        float fSlow1  = (0.00100000005f * float(fVslider1));
+        float fSlow2  = float(fVslider2);
+        float fSlow3  = std::pow(10.0f, (0.0500000007f * float(fVslider3)));
+        float fSlow4  = (fConst1 * (fSlow2 / std::sqrt(std::max<float>(0.0f, fSlow3))));
+        float fSlow5  = ((1.0f - fSlow4) / (fSlow4 + 1.0f));
+        float fSlow6  = float(fVslider4);
+        float fSlow7  = std::pow(10.0f, (0.0500000007f * float(fVslider5)));
+        float fSlow8  = (fConst1 * (fSlow6 / std::sqrt(std::max<float>(0.0f, fSlow7))));
+        float fSlow9  = ((1.0f - fSlow8) / (fSlow8 + 1.0f));
+        float fSlow10 = float(fVslider6);
+        float fSlow11 = std::exp((fConst3 / fSlow10));
+        float fSlow12 = zitarevdsp_faustpower2_f(fSlow11);
+        float fSlow13 = std::cos((fConst1 * float(fVslider7)));
+        float fSlow14 = (1.0f - (fSlow12 * fSlow13));
+        float fSlow15 = (1.0f - fSlow12);
+        float fSlow16 = (fSlow14 / fSlow15);
+        float fSlow17 = std::sqrt(std::max<float>(
+            0.0f, ((zitarevdsp_faustpower2_f(fSlow14) / zitarevdsp_faustpower2_f(fSlow15))
+                   + -1.0f)));
+        float fSlow18 = (fSlow16 - fSlow17);
+        float fSlow19 = (fSlow11 * (fSlow17 + (1.0f - fSlow16)));
+        float fSlow20 = float(fVslider8);
+        float fSlow21 = ((std::exp((fConst3 / fSlow20)) / fSlow11) + -1.0f);
+        float fSlow22 = (1.0f / std::tan((fConst4 * float(fVslider9))));
+        float fSlow23 = (1.0f / (fSlow22 + 1.0f));
+        float fSlow24 = (1.0f - fSlow22);
+        int iSlow25   = int(std::min<float>(
+            8192.0f, std::max<float>(0.0f, (fConst7 * float(fVslider10)))));
+        float fSlow26 = std::exp((fConst10 / fSlow10));
+        float fSlow27 = zitarevdsp_faustpower2_f(fSlow26);
+        float fSlow28 = (1.0f - (fSlow27 * fSlow13));
+        float fSlow29 = (1.0f - fSlow27);
+        float fSlow30 = (fSlow28 / fSlow29);
+        float fSlow31 = std::sqrt(std::max<float>(
+            0.0f, ((zitarevdsp_faustpower2_f(fSlow28) / zitarevdsp_faustpower2_f(fSlow29))
+                   + -1.0f)));
+        float fSlow32 = (fSlow30 - fSlow31);
+        float fSlow33 = (fSlow26 * (fSlow31 + (1.0f - fSlow30)));
+        float fSlow34 = ((std::exp((fConst10 / fSlow20)) / fSlow26) + -1.0f);
+        float fSlow35 = std::exp((fConst15 / fSlow10));
+        float fSlow36 = zitarevdsp_faustpower2_f(fSlow35);
+        float fSlow37 = (1.0f - (fSlow36 * fSlow13));
+        float fSlow38 = (1.0f - fSlow36);
+        float fSlow39 = (fSlow37 / fSlow38);
+        float fSlow40 = std::sqrt(std::max<float>(
+            0.0f, ((zitarevdsp_faustpower2_f(fSlow37) / zitarevdsp_faustpower2_f(fSlow38))
+                   + -1.0f)));
+        float fSlow41 = (fSlow39 - fSlow40);
+        float fSlow42 = (fSlow35 * (fSlow40 + (1.0f - fSlow39)));
+        float fSlow43 = ((std::exp((fConst15 / fSlow20)) / fSlow35) + -1.0f);
+        float fSlow44 = std::exp((fConst20 / fSlow10));
+        float fSlow45 = zitarevdsp_faustpower2_f(fSlow44);
+        float fSlow46 = (1.0f - (fSlow45 * fSlow13));
+        float fSlow47 = (1.0f - fSlow45);
+        float fSlow48 = (fSlow46 / fSlow47);
+        float fSlow49 = std::sqrt(std::max<float>(
+            0.0f, ((zitarevdsp_faustpower2_f(fSlow46) / zitarevdsp_faustpower2_f(fSlow47))
+                   + -1.0f)));
+        float fSlow50 = (fSlow48 - fSlow49);
+        float fSlow51 = (fSlow44 * (fSlow49 + (1.0f - fSlow48)));
+        float fSlow52 = ((std::exp((fConst20 / fSlow20)) / fSlow44) + -1.0f);
+        float fSlow53 = std::exp((fConst25 / fSlow10));
+        float fSlow54 = zitarevdsp_faustpower2_f(fSlow53);
+        float fSlow55 = (1.0f - (fSlow54 * fSlow13));
+        float fSlow56 = (1.0f - fSlow54);
+        float fSlow57 = (fSlow55 / fSlow56);
+        float fSlow58 = std::sqrt(std::max<float>(
+            0.0f, ((zitarevdsp_faustpower2_f(fSlow55) / zitarevdsp_faustpower2_f(fSlow56))
+                   + -1.0f)));
+        float fSlow59 = (fSlow57 - fSlow58);
+        float fSlow60 = (fSlow53 * (fSlow58 + (1.0f - fSlow57)));
+        float fSlow61 = ((std::exp((fConst25 / fSlow20)) / fSlow53) + -1.0f);
+        float fSlow62 = std::exp((fConst30 / fSlow10));
+        float fSlow63 = zitarevdsp_faustpower2_f(fSlow62);
+        float fSlow64 = (1.0f - (fSlow63 * fSlow13));
+        float fSlow65 = (1.0f - fSlow63);
+        float fSlow66 = (fSlow64 / fSlow65);
+        float fSlow67 = std::sqrt(std::max<float>(
+            0.0f, ((zitarevdsp_faustpower2_f(fSlow64) / zitarevdsp_faustpower2_f(fSlow65))
+                   + -1.0f)));
+        float fSlow68 = (fSlow66 - fSlow67);
+        float fSlow69 = (fSlow62 * (fSlow67 + (1.0f - fSlow66)));
+        float fSlow70 = ((std::exp((fConst30 / fSlow20)) / fSlow62) + -1.0f);
+        float fSlow71 = std::exp((fConst35 / fSlow10));
+        float fSlow72 = zitarevdsp_faustpower2_f(fSlow71);
+        float fSlow73 = (1.0f - (fSlow72 * fSlow13));
+        float fSlow74 = (1.0f - fSlow72);
+        float fSlow75 = (fSlow73 / fSlow74);
+        float fSlow76 = std::sqrt(std::max<float>(
+            0.0f, ((zitarevdsp_faustpower2_f(fSlow73) / zitarevdsp_faustpower2_f(fSlow74))
+                   + -1.0f)));
+        float fSlow77 = (fSlow75 - fSlow76);
+        float fSlow78 = (fSlow71 * (fSlow76 + (1.0f - fSlow75)));
+        float fSlow79 = ((std::exp((fConst35 / fSlow20)) / fSlow71) + -1.0f);
+        float fSlow80 = std::exp((fConst40 / fSlow10));
+        float fSlow81 = zitarevdsp_faustpower2_f(fSlow80);
+        float fSlow82 = (1.0f - (fSlow81 * fSlow13));
+        float fSlow83 = (1.0f - fSlow81);
+        float fSlow84 = (fSlow82 / fSlow83);
+        float fSlow85 = std::sqrt(std::max<float>(
+            0.0f, ((zitarevdsp_faustpower2_f(fSlow82) / zitarevdsp_faustpower2_f(fSlow83))
+                   + -1.0f)));
+        float fSlow86 = (fSlow84 - fSlow85);
+        float fSlow87 = (fSlow80 * (fSlow85 + (1.0f - fSlow84)));
+        float fSlow88 = ((std::exp((fConst40 / fSlow20)) / fSlow80) + -1.0f);
+        float fSlow89 = (0.0f - (std::cos((fConst1 * fSlow6)) * (fSlow9 + 1.0f)));
+        float fSlow90 = (0.0f - (std::cos((fConst1 * fSlow2)) * (fSlow5 + 1.0f)));
+        for (int i = 0; (i < count); i = (i + 1)) {
+            float fTemp0          = float(input0[i]);
+            fVec0[(IOTA & 16383)] = fTemp0;
+            float fTemp1          = float(input1[i]);
+            fVec1[(IOTA & 16383)] = fTemp1;
+            fRec0[0]              = (fSlow0 + (0.999000013f * fRec0[1]));
+            fRec1[0]              = (fSlow1 + (0.999000013f * fRec1[1]));
+            fRec15[0] =
+                (0.0f - (fSlow23 * ((fSlow24 * fRec15[1]) - (fRec11[1] + fRec11[2]))));
+            fRec14[0] =
+                ((fSlow18 * fRec14[1]) + (fSlow19 * (fRec11[1] + (fSlow21 * fRec15[0]))));
+            fVec2[(IOTA & 32767)] = ((0.353553385f * fRec14[0]) + 9.99999968e-21f);
+            float fTemp2          = (0.300000012f * fVec1[((IOTA - iSlow25) & 16383)]);
+            float fTemp3 =
+                (((0.600000024f * fRec12[1]) + fVec2[((IOTA - iConst6) & 32767)])
+                 - fTemp2);
+            fVec3[(IOTA & 2047)] = fTemp3;
+            fRec12[0]            = fVec3[((IOTA - iConst8) & 2047)];
+            float fRec13         = (0.0f - (0.600000024f * fTemp3));
+            fRec19[0] =
+                (0.0f - (fSlow23 * ((fSlow24 * fRec19[1]) - (fRec7[1] + fRec7[2]))));
+            fRec18[0] =
+                ((fSlow32 * fRec18[1]) + (fSlow33 * (fRec7[1] + (fSlow34 * fRec19[0]))));
+            fVec4[(IOTA & 32767)] = ((0.353553385f * fRec18[0]) + 9.99999968e-21f);
+            float fTemp4 =
+                (((0.600000024f * fRec16[1]) + fVec4[((IOTA - iConst12) & 32767)])
+                 - fTemp2);
+            fVec5[(IOTA & 4095)] = fTemp4;
+            fRec16[0]            = fVec5[((IOTA - iConst13) & 4095)];
+            float fRec17         = (0.0f - (0.600000024f * fTemp4));
+            fRec23[0] =
+                (0.0f - (fSlow23 * ((fSlow24 * fRec23[1]) - (fRec9[1] + fRec9[2]))));
+            fRec22[0] =
+                ((fSlow41 * fRec22[1]) + (fSlow42 * (fRec9[1] + (fSlow43 * fRec23[0]))));
+            fVec6[(IOTA & 16383)] = ((0.353553385f * fRec22[0]) + 9.99999968e-21f);
+            float fTemp5          = (fVec6[((IOTA - iConst17) & 16383)]
+                            + (fTemp2 + (0.600000024f * fRec20[1])));
+            fVec7[(IOTA & 4095)]  = fTemp5;
+            fRec20[0]             = fVec7[((IOTA - iConst18) & 4095)];
+            float fRec21          = (0.0f - (0.600000024f * fTemp5));
+            fRec27[0] =
+                (0.0f - (fSlow23 * ((fSlow24 * fRec27[1]) - (fRec5[1] + fRec5[2]))));
+            fRec26[0] =
+                ((fSlow50 * fRec26[1]) + (fSlow51 * (fRec5[1] + (fSlow52 * fRec27[0]))));
+            fVec8[(IOTA & 32767)] = ((0.353553385f * fRec26[0]) + 9.99999968e-21f);
+            float fTemp6 =
+                (fTemp2
+                 + ((0.600000024f * fRec24[1]) + fVec8[((IOTA - iConst22) & 32767)]));
+            fVec9[(IOTA & 4095)] = fTemp6;
+            fRec24[0]            = fVec9[((IOTA - iConst23) & 4095)];
+            float fRec25         = (0.0f - (0.600000024f * fTemp6));
+            fRec31[0] =
+                (0.0f - (fSlow23 * ((fSlow24 * fRec31[1]) - (fRec10[1] + fRec10[2]))));
+            fRec30[0] =
+                ((fSlow59 * fRec30[1]) + (fSlow60 * (fRec10[1] + (fSlow61 * fRec31[0]))));
+            fVec10[(IOTA & 16383)] = ((0.353553385f * fRec30[0]) + 9.99999968e-21f);
+            float fTemp7           = (0.300000012f * fVec0[((IOTA - iSlow25) & 16383)]);
+            float fTemp8           = (fVec10[((IOTA - iConst27) & 16383)]
+                            - (fTemp7 + (0.600000024f * fRec28[1])));
+            fVec11[(IOTA & 2047)]  = fTemp8;
+            fRec28[0]              = fVec11[((IOTA - iConst28) & 2047)];
+            float fRec29           = (0.600000024f * fTemp8);
+            fRec35[0] =
+                (0.0f - (fSlow23 * ((fSlow24 * fRec35[1]) - (fRec6[1] + fRec6[2]))));
+            fRec34[0] =
+                ((fSlow68 * fRec34[1]) + (fSlow69 * (fRec6[1] + (fSlow70 * fRec35[0]))));
+            fVec12[(IOTA & 16383)] = ((0.353553385f * fRec34[0]) + 9.99999968e-21f);
+            float fTemp9           = (fVec12[((IOTA - iConst32) & 16383)]
+                            - (fTemp7 + (0.600000024f * fRec32[1])));
+            fVec13[(IOTA & 4095)]  = fTemp9;
+            fRec32[0]              = fVec13[((IOTA - iConst33) & 4095)];
+            float fRec33           = (0.600000024f * fTemp9);
+            fRec39[0] =
+                (0.0f - (fSlow23 * ((fSlow24 * fRec39[1]) - (fRec8[1] + fRec8[2]))));
+            fRec38[0] =
+                ((fSlow77 * fRec38[1]) + (fSlow78 * (fRec8[1] + (fSlow79 * fRec39[0]))));
+            fVec14[(IOTA & 16383)] = ((0.353553385f * fRec38[0]) + 9.99999968e-21f);
+            float fTemp10          = ((fTemp7 + fVec14[((IOTA - iConst37) & 16383)])
+                             - (0.600000024f * fRec36[1]));
+            fVec15[(IOTA & 4095)]  = fTemp10;
+            fRec36[0]              = fVec15[((IOTA - iConst38) & 4095)];
+            float fRec37           = (0.600000024f * fTemp10);
+            fRec43[0] =
+                (0.0f - (fSlow23 * ((fSlow24 * fRec43[1]) - (fRec4[1] + fRec4[2]))));
+            fRec42[0] =
+                ((fSlow86 * fRec42[1]) + (fSlow87 * (fRec4[1] + (fSlow88 * fRec43[0]))));
+            fVec16[(IOTA & 16383)] = ((0.353553385f * fRec42[0]) + 9.99999968e-21f);
+            float fTemp11          = ((fVec16[((IOTA - iConst42) & 16383)] + fTemp7)
+                             - (0.600000024f * fRec40[1]));
+            fVec17[(IOTA & 2047)]  = fTemp11;
+            fRec40[0]              = fVec17[((IOTA - iConst43) & 2047)];
+            float fRec41           = (0.600000024f * fTemp11);
+            float fTemp12          = (fRec41 + fRec37);
+            float fTemp13          = (fRec29 + (fRec33 + fTemp12));
+            fRec4[0] =
+                (fRec12[1]
+                 + (fRec16[1]
+                    + (fRec20[1]
+                       + (fRec24[1]
+                          + (fRec28[1]
+                             + (fRec32[1]
+                                + (fRec36[1]
+                                   + (fRec40[1]
+                                      + (fRec13
+                                         + (fRec17
+                                            + (fRec21 + (fRec25 + fTemp13))))))))))));
+            fRec5[0] =
+                ((fRec28[1] + (fRec32[1] + (fRec36[1] + (fRec40[1] + fTemp13))))
+                 - (fRec12[1]
+                    + (fRec16[1]
+                       + (fRec20[1]
+                          + (fRec24[1] + (fRec13 + (fRec17 + (fRec25 + fRec21))))))));
+            float fTemp14 = (fRec33 + fRec29);
+            fRec6[0] =
+                ((fRec20[1]
+                  + (fRec24[1]
+                     + (fRec36[1] + (fRec40[1] + (fRec21 + (fRec25 + fTemp12))))))
+                 - (fRec12[1]
+                    + (fRec16[1]
+                       + (fRec28[1] + (fRec32[1] + (fRec13 + (fRec17 + fTemp14)))))));
+            fRec7[0] =
+                ((fRec12[1]
+                  + (fRec16[1]
+                     + (fRec36[1] + (fRec40[1] + (fRec13 + (fRec17 + fTemp12))))))
+                 - (fRec20[1]
+                    + (fRec24[1]
+                       + (fRec28[1] + (fRec32[1] + (fRec21 + (fRec25 + fTemp14)))))));
+            float fTemp15 = (fRec41 + fRec33);
+            float fTemp16 = (fRec37 + fRec29);
+            fRec8[0] =
+                ((fRec16[1]
+                  + (fRec24[1]
+                     + (fRec32[1] + (fRec40[1] + (fRec17 + (fRec25 + fTemp15))))))
+                 - (fRec12[1]
+                    + (fRec20[1]
+                       + (fRec28[1] + (fRec36[1] + (fRec13 + (fRec21 + fTemp16)))))));
+            fRec9[0] =
+                ((fRec12[1]
+                  + (fRec20[1]
+                     + (fRec32[1] + (fRec40[1] + (fRec13 + (fRec21 + fTemp15))))))
+                 - (fRec16[1]
+                    + (fRec24[1]
+                       + (fRec28[1] + (fRec36[1] + (fRec17 + (fRec25 + fTemp16)))))));
+            float fTemp17 = (fRec41 + fRec29);
+            float fTemp18 = (fRec37 + fRec33);
+            fRec10[0] =
+                ((fRec12[1]
+                  + (fRec24[1]
+                     + (fRec28[1] + (fRec40[1] + (fRec13 + (fRec25 + fTemp17))))))
+                 - (fRec16[1]
+                    + (fRec20[1]
+                       + (fRec32[1] + (fRec36[1] + (fRec17 + (fRec21 + fTemp18)))))));
+            fRec11[0] =
+                ((fRec16[1]
+                  + (fRec20[1]
+                     + (fRec28[1] + (fRec40[1] + (fRec17 + (fRec21 + fTemp17))))))
+                 - (fRec12[1]
+                    + (fRec24[1]
+                       + (fRec32[1] + (fRec36[1] + (fRec13 + (fRec25 + fTemp18)))))));
+            float fTemp19 = (0.370000005f * (fRec5[0] + fRec6[0]));
+            float fTemp20 = (fSlow89 * fRec3[1]);
+            fRec3[0]      = (fTemp19 - (fTemp20 + (fSlow9 * fRec3[2])));
+            float fTemp21 = (fSlow9 * fRec3[0]);
+            float fTemp22 =
+                (0.5f
+                 * ((fTemp21 + (fRec3[2] + (fTemp19 + fTemp20)))
+                    + (fSlow7 * ((fTemp21 + (fTemp20 + fRec3[2])) - fTemp19))));
+            float fTemp23 = (fSlow90 * fRec2[1]);
+            fRec2[0]      = (fTemp22 - (fTemp23 + (fSlow5 * fRec2[2])));
+            float fTemp24 = (fSlow5 * fRec2[0]);
+            float fTemp25 = (1.0f - fRec1[0]);
+            output0[i]    = FAUSTFLOAT(
+                (fRec0[0]
+                 * ((0.5f
+                     * (fRec1[0]
+                        * ((fTemp24 + (fRec2[2] + (fTemp22 + fTemp23)))
+                           + (fSlow3 * ((fTemp24 + (fTemp23 + fRec2[2])) - fTemp22)))))
+                    + (fTemp0 * fTemp25))));
+            float fTemp26 = (0.370000005f * (fRec5[0] - fRec6[0]));
+            float fTemp27 = (fSlow89 * fRec45[1]);
+            fRec45[0]     = (fTemp26 - (fTemp27 + (fSlow9 * fRec45[2])));
+            float fTemp28 = (fSlow9 * fRec45[0]);
+            float fTemp29 =
+                (0.5f
+                 * ((fTemp28 + (fRec45[2] + (fTemp26 + fTemp27)))
+                    + (fSlow7 * ((fTemp28 + (fTemp27 + fRec45[2])) - fTemp26))));
+            float fTemp30 = (fSlow90 * fRec44[1]);
+            fRec44[0]     = (fTemp29 - (fTemp30 + (fSlow5 * fRec44[2])));
+            float fTemp31 = (fSlow5 * fRec44[0]);
+            output1[i]    = FAUSTFLOAT(
+                (fRec0[0]
+                 * ((0.5f
+                     * (fRec1[0]
+                        * ((fTemp31 + (fRec44[2] + (fTemp29 + fTemp30)))
+                           + (fSlow3 * ((fTemp31 + (fTemp30 + fRec44[2])) - fTemp29)))))
+                    + (fTemp1 * fTemp25))));
+            IOTA      = (IOTA + 1);
+            fRec0[1]  = fRec0[0];
+            fRec1[1]  = fRec1[0];
+            fRec15[1] = fRec15[0];
+            fRec14[1] = fRec14[0];
+            fRec12[1] = fRec12[0];
+            fRec19[1] = fRec19[0];
+            fRec18[1] = fRec18[0];
+            fRec16[1] = fRec16[0];
+            fRec23[1] = fRec23[0];
+            fRec22[1] = fRec22[0];
+            fRec20[1] = fRec20[0];
+            fRec27[1] = fRec27[0];
+            fRec26[1] = fRec26[0];
+            fRec24[1] = fRec24[0];
+            fRec31[1] = fRec31[0];
+            fRec30[1] = fRec30[0];
+            fRec28[1] = fRec28[0];
+            fRec35[1] = fRec35[0];
+            fRec34[1] = fRec34[0];
+            fRec32[1] = fRec32[0];
+            fRec39[1] = fRec39[0];
+            fRec38[1] = fRec38[0];
+            fRec36[1] = fRec36[0];
+            fRec43[1] = fRec43[0];
+            fRec42[1] = fRec42[0];
+            fRec40[1] = fRec40[0];
+            fRec4[2]  = fRec4[1];
+            fRec4[1]  = fRec4[0];
+            fRec5[2]  = fRec5[1];
+            fRec5[1]  = fRec5[0];
+            fRec6[2]  = fRec6[1];
+            fRec6[1]  = fRec6[0];
+            fRec7[2]  = fRec7[1];
+            fRec7[1]  = fRec7[0];
+            fRec8[2]  = fRec8[1];
+            fRec8[1]  = fRec8[0];
+            fRec9[2]  = fRec9[1];
+            fRec9[1]  = fRec9[0];
+            fRec10[2] = fRec10[1];
+            fRec10[1] = fRec10[0];
+            fRec11[2] = fRec11[1];
+            fRec11[1] = fRec11[0];
+            fRec3[2]  = fRec3[1];
+            fRec3[1]  = fRec3[0];
+            fRec2[2]  = fRec2[1];
+            fRec2[1]  = fRec2[0];
+            fRec45[2] = fRec45[1];
+            fRec45[1] = fRec45[0];
+            fRec44[2] = fRec44[1];
+            fRec44[1] = fRec44[0];
+        }
+    }
 };
 
 #endif

--- a/src/zitarevmonodsp.h
+++ b/src/zitarevmonodsp.h
@@ -4,8 +4,8 @@ Code generated with Faust 2.28.6 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -scal -ftz 0
 ------------------------------------------------------------ */
 
-#ifndef  __zitarevmonodsp_H__
-#define  __zitarevmonodsp_H__
+#ifndef __zitarevmonodsp_H__
+#define __zitarevmonodsp_H__
 
 // NOTE: ANY INCLUDE-GUARD HERE MUST BE DERIVED FROM THE CLASS NAME
 //
@@ -56,86 +56,83 @@ struct Meta;
  */
 
 struct dsp_memory_manager {
-    
     virtual ~dsp_memory_manager() {}
-    
+
     virtual void* allocate(size_t size) = 0;
-    virtual void destroy(void* ptr) = 0;
-    
+    virtual void destroy(void* ptr)     = 0;
 };
 
 /**
 * Signal processor definition.
 */
 
-class dsp {
+class dsp
+{
+   public:
+    dsp() {}
+    virtual ~dsp() {}
 
-    public:
+    /* Return instance number of audio inputs */
+    virtual int getNumInputs() = 0;
 
-        dsp() {}
-        virtual ~dsp() {}
+    /* Return instance number of audio outputs */
+    virtual int getNumOutputs() = 0;
 
-        /* Return instance number of audio inputs */
-        virtual int getNumInputs() = 0;
-    
-        /* Return instance number of audio outputs */
-        virtual int getNumOutputs() = 0;
-    
-        /**
+    /**
          * Trigger the ui_interface parameter with instance specific calls
          * to 'openTabBox', 'addButton', 'addVerticalSlider'... in order to build the UI.
          *
          * @param ui_interface - the user interface builder
          */
-        virtual void buildUserInterface(UI* ui_interface) = 0;
-    
-        /* Returns the sample rate currently used by the instance */
-        virtual int getSampleRate() = 0;
-    
-        /**
+    virtual void buildUserInterface(UI* ui_interface) = 0;
+
+    /* Returns the sample rate currently used by the instance */
+    virtual int getSampleRate() = 0;
+
+    /**
          * Global init, calls the following methods:
          * - static class 'classInit': static tables initialization
          * - 'instanceInit': constants and instance state initialization
          *
          * @param sample_rate - the sampling rate in Hertz
          */
-        virtual void init(int sample_rate) = 0;
+    virtual void init(int sample_rate) = 0;
 
-        /**
+    /**
          * Init instance state
          *
          * @param sample_rate - the sampling rate in Hertz
          */
-        virtual void instanceInit(int sample_rate) = 0;
+    virtual void instanceInit(int sample_rate) = 0;
 
-        /**
+    /**
          * Init instance constant state
          *
          * @param sample_rate - the sampling rate in Hertz
          */
-        virtual void instanceConstants(int sample_rate) = 0;
-    
-        /* Init default control parameters values */
-        virtual void instanceResetUserInterface() = 0;
-    
-        /* Init instance state (delay lines...) */
-        virtual void instanceClear() = 0;
- 
-        /**
+    virtual void instanceConstants(int sample_rate) = 0;
+
+    /* Init default control parameters values */
+    virtual void instanceResetUserInterface() = 0;
+
+    /* Init instance state (delay lines...) */
+    virtual void instanceClear() = 0;
+
+    /**
          * Return a clone of the instance.
          *
          * @return a copy of the instance on success, otherwise a null pointer.
          */
-        virtual dsp* clone() = 0;
-    
-        /**
+    virtual dsp* clone() = 0;
+
+    /**
          * Trigger the Meta* parameter with instance specific calls to 'declare' (key, value) metadata.
          *
          * @param m - the Meta* meta user
          */
-        virtual void metadata(Meta* m) = 0;
-    
-        /**
+    virtual void metadata(Meta* m) = 0;
+
+    /**
          * DSP instance computation, to be called with successive in/out audio buffers.
          *
          * @param count - the number of frames to compute
@@ -143,9 +140,9 @@ class dsp {
          * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (eiher float, double or quad)
          *
          */
-        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
-    
-        /**
+    virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) = 0;
+
+    /**
          * DSP instance computation: alternative method to be used by subclasses.
          *
          * @param date_usec - the timestamp in microsec given by audio driver.
@@ -154,67 +151,77 @@ class dsp {
          * @param outputs - the output audio buffers as an array of non-interleaved FAUSTFLOAT samples (either float, double or quad)
          *
          */
-        virtual void compute(double /*date_usec*/, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { compute(count, inputs, outputs); }
-       
+    virtual void compute(double /*date_usec*/, int count, FAUSTFLOAT** inputs,
+                         FAUSTFLOAT** outputs)
+    {
+        compute(count, inputs, outputs);
+    }
 };
 
 /**
  * Generic DSP decorator.
  */
 
-class decorator_dsp : public dsp {
+class decorator_dsp : public dsp
+{
+   protected:
+    dsp* fDSP;
 
-    protected:
+   public:
+    decorator_dsp(dsp* dsp = nullptr) : fDSP(dsp) {}
+    virtual ~decorator_dsp() { delete fDSP; }
 
-        dsp* fDSP;
-
-    public:
-
-        decorator_dsp(dsp* dsp = nullptr):fDSP(dsp) {}
-        virtual ~decorator_dsp() { delete fDSP; }
-
-        virtual int getNumInputs() { return fDSP->getNumInputs(); }
-        virtual int getNumOutputs() { return fDSP->getNumOutputs(); }
-        virtual void buildUserInterface(UI* ui_interface) { fDSP->buildUserInterface(ui_interface); }
-        virtual int getSampleRate() { return fDSP->getSampleRate(); }
-        virtual void init(int sample_rate) { fDSP->init(sample_rate); }
-        virtual void instanceInit(int sample_rate) { fDSP->instanceInit(sample_rate); }
-        virtual void instanceConstants(int sample_rate) { fDSP->instanceConstants(sample_rate); }
-        virtual void instanceResetUserInterface() { fDSP->instanceResetUserInterface(); }
-        virtual void instanceClear() { fDSP->instanceClear(); }
-        virtual decorator_dsp* clone() { return new decorator_dsp(fDSP->clone()); }
-        virtual void metadata(Meta* m) { fDSP->metadata(m); }
-        // Beware: subclasses usually have to overload the two 'compute' methods
-        virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(count, inputs, outputs); }
-        virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) { fDSP->compute(date_usec, count, inputs, outputs); }
-    
+    virtual int getNumInputs() { return fDSP->getNumInputs(); }
+    virtual int getNumOutputs() { return fDSP->getNumOutputs(); }
+    virtual void buildUserInterface(UI* ui_interface)
+    {
+        fDSP->buildUserInterface(ui_interface);
+    }
+    virtual int getSampleRate() { return fDSP->getSampleRate(); }
+    virtual void init(int sample_rate) { fDSP->init(sample_rate); }
+    virtual void instanceInit(int sample_rate) { fDSP->instanceInit(sample_rate); }
+    virtual void instanceConstants(int sample_rate)
+    {
+        fDSP->instanceConstants(sample_rate);
+    }
+    virtual void instanceResetUserInterface() { fDSP->instanceResetUserInterface(); }
+    virtual void instanceClear() { fDSP->instanceClear(); }
+    virtual decorator_dsp* clone() { return new decorator_dsp(fDSP->clone()); }
+    virtual void metadata(Meta* m) { fDSP->metadata(m); }
+    // Beware: subclasses usually have to overload the two 'compute' methods
+    virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+    {
+        fDSP->compute(count, inputs, outputs);
+    }
+    virtual void compute(double date_usec, int count, FAUSTFLOAT** inputs,
+                         FAUSTFLOAT** outputs)
+    {
+        fDSP->compute(date_usec, count, inputs, outputs);
+    }
 };
 
 /**
  * DSP factory class.
  */
 
-class dsp_factory {
-    
-    protected:
-    
-        // So that to force sub-classes to use deleteDSPFactory(dsp_factory* factory);
-        virtual ~dsp_factory() {}
-    
-    public:
-    
-        virtual std::string getName() = 0;
-        virtual std::string getSHAKey() = 0;
-        virtual std::string getDSPCode() = 0;
-        virtual std::string getCompileOptions() = 0;
-        virtual std::vector<std::string> getLibraryList() = 0;
-        virtual std::vector<std::string> getIncludePathnames() = 0;
-    
-        virtual dsp* createDSPInstance() = 0;
-    
-        virtual void setMemoryManager(dsp_memory_manager* manager) = 0;
-        virtual dsp_memory_manager* getMemoryManager() = 0;
-    
+class dsp_factory
+{
+   protected:
+    // So that to force sub-classes to use deleteDSPFactory(dsp_factory* factory);
+    virtual ~dsp_factory() {}
+
+   public:
+    virtual std::string getName()                          = 0;
+    virtual std::string getSHAKey()                        = 0;
+    virtual std::string getDSPCode()                       = 0;
+    virtual std::string getCompileOptions()                = 0;
+    virtual std::vector<std::string> getLibraryList()      = 0;
+    virtual std::vector<std::string> getIncludePathnames() = 0;
+
+    virtual dsp* createDSPInstance() = 0;
+
+    virtual void setMemoryManager(dsp_memory_manager* manager) = 0;
+    virtual dsp_memory_manager* getMemoryManager()             = 0;
 };
 
 /**
@@ -223,14 +230,14 @@ class dsp_factory {
  */
 
 #ifdef __SSE__
-    #include <xmmintrin.h>
-    #ifdef __SSE2__
-        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8040)
-    #else
-        #define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8000)
-    #endif
+#include <xmmintrin.h>
+#ifdef __SSE2__
+#define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8040)
 #else
-    #define AVOIDDENORMALS
+#define AVOIDDENORMALS _mm_setcsr(_mm_getcsr() | 0x8000)
+#endif
+#else
+#define AVOIDDENORMALS
 #endif
 
 #endif
@@ -263,11 +270,11 @@ class dsp_factory {
 #ifndef API_UI_H
 #define API_UI_H
 
+#include <iostream>
+#include <map>
 #include <sstream>
 #include <string>
 #include <vector>
-#include <iostream>
-#include <map>
 
 /************************** BEGIN meta.h **************************/
 /************************************************************************
@@ -296,11 +303,9 @@ class dsp_factory {
 #ifndef __meta__
 #define __meta__
 
-struct Meta
-{
-    virtual ~Meta() {};
+struct Meta {
+    virtual ~Meta(){};
     virtual void declare(const char* key, const char* value) = 0;
-    
 };
 
 #endif
@@ -345,43 +350,47 @@ struct Meta
 
 struct Soundfile;
 
-template <typename REAL>
-struct UIReal
-{
+template<typename REAL>
+struct UIReal {
     UIReal() {}
     virtual ~UIReal() {}
-    
+
     // -- widget's layouts
-    
-    virtual void openTabBox(const char* label) = 0;
+
+    virtual void openTabBox(const char* label)        = 0;
     virtual void openHorizontalBox(const char* label) = 0;
-    virtual void openVerticalBox(const char* label) = 0;
-    virtual void closeBox() = 0;
-    
+    virtual void openVerticalBox(const char* label)   = 0;
+    virtual void closeBox()                           = 0;
+
     // -- active widgets
-    
-    virtual void addButton(const char* label, REAL* zone) = 0;
+
+    virtual void addButton(const char* label, REAL* zone)      = 0;
     virtual void addCheckButton(const char* label, REAL* zone) = 0;
-    virtual void addVerticalSlider(const char* label, REAL* zone, REAL init, REAL min, REAL max, REAL step) = 0;
-    virtual void addHorizontalSlider(const char* label, REAL* zone, REAL init, REAL min, REAL max, REAL step) = 0;
-    virtual void addNumEntry(const char* label, REAL* zone, REAL init, REAL min, REAL max, REAL step) = 0;
-    
+    virtual void addVerticalSlider(const char* label, REAL* zone, REAL init, REAL min,
+                                   REAL max, REAL step)        = 0;
+    virtual void addHorizontalSlider(const char* label, REAL* zone, REAL init, REAL min,
+                                     REAL max, REAL step)      = 0;
+    virtual void addNumEntry(const char* label, REAL* zone, REAL init, REAL min, REAL max,
+                             REAL step)                        = 0;
+
     // -- passive widgets
-    
-    virtual void addHorizontalBargraph(const char* label, REAL* zone, REAL min, REAL max) = 0;
-    virtual void addVerticalBargraph(const char* label, REAL* zone, REAL min, REAL max) = 0;
-    
+
+    virtual void addHorizontalBargraph(const char* label, REAL* zone, REAL min,
+                                       REAL max) = 0;
+    virtual void addVerticalBargraph(const char* label, REAL* zone, REAL min,
+                                     REAL max)   = 0;
+
     // -- soundfiles
-    
-    virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) = 0;
-    
+
+    virtual void addSoundfile(const char* label, const char* filename,
+                              Soundfile** sf_zone) = 0;
+
     // -- metadata declarations
-    
+
     virtual void declare(REAL* zone, const char* key, const char* val) {}
 };
 
-struct UI : public UIReal<FAUSTFLOAT>
-{
+struct UI : public UIReal<FAUSTFLOAT> {
     UI() {}
     virtual ~UI() {}
 };
@@ -415,9 +424,9 @@ struct UI : public UIReal<FAUSTFLOAT>
 #ifndef FAUST_PATHBUILDER_H
 #define FAUST_PATHBUILDER_H
 
-#include <vector>
-#include <string>
 #include <algorithm>
+#include <string>
+#include <vector>
 
 /*******************************************************************************
  * PathBuilder : Faust User Interface
@@ -426,37 +435,33 @@ struct UI : public UIReal<FAUSTFLOAT>
 
 class PathBuilder
 {
+   protected:
+    std::vector<std::string> fControlsLevel;
 
-    protected:
-    
-        std::vector<std::string> fControlsLevel;
-       
-    public:
-    
-        PathBuilder() {}
-        virtual ~PathBuilder() {}
-    
-        std::string buildPath(const std::string& label) 
-        {
-            std::string res = "/";
-            for (size_t i = 0; i < fControlsLevel.size(); i++) {
-                res += fControlsLevel[i];
-                res += "/";
-            }
-            res += label;
-            std::replace(res.begin(), res.end(), ' ', '_');
-            return res;
+   public:
+    PathBuilder() {}
+    virtual ~PathBuilder() {}
+
+    std::string buildPath(const std::string& label)
+    {
+        std::string res = "/";
+        for (size_t i = 0; i < fControlsLevel.size(); i++) {
+            res += fControlsLevel[i];
+            res += "/";
         }
-    
-        std::string buildLabel(std::string label)
-        {
-            std::replace(label.begin(), label.end(), ' ', '_');
-            return label;
-        }
-    
-        void pushLabel(const std::string& label) { fControlsLevel.push_back(label); }
-        void popLabel() { fControlsLevel.pop_back(); }
-    
+        res += label;
+        std::replace(res.begin(), res.end(), ' ', '_');
+        return res;
+    }
+
+    std::string buildLabel(std::string label)
+    {
+        std::replace(label.begin(), label.end(), ' ', '_');
+        return label;
+    }
+
+    void pushLabel(const std::string& label) { fControlsLevel.push_back(label); }
+    void popLabel() { fControlsLevel.pop_back(); }
 };
 
 #endif  // FAUST_PATHBUILDER_H
@@ -531,11 +536,12 @@ ZoneReader(zone, valueConverter) : a zone with a data converter
 
 ****************************************************************************************/
 
+#include <assert.h>
 #include <float.h>
-#include <algorithm>    // std::max
+
+#include <algorithm>  // std::max
 #include <cmath>
 #include <vector>
-#include <assert.h>
 
 //--------------------------------------------------------------------------------------
 // Interpolator(lo,hi,v1,v2)
@@ -548,50 +554,49 @@ ZoneReader(zone, valueConverter) : a zone with a data converter
 //--------------------------------------------------------------------------------------
 class Interpolator
 {
-    private:
+   private:
+    //--------------------------------------------------------------------------------------
+    // Range(lo,hi) clip a value between lo and hi
+    //--------------------------------------------------------------------------------------
+    struct Range {
+        double fLo;
+        double fHi;
 
-        //--------------------------------------------------------------------------------------
-        // Range(lo,hi) clip a value between lo and hi
-        //--------------------------------------------------------------------------------------
-        struct Range
+        Range(double x, double y)
+            : fLo(std::min<double>(x, y)), fHi(std::max<double>(x, y))
         {
-            double fLo;
-            double fHi;
-
-            Range(double x, double y) : fLo(std::min<double>(x,y)), fHi(std::max<double>(x,y)) {}
-            double operator()(double x) { return (x<fLo) ? fLo : (x>fHi) ? fHi : x; }
-        };
-
-
-        Range fRange;
-        double fCoef;
-        double fOffset;
-
-    public:
-
-        Interpolator(double lo, double hi, double v1, double v2) : fRange(lo,hi)
-        {
-            if (hi != lo) {
-                // regular case
-                fCoef = (v2-v1)/(hi-lo);
-                fOffset = v1 - lo*fCoef;
-            } else {
-                // degenerate case, avoids division by zero
-                fCoef = 0;
-                fOffset = (v1+v2)/2;
-            }
         }
-        double operator()(double v)
-        {
-            double x = fRange(v);
-            return  fOffset + x*fCoef;
-        }
+        double operator()(double x) { return (x < fLo) ? fLo : (x > fHi) ? fHi : x; }
+    };
 
-        void getLowHigh(double& amin, double& amax)
-        {
-            amin = fRange.fLo;
-            amax = fRange.fHi;
+    Range fRange;
+    double fCoef;
+    double fOffset;
+
+   public:
+    Interpolator(double lo, double hi, double v1, double v2) : fRange(lo, hi)
+    {
+        if (hi != lo) {
+            // regular case
+            fCoef   = (v2 - v1) / (hi - lo);
+            fOffset = v1 - lo * fCoef;
+        } else {
+            // degenerate case, avoids division by zero
+            fCoef   = 0;
+            fOffset = (v1 + v2) / 2;
         }
+    }
+    double operator()(double v)
+    {
+        double x = fRange(v);
+        return fOffset + x * fCoef;
+    }
+
+    void getLowHigh(double& amin, double& amax)
+    {
+        amin = fRange.fLo;
+        amax = fRange.fHi;
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -600,26 +605,23 @@ class Interpolator
 //--------------------------------------------------------------------------------------
 class Interpolator3pt
 {
+   private:
+    Interpolator fSegment1;
+    Interpolator fSegment2;
+    double fMid;
 
-    private:
+   public:
+    Interpolator3pt(double lo, double mi, double hi, double v1, double vm, double v2)
+        : fSegment1(lo, mi, v1, vm), fSegment2(mi, hi, vm, v2), fMid(mi)
+    {
+    }
+    double operator()(double x) { return (x < fMid) ? fSegment1(x) : fSegment2(x); }
 
-        Interpolator fSegment1;
-        Interpolator fSegment2;
-        double fMid;
-
-    public:
-
-        Interpolator3pt(double lo, double mi, double hi, double v1, double vm, double v2) :
-            fSegment1(lo, mi, v1, vm),
-            fSegment2(mi, hi, vm, v2),
-            fMid(mi) {}
-        double operator()(double x) { return  (x < fMid) ? fSegment1(x) : fSegment2(x); }
-
-        void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fSegment1.getLowHigh(amin, amid);
-            fSegment2.getLowHigh(amid, amax);
-        }
+    void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fSegment1.getLowHigh(amin, amid);
+        fSegment2.getLowHigh(amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -627,62 +629,51 @@ class Interpolator3pt
 //--------------------------------------------------------------------------------------
 class ValueConverter
 {
-
-    public:
-
-        virtual ~ValueConverter() {}
-        virtual double ui2faust(double x) = 0;
-        virtual double faust2ui(double x) = 0;
+   public:
+    virtual ~ValueConverter() {}
+    virtual double ui2faust(double x) = 0;
+    virtual double faust2ui(double x) = 0;
 };
 
 //--------------------------------------------------------------------------------------
 // A converter than can be updated
 //--------------------------------------------------------------------------------------
 
-class UpdatableValueConverter : public ValueConverter {
-    
-    protected:
-        
-        bool fActive;
-        
-    public:
-        
-        UpdatableValueConverter():fActive(true)
-        {}
-        virtual ~UpdatableValueConverter()
-        {}
-        
-        virtual void setMappingValues(double amin, double amid, double amax, double min, double init, double max) = 0;
-        virtual void getMappingValues(double& amin, double& amid, double& amax) = 0;
-        
-        void setActive(bool on_off) { fActive = on_off; }
-        bool getActive() { return fActive; }
-    
-};
+class UpdatableValueConverter : public ValueConverter
+{
+   protected:
+    bool fActive;
 
+   public:
+    UpdatableValueConverter() : fActive(true) {}
+    virtual ~UpdatableValueConverter() {}
+
+    virtual void setMappingValues(double amin, double amid, double amax, double min,
+                                  double init, double max)                  = 0;
+    virtual void getMappingValues(double& amin, double& amid, double& amax) = 0;
+
+    void setActive(bool on_off) { fActive = on_off; }
+    bool getActive() { return fActive; }
+};
 
 //--------------------------------------------------------------------------------------
 // Linear conversion between ui and Faust values
 //--------------------------------------------------------------------------------------
 class LinearValueConverter : public ValueConverter
 {
-    
-    private:
-        
-        Interpolator fUI2F;
-        Interpolator fF2UI;
-        
-    public:
-        
-        LinearValueConverter(double umin, double umax, double fmin, double fmax) :
-            fUI2F(umin,umax,fmin,fmax), fF2UI(fmin,fmax,umin,umax)
-        {}
-        
-        LinearValueConverter() : fUI2F(0.,0.,0.,0.), fF2UI(0.,0.,0.,0.)
-        {}
-        virtual double ui2faust(double x) { return fUI2F(x); }
-        virtual double faust2ui(double x) { return fF2UI(x); }
-    
+   private:
+    Interpolator fUI2F;
+    Interpolator fF2UI;
+
+   public:
+    LinearValueConverter(double umin, double umax, double fmin, double fmax)
+        : fUI2F(umin, umax, fmin, fmax), fF2UI(fmin, fmax, umin, umax)
+    {
+    }
+
+    LinearValueConverter() : fUI2F(0., 0., 0., 0.), fF2UI(0., 0., 0., 0.) {}
+    virtual double ui2faust(double x) { return fUI2F(x); }
+    virtual double faust2ui(double x) { return fF2UI(x); }
 };
 
 //--------------------------------------------------------------------------------------
@@ -690,35 +681,35 @@ class LinearValueConverter : public ValueConverter
 //--------------------------------------------------------------------------------------
 class LinearValueConverter2 : public UpdatableValueConverter
 {
-    
-    private:
-    
-        Interpolator3pt fUI2F;
-        Interpolator3pt fF2UI;
-        
-    public:
-    
-        LinearValueConverter2(double amin, double amid, double amax, double min, double init, double max) :
-            fUI2F(amin, amid, amax, min, init, max), fF2UI(min, init, max, amin, amid, amax)
-        {}
-        
-        LinearValueConverter2() : fUI2F(0.,0.,0.,0.,0.,0.), fF2UI(0.,0.,0.,0.,0.,0.)
-        {}
-    
-        virtual double ui2faust(double x) { return fUI2F(x); }
-        virtual double faust2ui(double x) { return fF2UI(x); }
-    
-        virtual void setMappingValues(double amin, double amid, double amax, double min, double init, double max)
-        {
-            fUI2F = Interpolator3pt(amin, amid, amax, min, init, max);
-            fF2UI = Interpolator3pt(min, init, max, amin, amid, amax);
-        }
+   private:
+    Interpolator3pt fUI2F;
+    Interpolator3pt fF2UI;
 
-        virtual void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fUI2F.getMappingValues(amin, amid, amax);
-        }
-    
+   public:
+    LinearValueConverter2(double amin, double amid, double amax, double min, double init,
+                          double max)
+        : fUI2F(amin, amid, amax, min, init, max), fF2UI(min, init, max, amin, amid, amax)
+    {
+    }
+
+    LinearValueConverter2() : fUI2F(0., 0., 0., 0., 0., 0.), fF2UI(0., 0., 0., 0., 0., 0.)
+    {
+    }
+
+    virtual double ui2faust(double x) { return fUI2F(x); }
+    virtual double faust2ui(double x) { return fF2UI(x); }
+
+    virtual void setMappingValues(double amin, double amid, double amax, double min,
+                                  double init, double max)
+    {
+        fUI2F = Interpolator3pt(amin, amid, amax, min, init, max);
+        fF2UI = Interpolator3pt(min, init, max, amin, amid, amax);
+    }
+
+    virtual void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fUI2F.getMappingValues(amin, amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -726,16 +717,21 @@ class LinearValueConverter2 : public UpdatableValueConverter
 //--------------------------------------------------------------------------------------
 class LogValueConverter : public LinearValueConverter
 {
+   public:
+    LogValueConverter(double umin, double umax, double fmin, double fmax)
+        : LinearValueConverter(umin, umax, std::log(std::max<double>(DBL_MIN, fmin)),
+                               std::log(std::max<double>(DBL_MIN, fmax)))
+    {
+    }
 
-    public:
-
-        LogValueConverter(double umin, double umax, double fmin, double fmax) :
-            LinearValueConverter(umin, umax, std::log(std::max<double>(DBL_MIN, fmin)), std::log(std::max<double>(DBL_MIN, fmax)))
-        {}
-
-        virtual double ui2faust(double x) { return std::exp(LinearValueConverter::ui2faust(x)); }
-        virtual double faust2ui(double x) { return LinearValueConverter::faust2ui(std::log(std::max<double>(x, DBL_MIN))); }
-
+    virtual double ui2faust(double x)
+    {
+        return std::exp(LinearValueConverter::ui2faust(x));
+    }
+    virtual double faust2ui(double x)
+    {
+        return LinearValueConverter::faust2ui(std::log(std::max<double>(x, DBL_MIN)));
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -743,16 +739,21 @@ class LogValueConverter : public LinearValueConverter
 //--------------------------------------------------------------------------------------
 class ExpValueConverter : public LinearValueConverter
 {
+   public:
+    ExpValueConverter(double umin, double umax, double fmin, double fmax)
+        : LinearValueConverter(umin, umax, std::min<double>(DBL_MAX, std::exp(fmin)),
+                               std::min<double>(DBL_MAX, std::exp(fmax)))
+    {
+    }
 
-    public:
-
-        ExpValueConverter(double umin, double umax, double fmin, double fmax) :
-            LinearValueConverter(umin, umax, std::min<double>(DBL_MAX, std::exp(fmin)), std::min<double>(DBL_MAX, std::exp(fmax)))
-        {}
-
-        virtual double ui2faust(double x) { return std::log(LinearValueConverter::ui2faust(x)); }
-        virtual double faust2ui(double x) { return LinearValueConverter::faust2ui(std::min<double>(DBL_MAX, std::exp(x))); }
-
+    virtual double ui2faust(double x)
+    {
+        return std::log(LinearValueConverter::ui2faust(x));
+    }
+    virtual double faust2ui(double x)
+    {
+        return LinearValueConverter::faust2ui(std::min<double>(DBL_MAX, std::exp(x)));
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -761,34 +762,33 @@ class ExpValueConverter : public LinearValueConverter
 //--------------------------------------------------------------------------------------
 class AccUpConverter : public UpdatableValueConverter
 {
+   private:
+    Interpolator3pt fA2F;
+    Interpolator3pt fF2A;
 
-    private:
+   public:
+    AccUpConverter(double amin, double amid, double amax, double fmin, double fmid,
+                   double fmax)
+        : fA2F(amin, amid, amax, fmin, fmid, fmax)
+        , fF2A(fmin, fmid, fmax, amin, amid, amax)
+    {
+    }
 
-        Interpolator3pt fA2F;
-        Interpolator3pt fF2A;
+    virtual double ui2faust(double x) { return fA2F(x); }
+    virtual double faust2ui(double x) { return fF2A(x); }
 
-    public:
+    virtual void setMappingValues(double amin, double amid, double amax, double fmin,
+                                  double fmid, double fmax)
+    {
+        //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccUpConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
+        fA2F = Interpolator3pt(amin, amid, amax, fmin, fmid, fmax);
+        fF2A = Interpolator3pt(fmin, fmid, fmax, amin, amid, amax);
+    }
 
-        AccUpConverter(double amin, double amid, double amax, double fmin, double fmid, double fmax) :
-            fA2F(amin,amid,amax,fmin,fmid,fmax),
-            fF2A(fmin,fmid,fmax,amin,amid,amax)
-        {}
-
-        virtual double ui2faust(double x) { return fA2F(x); }
-        virtual double faust2ui(double x) { return fF2A(x); }
-
-        virtual void setMappingValues(double amin, double amid, double amax, double fmin, double fmid, double fmax)
-        {
-            //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccUpConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
-            fA2F = Interpolator3pt(amin, amid, amax, fmin, fmid, fmax);
-            fF2A = Interpolator3pt(fmin, fmid, fmax, amin, amid, amax);
-        }
-
-        virtual void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fA2F.getMappingValues(amin, amid, amax);
-        }
-
+    virtual void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fA2F.getMappingValues(amin, amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -797,33 +797,33 @@ class AccUpConverter : public UpdatableValueConverter
 //--------------------------------------------------------------------------------------
 class AccDownConverter : public UpdatableValueConverter
 {
+   private:
+    Interpolator3pt fA2F;
+    Interpolator3pt fF2A;
 
-    private:
+   public:
+    AccDownConverter(double amin, double amid, double amax, double fmin, double fmid,
+                     double fmax)
+        : fA2F(amin, amid, amax, fmax, fmid, fmin)
+        , fF2A(fmin, fmid, fmax, amax, amid, amin)
+    {
+    }
 
-        Interpolator3pt	fA2F;
-        Interpolator3pt	fF2A;
+    virtual double ui2faust(double x) { return fA2F(x); }
+    virtual double faust2ui(double x) { return fF2A(x); }
 
-    public:
+    virtual void setMappingValues(double amin, double amid, double amax, double fmin,
+                                  double fmid, double fmax)
+    {
+        //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccDownConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
+        fA2F = Interpolator3pt(amin, amid, amax, fmax, fmid, fmin);
+        fF2A = Interpolator3pt(fmin, fmid, fmax, amax, amid, amin);
+    }
 
-        AccDownConverter(double amin, double amid, double amax, double fmin, double fmid, double fmax) :
-            fA2F(amin,amid,amax,fmax,fmid,fmin),
-            fF2A(fmin,fmid,fmax,amax,amid,amin)
-        {}
-
-        virtual double ui2faust(double x) { return fA2F(x); }
-        virtual double faust2ui(double x) { return fF2A(x); }
-
-        virtual void setMappingValues(double amin, double amid, double amax, double fmin, double fmid, double fmax)
-        {
-             //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccDownConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
-            fA2F = Interpolator3pt(amin, amid, amax, fmax, fmid, fmin);
-            fF2A = Interpolator3pt(fmin, fmid, fmax, amax, amid, amin);
-        }
-
-        virtual void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fA2F.getMappingValues(amin, amid, amax);
-        }
+    virtual void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fA2F.getMappingValues(amin, amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -832,33 +832,34 @@ class AccDownConverter : public UpdatableValueConverter
 //--------------------------------------------------------------------------------------
 class AccUpDownConverter : public UpdatableValueConverter
 {
+   private:
+    Interpolator3pt fA2F;
+    Interpolator fF2A;
 
-    private:
+   public:
+    AccUpDownConverter(double amin, double amid, double amax, double fmin, double fmid,
+                       double fmax)
+        : fA2F(amin, amid, amax, fmin, fmax, fmin)
+        , fF2A(fmin, fmax, amin,
+               amax)  // Special, pseudo inverse of a non monotonic function
+    {
+    }
 
-        Interpolator3pt	fA2F;
-        Interpolator fF2A;
+    virtual double ui2faust(double x) { return fA2F(x); }
+    virtual double faust2ui(double x) { return fF2A(x); }
 
-    public:
+    virtual void setMappingValues(double amin, double amid, double amax, double fmin,
+                                  double fmid, double fmax)
+    {
+        //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccUpDownConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
+        fA2F = Interpolator3pt(amin, amid, amax, fmin, fmax, fmin);
+        fF2A = Interpolator(fmin, fmax, amin, amax);
+    }
 
-        AccUpDownConverter(double amin, double amid, double amax, double fmin, double fmid, double fmax) :
-            fA2F(amin,amid,amax,fmin,fmax,fmin),
-            fF2A(fmin,fmax,amin,amax)				// Special, pseudo inverse of a non monotonic function
-        {}
-
-        virtual double ui2faust(double x) { return fA2F(x); }
-        virtual double faust2ui(double x) { return fF2A(x); }
-
-        virtual void setMappingValues(double amin, double amid, double amax, double fmin, double fmid, double fmax)
-        {
-            //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccUpDownConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
-            fA2F = Interpolator3pt(amin, amid, amax, fmin, fmax, fmin);
-            fF2A = Interpolator(fmin, fmax, amin, amax);
-        }
-
-        virtual void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fA2F.getMappingValues(amin, amid, amax);
-        }
+    virtual void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fA2F.getMappingValues(amin, amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -867,33 +868,34 @@ class AccUpDownConverter : public UpdatableValueConverter
 //--------------------------------------------------------------------------------------
 class AccDownUpConverter : public UpdatableValueConverter
 {
+   private:
+    Interpolator3pt fA2F;
+    Interpolator fF2A;
 
-    private:
+   public:
+    AccDownUpConverter(double amin, double amid, double amax, double fmin, double fmid,
+                       double fmax)
+        : fA2F(amin, amid, amax, fmax, fmin, fmax)
+        , fF2A(fmin, fmax, amin,
+               amax)  // Special, pseudo inverse of a non monotonic function
+    {
+    }
 
-        Interpolator3pt	fA2F;
-        Interpolator fF2A;
+    virtual double ui2faust(double x) { return fA2F(x); }
+    virtual double faust2ui(double x) { return fF2A(x); }
 
-    public:
+    virtual void setMappingValues(double amin, double amid, double amax, double fmin,
+                                  double fmid, double fmax)
+    {
+        //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccDownUpConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
+        fA2F = Interpolator3pt(amin, amid, amax, fmax, fmin, fmax);
+        fF2A = Interpolator(fmin, fmax, amin, amax);
+    }
 
-        AccDownUpConverter(double amin, double amid, double amax, double fmin, double fmid, double fmax) :
-            fA2F(amin,amid,amax,fmax,fmin,fmax),
-            fF2A(fmin,fmax,amin,amax)				// Special, pseudo inverse of a non monotonic function
-        {}
-
-        virtual double ui2faust(double x) { return fA2F(x); }
-        virtual double faust2ui(double x) { return fF2A(x); }
-
-        virtual void setMappingValues(double amin, double amid, double amax, double fmin, double fmid, double fmax)
-        {
-            //__android_log_print(ANDROID_LOG_ERROR, "Faust", "AccDownUpConverter update %f %f %f %f %f %f", amin,amid,amax,fmin,fmid,fmax);
-            fA2F = Interpolator3pt(amin, amid, amax, fmax, fmin, fmax);
-            fF2A = Interpolator(fmin, fmax, amin, amax);
-        }
-
-        virtual void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fA2F.getMappingValues(amin, amid, amax);
-        }
+    virtual void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fA2F.getMappingValues(amin, amid, amax);
+    }
 };
 
 //--------------------------------------------------------------------------------------
@@ -901,28 +903,27 @@ class AccDownUpConverter : public UpdatableValueConverter
 //--------------------------------------------------------------------------------------
 class ZoneControl
 {
+   protected:
+    FAUSTFLOAT* fZone;
 
-    protected:
+   public:
+    ZoneControl(FAUSTFLOAT* zone) : fZone(zone) {}
+    virtual ~ZoneControl() {}
 
-        FAUSTFLOAT*	fZone;
+    virtual void update(double v) const {}
 
-    public:
+    virtual void setMappingValues(int curve, double amin, double amid, double amax,
+                                  double min, double init, double max)
+    {
+    }
+    virtual void getMappingValues(double& amin, double& amid, double& amax) {}
 
-        ZoneControl(FAUSTFLOAT* zone) : fZone(zone) {}
-        virtual ~ZoneControl() {}
+    FAUSTFLOAT* getZone() { return fZone; }
 
-        virtual void update(double v) const {}
+    virtual void setActive(bool on_off) {}
+    virtual bool getActive() { return false; }
 
-        virtual void setMappingValues(int curve, double amin, double amid, double amax, double min, double init, double max) {}
-        virtual void getMappingValues(double& amin, double& amid, double& amax) {}
-
-        FAUSTFLOAT* getZone() { return fZone; }
-
-        virtual void setActive(bool on_off) {}
-        virtual bool getActive() { return false; }
-
-        virtual int getCurve() { return -1; }
-
+    virtual int getCurve() { return -1; }
 };
 
 //--------------------------------------------------------------------------------------
@@ -930,20 +931,22 @@ class ZoneControl
 //--------------------------------------------------------------------------------------
 class ConverterZoneControl : public ZoneControl
 {
+   protected:
+    ValueConverter* fValueConverter;
 
-    protected:
+   public:
+    ConverterZoneControl(FAUSTFLOAT* zone, ValueConverter* converter)
+        : ZoneControl(zone), fValueConverter(converter)
+    {
+    }
+    virtual ~ConverterZoneControl()
+    {
+        delete fValueConverter;
+    }  // Assuming fValueConverter is not kept elsewhere...
 
-        ValueConverter* fValueConverter;
+    virtual void update(double v) const { *fZone = fValueConverter->ui2faust(v); }
 
-    public:
-
-        ConverterZoneControl(FAUSTFLOAT* zone, ValueConverter* converter) : ZoneControl(zone), fValueConverter(converter) {}
-        virtual ~ConverterZoneControl() { delete fValueConverter; } // Assuming fValueConverter is not kept elsewhere...
-
-        virtual void update(double v) const { *fZone = fValueConverter->ui2faust(v); }
-
-        ValueConverter* getConverter() { return fValueConverter; }
-
+    ValueConverter* getConverter() { return fValueConverter; }
 };
 
 //--------------------------------------------------------------------------------------
@@ -952,477 +955,496 @@ class ConverterZoneControl : public ZoneControl
 //--------------------------------------------------------------------------------------
 class CurveZoneControl : public ZoneControl
 {
+   private:
+    std::vector<UpdatableValueConverter*> fValueConverters;
+    int fCurve;
 
-    private:
-
-        std::vector<UpdatableValueConverter*> fValueConverters;
-        int fCurve;
-
-    public:
-
-        CurveZoneControl(FAUSTFLOAT* zone, int curve, double amin, double amid, double amax, double min, double init, double max) : ZoneControl(zone), fCurve(0)
-        {
-            assert(curve >= 0 && curve <= 3);
-            fValueConverters.push_back(new AccUpConverter(amin, amid, amax, min, init, max));
-            fValueConverters.push_back(new AccDownConverter(amin, amid, amax, min, init, max));
-            fValueConverters.push_back(new AccUpDownConverter(amin, amid, amax, min, init, max));
-            fValueConverters.push_back(new AccDownUpConverter(amin, amid, amax, min, init, max));
-            fCurve = curve;
+   public:
+    CurveZoneControl(FAUSTFLOAT* zone, int curve, double amin, double amid, double amax,
+                     double min, double init, double max)
+        : ZoneControl(zone), fCurve(0)
+    {
+        assert(curve >= 0 && curve <= 3);
+        fValueConverters.push_back(new AccUpConverter(amin, amid, amax, min, init, max));
+        fValueConverters.push_back(
+            new AccDownConverter(amin, amid, amax, min, init, max));
+        fValueConverters.push_back(
+            new AccUpDownConverter(amin, amid, amax, min, init, max));
+        fValueConverters.push_back(
+            new AccDownUpConverter(amin, amid, amax, min, init, max));
+        fCurve = curve;
+    }
+    virtual ~CurveZoneControl()
+    {
+        std::vector<UpdatableValueConverter*>::iterator it;
+        for (it = fValueConverters.begin(); it != fValueConverters.end(); it++) {
+            delete (*it);
         }
-        virtual ~CurveZoneControl()
-        {
-            std::vector<UpdatableValueConverter*>::iterator it;
-            for (it = fValueConverters.begin(); it != fValueConverters.end(); it++) {
-                delete(*it);
-            }
-        }
-        void update(double v) const { if (fValueConverters[fCurve]->getActive()) *fZone = fValueConverters[fCurve]->ui2faust(v); }
+    }
+    void update(double v) const
+    {
+        if (fValueConverters[fCurve]->getActive())
+            *fZone = fValueConverters[fCurve]->ui2faust(v);
+    }
 
-        void setMappingValues(int curve, double amin, double amid, double amax, double min, double init, double max)
-        {
-            fValueConverters[curve]->setMappingValues(amin, amid, amax, min, init, max);
-            fCurve = curve;
-        }
+    void setMappingValues(int curve, double amin, double amid, double amax, double min,
+                          double init, double max)
+    {
+        fValueConverters[curve]->setMappingValues(amin, amid, amax, min, init, max);
+        fCurve = curve;
+    }
 
-        void getMappingValues(double& amin, double& amid, double& amax)
-        {
-            fValueConverters[fCurve]->getMappingValues(amin, amid, amax);
-        }
+    void getMappingValues(double& amin, double& amid, double& amax)
+    {
+        fValueConverters[fCurve]->getMappingValues(amin, amid, amax);
+    }
 
-        void setActive(bool on_off)
-        {
-            std::vector<UpdatableValueConverter*>::iterator it;
-            for (it = fValueConverters.begin(); it != fValueConverters.end(); it++) {
-                (*it)->setActive(on_off);
-            }
+    void setActive(bool on_off)
+    {
+        std::vector<UpdatableValueConverter*>::iterator it;
+        for (it = fValueConverters.begin(); it != fValueConverters.end(); it++) {
+            (*it)->setActive(on_off);
         }
+    }
 
-        int getCurve() { return fCurve; }
+    int getCurve() { return fCurve; }
 };
 
 class ZoneReader
 {
+   private:
+    FAUSTFLOAT* fZone;
+    Interpolator fInterpolator;
 
-    private:
+   public:
+    ZoneReader(FAUSTFLOAT* zone, double lo, double hi)
+        : fZone(zone), fInterpolator(lo, hi, 0, 255)
+    {
+    }
 
-        FAUSTFLOAT* fZone;
-        Interpolator fInterpolator;
+    virtual ~ZoneReader() {}
 
-    public:
-
-        ZoneReader(FAUSTFLOAT* zone, double lo, double hi) : fZone(zone), fInterpolator(lo, hi, 0, 255) {}
-
-        virtual ~ZoneReader() {}
-
-        int getValue()
-        {
-            return (fZone != nullptr) ? int(fInterpolator(*fZone)) : 127;
-        }
-
+    int getValue() { return (fZone != nullptr) ? int(fInterpolator(*fZone)) : 127; }
 };
 
 #endif
 /**************************  END  ValueConverter.h **************************/
 
-class APIUI : public PathBuilder, public Meta, public UI
+class APIUI
+    : public PathBuilder
+    , public Meta
+    , public UI
 {
-    public:
-    
-        enum ItemType { kButton = 0, kCheckButton, kVSlider, kHSlider, kNumEntry, kHBargraph, kVBargraph };
-  
-    protected:
-    
-        enum { kLin = 0, kLog = 1, kExp = 2 };
-    
-        int fNumParameters;
-        std::vector<std::string> fPaths;
-        std::vector<std::string> fLabels;
-        std::map<std::string, int> fPathMap;
-        std::map<std::string, int> fLabelMap;
-        std::vector<ValueConverter*> fConversion;
-        std::vector<FAUSTFLOAT*> fZone;
-        std::vector<FAUSTFLOAT> fInit;
-        std::vector<FAUSTFLOAT> fMin;
-        std::vector<FAUSTFLOAT> fMax;
-        std::vector<FAUSTFLOAT> fStep;
-        std::vector<ItemType> fItemType;
-        std::vector<std::map<std::string, std::string> > fMetaData;
-        std::vector<ZoneControl*> fAcc[3];
-        std::vector<ZoneControl*> fGyr[3];
+   public:
+    enum ItemType {
+        kButton = 0,
+        kCheckButton,
+        kVSlider,
+        kHSlider,
+        kNumEntry,
+        kHBargraph,
+        kVBargraph
+    };
 
-        // Screen color control
-        // "...[screencolor:red]..." etc.
-        bool fHasScreenControl;      // true if control screen color metadata
-        ZoneReader* fRedReader;
-        ZoneReader* fGreenReader;
-        ZoneReader* fBlueReader;
+   protected:
+    enum { kLin = 0, kLog = 1, kExp = 2 };
 
-        // Current values controlled by metadata
-        std::string fCurrentUnit;
-        int fCurrentScale;
-        std::string fCurrentAcc;
-        std::string fCurrentGyr;
-        std::string fCurrentColor;
-        std::string fCurrentTooltip;
-        std::map<std::string, std::string> fCurrentMetadata;
-    
-        // Add a generic parameter
-        virtual void addParameter(const char* label,
-                                FAUSTFLOAT* zone,
-                                FAUSTFLOAT init,
-                                FAUSTFLOAT min,
-                                FAUSTFLOAT max,
-                                FAUSTFLOAT step,
-                                ItemType type)
-        {
-            std::string path = buildPath(label);
-            fPathMap[path] = fLabelMap[label] = fNumParameters++;
-            fPaths.push_back(path);
-            fLabels.push_back(label);
-            fZone.push_back(zone);
-            fInit.push_back(init);
-            fMin.push_back(min);
-            fMax.push_back(max);
-            fStep.push_back(step);
-            fItemType.push_back(type);
-            
-            // handle scale metadata
-            switch (fCurrentScale) {
-                case kLin:
-                    fConversion.push_back(new LinearValueConverter(0, 1, min, max));
-                    break;
-                case kLog:
-                    fConversion.push_back(new LogValueConverter(0, 1, min, max));
-                    break;
-                case kExp: fConversion.push_back(new ExpValueConverter(0, 1, min, max));
-                    break;
-            }
-            fCurrentScale = kLin;
-            
-            if (fCurrentAcc.size() > 0 && fCurrentGyr.size() > 0) {
-                std::cerr << "warning : 'acc' and 'gyr' metadata used for the same " << label << " parameter !!\n";
-            }
+    int fNumParameters;
+    std::vector<std::string> fPaths;
+    std::vector<std::string> fLabels;
+    std::map<std::string, int> fPathMap;
+    std::map<std::string, int> fLabelMap;
+    std::vector<ValueConverter*> fConversion;
+    std::vector<FAUSTFLOAT*> fZone;
+    std::vector<FAUSTFLOAT> fInit;
+    std::vector<FAUSTFLOAT> fMin;
+    std::vector<FAUSTFLOAT> fMax;
+    std::vector<FAUSTFLOAT> fStep;
+    std::vector<ItemType> fItemType;
+    std::vector<std::map<std::string, std::string> > fMetaData;
+    std::vector<ZoneControl*> fAcc[3];
+    std::vector<ZoneControl*> fGyr[3];
 
-            // handle acc metadata "...[acc : <axe> <curve> <amin> <amid> <amax>]..."
-            if (fCurrentAcc.size() > 0) {
-                std::istringstream iss(fCurrentAcc);
-                int axe, curve;
-                double amin, amid, amax;
-                iss >> axe >> curve >> amin >> amid >> amax;
+    // Screen color control
+    // "...[screencolor:red]..." etc.
+    bool fHasScreenControl;  // true if control screen color metadata
+    ZoneReader* fRedReader;
+    ZoneReader* fGreenReader;
+    ZoneReader* fBlueReader;
 
-                if ((0 <= axe) && (axe < 3) &&
-                    (0 <= curve) && (curve < 4) &&
-                    (amin < amax) && (amin <= amid) && (amid <= amax))
-                {
-                    fAcc[axe].push_back(new CurveZoneControl(zone, curve, amin, amid, amax, min, init, max));
-                } else {
-                    std::cerr << "incorrect acc metadata : " << fCurrentAcc << std::endl;
-                }
-                fCurrentAcc = "";
-            }
-       
-            // handle gyr metadata "...[gyr : <axe> <curve> <amin> <amid> <amax>]..."
-            if (fCurrentGyr.size() > 0) {
-                std::istringstream iss(fCurrentGyr);
-                int axe, curve;
-                double amin, amid, amax;
-                iss >> axe >> curve >> amin >> amid >> amax;
+    // Current values controlled by metadata
+    std::string fCurrentUnit;
+    int fCurrentScale;
+    std::string fCurrentAcc;
+    std::string fCurrentGyr;
+    std::string fCurrentColor;
+    std::string fCurrentTooltip;
+    std::map<std::string, std::string> fCurrentMetadata;
 
-                if ((0 <= axe) && (axe < 3) &&
-                    (0 <= curve) && (curve < 4) &&
-                    (amin < amax) && (amin <= amid) && (amid <= amax))
-                {
-                    fGyr[axe].push_back(new CurveZoneControl(zone, curve, amin, amid, amax, min, init, max));
-                } else {
-                    std::cerr << "incorrect gyr metadata : " << fCurrentGyr << std::endl;
-                }
-                fCurrentGyr = "";
-            }
-        
-            // handle screencolor metadata "...[screencolor:red|green|blue|white]..."
-            if (fCurrentColor.size() > 0) {
-                if ((fCurrentColor == "red") && (fRedReader == 0)) {
-                    fRedReader = new ZoneReader(zone, min, max);
-                    fHasScreenControl = true;
-                } else if ((fCurrentColor == "green") && (fGreenReader == 0)) {
-                    fGreenReader = new ZoneReader(zone, min, max);
-                    fHasScreenControl = true;
-                } else if ((fCurrentColor == "blue") && (fBlueReader == 0)) {
-                    fBlueReader = new ZoneReader(zone, min, max);
-                    fHasScreenControl = true;
-                } else if ((fCurrentColor == "white") && (fRedReader == 0) && (fGreenReader == 0) && (fBlueReader == 0)) {
-                    fRedReader = new ZoneReader(zone, min, max);
-                    fGreenReader = new ZoneReader(zone, min, max);
-                    fBlueReader = new ZoneReader(zone, min, max);
-                    fHasScreenControl = true;
-                } else {
-                    std::cerr << "incorrect screencolor metadata : " << fCurrentColor << std::endl;
-                }
-            }
-            fCurrentColor = "";
-            
-            fMetaData.push_back(fCurrentMetadata);
-            fCurrentMetadata.clear();
+    // Add a generic parameter
+    virtual void addParameter(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init,
+                              FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step,
+                              ItemType type)
+    {
+        std::string path = buildPath(label);
+        fPathMap[path] = fLabelMap[label] = fNumParameters++;
+        fPaths.push_back(path);
+        fLabels.push_back(label);
+        fZone.push_back(zone);
+        fInit.push_back(init);
+        fMin.push_back(min);
+        fMax.push_back(max);
+        fStep.push_back(step);
+        fItemType.push_back(type);
+
+        // handle scale metadata
+        switch (fCurrentScale) {
+        case kLin:
+            fConversion.push_back(new LinearValueConverter(0, 1, min, max));
+            break;
+        case kLog:
+            fConversion.push_back(new LogValueConverter(0, 1, min, max));
+            break;
+        case kExp:
+            fConversion.push_back(new ExpValueConverter(0, 1, min, max));
+            break;
+        }
+        fCurrentScale = kLin;
+
+        if (fCurrentAcc.size() > 0 && fCurrentGyr.size() > 0) {
+            std::cerr << "warning : 'acc' and 'gyr' metadata used for the same " << label
+                      << " parameter !!\n";
         }
 
-        int getZoneIndex(std::vector<ZoneControl*>* table, int p, int val)
-        {
-            FAUSTFLOAT* zone = fZone[p];
-            for (size_t i = 0; i < table[val].size(); i++) {
-                if (zone == table[val][i]->getZone()) return int(i);
+        // handle acc metadata "...[acc : <axe> <curve> <amin> <amid> <amax>]..."
+        if (fCurrentAcc.size() > 0) {
+            std::istringstream iss(fCurrentAcc);
+            int axe, curve;
+            double amin, amid, amax;
+            iss >> axe >> curve >> amin >> amid >> amax;
+
+            if ((0 <= axe) && (axe < 3) && (0 <= curve) && (curve < 4) && (amin < amax)
+                && (amin <= amid) && (amid <= amax)) {
+                fAcc[axe].push_back(
+                    new CurveZoneControl(zone, curve, amin, amid, amax, min, init, max));
+            } else {
+                std::cerr << "incorrect acc metadata : " << fCurrentAcc << std::endl;
             }
+            fCurrentAcc = "";
+        }
+
+        // handle gyr metadata "...[gyr : <axe> <curve> <amin> <amid> <amax>]..."
+        if (fCurrentGyr.size() > 0) {
+            std::istringstream iss(fCurrentGyr);
+            int axe, curve;
+            double amin, amid, amax;
+            iss >> axe >> curve >> amin >> amid >> amax;
+
+            if ((0 <= axe) && (axe < 3) && (0 <= curve) && (curve < 4) && (amin < amax)
+                && (amin <= amid) && (amid <= amax)) {
+                fGyr[axe].push_back(
+                    new CurveZoneControl(zone, curve, amin, amid, amax, min, init, max));
+            } else {
+                std::cerr << "incorrect gyr metadata : " << fCurrentGyr << std::endl;
+            }
+            fCurrentGyr = "";
+        }
+
+        // handle screencolor metadata "...[screencolor:red|green|blue|white]..."
+        if (fCurrentColor.size() > 0) {
+            if ((fCurrentColor == "red") && (fRedReader == 0)) {
+                fRedReader        = new ZoneReader(zone, min, max);
+                fHasScreenControl = true;
+            } else if ((fCurrentColor == "green") && (fGreenReader == 0)) {
+                fGreenReader      = new ZoneReader(zone, min, max);
+                fHasScreenControl = true;
+            } else if ((fCurrentColor == "blue") && (fBlueReader == 0)) {
+                fBlueReader       = new ZoneReader(zone, min, max);
+                fHasScreenControl = true;
+            } else if ((fCurrentColor == "white") && (fRedReader == 0)
+                       && (fGreenReader == 0) && (fBlueReader == 0)) {
+                fRedReader        = new ZoneReader(zone, min, max);
+                fGreenReader      = new ZoneReader(zone, min, max);
+                fBlueReader       = new ZoneReader(zone, min, max);
+                fHasScreenControl = true;
+            } else {
+                std::cerr << "incorrect screencolor metadata : " << fCurrentColor
+                          << std::endl;
+            }
+        }
+        fCurrentColor = "";
+
+        fMetaData.push_back(fCurrentMetadata);
+        fCurrentMetadata.clear();
+    }
+
+    int getZoneIndex(std::vector<ZoneControl*>* table, int p, int val)
+    {
+        FAUSTFLOAT* zone = fZone[p];
+        for (size_t i = 0; i < table[val].size(); i++) {
+            if (zone == table[val][i]->getZone()) return int(i);
+        }
+        return -1;
+    }
+
+    void setConverter(std::vector<ZoneControl*>* table, int p, int val, int curve,
+                      double amin, double amid, double amax)
+    {
+        int id1 = getZoneIndex(table, p, 0);
+        int id2 = getZoneIndex(table, p, 1);
+        int id3 = getZoneIndex(table, p, 2);
+
+        // Deactivates everywhere..
+        if (id1 != -1) table[0][id1]->setActive(false);
+        if (id2 != -1) table[1][id2]->setActive(false);
+        if (id3 != -1) table[2][id3]->setActive(false);
+
+        if (val == -1) {  // Means: no more mapping...
+            // So stay all deactivated...
+        } else {
+            int id4 = getZoneIndex(table, p, val);
+            if (id4 != -1) {
+                // Reactivate the one we edit...
+                table[val][id4]->setMappingValues(curve, amin, amid, amax, fMin[p],
+                                                  fInit[p], fMax[p]);
+                table[val][id4]->setActive(true);
+            } else {
+                // Allocate a new CurveZoneControl which is 'active' by default
+                FAUSTFLOAT* zone = fZone[p];
+                table[val].push_back(new CurveZoneControl(zone, curve, amin, amid, amax,
+                                                          fMin[p], fInit[p], fMax[p]));
+            }
+        }
+    }
+
+    void getConverter(std::vector<ZoneControl*>* table, int p, int& val, int& curve,
+                      double& amin, double& amid, double& amax)
+    {
+        int id1 = getZoneIndex(table, p, 0);
+        int id2 = getZoneIndex(table, p, 1);
+        int id3 = getZoneIndex(table, p, 2);
+
+        if (id1 != -1) {
+            val   = 0;
+            curve = table[val][id1]->getCurve();
+            table[val][id1]->getMappingValues(amin, amid, amax);
+        } else if (id2 != -1) {
+            val   = 1;
+            curve = table[val][id2]->getCurve();
+            table[val][id2]->getMappingValues(amin, amid, amax);
+        } else if (id3 != -1) {
+            val   = 2;
+            curve = table[val][id3]->getCurve();
+            table[val][id3]->getMappingValues(amin, amid, amax);
+        } else {
+            val   = -1;  // No mapping
+            curve = 0;
+            amin  = -100.;
+            amid  = 0.;
+            amax  = 100.;
+        }
+    }
+
+   public:
+    enum Type { kAcc = 0, kGyr = 1, kNoType };
+
+    APIUI()
+        : fNumParameters(0)
+        , fHasScreenControl(false)
+        , fRedReader(0)
+        , fGreenReader(0)
+        , fBlueReader(0)
+        , fCurrentScale(kLin)
+    {
+    }
+
+    virtual ~APIUI()
+    {
+        for (auto& it : fConversion) delete it;
+        for (int i = 0; i < 3; i++) {
+            for (auto& it : fAcc[i]) delete it;
+            for (auto& it : fGyr[i]) delete it;
+        }
+        delete fRedReader;
+        delete fGreenReader;
+        delete fBlueReader;
+    }
+
+    // -- widget's layouts
+
+    virtual void openTabBox(const char* label) { pushLabel(label); }
+    virtual void openHorizontalBox(const char* label) { pushLabel(label); }
+    virtual void openVerticalBox(const char* label) { pushLabel(label); }
+    virtual void closeBox() { popLabel(); }
+
+    // -- active widgets
+
+    virtual void addButton(const char* label, FAUSTFLOAT* zone)
+    {
+        addParameter(label, zone, 0, 0, 1, 1, kButton);
+    }
+
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
+    {
+        addParameter(label, zone, 0, 0, 1, 1, kCheckButton);
+    }
+
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init,
+                                   FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addParameter(label, zone, init, min, max, step, kVSlider);
+    }
+
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init,
+                                     FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addParameter(label, zone, init, min, max, step, kHSlider);
+    }
+
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init,
+                             FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
+    {
+        addParameter(label, zone, init, min, max, step, kNumEntry);
+    }
+
+    // -- passive widgets
+
+    virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone,
+                                       FAUSTFLOAT min, FAUSTFLOAT max)
+    {
+        addParameter(label, zone, min, min, max, (max - min) / 1000.0, kHBargraph);
+    }
+
+    virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min,
+                                     FAUSTFLOAT max)
+    {
+        addParameter(label, zone, min, min, max, (max - min) / 1000.0, kVBargraph);
+    }
+
+    // -- soundfiles
+
+    virtual void addSoundfile(const char* label, const char* filename,
+                              Soundfile** sf_zone)
+    {
+    }
+
+    // -- metadata declarations
+
+    virtual void declare(FAUSTFLOAT* zone, const char* key, const char* val)
+    {
+        // Keep metadata
+        fCurrentMetadata[key] = val;
+
+        if (strcmp(key, "scale") == 0) {
+            if (strcmp(val, "log") == 0) {
+                fCurrentScale = kLog;
+            } else if (strcmp(val, "exp") == 0) {
+                fCurrentScale = kExp;
+            } else {
+                fCurrentScale = kLin;
+            }
+        } else if (strcmp(key, "unit") == 0) {
+            fCurrentUnit = val;
+        } else if (strcmp(key, "acc") == 0) {
+            fCurrentAcc = val;
+        } else if (strcmp(key, "gyr") == 0) {
+            fCurrentGyr = val;
+        } else if (strcmp(key, "screencolor") == 0) {
+            fCurrentColor = val;  // val = "red", "green", "blue" or "white"
+        } else if (strcmp(key, "tooltip") == 0) {
+            fCurrentTooltip = val;
+        }
+    }
+
+    virtual void declare(const char* key, const char* val) {}
+
+    //-------------------------------------------------------------------------------
+    // Simple API part
+    //-------------------------------------------------------------------------------
+    int getParamsCount() { return fNumParameters; }
+    int getParamIndex(const char* path)
+    {
+        if (fPathMap.find(path) != fPathMap.end()) {
+            return fPathMap[path];
+        } else if (fLabelMap.find(path) != fLabelMap.end()) {
+            return fLabelMap[path];
+        } else {
             return -1;
         }
-    
-        void setConverter(std::vector<ZoneControl*>* table, int p, int val, int curve, double amin, double amid, double amax)
-        {
-            int id1 = getZoneIndex(table, p, 0);
-            int id2 = getZoneIndex(table, p, 1);
-            int id3 = getZoneIndex(table, p, 2);
-            
-            // Deactivates everywhere..
-            if (id1 != -1) table[0][id1]->setActive(false);
-            if (id2 != -1) table[1][id2]->setActive(false);
-            if (id3 != -1) table[2][id3]->setActive(false);
-            
-            if (val == -1) { // Means: no more mapping...
-                // So stay all deactivated...
-            } else {
-                int id4 = getZoneIndex(table, p, val);
-                if (id4 != -1) {
-                    // Reactivate the one we edit...
-                    table[val][id4]->setMappingValues(curve, amin, amid, amax, fMin[p], fInit[p], fMax[p]);
-                    table[val][id4]->setActive(true);
-                } else {
-                    // Allocate a new CurveZoneControl which is 'active' by default
-                    FAUSTFLOAT* zone = fZone[p];
-                    table[val].push_back(new CurveZoneControl(zone, curve, amin, amid, amax, fMin[p], fInit[p], fMax[p]));
-                }
-            }
-        }
-    
-        void getConverter(std::vector<ZoneControl*>* table, int p, int& val, int& curve, double& amin, double& amid, double& amax)
-        {
-            int id1 = getZoneIndex(table, p, 0);
-            int id2 = getZoneIndex(table, p, 1);
-            int id3 = getZoneIndex(table, p, 2);
-            
-            if (id1 != -1) {
-                val = 0;
-                curve = table[val][id1]->getCurve();
-                table[val][id1]->getMappingValues(amin, amid, amax);
-            } else if (id2 != -1) {
-                val = 1;
-                curve = table[val][id2]->getCurve();
-                table[val][id2]->getMappingValues(amin, amid, amax);
-            } else if (id3 != -1) {
-                val = 2;
-                curve = table[val][id3]->getCurve();
-                table[val][id3]->getMappingValues(amin, amid, amax);
-            } else {
-                val = -1; // No mapping
-                curve = 0;
-                amin = -100.;
-                amid = 0.;
-                amax = 100.;
-            }
-        }
+    }
+    const char* getParamAddress(int p) { return fPaths[p].c_str(); }
+    const char* getParamLabel(int p) { return fLabels[p].c_str(); }
+    std::map<const char*, const char*> getMetadata(int p)
+    {
+        std::map<const char*, const char*> res;
+        std::map<std::string, std::string> metadata = fMetaData[p];
+        for (auto it : metadata) { res[it.first.c_str()] = it.second.c_str(); }
+        return res;
+    }
 
-     public:
-    
-        enum Type { kAcc = 0, kGyr = 1, kNoType };
-   
-        APIUI() : fNumParameters(0), fHasScreenControl(false), fRedReader(0), fGreenReader(0), fBlueReader(0), fCurrentScale(kLin)
-        {}
+    const char* getMetadata(int p, const char* key)
+    {
+        return (fMetaData[p].find(key) != fMetaData[p].end()) ? fMetaData[p][key].c_str()
+                                                              : "";
+    }
+    FAUSTFLOAT getParamMin(int p) { return fMin[p]; }
+    FAUSTFLOAT getParamMax(int p) { return fMax[p]; }
+    FAUSTFLOAT getParamStep(int p) { return fStep[p]; }
+    FAUSTFLOAT getParamInit(int p) { return fInit[p]; }
 
-        virtual ~APIUI()
-        {
-            for (auto& it : fConversion) delete it;
-            for (int i = 0; i < 3; i++) {
-                for (auto& it : fAcc[i]) delete it;
-                for (auto& it : fGyr[i]) delete it;
-            }
-            delete fRedReader;
-            delete fGreenReader;
-            delete fBlueReader;
-        }
-    
-        // -- widget's layouts
+    FAUSTFLOAT* getParamZone(int p) { return fZone[p]; }
+    FAUSTFLOAT getParamValue(int p) { return *fZone[p]; }
+    void setParamValue(int p, FAUSTFLOAT v) { *fZone[p] = v; }
 
-        virtual void openTabBox(const char* label) { pushLabel(label); }
-        virtual void openHorizontalBox(const char* label) { pushLabel(label); }
-        virtual void openVerticalBox(const char* label) { pushLabel(label); }
-        virtual void closeBox() { popLabel(); }
+    double getParamRatio(int p) { return fConversion[p]->faust2ui(*fZone[p]); }
+    void setParamRatio(int p, double r) { *fZone[p] = fConversion[p]->ui2faust(r); }
 
-        // -- active widgets
+    double value2ratio(int p, double r) { return fConversion[p]->faust2ui(r); }
+    double ratio2value(int p, double r) { return fConversion[p]->ui2faust(r); }
 
-        virtual void addButton(const char* label, FAUSTFLOAT* zone)
-        {
-            addParameter(label, zone, 0, 0, 1, 1, kButton);
-        }
-
-        virtual void addCheckButton(const char* label, FAUSTFLOAT* zone)
-        {
-            addParameter(label, zone, 0, 0, 1, 1, kCheckButton);
-        }
-
-        virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
-        {
-            addParameter(label, zone, init, min, max, step, kVSlider);
-        }
-
-        virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
-        {
-            addParameter(label, zone, init, min, max, step, kHSlider);
-        }
-
-        virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT min, FAUSTFLOAT max, FAUSTFLOAT step)
-        {
-            addParameter(label, zone, init, min, max, step, kNumEntry);
-        }
-
-        // -- passive widgets
-
-        virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
-        {
-            addParameter(label, zone, min, min, max, (max-min)/1000.0, kHBargraph);
-        }
-
-        virtual void addVerticalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT min, FAUSTFLOAT max)
-        {
-            addParameter(label, zone, min, min, max, (max-min)/1000.0, kVBargraph);
-        }
-    
-        // -- soundfiles
-    
-        virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
-
-        // -- metadata declarations
-
-        virtual void declare(FAUSTFLOAT* zone, const char* key, const char* val)
-        {
-            // Keep metadata
-            fCurrentMetadata[key] = val;
-            
-            if (strcmp(key, "scale") == 0) {
-                if (strcmp(val, "log") == 0) {
-                    fCurrentScale = kLog;
-                } else if (strcmp(val, "exp") == 0) {
-                    fCurrentScale = kExp;
-                } else {
-                    fCurrentScale = kLin;
-                }
-            } else if (strcmp(key, "unit") == 0) {
-                fCurrentUnit = val;
-            } else if (strcmp(key, "acc") == 0) {
-                fCurrentAcc = val;
-            } else if (strcmp(key, "gyr") == 0) {
-                fCurrentGyr = val;
-            } else if (strcmp(key, "screencolor") == 0) {
-                fCurrentColor = val; // val = "red", "green", "blue" or "white"
-            } else if (strcmp(key, "tooltip") == 0) {
-                fCurrentTooltip = val;
-            }
-        }
-
-        virtual void declare(const char* key, const char* val)
-        {}
-
-		//-------------------------------------------------------------------------------
-		// Simple API part
-		//-------------------------------------------------------------------------------
-		int getParamsCount() { return fNumParameters; }
-        int getParamIndex(const char* path)
-        {
-            if (fPathMap.find(path) != fPathMap.end()) {
-                return fPathMap[path];
-            } else if (fLabelMap.find(path) != fLabelMap.end()) {
-                return fLabelMap[path];
-            } else {
-                return -1;
-            }
-        }
-        const char* getParamAddress(int p) { return fPaths[p].c_str(); }
-        const char* getParamLabel(int p) { return fLabels[p].c_str(); }
-        std::map<const char*, const char*> getMetadata(int p)
-        {
-            std::map<const char*, const char*> res;
-            std::map<std::string, std::string> metadata = fMetaData[p];
-            for (auto it : metadata) {
-                res[it.first.c_str()] = it.second.c_str();
-            }
-            return res;
-        }
-
-        const char* getMetadata(int p, const char* key)
-        {
-            return (fMetaData[p].find(key) != fMetaData[p].end()) ? fMetaData[p][key].c_str() : "";
-        }
-        FAUSTFLOAT getParamMin(int p) { return fMin[p]; }
-        FAUSTFLOAT getParamMax(int p) { return fMax[p]; }
-        FAUSTFLOAT getParamStep(int p) { return fStep[p]; }
-        FAUSTFLOAT getParamInit(int p) { return fInit[p]; }
-
-        FAUSTFLOAT* getParamZone(int p) { return fZone[p]; }
-        FAUSTFLOAT getParamValue(int p) { return *fZone[p]; }
-        void setParamValue(int p, FAUSTFLOAT v) { *fZone[p] = v; }
-
-        double getParamRatio(int p) { return fConversion[p]->faust2ui(*fZone[p]); }
-        void setParamRatio(int p, double r) { *fZone[p] = fConversion[p]->ui2faust(r); }
-
-        double value2ratio(int p, double r)	{ return fConversion[p]->faust2ui(r); }
-        double ratio2value(int p, double r)	{ return fConversion[p]->ui2faust(r); }
-    
-        /**
+    /**
          * Return the control type (kAcc, kGyr, or -1) for a given parameter
          *
          * @param p - the UI parameter index
          *
          * @return the type
          */
-        Type getParamType(int p)
-        {
-            if (p >= 0) {
-                if (getZoneIndex(fAcc, p, 0) != -1
-                    || getZoneIndex(fAcc, p, 1) != -1
-                    || getZoneIndex(fAcc, p, 2) != -1) {
-                    return kAcc;
-                } else if (getZoneIndex(fGyr, p, 0) != -1
-                           || getZoneIndex(fGyr, p, 1) != -1
-                           || getZoneIndex(fGyr, p, 2) != -1) {
-                    return kGyr;
-                }
+    Type getParamType(int p)
+    {
+        if (p >= 0) {
+            if (getZoneIndex(fAcc, p, 0) != -1 || getZoneIndex(fAcc, p, 1) != -1
+                || getZoneIndex(fAcc, p, 2) != -1) {
+                return kAcc;
+            } else if (getZoneIndex(fGyr, p, 0) != -1 || getZoneIndex(fGyr, p, 1) != -1
+                       || getZoneIndex(fGyr, p, 2) != -1) {
+                return kGyr;
             }
-            return kNoType;
         }
-    
-        /**
+        return kNoType;
+    }
+
+    /**
          * Return the Item type (kButton = 0, kCheckButton, kVSlider, kHSlider, kNumEntry, kHBargraph, kVBargraph) for a given parameter
          *
          * @param p - the UI parameter index
          *
          * @return the Item type
          */
-        ItemType getParamItemType(int p)
-        {
-            return fItemType[p];
-        }
-   
-        /**
+    ItemType getParamItemType(int p) { return fItemType[p]; }
+
+    /**
          * Set a new value coming from an accelerometer, propagate it to all relevant FAUSTFLOAT* zones.
          *
          * @param acc - 0 for X accelerometer, 1 for Y accelerometer, 2 for Z accelerometer
          * @param value - the new value
          *
          */
-        void propagateAcc(int acc, double value)
-        {
-            for (size_t i = 0; i < fAcc[acc].size(); i++) {
-                fAcc[acc][i]->update(value);
-            }
-        }
-    
-        /**
+    void propagateAcc(int acc, double value)
+    {
+        for (size_t i = 0; i < fAcc[acc].size(); i++) { fAcc[acc][i]->update(value); }
+    }
+
+    /**
          * Used to edit accelerometer curves and mapping. Set curve and related mapping for a given UI parameter.
          *
          * @param p - the UI parameter index
@@ -1433,12 +1455,12 @@ class APIUI : public PathBuilder, public Meta, public UI
          * @param amax - mapping 'max' point
          *
          */
-        void setAccConverter(int p, int acc, int curve, double amin, double amid, double amax)
-        {
-            setConverter(fAcc, p, acc, curve, amin, amid, amax);
-        }
-    
-        /**
+    void setAccConverter(int p, int acc, int curve, double amin, double amid, double amax)
+    {
+        setConverter(fAcc, p, acc, curve, amin, amid, amax);
+    }
+
+    /**
          * Used to edit gyroscope curves and mapping. Set curve and related mapping for a given UI parameter.
          *
          * @param p - the UI parameter index
@@ -1449,12 +1471,12 @@ class APIUI : public PathBuilder, public Meta, public UI
          * @param amax - mapping 'max' point
          *
          */
-        void setGyrConverter(int p, int gyr, int curve, double amin, double amid, double amax)
-        {
-             setConverter(fGyr, p, gyr, curve, amin, amid, amax);
-        }
-    
-        /**
+    void setGyrConverter(int p, int gyr, int curve, double amin, double amid, double amax)
+    {
+        setConverter(fGyr, p, gyr, curve, amin, amid, amax);
+    }
+
+    /**
          * Used to edit accelerometer curves and mapping. Get curve and related mapping for a given UI parameter.
          *
          * @param p - the UI parameter index
@@ -1465,12 +1487,13 @@ class APIUI : public PathBuilder, public Meta, public UI
          * @param amax - the amax value to be retrieved
          *
          */
-        void getAccConverter(int p, int& acc, int& curve, double& amin, double& amid, double& amax)
-        {
-            getConverter(fAcc, p, acc, curve, amin, amid, amax);
-        }
+    void getAccConverter(int p, int& acc, int& curve, double& amin, double& amid,
+                         double& amax)
+    {
+        getConverter(fAcc, p, acc, curve, amin, amid, amax);
+    }
 
-        /**
+    /**
          * Used to edit gyroscope curves and mapping. Get curve and related mapping for a given UI parameter.
          *
          * @param p - the UI parameter index
@@ -1481,63 +1504,55 @@ class APIUI : public PathBuilder, public Meta, public UI
          * @param amax - the amax value to be retrieved
          *
          */
-        void getGyrConverter(int p, int& gyr, int& curve, double& amin, double& amid, double& amax)
-        {
-            getConverter(fGyr, p, gyr, curve, amin, amid, amax);
-        }
-    
-        /**
+    void getGyrConverter(int p, int& gyr, int& curve, double& amin, double& amid,
+                         double& amax)
+    {
+        getConverter(fGyr, p, gyr, curve, amin, amid, amax);
+    }
+
+    /**
          * Set a new value coming from an gyroscope, propagate it to all relevant FAUSTFLOAT* zones.
          *
          * @param gyr - 0 for X gyroscope, 1 for Y gyroscope, 2 for Z gyroscope
          * @param value - the new value
          *
          */
-        void propagateGyr(int gyr, double value)
-        {
-            for (size_t i = 0; i < fGyr[gyr].size(); i++) {
-                fGyr[gyr][i]->update(value);
-            }
-        }
-    
-        /**
+    void propagateGyr(int gyr, double value)
+    {
+        for (size_t i = 0; i < fGyr[gyr].size(); i++) { fGyr[gyr][i]->update(value); }
+    }
+
+    /**
          * Get the number of FAUSTFLOAT* zones controlled with the accelerometer
          *
          * @param acc - 0 for X accelerometer, 1 for Y accelerometer, 2 for Z accelerometer
          * @return the number of zones
          *
          */
-        int getAccCount(int acc)
-        {
-            return (acc >= 0 && acc < 3) ? int(fAcc[acc].size()) : 0;
-        }
-    
-        /**
+    int getAccCount(int acc) { return (acc >= 0 && acc < 3) ? int(fAcc[acc].size()) : 0; }
+
+    /**
          * Get the number of FAUSTFLOAT* zones controlled with the gyroscope
          *
          * @param gyr - 0 for X gyroscope, 1 for Y gyroscope, 2 for Z gyroscope
          * @param the number of zones
          *
          */
-        int getGyrCount(int gyr)
-        {
-            return (gyr >= 0 && gyr < 3) ? int(fGyr[gyr].size()) : 0;
+    int getGyrCount(int gyr) { return (gyr >= 0 && gyr < 3) ? int(fGyr[gyr].size()) : 0; }
+
+    // getScreenColor() : -1 means no screen color control (no screencolor metadata found)
+    // otherwise return 0x00RRGGBB a ready to use color
+    int getScreenColor()
+    {
+        if (fHasScreenControl) {
+            int r = (fRedReader) ? fRedReader->getValue() : 0;
+            int g = (fGreenReader) ? fGreenReader->getValue() : 0;
+            int b = (fBlueReader) ? fBlueReader->getValue() : 0;
+            return (r << 16) | (g << 8) | b;
+        } else {
+            return -1;
         }
-   
-        // getScreenColor() : -1 means no screen color control (no screencolor metadata found)
-        // otherwise return 0x00RRGGBB a ready to use color
-        int getScreenColor()
-        {
-            if (fHasScreenControl) {
-                int r = (fRedReader) ? fRedReader->getValue() : 0;
-                int g = (fGreenReader) ? fGreenReader->getValue() : 0;
-                int b = (fBlueReader) ? fBlueReader->getValue() : 0;
-                return (r<<16) | (g<<8) | b;
-            } else {
-                return -1;
-            }
-        }
- 
+    }
 };
 
 #endif
@@ -1550,808 +1565,876 @@ class APIUI : public PathBuilder, public Meta, public UI
 //  FAUST Generated Code
 //----------------------------------------------------------------------------
 
-
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
+
+#include <math.h>
 
 #include <algorithm>
 #include <cmath>
-#include <math.h>
 
-static float zitarevmonodsp_faustpower2_f(float value) {
-	return (value * value);
-}
+static float zitarevmonodsp_faustpower2_f(float value) { return (value * value); }
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS zitarevmonodsp
 #endif
 
-#ifdef __APPLE__ 
+#ifdef __APPLE__
 #define exp10f __exp10f
-#define exp10 __exp10
+#define exp10  __exp10
 #endif
 
-class zitarevmonodsp : public dsp {
-	
- private:
-	
-	int IOTA;
-	float fVec0[16384];
-	FAUSTFLOAT fVslider0;
-	float fRec0[2];
-	FAUSTFLOAT fVslider1;
-	float fRec1[2];
-	int fSampleRate;
-	float fConst0;
-	float fConst1;
-	FAUSTFLOAT fVslider2;
-	FAUSTFLOAT fVslider3;
-	FAUSTFLOAT fVslider4;
-	FAUSTFLOAT fVslider5;
-	float fConst2;
-	float fConst3;
-	FAUSTFLOAT fVslider6;
-	FAUSTFLOAT fVslider7;
-	FAUSTFLOAT fVslider8;
-	float fConst4;
-	FAUSTFLOAT fVslider9;
-	float fRec15[2];
-	float fRec14[2];
-	float fVec1[32768];
-	float fConst5;
-	int iConst6;
-	float fConst7;
-	FAUSTFLOAT fVslider10;
-	float fVec2[2048];
-	int iConst8;
-	float fRec12[2];
-	float fConst9;
-	float fConst10;
-	float fRec19[2];
-	float fRec18[2];
-	float fVec3[32768];
-	float fConst11;
-	int iConst12;
-	float fVec4[4096];
-	int iConst13;
-	float fRec16[2];
-	float fConst14;
-	float fConst15;
-	float fRec23[2];
-	float fRec22[2];
-	float fVec5[16384];
-	float fConst16;
-	int iConst17;
-	float fVec6[4096];
-	int iConst18;
-	float fRec20[2];
-	float fConst19;
-	float fConst20;
-	float fRec27[2];
-	float fRec26[2];
-	float fVec7[32768];
-	float fConst21;
-	int iConst22;
-	float fVec8[4096];
-	int iConst23;
-	float fRec24[2];
-	float fConst24;
-	float fConst25;
-	float fRec31[2];
-	float fRec30[2];
-	float fVec9[16384];
-	float fConst26;
-	int iConst27;
-	float fVec10[2048];
-	int iConst28;
-	float fRec28[2];
-	float fConst29;
-	float fConst30;
-	float fRec35[2];
-	float fRec34[2];
-	float fVec11[16384];
-	float fConst31;
-	int iConst32;
-	float fVec12[4096];
-	int iConst33;
-	float fRec32[2];
-	float fConst34;
-	float fConst35;
-	float fRec39[2];
-	float fRec38[2];
-	float fVec13[16384];
-	float fConst36;
-	int iConst37;
-	float fVec14[4096];
-	int iConst38;
-	float fRec36[2];
-	float fConst39;
-	float fConst40;
-	float fRec43[2];
-	float fRec42[2];
-	float fVec15[16384];
-	float fConst41;
-	int iConst42;
-	float fVec16[2048];
-	int iConst43;
-	float fRec40[2];
-	float fRec4[3];
-	float fRec5[3];
-	float fRec6[3];
-	float fRec7[3];
-	float fRec8[3];
-	float fRec9[3];
-	float fRec10[3];
-	float fRec11[3];
-	float fRec3[3];
-	float fRec2[3];
-	float fRec45[3];
-	float fRec44[3];
-	
- public:
-	
-	void metadata(Meta* m) { 
-		m->declare("basics.lib/name", "Faust Basic Element Library");
-		m->declare("basics.lib/version", "0.1");
-		m->declare("delays.lib/name", "Faust Delay Library");
-		m->declare("delays.lib/version", "0.1");
-		m->declare("filename", "zitarevmonodsp.dsp");
-		m->declare("filters.lib/allpass_comb:author", "Julius O. Smith III");
-		m->declare("filters.lib/allpass_comb:copyright", "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
-		m->declare("filters.lib/allpass_comb:license", "MIT-style STK-4.3 license");
-		m->declare("filters.lib/fir:author", "Julius O. Smith III");
-		m->declare("filters.lib/fir:copyright", "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
-		m->declare("filters.lib/fir:license", "MIT-style STK-4.3 license");
-		m->declare("filters.lib/iir:author", "Julius O. Smith III");
-		m->declare("filters.lib/iir:copyright", "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
-		m->declare("filters.lib/iir:license", "MIT-style STK-4.3 license");
-		m->declare("filters.lib/lowpass0_highpass1", "MIT-style STK-4.3 license");
-		m->declare("filters.lib/lowpass0_highpass1:author", "Julius O. Smith III");
-		m->declare("filters.lib/lowpass:author", "Julius O. Smith III");
-		m->declare("filters.lib/lowpass:copyright", "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
-		m->declare("filters.lib/lowpass:license", "MIT-style STK-4.3 license");
-		m->declare("filters.lib/name", "Faust Filters Library");
-		m->declare("filters.lib/peak_eq_rm:author", "Julius O. Smith III");
-		m->declare("filters.lib/peak_eq_rm:copyright", "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
-		m->declare("filters.lib/peak_eq_rm:license", "MIT-style STK-4.3 license");
-		m->declare("filters.lib/tf1:author", "Julius O. Smith III");
-		m->declare("filters.lib/tf1:copyright", "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
-		m->declare("filters.lib/tf1:license", "MIT-style STK-4.3 license");
-		m->declare("filters.lib/tf1s:author", "Julius O. Smith III");
-		m->declare("filters.lib/tf1s:copyright", "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
-		m->declare("filters.lib/tf1s:license", "MIT-style STK-4.3 license");
-		m->declare("filters.lib/tf2:author", "Julius O. Smith III");
-		m->declare("filters.lib/tf2:copyright", "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
-		m->declare("filters.lib/tf2:license", "MIT-style STK-4.3 license");
-		m->declare("maths.lib/author", "GRAME");
-		m->declare("maths.lib/copyright", "GRAME");
-		m->declare("maths.lib/license", "LGPL with exception");
-		m->declare("maths.lib/name", "Faust Math Library");
-		m->declare("maths.lib/version", "2.3");
-		m->declare("name", "zitarevmonodsp");
-		m->declare("platform.lib/name", "Generic Platform Library");
-		m->declare("platform.lib/version", "0.1");
-		m->declare("reverbs.lib/name", "Faust Reverb Library");
-		m->declare("reverbs.lib/version", "0.0");
-		m->declare("routes.lib/name", "Faust Signal Routing Library");
-		m->declare("routes.lib/version", "0.2");
-		m->declare("signals.lib/name", "Faust Signal Routing Library");
-		m->declare("signals.lib/version", "0.0");
-	}
+class zitarevmonodsp : public dsp
+{
+   private:
+    int IOTA;
+    float fVec0[16384];
+    FAUSTFLOAT fVslider0;
+    float fRec0[2];
+    FAUSTFLOAT fVslider1;
+    float fRec1[2];
+    int fSampleRate;
+    float fConst0;
+    float fConst1;
+    FAUSTFLOAT fVslider2;
+    FAUSTFLOAT fVslider3;
+    FAUSTFLOAT fVslider4;
+    FAUSTFLOAT fVslider5;
+    float fConst2;
+    float fConst3;
+    FAUSTFLOAT fVslider6;
+    FAUSTFLOAT fVslider7;
+    FAUSTFLOAT fVslider8;
+    float fConst4;
+    FAUSTFLOAT fVslider9;
+    float fRec15[2];
+    float fRec14[2];
+    float fVec1[32768];
+    float fConst5;
+    int iConst6;
+    float fConst7;
+    FAUSTFLOAT fVslider10;
+    float fVec2[2048];
+    int iConst8;
+    float fRec12[2];
+    float fConst9;
+    float fConst10;
+    float fRec19[2];
+    float fRec18[2];
+    float fVec3[32768];
+    float fConst11;
+    int iConst12;
+    float fVec4[4096];
+    int iConst13;
+    float fRec16[2];
+    float fConst14;
+    float fConst15;
+    float fRec23[2];
+    float fRec22[2];
+    float fVec5[16384];
+    float fConst16;
+    int iConst17;
+    float fVec6[4096];
+    int iConst18;
+    float fRec20[2];
+    float fConst19;
+    float fConst20;
+    float fRec27[2];
+    float fRec26[2];
+    float fVec7[32768];
+    float fConst21;
+    int iConst22;
+    float fVec8[4096];
+    int iConst23;
+    float fRec24[2];
+    float fConst24;
+    float fConst25;
+    float fRec31[2];
+    float fRec30[2];
+    float fVec9[16384];
+    float fConst26;
+    int iConst27;
+    float fVec10[2048];
+    int iConst28;
+    float fRec28[2];
+    float fConst29;
+    float fConst30;
+    float fRec35[2];
+    float fRec34[2];
+    float fVec11[16384];
+    float fConst31;
+    int iConst32;
+    float fVec12[4096];
+    int iConst33;
+    float fRec32[2];
+    float fConst34;
+    float fConst35;
+    float fRec39[2];
+    float fRec38[2];
+    float fVec13[16384];
+    float fConst36;
+    int iConst37;
+    float fVec14[4096];
+    int iConst38;
+    float fRec36[2];
+    float fConst39;
+    float fConst40;
+    float fRec43[2];
+    float fRec42[2];
+    float fVec15[16384];
+    float fConst41;
+    int iConst42;
+    float fVec16[2048];
+    int iConst43;
+    float fRec40[2];
+    float fRec4[3];
+    float fRec5[3];
+    float fRec6[3];
+    float fRec7[3];
+    float fRec8[3];
+    float fRec9[3];
+    float fRec10[3];
+    float fRec11[3];
+    float fRec3[3];
+    float fRec2[3];
+    float fRec45[3];
+    float fRec44[3];
 
-	virtual int getNumInputs() {
-		return 1;
-	}
-	virtual int getNumOutputs() {
-		return 1;
-	}
-	virtual int getInputRate(int channel) {
-		int rate;
-		switch ((channel)) {
-			case 0: {
-				rate = 1;
-				break;
-			}
-			default: {
-				rate = -1;
-				break;
-			}
-		}
-		return rate;
-	}
-	virtual int getOutputRate(int channel) {
-		int rate;
-		switch ((channel)) {
-			case 0: {
-				rate = 1;
-				break;
-			}
-			default: {
-				rate = -1;
-				break;
-			}
-		}
-		return rate;
-	}
-	
-	static void classInit(int sample_rate) {
-	}
-	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = std::min<float>(192000.0f, std::max<float>(1.0f, float(fSampleRate)));
-		fConst1 = (6.28318548f / fConst0);
-		fConst2 = std::floor(((0.219990999f * fConst0) + 0.5f));
-		fConst3 = ((0.0f - (6.90775537f * fConst2)) / fConst0);
-		fConst4 = (3.14159274f / fConst0);
-		fConst5 = std::floor(((0.0191229992f * fConst0) + 0.5f));
-		iConst6 = int(std::min<float>(16384.0f, std::max<float>(0.0f, (fConst2 - fConst5))));
-		fConst7 = (0.00100000005f * fConst0);
-		iConst8 = int(std::min<float>(1024.0f, std::max<float>(0.0f, (fConst5 + -1.0f))));
-		fConst9 = std::floor(((0.256891012f * fConst0) + 0.5f));
-		fConst10 = ((0.0f - (6.90775537f * fConst9)) / fConst0);
-		fConst11 = std::floor(((0.0273330007f * fConst0) + 0.5f));
-		iConst12 = int(std::min<float>(16384.0f, std::max<float>(0.0f, (fConst9 - fConst11))));
-		iConst13 = int(std::min<float>(2048.0f, std::max<float>(0.0f, (fConst11 + -1.0f))));
-		fConst14 = std::floor(((0.192303002f * fConst0) + 0.5f));
-		fConst15 = ((0.0f - (6.90775537f * fConst14)) / fConst0);
-		fConst16 = std::floor(((0.0292910002f * fConst0) + 0.5f));
-		iConst17 = int(std::min<float>(8192.0f, std::max<float>(0.0f, (fConst14 - fConst16))));
-		iConst18 = int(std::min<float>(2048.0f, std::max<float>(0.0f, (fConst16 + -1.0f))));
-		fConst19 = std::floor(((0.210389003f * fConst0) + 0.5f));
-		fConst20 = ((0.0f - (6.90775537f * fConst19)) / fConst0);
-		fConst21 = std::floor(((0.0244210009f * fConst0) + 0.5f));
-		iConst22 = int(std::min<float>(16384.0f, std::max<float>(0.0f, (fConst19 - fConst21))));
-		iConst23 = int(std::min<float>(2048.0f, std::max<float>(0.0f, (fConst21 + -1.0f))));
-		fConst24 = std::floor(((0.125f * fConst0) + 0.5f));
-		fConst25 = ((0.0f - (6.90775537f * fConst24)) / fConst0);
-		fConst26 = std::floor(((0.0134579996f * fConst0) + 0.5f));
-		iConst27 = int(std::min<float>(8192.0f, std::max<float>(0.0f, (fConst24 - fConst26))));
-		iConst28 = int(std::min<float>(1024.0f, std::max<float>(0.0f, (fConst26 + -1.0f))));
-		fConst29 = std::floor(((0.127837002f * fConst0) + 0.5f));
-		fConst30 = ((0.0f - (6.90775537f * fConst29)) / fConst0);
-		fConst31 = std::floor(((0.0316039994f * fConst0) + 0.5f));
-		iConst32 = int(std::min<float>(8192.0f, std::max<float>(0.0f, (fConst29 - fConst31))));
-		iConst33 = int(std::min<float>(2048.0f, std::max<float>(0.0f, (fConst31 + -1.0f))));
-		fConst34 = std::floor(((0.174713001f * fConst0) + 0.5f));
-		fConst35 = ((0.0f - (6.90775537f * fConst34)) / fConst0);
-		fConst36 = std::floor(((0.0229039993f * fConst0) + 0.5f));
-		iConst37 = int(std::min<float>(8192.0f, std::max<float>(0.0f, (fConst34 - fConst36))));
-		iConst38 = int(std::min<float>(2048.0f, std::max<float>(0.0f, (fConst36 + -1.0f))));
-		fConst39 = std::floor(((0.153128996f * fConst0) + 0.5f));
-		fConst40 = ((0.0f - (6.90775537f * fConst39)) / fConst0);
-		fConst41 = std::floor(((0.0203460008f * fConst0) + 0.5f));
-		iConst42 = int(std::min<float>(8192.0f, std::max<float>(0.0f, (fConst39 - fConst41))));
-		iConst43 = int(std::min<float>(1024.0f, std::max<float>(0.0f, (fConst41 + -1.0f))));
-	}
-	
-	virtual void instanceResetUserInterface() {
-		fVslider0 = FAUSTFLOAT(-3.0f);
-		fVslider1 = FAUSTFLOAT(0.0f);
-		fVslider2 = FAUSTFLOAT(1500.0f);
-		fVslider3 = FAUSTFLOAT(0.0f);
-		fVslider4 = FAUSTFLOAT(315.0f);
-		fVslider5 = FAUSTFLOAT(0.0f);
-		fVslider6 = FAUSTFLOAT(2.0f);
-		fVslider7 = FAUSTFLOAT(6000.0f);
-		fVslider8 = FAUSTFLOAT(3.0f);
-		fVslider9 = FAUSTFLOAT(200.0f);
-		fVslider10 = FAUSTFLOAT(60.0f);
-	}
-	
-	virtual void instanceClear() {
-		IOTA = 0;
-		for (int l0 = 0; (l0 < 16384); l0 = (l0 + 1)) {
-			fVec0[l0] = 0.0f;
-		}
-		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
-			fRec0[l1] = 0.0f;
-		}
-		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
-			fRec1[l2] = 0.0f;
-		}
-		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
-			fRec15[l3] = 0.0f;
-		}
-		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
-			fRec14[l4] = 0.0f;
-		}
-		for (int l5 = 0; (l5 < 32768); l5 = (l5 + 1)) {
-			fVec1[l5] = 0.0f;
-		}
-		for (int l6 = 0; (l6 < 2048); l6 = (l6 + 1)) {
-			fVec2[l6] = 0.0f;
-		}
-		for (int l7 = 0; (l7 < 2); l7 = (l7 + 1)) {
-			fRec12[l7] = 0.0f;
-		}
-		for (int l8 = 0; (l8 < 2); l8 = (l8 + 1)) {
-			fRec19[l8] = 0.0f;
-		}
-		for (int l9 = 0; (l9 < 2); l9 = (l9 + 1)) {
-			fRec18[l9] = 0.0f;
-		}
-		for (int l10 = 0; (l10 < 32768); l10 = (l10 + 1)) {
-			fVec3[l10] = 0.0f;
-		}
-		for (int l11 = 0; (l11 < 4096); l11 = (l11 + 1)) {
-			fVec4[l11] = 0.0f;
-		}
-		for (int l12 = 0; (l12 < 2); l12 = (l12 + 1)) {
-			fRec16[l12] = 0.0f;
-		}
-		for (int l13 = 0; (l13 < 2); l13 = (l13 + 1)) {
-			fRec23[l13] = 0.0f;
-		}
-		for (int l14 = 0; (l14 < 2); l14 = (l14 + 1)) {
-			fRec22[l14] = 0.0f;
-		}
-		for (int l15 = 0; (l15 < 16384); l15 = (l15 + 1)) {
-			fVec5[l15] = 0.0f;
-		}
-		for (int l16 = 0; (l16 < 4096); l16 = (l16 + 1)) {
-			fVec6[l16] = 0.0f;
-		}
-		for (int l17 = 0; (l17 < 2); l17 = (l17 + 1)) {
-			fRec20[l17] = 0.0f;
-		}
-		for (int l18 = 0; (l18 < 2); l18 = (l18 + 1)) {
-			fRec27[l18] = 0.0f;
-		}
-		for (int l19 = 0; (l19 < 2); l19 = (l19 + 1)) {
-			fRec26[l19] = 0.0f;
-		}
-		for (int l20 = 0; (l20 < 32768); l20 = (l20 + 1)) {
-			fVec7[l20] = 0.0f;
-		}
-		for (int l21 = 0; (l21 < 4096); l21 = (l21 + 1)) {
-			fVec8[l21] = 0.0f;
-		}
-		for (int l22 = 0; (l22 < 2); l22 = (l22 + 1)) {
-			fRec24[l22] = 0.0f;
-		}
-		for (int l23 = 0; (l23 < 2); l23 = (l23 + 1)) {
-			fRec31[l23] = 0.0f;
-		}
-		for (int l24 = 0; (l24 < 2); l24 = (l24 + 1)) {
-			fRec30[l24] = 0.0f;
-		}
-		for (int l25 = 0; (l25 < 16384); l25 = (l25 + 1)) {
-			fVec9[l25] = 0.0f;
-		}
-		for (int l26 = 0; (l26 < 2048); l26 = (l26 + 1)) {
-			fVec10[l26] = 0.0f;
-		}
-		for (int l27 = 0; (l27 < 2); l27 = (l27 + 1)) {
-			fRec28[l27] = 0.0f;
-		}
-		for (int l28 = 0; (l28 < 2); l28 = (l28 + 1)) {
-			fRec35[l28] = 0.0f;
-		}
-		for (int l29 = 0; (l29 < 2); l29 = (l29 + 1)) {
-			fRec34[l29] = 0.0f;
-		}
-		for (int l30 = 0; (l30 < 16384); l30 = (l30 + 1)) {
-			fVec11[l30] = 0.0f;
-		}
-		for (int l31 = 0; (l31 < 4096); l31 = (l31 + 1)) {
-			fVec12[l31] = 0.0f;
-		}
-		for (int l32 = 0; (l32 < 2); l32 = (l32 + 1)) {
-			fRec32[l32] = 0.0f;
-		}
-		for (int l33 = 0; (l33 < 2); l33 = (l33 + 1)) {
-			fRec39[l33] = 0.0f;
-		}
-		for (int l34 = 0; (l34 < 2); l34 = (l34 + 1)) {
-			fRec38[l34] = 0.0f;
-		}
-		for (int l35 = 0; (l35 < 16384); l35 = (l35 + 1)) {
-			fVec13[l35] = 0.0f;
-		}
-		for (int l36 = 0; (l36 < 4096); l36 = (l36 + 1)) {
-			fVec14[l36] = 0.0f;
-		}
-		for (int l37 = 0; (l37 < 2); l37 = (l37 + 1)) {
-			fRec36[l37] = 0.0f;
-		}
-		for (int l38 = 0; (l38 < 2); l38 = (l38 + 1)) {
-			fRec43[l38] = 0.0f;
-		}
-		for (int l39 = 0; (l39 < 2); l39 = (l39 + 1)) {
-			fRec42[l39] = 0.0f;
-		}
-		for (int l40 = 0; (l40 < 16384); l40 = (l40 + 1)) {
-			fVec15[l40] = 0.0f;
-		}
-		for (int l41 = 0; (l41 < 2048); l41 = (l41 + 1)) {
-			fVec16[l41] = 0.0f;
-		}
-		for (int l42 = 0; (l42 < 2); l42 = (l42 + 1)) {
-			fRec40[l42] = 0.0f;
-		}
-		for (int l43 = 0; (l43 < 3); l43 = (l43 + 1)) {
-			fRec4[l43] = 0.0f;
-		}
-		for (int l44 = 0; (l44 < 3); l44 = (l44 + 1)) {
-			fRec5[l44] = 0.0f;
-		}
-		for (int l45 = 0; (l45 < 3); l45 = (l45 + 1)) {
-			fRec6[l45] = 0.0f;
-		}
-		for (int l46 = 0; (l46 < 3); l46 = (l46 + 1)) {
-			fRec7[l46] = 0.0f;
-		}
-		for (int l47 = 0; (l47 < 3); l47 = (l47 + 1)) {
-			fRec8[l47] = 0.0f;
-		}
-		for (int l48 = 0; (l48 < 3); l48 = (l48 + 1)) {
-			fRec9[l48] = 0.0f;
-		}
-		for (int l49 = 0; (l49 < 3); l49 = (l49 + 1)) {
-			fRec10[l49] = 0.0f;
-		}
-		for (int l50 = 0; (l50 < 3); l50 = (l50 + 1)) {
-			fRec11[l50] = 0.0f;
-		}
-		for (int l51 = 0; (l51 < 3); l51 = (l51 + 1)) {
-			fRec3[l51] = 0.0f;
-		}
-		for (int l52 = 0; (l52 < 3); l52 = (l52 + 1)) {
-			fRec2[l52] = 0.0f;
-		}
-		for (int l53 = 0; (l53 < 3); l53 = (l53 + 1)) {
-			fRec45[l53] = 0.0f;
-		}
-		for (int l54 = 0; (l54 < 3); l54 = (l54 + 1)) {
-			fRec44[l54] = 0.0f;
-		}
-	}
-	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
-	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
-		instanceResetUserInterface();
-		instanceClear();
-	}
-	
-	virtual zitarevmonodsp* clone() {
-		return new zitarevmonodsp();
-	}
-	
-	virtual int getSampleRate() {
-		return fSampleRate;
-	}
-	
-	virtual void buildUserInterface(UI* ui_interface) {
-		ui_interface->declare(0, "0", "");
-		ui_interface->declare(0, "tooltip", "~ ZITA REV1 FEEDBACK DELAY NETWORK (FDN) & SCHROEDER  ALLPASS-COMB REVERBERATOR (8x8). See Faust's reverbs.lib for documentation and  references");
-		ui_interface->openHorizontalBox("Zita_Rev1");
-		ui_interface->declare(0, "1", "");
-		ui_interface->openHorizontalBox("Input");
-		ui_interface->declare(&fVslider10, "1", "");
-		ui_interface->declare(&fVslider10, "style", "knob");
-		ui_interface->declare(&fVslider10, "tooltip", "Delay in ms   before reverberation begins");
-		ui_interface->declare(&fVslider10, "unit", "ms");
-		ui_interface->addVerticalSlider("In Delay", &fVslider10, 60.0f, 20.0f, 100.0f, 1.0f);
-		ui_interface->closeBox();
-		ui_interface->declare(0, "2", "");
-		ui_interface->openHorizontalBox("Decay Times in Bands (see tooltips)");
-		ui_interface->declare(&fVslider9, "1", "");
-		ui_interface->declare(&fVslider9, "scale", "log");
-		ui_interface->declare(&fVslider9, "style", "knob");
-		ui_interface->declare(&fVslider9, "tooltip", "Crossover frequency (Hz) separating low and middle frequencies");
-		ui_interface->declare(&fVslider9, "unit", "Hz");
-		ui_interface->addVerticalSlider("LF X", &fVslider9, 200.0f, 50.0f, 1000.0f, 1.0f);
-		ui_interface->declare(&fVslider8, "2", "");
-		ui_interface->declare(&fVslider8, "scale", "log");
-		ui_interface->declare(&fVslider8, "style", "knob");
-		ui_interface->declare(&fVslider8, "tooltip", "T60 = time (in seconds) to decay 60dB in low-frequency band");
-		ui_interface->declare(&fVslider8, "unit", "s");
-		ui_interface->addVerticalSlider("Low RT60", &fVslider8, 3.0f, 1.0f, 8.0f, 0.100000001f);
-		ui_interface->declare(&fVslider6, "3", "");
-		ui_interface->declare(&fVslider6, "scale", "log");
-		ui_interface->declare(&fVslider6, "style", "knob");
-		ui_interface->declare(&fVslider6, "tooltip", "T60 = time (in seconds) to decay 60dB in middle band");
-		ui_interface->declare(&fVslider6, "unit", "s");
-		ui_interface->addVerticalSlider("Mid RT60", &fVslider6, 2.0f, 1.0f, 8.0f, 0.100000001f);
-		ui_interface->declare(&fVslider7, "4", "");
-		ui_interface->declare(&fVslider7, "scale", "log");
-		ui_interface->declare(&fVslider7, "style", "knob");
-		ui_interface->declare(&fVslider7, "tooltip", "Frequency (Hz) at which the high-frequency T60 is half the middle-band's T60");
-		ui_interface->declare(&fVslider7, "unit", "Hz");
-		ui_interface->addVerticalSlider("HF Damping", &fVslider7, 6000.0f, 1500.0f, 23520.0f, 1.0f);
-		ui_interface->closeBox();
-		ui_interface->declare(0, "3", "");
-		ui_interface->openHorizontalBox("RM Peaking Equalizer 1");
-		ui_interface->declare(&fVslider4, "1", "");
-		ui_interface->declare(&fVslider4, "scale", "log");
-		ui_interface->declare(&fVslider4, "style", "knob");
-		ui_interface->declare(&fVslider4, "tooltip", "Center-frequency of second-order Regalia-Mitra peaking equalizer section 1");
-		ui_interface->declare(&fVslider4, "unit", "Hz");
-		ui_interface->addVerticalSlider("Eq1 Freq", &fVslider4, 315.0f, 40.0f, 2500.0f, 1.0f);
-		ui_interface->declare(&fVslider5, "2", "");
-		ui_interface->declare(&fVslider5, "style", "knob");
-		ui_interface->declare(&fVslider5, "tooltip", "Peak level   in dB of second-order Regalia-Mitra peaking equalizer section 1");
-		ui_interface->declare(&fVslider5, "unit", "dB");
-		ui_interface->addVerticalSlider("Eq1 Level", &fVslider5, 0.0f, -15.0f, 15.0f, 0.100000001f);
-		ui_interface->closeBox();
-		ui_interface->declare(0, "4", "");
-		ui_interface->openHorizontalBox("RM Peaking Equalizer 2");
-		ui_interface->declare(&fVslider2, "1", "");
-		ui_interface->declare(&fVslider2, "scale", "log");
-		ui_interface->declare(&fVslider2, "style", "knob");
-		ui_interface->declare(&fVslider2, "tooltip", "Center-frequency of second-order Regalia-Mitra peaking equalizer section 2");
-		ui_interface->declare(&fVslider2, "unit", "Hz");
-		ui_interface->addVerticalSlider("Eq2 Freq", &fVslider2, 1500.0f, 160.0f, 10000.0f, 1.0f);
-		ui_interface->declare(&fVslider3, "2", "");
-		ui_interface->declare(&fVslider3, "style", "knob");
-		ui_interface->declare(&fVslider3, "tooltip", "Peak level   in dB of second-order Regalia-Mitra peaking equalizer section 2");
-		ui_interface->declare(&fVslider3, "unit", "dB");
-		ui_interface->addVerticalSlider("Eq2 Level", &fVslider3, 0.0f, -15.0f, 15.0f, 0.100000001f);
-		ui_interface->closeBox();
-		ui_interface->declare(0, "5", "");
-		ui_interface->openHorizontalBox("Output");
-		ui_interface->declare(&fVslider1, "1", "");
-		ui_interface->declare(&fVslider1, "style", "knob");
-		ui_interface->declare(&fVslider1, "tooltip", "Dry/Wet Mix: 0 = dry, 1 = wet");
-		ui_interface->addVerticalSlider("Wet", &fVslider1, 0.0f, 0.0f, 1.0f, 0.00999999978f);
-		ui_interface->declare(&fVslider0, "2", "");
-		ui_interface->declare(&fVslider0, "style", "knob");
-		ui_interface->declare(&fVslider0, "tooltip", "Output scale   factor");
-		ui_interface->declare(&fVslider0, "unit", "dB");
-		ui_interface->addVerticalSlider("Level", &fVslider0, -3.0f, -70.0f, 20.0f, 0.100000001f);
-		ui_interface->closeBox();
-		ui_interface->closeBox();
-	}
-	
-	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
-		FAUSTFLOAT* input0 = inputs[0];
-		FAUSTFLOAT* output0 = outputs[0];
-		float fSlow0 = (0.00100000005f * std::pow(10.0f, (0.0500000007f * float(fVslider0))));
-		float fSlow1 = (0.00100000005f * float(fVslider1));
-		float fSlow2 = float(fVslider2);
-		float fSlow3 = std::pow(10.0f, (0.0500000007f * float(fVslider3)));
-		float fSlow4 = (fConst1 * (fSlow2 / std::sqrt(std::max<float>(0.0f, fSlow3))));
-		float fSlow5 = ((1.0f - fSlow4) / (fSlow4 + 1.0f));
-		float fSlow6 = float(fVslider4);
-		float fSlow7 = std::pow(10.0f, (0.0500000007f * float(fVslider5)));
-		float fSlow8 = (fConst1 * (fSlow6 / std::sqrt(std::max<float>(0.0f, fSlow7))));
-		float fSlow9 = ((1.0f - fSlow8) / (fSlow8 + 1.0f));
-		float fSlow10 = float(fVslider6);
-		float fSlow11 = std::exp((fConst3 / fSlow10));
-		float fSlow12 = zitarevmonodsp_faustpower2_f(fSlow11);
-		float fSlow13 = std::cos((fConst1 * float(fVslider7)));
-		float fSlow14 = (1.0f - (fSlow12 * fSlow13));
-		float fSlow15 = (1.0f - fSlow12);
-		float fSlow16 = (fSlow14 / fSlow15);
-		float fSlow17 = std::sqrt(std::max<float>(0.0f, ((zitarevmonodsp_faustpower2_f(fSlow14) / zitarevmonodsp_faustpower2_f(fSlow15)) + -1.0f)));
-		float fSlow18 = (fSlow16 - fSlow17);
-		float fSlow19 = (fSlow11 * (fSlow17 + (1.0f - fSlow16)));
-		float fSlow20 = float(fVslider8);
-		float fSlow21 = ((std::exp((fConst3 / fSlow20)) / fSlow11) + -1.0f);
-		float fSlow22 = (1.0f / std::tan((fConst4 * float(fVslider9))));
-		float fSlow23 = (1.0f / (fSlow22 + 1.0f));
-		float fSlow24 = (1.0f - fSlow22);
-		int iSlow25 = int(std::min<float>(8192.0f, std::max<float>(0.0f, (fConst7 * float(fVslider10)))));
-		float fSlow26 = std::exp((fConst10 / fSlow10));
-		float fSlow27 = zitarevmonodsp_faustpower2_f(fSlow26);
-		float fSlow28 = (1.0f - (fSlow27 * fSlow13));
-		float fSlow29 = (1.0f - fSlow27);
-		float fSlow30 = (fSlow28 / fSlow29);
-		float fSlow31 = std::sqrt(std::max<float>(0.0f, ((zitarevmonodsp_faustpower2_f(fSlow28) / zitarevmonodsp_faustpower2_f(fSlow29)) + -1.0f)));
-		float fSlow32 = (fSlow30 - fSlow31);
-		float fSlow33 = (fSlow26 * (fSlow31 + (1.0f - fSlow30)));
-		float fSlow34 = ((std::exp((fConst10 / fSlow20)) / fSlow26) + -1.0f);
-		float fSlow35 = std::exp((fConst15 / fSlow10));
-		float fSlow36 = zitarevmonodsp_faustpower2_f(fSlow35);
-		float fSlow37 = (1.0f - (fSlow36 * fSlow13));
-		float fSlow38 = (1.0f - fSlow36);
-		float fSlow39 = (fSlow37 / fSlow38);
-		float fSlow40 = std::sqrt(std::max<float>(0.0f, ((zitarevmonodsp_faustpower2_f(fSlow37) / zitarevmonodsp_faustpower2_f(fSlow38)) + -1.0f)));
-		float fSlow41 = (fSlow39 - fSlow40);
-		float fSlow42 = (fSlow35 * (fSlow40 + (1.0f - fSlow39)));
-		float fSlow43 = ((std::exp((fConst15 / fSlow20)) / fSlow35) + -1.0f);
-		float fSlow44 = std::exp((fConst20 / fSlow10));
-		float fSlow45 = zitarevmonodsp_faustpower2_f(fSlow44);
-		float fSlow46 = (1.0f - (fSlow45 * fSlow13));
-		float fSlow47 = (1.0f - fSlow45);
-		float fSlow48 = (fSlow46 / fSlow47);
-		float fSlow49 = std::sqrt(std::max<float>(0.0f, ((zitarevmonodsp_faustpower2_f(fSlow46) / zitarevmonodsp_faustpower2_f(fSlow47)) + -1.0f)));
-		float fSlow50 = (fSlow48 - fSlow49);
-		float fSlow51 = (fSlow44 * (fSlow49 + (1.0f - fSlow48)));
-		float fSlow52 = ((std::exp((fConst20 / fSlow20)) / fSlow44) + -1.0f);
-		float fSlow53 = std::exp((fConst25 / fSlow10));
-		float fSlow54 = zitarevmonodsp_faustpower2_f(fSlow53);
-		float fSlow55 = (1.0f - (fSlow54 * fSlow13));
-		float fSlow56 = (1.0f - fSlow54);
-		float fSlow57 = (fSlow55 / fSlow56);
-		float fSlow58 = std::sqrt(std::max<float>(0.0f, ((zitarevmonodsp_faustpower2_f(fSlow55) / zitarevmonodsp_faustpower2_f(fSlow56)) + -1.0f)));
-		float fSlow59 = (fSlow57 - fSlow58);
-		float fSlow60 = (fSlow53 * (fSlow58 + (1.0f - fSlow57)));
-		float fSlow61 = ((std::exp((fConst25 / fSlow20)) / fSlow53) + -1.0f);
-		float fSlow62 = std::exp((fConst30 / fSlow10));
-		float fSlow63 = zitarevmonodsp_faustpower2_f(fSlow62);
-		float fSlow64 = (1.0f - (fSlow63 * fSlow13));
-		float fSlow65 = (1.0f - fSlow63);
-		float fSlow66 = (fSlow64 / fSlow65);
-		float fSlow67 = std::sqrt(std::max<float>(0.0f, ((zitarevmonodsp_faustpower2_f(fSlow64) / zitarevmonodsp_faustpower2_f(fSlow65)) + -1.0f)));
-		float fSlow68 = (fSlow66 - fSlow67);
-		float fSlow69 = (fSlow62 * (fSlow67 + (1.0f - fSlow66)));
-		float fSlow70 = ((std::exp((fConst30 / fSlow20)) / fSlow62) + -1.0f);
-		float fSlow71 = std::exp((fConst35 / fSlow10));
-		float fSlow72 = zitarevmonodsp_faustpower2_f(fSlow71);
-		float fSlow73 = (1.0f - (fSlow72 * fSlow13));
-		float fSlow74 = (1.0f - fSlow72);
-		float fSlow75 = (fSlow73 / fSlow74);
-		float fSlow76 = std::sqrt(std::max<float>(0.0f, ((zitarevmonodsp_faustpower2_f(fSlow73) / zitarevmonodsp_faustpower2_f(fSlow74)) + -1.0f)));
-		float fSlow77 = (fSlow75 - fSlow76);
-		float fSlow78 = (fSlow71 * (fSlow76 + (1.0f - fSlow75)));
-		float fSlow79 = ((std::exp((fConst35 / fSlow20)) / fSlow71) + -1.0f);
-		float fSlow80 = std::exp((fConst40 / fSlow10));
-		float fSlow81 = zitarevmonodsp_faustpower2_f(fSlow80);
-		float fSlow82 = (1.0f - (fSlow81 * fSlow13));
-		float fSlow83 = (1.0f - fSlow81);
-		float fSlow84 = (fSlow82 / fSlow83);
-		float fSlow85 = std::sqrt(std::max<float>(0.0f, ((zitarevmonodsp_faustpower2_f(fSlow82) / zitarevmonodsp_faustpower2_f(fSlow83)) + -1.0f)));
-		float fSlow86 = (fSlow84 - fSlow85);
-		float fSlow87 = (fSlow80 * (fSlow85 + (1.0f - fSlow84)));
-		float fSlow88 = ((std::exp((fConst40 / fSlow20)) / fSlow80) + -1.0f);
-		float fSlow89 = (0.0f - (std::cos((fConst1 * fSlow6)) * (fSlow9 + 1.0f)));
-		float fSlow90 = (0.0f - (std::cos((fConst1 * fSlow2)) * (fSlow5 + 1.0f)));
-		for (int i = 0; (i < count); i = (i + 1)) {
-			float fTemp0 = float(input0[i]);
-			fVec0[(IOTA & 16383)] = fTemp0;
-			fRec0[0] = (fSlow0 + (0.999000013f * fRec0[1]));
-			fRec1[0] = (fSlow1 + (0.999000013f * fRec1[1]));
-			fRec15[0] = (0.0f - (fSlow23 * ((fSlow24 * fRec15[1]) - (fRec11[1] + fRec11[2]))));
-			fRec14[0] = ((fSlow18 * fRec14[1]) + (fSlow19 * (fRec11[1] + (fSlow21 * fRec15[0]))));
-			fVec1[(IOTA & 32767)] = ((0.353553385f * fRec14[0]) + 9.99999968e-21f);
-			float fTemp1 = (0.300000012f * fVec0[((IOTA - iSlow25) & 16383)]);
-			float fTemp2 = (((0.600000024f * fRec12[1]) + fVec1[((IOTA - iConst6) & 32767)]) - fTemp1);
-			fVec2[(IOTA & 2047)] = fTemp2;
-			fRec12[0] = fVec2[((IOTA - iConst8) & 2047)];
-			float fRec13 = (0.0f - (0.600000024f * fTemp2));
-			fRec19[0] = (0.0f - (fSlow23 * ((fSlow24 * fRec19[1]) - (fRec7[1] + fRec7[2]))));
-			fRec18[0] = ((fSlow32 * fRec18[1]) + (fSlow33 * (fRec7[1] + (fSlow34 * fRec19[0]))));
-			fVec3[(IOTA & 32767)] = ((0.353553385f * fRec18[0]) + 9.99999968e-21f);
-			float fTemp3 = (((0.600000024f * fRec16[1]) + fVec3[((IOTA - iConst12) & 32767)]) - fTemp1);
-			fVec4[(IOTA & 4095)] = fTemp3;
-			fRec16[0] = fVec4[((IOTA - iConst13) & 4095)];
-			float fRec17 = (0.0f - (0.600000024f * fTemp3));
-			fRec23[0] = (0.0f - (fSlow23 * ((fSlow24 * fRec23[1]) - (fRec9[1] + fRec9[2]))));
-			fRec22[0] = ((fSlow41 * fRec22[1]) + (fSlow42 * (fRec9[1] + (fSlow43 * fRec23[0]))));
-			fVec5[(IOTA & 16383)] = ((0.353553385f * fRec22[0]) + 9.99999968e-21f);
-			float fTemp4 = (fVec5[((IOTA - iConst17) & 16383)] + (fTemp1 + (0.600000024f * fRec20[1])));
-			fVec6[(IOTA & 4095)] = fTemp4;
-			fRec20[0] = fVec6[((IOTA - iConst18) & 4095)];
-			float fRec21 = (0.0f - (0.600000024f * fTemp4));
-			fRec27[0] = (0.0f - (fSlow23 * ((fSlow24 * fRec27[1]) - (fRec5[1] + fRec5[2]))));
-			fRec26[0] = ((fSlow50 * fRec26[1]) + (fSlow51 * (fRec5[1] + (fSlow52 * fRec27[0]))));
-			fVec7[(IOTA & 32767)] = ((0.353553385f * fRec26[0]) + 9.99999968e-21f);
-			float fTemp5 = (fVec7[((IOTA - iConst22) & 32767)] + (fTemp1 + (0.600000024f * fRec24[1])));
-			fVec8[(IOTA & 4095)] = fTemp5;
-			fRec24[0] = fVec8[((IOTA - iConst23) & 4095)];
-			float fRec25 = (0.0f - (0.600000024f * fTemp5));
-			fRec31[0] = (0.0f - (fSlow23 * ((fSlow24 * fRec31[1]) - (fRec10[1] + fRec10[2]))));
-			fRec30[0] = ((fSlow59 * fRec30[1]) + (fSlow60 * (fRec10[1] + (fSlow61 * fRec31[0]))));
-			fVec9[(IOTA & 16383)] = ((0.353553385f * fRec30[0]) + 9.99999968e-21f);
-			float fTemp6 = (fVec9[((IOTA - iConst27) & 16383)] - (fTemp1 + (0.600000024f * fRec28[1])));
-			fVec10[(IOTA & 2047)] = fTemp6;
-			fRec28[0] = fVec10[((IOTA - iConst28) & 2047)];
-			float fRec29 = (0.600000024f * fTemp6);
-			fRec35[0] = (0.0f - (fSlow23 * ((fSlow24 * fRec35[1]) - (fRec6[1] + fRec6[2]))));
-			fRec34[0] = ((fSlow68 * fRec34[1]) + (fSlow69 * (fRec6[1] + (fSlow70 * fRec35[0]))));
-			fVec11[(IOTA & 16383)] = ((0.353553385f * fRec34[0]) + 9.99999968e-21f);
-			float fTemp7 = (fVec11[((IOTA - iConst32) & 16383)] - (fTemp1 + (0.600000024f * fRec32[1])));
-			fVec12[(IOTA & 4095)] = fTemp7;
-			fRec32[0] = fVec12[((IOTA - iConst33) & 4095)];
-			float fRec33 = (0.600000024f * fTemp7);
-			fRec39[0] = (0.0f - (fSlow23 * ((fSlow24 * fRec39[1]) - (fRec8[1] + fRec8[2]))));
-			fRec38[0] = ((fSlow77 * fRec38[1]) + (fSlow78 * (fRec8[1] + (fSlow79 * fRec39[0]))));
-			fVec13[(IOTA & 16383)] = ((0.353553385f * fRec38[0]) + 9.99999968e-21f);
-			float fTemp8 = ((fTemp1 + fVec13[((IOTA - iConst37) & 16383)]) - (0.600000024f * fRec36[1]));
-			fVec14[(IOTA & 4095)] = fTemp8;
-			fRec36[0] = fVec14[((IOTA - iConst38) & 4095)];
-			float fRec37 = (0.600000024f * fTemp8);
-			fRec43[0] = (0.0f - (fSlow23 * ((fSlow24 * fRec43[1]) - (fRec4[1] + fRec4[2]))));
-			fRec42[0] = ((fSlow86 * fRec42[1]) + (fSlow87 * (fRec4[1] + (fSlow88 * fRec43[0]))));
-			fVec15[(IOTA & 16383)] = ((0.353553385f * fRec42[0]) + 9.99999968e-21f);
-			float fTemp9 = ((fVec15[((IOTA - iConst42) & 16383)] + fTemp1) - (0.600000024f * fRec40[1]));
-			fVec16[(IOTA & 2047)] = fTemp9;
-			fRec40[0] = fVec16[((IOTA - iConst43) & 2047)];
-			float fRec41 = (0.600000024f * fTemp9);
-			float fTemp10 = (fRec41 + fRec37);
-			float fTemp11 = (fRec29 + (fRec33 + fTemp10));
-			fRec4[0] = (fRec12[1] + (fRec16[1] + (fRec20[1] + (fRec24[1] + (fRec28[1] + (fRec32[1] + (fRec36[1] + (fRec40[1] + (fRec13 + (fRec17 + (fRec21 + (fRec25 + fTemp11))))))))))));
-			fRec5[0] = ((fRec28[1] + (fRec32[1] + (fRec36[1] + (fRec40[1] + fTemp11)))) - (fRec12[1] + (fRec16[1] + (fRec20[1] + (fRec24[1] + (fRec13 + (fRec17 + (fRec25 + fRec21))))))));
-			float fTemp12 = (fRec33 + fRec29);
-			fRec6[0] = ((fRec20[1] + (fRec24[1] + (fRec36[1] + (fRec40[1] + (fRec21 + (fRec25 + fTemp10)))))) - (fRec12[1] + (fRec16[1] + (fRec28[1] + (fRec32[1] + (fRec13 + (fRec17 + fTemp12)))))));
-			fRec7[0] = ((fRec12[1] + (fRec16[1] + (fRec36[1] + (fRec40[1] + (fRec13 + (fRec17 + fTemp10)))))) - (fRec20[1] + (fRec24[1] + (fRec28[1] + (fRec32[1] + (fRec21 + (fRec25 + fTemp12)))))));
-			float fTemp13 = (fRec41 + fRec33);
-			float fTemp14 = (fRec37 + fRec29);
-			fRec8[0] = ((fRec16[1] + (fRec24[1] + (fRec32[1] + (fRec40[1] + (fRec17 + (fRec25 + fTemp13)))))) - (fRec12[1] + (fRec20[1] + (fRec28[1] + (fRec36[1] + (fRec13 + (fRec21 + fTemp14)))))));
-			fRec9[0] = ((fRec12[1] + (fRec20[1] + (fRec32[1] + (fRec40[1] + (fRec13 + (fRec21 + fTemp13)))))) - (fRec16[1] + (fRec24[1] + (fRec28[1] + (fRec36[1] + (fRec17 + (fRec25 + fTemp14)))))));
-			float fTemp15 = (fRec41 + fRec29);
-			float fTemp16 = (fRec37 + fRec33);
-			fRec10[0] = ((fRec12[1] + (fRec24[1] + (fRec28[1] + (fRec40[1] + (fRec13 + (fRec25 + fTemp15)))))) - (fRec16[1] + (fRec20[1] + (fRec32[1] + (fRec36[1] + (fRec17 + (fRec21 + fTemp16)))))));
-			fRec11[0] = ((fRec16[1] + (fRec20[1] + (fRec28[1] + (fRec40[1] + (fRec17 + (fRec21 + fTemp15)))))) - (fRec12[1] + (fRec24[1] + (fRec32[1] + (fRec36[1] + (fRec13 + (fRec25 + fTemp16)))))));
-			float fTemp17 = (0.370000005f * (fRec5[0] + fRec6[0]));
-			float fTemp18 = (fSlow89 * fRec3[1]);
-			fRec3[0] = (fTemp17 - (fTemp18 + (fSlow9 * fRec3[2])));
-			float fTemp19 = (fSlow9 * fRec3[0]);
-			float fTemp20 = (0.5f * ((fTemp19 + (fRec3[2] + (fTemp17 + fTemp18))) + (fSlow7 * ((fTemp19 + (fTemp18 + fRec3[2])) - fTemp17))));
-			float fTemp21 = (fSlow90 * fRec2[1]);
-			fRec2[0] = (fTemp20 - (fTemp21 + (fSlow5 * fRec2[2])));
-			float fTemp22 = (fSlow5 * fRec2[0]);
-			float fTemp23 = (fTemp0 * (1.0f - fRec1[0]));
-			float fTemp24 = (0.370000005f * (fRec5[0] - fRec6[0]));
-			float fTemp25 = (fSlow89 * fRec45[1]);
-			fRec45[0] = (fTemp24 - (fTemp25 + (fSlow9 * fRec45[2])));
-			float fTemp26 = (fSlow9 * fRec45[0]);
-			float fTemp27 = (0.5f * ((fTemp26 + (fRec45[2] + (fTemp24 + fTemp25))) + (fSlow7 * ((fTemp26 + (fTemp25 + fRec45[2])) - fTemp24))));
-			float fTemp28 = (fSlow90 * fRec44[1]);
-			fRec44[0] = (fTemp27 - (fTemp28 + (fSlow5 * fRec44[2])));
-			float fTemp29 = (fSlow5 * fRec44[0]);
-			output0[i] = FAUSTFLOAT((fRec0[0] * (((0.5f * (fRec1[0] * ((fTemp22 + (fRec2[2] + (fTemp20 + fTemp21))) + (fSlow3 * ((fTemp22 + (fTemp21 + fRec2[2])) - fTemp20))))) + fTemp23) + (fTemp23 + (0.5f * (fRec1[0] * ((fTemp29 + (fRec44[2] + (fTemp27 + fTemp28))) + (fSlow3 * ((fTemp29 + (fTemp28 + fRec44[2])) - fTemp27)))))))));
-			IOTA = (IOTA + 1);
-			fRec0[1] = fRec0[0];
-			fRec1[1] = fRec1[0];
-			fRec15[1] = fRec15[0];
-			fRec14[1] = fRec14[0];
-			fRec12[1] = fRec12[0];
-			fRec19[1] = fRec19[0];
-			fRec18[1] = fRec18[0];
-			fRec16[1] = fRec16[0];
-			fRec23[1] = fRec23[0];
-			fRec22[1] = fRec22[0];
-			fRec20[1] = fRec20[0];
-			fRec27[1] = fRec27[0];
-			fRec26[1] = fRec26[0];
-			fRec24[1] = fRec24[0];
-			fRec31[1] = fRec31[0];
-			fRec30[1] = fRec30[0];
-			fRec28[1] = fRec28[0];
-			fRec35[1] = fRec35[0];
-			fRec34[1] = fRec34[0];
-			fRec32[1] = fRec32[0];
-			fRec39[1] = fRec39[0];
-			fRec38[1] = fRec38[0];
-			fRec36[1] = fRec36[0];
-			fRec43[1] = fRec43[0];
-			fRec42[1] = fRec42[0];
-			fRec40[1] = fRec40[0];
-			fRec4[2] = fRec4[1];
-			fRec4[1] = fRec4[0];
-			fRec5[2] = fRec5[1];
-			fRec5[1] = fRec5[0];
-			fRec6[2] = fRec6[1];
-			fRec6[1] = fRec6[0];
-			fRec7[2] = fRec7[1];
-			fRec7[1] = fRec7[0];
-			fRec8[2] = fRec8[1];
-			fRec8[1] = fRec8[0];
-			fRec9[2] = fRec9[1];
-			fRec9[1] = fRec9[0];
-			fRec10[2] = fRec10[1];
-			fRec10[1] = fRec10[0];
-			fRec11[2] = fRec11[1];
-			fRec11[1] = fRec11[0];
-			fRec3[2] = fRec3[1];
-			fRec3[1] = fRec3[0];
-			fRec2[2] = fRec2[1];
-			fRec2[1] = fRec2[0];
-			fRec45[2] = fRec45[1];
-			fRec45[1] = fRec45[0];
-			fRec44[2] = fRec44[1];
-			fRec44[1] = fRec44[0];
-		}
-	}
+   public:
+    void metadata(Meta* m)
+    {
+        m->declare("basics.lib/name", "Faust Basic Element Library");
+        m->declare("basics.lib/version", "0.1");
+        m->declare("delays.lib/name", "Faust Delay Library");
+        m->declare("delays.lib/version", "0.1");
+        m->declare("filename", "zitarevmonodsp.dsp");
+        m->declare("filters.lib/allpass_comb:author", "Julius O. Smith III");
+        m->declare(
+            "filters.lib/allpass_comb:copyright",
+            "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
+        m->declare("filters.lib/allpass_comb:license", "MIT-style STK-4.3 license");
+        m->declare("filters.lib/fir:author", "Julius O. Smith III");
+        m->declare(
+            "filters.lib/fir:copyright",
+            "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
+        m->declare("filters.lib/fir:license", "MIT-style STK-4.3 license");
+        m->declare("filters.lib/iir:author", "Julius O. Smith III");
+        m->declare(
+            "filters.lib/iir:copyright",
+            "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
+        m->declare("filters.lib/iir:license", "MIT-style STK-4.3 license");
+        m->declare("filters.lib/lowpass0_highpass1", "MIT-style STK-4.3 license");
+        m->declare("filters.lib/lowpass0_highpass1:author", "Julius O. Smith III");
+        m->declare("filters.lib/lowpass:author", "Julius O. Smith III");
+        m->declare(
+            "filters.lib/lowpass:copyright",
+            "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
+        m->declare("filters.lib/lowpass:license", "MIT-style STK-4.3 license");
+        m->declare("filters.lib/name", "Faust Filters Library");
+        m->declare("filters.lib/peak_eq_rm:author", "Julius O. Smith III");
+        m->declare(
+            "filters.lib/peak_eq_rm:copyright",
+            "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
+        m->declare("filters.lib/peak_eq_rm:license", "MIT-style STK-4.3 license");
+        m->declare("filters.lib/tf1:author", "Julius O. Smith III");
+        m->declare(
+            "filters.lib/tf1:copyright",
+            "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
+        m->declare("filters.lib/tf1:license", "MIT-style STK-4.3 license");
+        m->declare("filters.lib/tf1s:author", "Julius O. Smith III");
+        m->declare(
+            "filters.lib/tf1s:copyright",
+            "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
+        m->declare("filters.lib/tf1s:license", "MIT-style STK-4.3 license");
+        m->declare("filters.lib/tf2:author", "Julius O. Smith III");
+        m->declare(
+            "filters.lib/tf2:copyright",
+            "Copyright (C) 2003-2019 by Julius O. Smith III <jos@ccrma.stanford.edu>");
+        m->declare("filters.lib/tf2:license", "MIT-style STK-4.3 license");
+        m->declare("maths.lib/author", "GRAME");
+        m->declare("maths.lib/copyright", "GRAME");
+        m->declare("maths.lib/license", "LGPL with exception");
+        m->declare("maths.lib/name", "Faust Math Library");
+        m->declare("maths.lib/version", "2.3");
+        m->declare("name", "zitarevmonodsp");
+        m->declare("platform.lib/name", "Generic Platform Library");
+        m->declare("platform.lib/version", "0.1");
+        m->declare("reverbs.lib/name", "Faust Reverb Library");
+        m->declare("reverbs.lib/version", "0.0");
+        m->declare("routes.lib/name", "Faust Signal Routing Library");
+        m->declare("routes.lib/version", "0.2");
+        m->declare("signals.lib/name", "Faust Signal Routing Library");
+        m->declare("signals.lib/version", "0.0");
+    }
 
+    virtual int getNumInputs() { return 1; }
+    virtual int getNumOutputs() { return 1; }
+    virtual int getInputRate(int channel)
+    {
+        int rate;
+        switch ((channel)) {
+        case 0: {
+            rate = 1;
+            break;
+        }
+        default: {
+            rate = -1;
+            break;
+        }
+        }
+        return rate;
+    }
+    virtual int getOutputRate(int channel)
+    {
+        int rate;
+        switch ((channel)) {
+        case 0: {
+            rate = 1;
+            break;
+        }
+        default: {
+            rate = -1;
+            break;
+        }
+        }
+        return rate;
+    }
+
+    static void classInit(int sample_rate) {}
+
+    virtual void instanceConstants(int sample_rate)
+    {
+        fSampleRate = sample_rate;
+        fConst0 = std::min<float>(192000.0f, std::max<float>(1.0f, float(fSampleRate)));
+        fConst1 = (6.28318548f / fConst0);
+        fConst2 = std::floor(((0.219990999f * fConst0) + 0.5f));
+        fConst3 = ((0.0f - (6.90775537f * fConst2)) / fConst0);
+        fConst4 = (3.14159274f / fConst0);
+        fConst5 = std::floor(((0.0191229992f * fConst0) + 0.5f));
+        iConst6 =
+            int(std::min<float>(16384.0f, std::max<float>(0.0f, (fConst2 - fConst5))));
+        fConst7 = (0.00100000005f * fConst0);
+        iConst8 = int(std::min<float>(1024.0f, std::max<float>(0.0f, (fConst5 + -1.0f))));
+        fConst9 = std::floor(((0.256891012f * fConst0) + 0.5f));
+        fConst10 = ((0.0f - (6.90775537f * fConst9)) / fConst0);
+        fConst11 = std::floor(((0.0273330007f * fConst0) + 0.5f));
+        iConst12 =
+            int(std::min<float>(16384.0f, std::max<float>(0.0f, (fConst9 - fConst11))));
+        iConst13 =
+            int(std::min<float>(2048.0f, std::max<float>(0.0f, (fConst11 + -1.0f))));
+        fConst14 = std::floor(((0.192303002f * fConst0) + 0.5f));
+        fConst15 = ((0.0f - (6.90775537f * fConst14)) / fConst0);
+        fConst16 = std::floor(((0.0292910002f * fConst0) + 0.5f));
+        iConst17 =
+            int(std::min<float>(8192.0f, std::max<float>(0.0f, (fConst14 - fConst16))));
+        iConst18 =
+            int(std::min<float>(2048.0f, std::max<float>(0.0f, (fConst16 + -1.0f))));
+        fConst19 = std::floor(((0.210389003f * fConst0) + 0.5f));
+        fConst20 = ((0.0f - (6.90775537f * fConst19)) / fConst0);
+        fConst21 = std::floor(((0.0244210009f * fConst0) + 0.5f));
+        iConst22 =
+            int(std::min<float>(16384.0f, std::max<float>(0.0f, (fConst19 - fConst21))));
+        iConst23 =
+            int(std::min<float>(2048.0f, std::max<float>(0.0f, (fConst21 + -1.0f))));
+        fConst24 = std::floor(((0.125f * fConst0) + 0.5f));
+        fConst25 = ((0.0f - (6.90775537f * fConst24)) / fConst0);
+        fConst26 = std::floor(((0.0134579996f * fConst0) + 0.5f));
+        iConst27 =
+            int(std::min<float>(8192.0f, std::max<float>(0.0f, (fConst24 - fConst26))));
+        iConst28 =
+            int(std::min<float>(1024.0f, std::max<float>(0.0f, (fConst26 + -1.0f))));
+        fConst29 = std::floor(((0.127837002f * fConst0) + 0.5f));
+        fConst30 = ((0.0f - (6.90775537f * fConst29)) / fConst0);
+        fConst31 = std::floor(((0.0316039994f * fConst0) + 0.5f));
+        iConst32 =
+            int(std::min<float>(8192.0f, std::max<float>(0.0f, (fConst29 - fConst31))));
+        iConst33 =
+            int(std::min<float>(2048.0f, std::max<float>(0.0f, (fConst31 + -1.0f))));
+        fConst34 = std::floor(((0.174713001f * fConst0) + 0.5f));
+        fConst35 = ((0.0f - (6.90775537f * fConst34)) / fConst0);
+        fConst36 = std::floor(((0.0229039993f * fConst0) + 0.5f));
+        iConst37 =
+            int(std::min<float>(8192.0f, std::max<float>(0.0f, (fConst34 - fConst36))));
+        iConst38 =
+            int(std::min<float>(2048.0f, std::max<float>(0.0f, (fConst36 + -1.0f))));
+        fConst39 = std::floor(((0.153128996f * fConst0) + 0.5f));
+        fConst40 = ((0.0f - (6.90775537f * fConst39)) / fConst0);
+        fConst41 = std::floor(((0.0203460008f * fConst0) + 0.5f));
+        iConst42 =
+            int(std::min<float>(8192.0f, std::max<float>(0.0f, (fConst39 - fConst41))));
+        iConst43 =
+            int(std::min<float>(1024.0f, std::max<float>(0.0f, (fConst41 + -1.0f))));
+    }
+
+    virtual void instanceResetUserInterface()
+    {
+        fVslider0  = FAUSTFLOAT(-3.0f);
+        fVslider1  = FAUSTFLOAT(0.0f);
+        fVslider2  = FAUSTFLOAT(1500.0f);
+        fVslider3  = FAUSTFLOAT(0.0f);
+        fVslider4  = FAUSTFLOAT(315.0f);
+        fVslider5  = FAUSTFLOAT(0.0f);
+        fVslider6  = FAUSTFLOAT(2.0f);
+        fVslider7  = FAUSTFLOAT(6000.0f);
+        fVslider8  = FAUSTFLOAT(3.0f);
+        fVslider9  = FAUSTFLOAT(200.0f);
+        fVslider10 = FAUSTFLOAT(60.0f);
+    }
+
+    virtual void instanceClear()
+    {
+        IOTA = 0;
+        for (int l0 = 0; (l0 < 16384); l0 = (l0 + 1)) { fVec0[l0] = 0.0f; }
+        for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) { fRec0[l1] = 0.0f; }
+        for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) { fRec1[l2] = 0.0f; }
+        for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) { fRec15[l3] = 0.0f; }
+        for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) { fRec14[l4] = 0.0f; }
+        for (int l5 = 0; (l5 < 32768); l5 = (l5 + 1)) { fVec1[l5] = 0.0f; }
+        for (int l6 = 0; (l6 < 2048); l6 = (l6 + 1)) { fVec2[l6] = 0.0f; }
+        for (int l7 = 0; (l7 < 2); l7 = (l7 + 1)) { fRec12[l7] = 0.0f; }
+        for (int l8 = 0; (l8 < 2); l8 = (l8 + 1)) { fRec19[l8] = 0.0f; }
+        for (int l9 = 0; (l9 < 2); l9 = (l9 + 1)) { fRec18[l9] = 0.0f; }
+        for (int l10 = 0; (l10 < 32768); l10 = (l10 + 1)) { fVec3[l10] = 0.0f; }
+        for (int l11 = 0; (l11 < 4096); l11 = (l11 + 1)) { fVec4[l11] = 0.0f; }
+        for (int l12 = 0; (l12 < 2); l12 = (l12 + 1)) { fRec16[l12] = 0.0f; }
+        for (int l13 = 0; (l13 < 2); l13 = (l13 + 1)) { fRec23[l13] = 0.0f; }
+        for (int l14 = 0; (l14 < 2); l14 = (l14 + 1)) { fRec22[l14] = 0.0f; }
+        for (int l15 = 0; (l15 < 16384); l15 = (l15 + 1)) { fVec5[l15] = 0.0f; }
+        for (int l16 = 0; (l16 < 4096); l16 = (l16 + 1)) { fVec6[l16] = 0.0f; }
+        for (int l17 = 0; (l17 < 2); l17 = (l17 + 1)) { fRec20[l17] = 0.0f; }
+        for (int l18 = 0; (l18 < 2); l18 = (l18 + 1)) { fRec27[l18] = 0.0f; }
+        for (int l19 = 0; (l19 < 2); l19 = (l19 + 1)) { fRec26[l19] = 0.0f; }
+        for (int l20 = 0; (l20 < 32768); l20 = (l20 + 1)) { fVec7[l20] = 0.0f; }
+        for (int l21 = 0; (l21 < 4096); l21 = (l21 + 1)) { fVec8[l21] = 0.0f; }
+        for (int l22 = 0; (l22 < 2); l22 = (l22 + 1)) { fRec24[l22] = 0.0f; }
+        for (int l23 = 0; (l23 < 2); l23 = (l23 + 1)) { fRec31[l23] = 0.0f; }
+        for (int l24 = 0; (l24 < 2); l24 = (l24 + 1)) { fRec30[l24] = 0.0f; }
+        for (int l25 = 0; (l25 < 16384); l25 = (l25 + 1)) { fVec9[l25] = 0.0f; }
+        for (int l26 = 0; (l26 < 2048); l26 = (l26 + 1)) { fVec10[l26] = 0.0f; }
+        for (int l27 = 0; (l27 < 2); l27 = (l27 + 1)) { fRec28[l27] = 0.0f; }
+        for (int l28 = 0; (l28 < 2); l28 = (l28 + 1)) { fRec35[l28] = 0.0f; }
+        for (int l29 = 0; (l29 < 2); l29 = (l29 + 1)) { fRec34[l29] = 0.0f; }
+        for (int l30 = 0; (l30 < 16384); l30 = (l30 + 1)) { fVec11[l30] = 0.0f; }
+        for (int l31 = 0; (l31 < 4096); l31 = (l31 + 1)) { fVec12[l31] = 0.0f; }
+        for (int l32 = 0; (l32 < 2); l32 = (l32 + 1)) { fRec32[l32] = 0.0f; }
+        for (int l33 = 0; (l33 < 2); l33 = (l33 + 1)) { fRec39[l33] = 0.0f; }
+        for (int l34 = 0; (l34 < 2); l34 = (l34 + 1)) { fRec38[l34] = 0.0f; }
+        for (int l35 = 0; (l35 < 16384); l35 = (l35 + 1)) { fVec13[l35] = 0.0f; }
+        for (int l36 = 0; (l36 < 4096); l36 = (l36 + 1)) { fVec14[l36] = 0.0f; }
+        for (int l37 = 0; (l37 < 2); l37 = (l37 + 1)) { fRec36[l37] = 0.0f; }
+        for (int l38 = 0; (l38 < 2); l38 = (l38 + 1)) { fRec43[l38] = 0.0f; }
+        for (int l39 = 0; (l39 < 2); l39 = (l39 + 1)) { fRec42[l39] = 0.0f; }
+        for (int l40 = 0; (l40 < 16384); l40 = (l40 + 1)) { fVec15[l40] = 0.0f; }
+        for (int l41 = 0; (l41 < 2048); l41 = (l41 + 1)) { fVec16[l41] = 0.0f; }
+        for (int l42 = 0; (l42 < 2); l42 = (l42 + 1)) { fRec40[l42] = 0.0f; }
+        for (int l43 = 0; (l43 < 3); l43 = (l43 + 1)) { fRec4[l43] = 0.0f; }
+        for (int l44 = 0; (l44 < 3); l44 = (l44 + 1)) { fRec5[l44] = 0.0f; }
+        for (int l45 = 0; (l45 < 3); l45 = (l45 + 1)) { fRec6[l45] = 0.0f; }
+        for (int l46 = 0; (l46 < 3); l46 = (l46 + 1)) { fRec7[l46] = 0.0f; }
+        for (int l47 = 0; (l47 < 3); l47 = (l47 + 1)) { fRec8[l47] = 0.0f; }
+        for (int l48 = 0; (l48 < 3); l48 = (l48 + 1)) { fRec9[l48] = 0.0f; }
+        for (int l49 = 0; (l49 < 3); l49 = (l49 + 1)) { fRec10[l49] = 0.0f; }
+        for (int l50 = 0; (l50 < 3); l50 = (l50 + 1)) { fRec11[l50] = 0.0f; }
+        for (int l51 = 0; (l51 < 3); l51 = (l51 + 1)) { fRec3[l51] = 0.0f; }
+        for (int l52 = 0; (l52 < 3); l52 = (l52 + 1)) { fRec2[l52] = 0.0f; }
+        for (int l53 = 0; (l53 < 3); l53 = (l53 + 1)) { fRec45[l53] = 0.0f; }
+        for (int l54 = 0; (l54 < 3); l54 = (l54 + 1)) { fRec44[l54] = 0.0f; }
+    }
+
+    virtual void init(int sample_rate)
+    {
+        classInit(sample_rate);
+        instanceInit(sample_rate);
+    }
+    virtual void instanceInit(int sample_rate)
+    {
+        instanceConstants(sample_rate);
+        instanceResetUserInterface();
+        instanceClear();
+    }
+
+    virtual zitarevmonodsp* clone() { return new zitarevmonodsp(); }
+
+    virtual int getSampleRate() { return fSampleRate; }
+
+    virtual void buildUserInterface(UI* ui_interface)
+    {
+        ui_interface->declare(0, "0", "");
+        ui_interface->declare(0, "tooltip",
+                              "~ ZITA REV1 FEEDBACK DELAY NETWORK (FDN) & SCHROEDER  "
+                              "ALLPASS-COMB REVERBERATOR (8x8). See Faust's reverbs.lib "
+                              "for documentation and  references");
+        ui_interface->openHorizontalBox("Zita_Rev1");
+        ui_interface->declare(0, "1", "");
+        ui_interface->openHorizontalBox("Input");
+        ui_interface->declare(&fVslider10, "1", "");
+        ui_interface->declare(&fVslider10, "style", "knob");
+        ui_interface->declare(&fVslider10, "tooltip",
+                              "Delay in ms   before reverberation begins");
+        ui_interface->declare(&fVslider10, "unit", "ms");
+        ui_interface->addVerticalSlider("In Delay", &fVslider10, 60.0f, 20.0f, 100.0f,
+                                        1.0f);
+        ui_interface->closeBox();
+        ui_interface->declare(0, "2", "");
+        ui_interface->openHorizontalBox("Decay Times in Bands (see tooltips)");
+        ui_interface->declare(&fVslider9, "1", "");
+        ui_interface->declare(&fVslider9, "scale", "log");
+        ui_interface->declare(&fVslider9, "style", "knob");
+        ui_interface->declare(
+            &fVslider9, "tooltip",
+            "Crossover frequency (Hz) separating low and middle frequencies");
+        ui_interface->declare(&fVslider9, "unit", "Hz");
+        ui_interface->addVerticalSlider("LF X", &fVslider9, 200.0f, 50.0f, 1000.0f, 1.0f);
+        ui_interface->declare(&fVslider8, "2", "");
+        ui_interface->declare(&fVslider8, "scale", "log");
+        ui_interface->declare(&fVslider8, "style", "knob");
+        ui_interface->declare(
+            &fVslider8, "tooltip",
+            "T60 = time (in seconds) to decay 60dB in low-frequency band");
+        ui_interface->declare(&fVslider8, "unit", "s");
+        ui_interface->addVerticalSlider("Low RT60", &fVslider8, 3.0f, 1.0f, 8.0f,
+                                        0.100000001f);
+        ui_interface->declare(&fVslider6, "3", "");
+        ui_interface->declare(&fVslider6, "scale", "log");
+        ui_interface->declare(&fVslider6, "style", "knob");
+        ui_interface->declare(&fVslider6, "tooltip",
+                              "T60 = time (in seconds) to decay 60dB in middle band");
+        ui_interface->declare(&fVslider6, "unit", "s");
+        ui_interface->addVerticalSlider("Mid RT60", &fVslider6, 2.0f, 1.0f, 8.0f,
+                                        0.100000001f);
+        ui_interface->declare(&fVslider7, "4", "");
+        ui_interface->declare(&fVslider7, "scale", "log");
+        ui_interface->declare(&fVslider7, "style", "knob");
+        ui_interface->declare(&fVslider7, "tooltip",
+                              "Frequency (Hz) at which the high-frequency T60 is half "
+                              "the middle-band's T60");
+        ui_interface->declare(&fVslider7, "unit", "Hz");
+        ui_interface->addVerticalSlider("HF Damping", &fVslider7, 6000.0f, 1500.0f,
+                                        23520.0f, 1.0f);
+        ui_interface->closeBox();
+        ui_interface->declare(0, "3", "");
+        ui_interface->openHorizontalBox("RM Peaking Equalizer 1");
+        ui_interface->declare(&fVslider4, "1", "");
+        ui_interface->declare(&fVslider4, "scale", "log");
+        ui_interface->declare(&fVslider4, "style", "knob");
+        ui_interface->declare(
+            &fVslider4, "tooltip",
+            "Center-frequency of second-order Regalia-Mitra peaking equalizer section 1");
+        ui_interface->declare(&fVslider4, "unit", "Hz");
+        ui_interface->addVerticalSlider("Eq1 Freq", &fVslider4, 315.0f, 40.0f, 2500.0f,
+                                        1.0f);
+        ui_interface->declare(&fVslider5, "2", "");
+        ui_interface->declare(&fVslider5, "style", "knob");
+        ui_interface->declare(&fVslider5, "tooltip",
+                              "Peak level   in dB of second-order Regalia-Mitra peaking "
+                              "equalizer section 1");
+        ui_interface->declare(&fVslider5, "unit", "dB");
+        ui_interface->addVerticalSlider("Eq1 Level", &fVslider5, 0.0f, -15.0f, 15.0f,
+                                        0.100000001f);
+        ui_interface->closeBox();
+        ui_interface->declare(0, "4", "");
+        ui_interface->openHorizontalBox("RM Peaking Equalizer 2");
+        ui_interface->declare(&fVslider2, "1", "");
+        ui_interface->declare(&fVslider2, "scale", "log");
+        ui_interface->declare(&fVslider2, "style", "knob");
+        ui_interface->declare(
+            &fVslider2, "tooltip",
+            "Center-frequency of second-order Regalia-Mitra peaking equalizer section 2");
+        ui_interface->declare(&fVslider2, "unit", "Hz");
+        ui_interface->addVerticalSlider("Eq2 Freq", &fVslider2, 1500.0f, 160.0f, 10000.0f,
+                                        1.0f);
+        ui_interface->declare(&fVslider3, "2", "");
+        ui_interface->declare(&fVslider3, "style", "knob");
+        ui_interface->declare(&fVslider3, "tooltip",
+                              "Peak level   in dB of second-order Regalia-Mitra peaking "
+                              "equalizer section 2");
+        ui_interface->declare(&fVslider3, "unit", "dB");
+        ui_interface->addVerticalSlider("Eq2 Level", &fVslider3, 0.0f, -15.0f, 15.0f,
+                                        0.100000001f);
+        ui_interface->closeBox();
+        ui_interface->declare(0, "5", "");
+        ui_interface->openHorizontalBox("Output");
+        ui_interface->declare(&fVslider1, "1", "");
+        ui_interface->declare(&fVslider1, "style", "knob");
+        ui_interface->declare(&fVslider1, "tooltip", "Dry/Wet Mix: 0 = dry, 1 = wet");
+        ui_interface->addVerticalSlider("Wet", &fVslider1, 0.0f, 0.0f, 1.0f,
+                                        0.00999999978f);
+        ui_interface->declare(&fVslider0, "2", "");
+        ui_interface->declare(&fVslider0, "style", "knob");
+        ui_interface->declare(&fVslider0, "tooltip", "Output scale   factor");
+        ui_interface->declare(&fVslider0, "unit", "dB");
+        ui_interface->addVerticalSlider("Level", &fVslider0, -3.0f, -70.0f, 20.0f,
+                                        0.100000001f);
+        ui_interface->closeBox();
+        ui_interface->closeBox();
+    }
+
+    virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs)
+    {
+        FAUSTFLOAT* input0  = inputs[0];
+        FAUSTFLOAT* output0 = outputs[0];
+        float fSlow0 =
+            (0.00100000005f * std::pow(10.0f, (0.0500000007f * float(fVslider0))));
+        float fSlow1  = (0.00100000005f * float(fVslider1));
+        float fSlow2  = float(fVslider2);
+        float fSlow3  = std::pow(10.0f, (0.0500000007f * float(fVslider3)));
+        float fSlow4  = (fConst1 * (fSlow2 / std::sqrt(std::max<float>(0.0f, fSlow3))));
+        float fSlow5  = ((1.0f - fSlow4) / (fSlow4 + 1.0f));
+        float fSlow6  = float(fVslider4);
+        float fSlow7  = std::pow(10.0f, (0.0500000007f * float(fVslider5)));
+        float fSlow8  = (fConst1 * (fSlow6 / std::sqrt(std::max<float>(0.0f, fSlow7))));
+        float fSlow9  = ((1.0f - fSlow8) / (fSlow8 + 1.0f));
+        float fSlow10 = float(fVslider6);
+        float fSlow11 = std::exp((fConst3 / fSlow10));
+        float fSlow12 = zitarevmonodsp_faustpower2_f(fSlow11);
+        float fSlow13 = std::cos((fConst1 * float(fVslider7)));
+        float fSlow14 = (1.0f - (fSlow12 * fSlow13));
+        float fSlow15 = (1.0f - fSlow12);
+        float fSlow16 = (fSlow14 / fSlow15);
+        float fSlow17 =
+            std::sqrt(std::max<float>(0.0f, ((zitarevmonodsp_faustpower2_f(fSlow14)
+                                              / zitarevmonodsp_faustpower2_f(fSlow15))
+                                             + -1.0f)));
+        float fSlow18 = (fSlow16 - fSlow17);
+        float fSlow19 = (fSlow11 * (fSlow17 + (1.0f - fSlow16)));
+        float fSlow20 = float(fVslider8);
+        float fSlow21 = ((std::exp((fConst3 / fSlow20)) / fSlow11) + -1.0f);
+        float fSlow22 = (1.0f / std::tan((fConst4 * float(fVslider9))));
+        float fSlow23 = (1.0f / (fSlow22 + 1.0f));
+        float fSlow24 = (1.0f - fSlow22);
+        int iSlow25   = int(std::min<float>(
+            8192.0f, std::max<float>(0.0f, (fConst7 * float(fVslider10)))));
+        float fSlow26 = std::exp((fConst10 / fSlow10));
+        float fSlow27 = zitarevmonodsp_faustpower2_f(fSlow26);
+        float fSlow28 = (1.0f - (fSlow27 * fSlow13));
+        float fSlow29 = (1.0f - fSlow27);
+        float fSlow30 = (fSlow28 / fSlow29);
+        float fSlow31 =
+            std::sqrt(std::max<float>(0.0f, ((zitarevmonodsp_faustpower2_f(fSlow28)
+                                              / zitarevmonodsp_faustpower2_f(fSlow29))
+                                             + -1.0f)));
+        float fSlow32 = (fSlow30 - fSlow31);
+        float fSlow33 = (fSlow26 * (fSlow31 + (1.0f - fSlow30)));
+        float fSlow34 = ((std::exp((fConst10 / fSlow20)) / fSlow26) + -1.0f);
+        float fSlow35 = std::exp((fConst15 / fSlow10));
+        float fSlow36 = zitarevmonodsp_faustpower2_f(fSlow35);
+        float fSlow37 = (1.0f - (fSlow36 * fSlow13));
+        float fSlow38 = (1.0f - fSlow36);
+        float fSlow39 = (fSlow37 / fSlow38);
+        float fSlow40 =
+            std::sqrt(std::max<float>(0.0f, ((zitarevmonodsp_faustpower2_f(fSlow37)
+                                              / zitarevmonodsp_faustpower2_f(fSlow38))
+                                             + -1.0f)));
+        float fSlow41 = (fSlow39 - fSlow40);
+        float fSlow42 = (fSlow35 * (fSlow40 + (1.0f - fSlow39)));
+        float fSlow43 = ((std::exp((fConst15 / fSlow20)) / fSlow35) + -1.0f);
+        float fSlow44 = std::exp((fConst20 / fSlow10));
+        float fSlow45 = zitarevmonodsp_faustpower2_f(fSlow44);
+        float fSlow46 = (1.0f - (fSlow45 * fSlow13));
+        float fSlow47 = (1.0f - fSlow45);
+        float fSlow48 = (fSlow46 / fSlow47);
+        float fSlow49 =
+            std::sqrt(std::max<float>(0.0f, ((zitarevmonodsp_faustpower2_f(fSlow46)
+                                              / zitarevmonodsp_faustpower2_f(fSlow47))
+                                             + -1.0f)));
+        float fSlow50 = (fSlow48 - fSlow49);
+        float fSlow51 = (fSlow44 * (fSlow49 + (1.0f - fSlow48)));
+        float fSlow52 = ((std::exp((fConst20 / fSlow20)) / fSlow44) + -1.0f);
+        float fSlow53 = std::exp((fConst25 / fSlow10));
+        float fSlow54 = zitarevmonodsp_faustpower2_f(fSlow53);
+        float fSlow55 = (1.0f - (fSlow54 * fSlow13));
+        float fSlow56 = (1.0f - fSlow54);
+        float fSlow57 = (fSlow55 / fSlow56);
+        float fSlow58 =
+            std::sqrt(std::max<float>(0.0f, ((zitarevmonodsp_faustpower2_f(fSlow55)
+                                              / zitarevmonodsp_faustpower2_f(fSlow56))
+                                             + -1.0f)));
+        float fSlow59 = (fSlow57 - fSlow58);
+        float fSlow60 = (fSlow53 * (fSlow58 + (1.0f - fSlow57)));
+        float fSlow61 = ((std::exp((fConst25 / fSlow20)) / fSlow53) + -1.0f);
+        float fSlow62 = std::exp((fConst30 / fSlow10));
+        float fSlow63 = zitarevmonodsp_faustpower2_f(fSlow62);
+        float fSlow64 = (1.0f - (fSlow63 * fSlow13));
+        float fSlow65 = (1.0f - fSlow63);
+        float fSlow66 = (fSlow64 / fSlow65);
+        float fSlow67 =
+            std::sqrt(std::max<float>(0.0f, ((zitarevmonodsp_faustpower2_f(fSlow64)
+                                              / zitarevmonodsp_faustpower2_f(fSlow65))
+                                             + -1.0f)));
+        float fSlow68 = (fSlow66 - fSlow67);
+        float fSlow69 = (fSlow62 * (fSlow67 + (1.0f - fSlow66)));
+        float fSlow70 = ((std::exp((fConst30 / fSlow20)) / fSlow62) + -1.0f);
+        float fSlow71 = std::exp((fConst35 / fSlow10));
+        float fSlow72 = zitarevmonodsp_faustpower2_f(fSlow71);
+        float fSlow73 = (1.0f - (fSlow72 * fSlow13));
+        float fSlow74 = (1.0f - fSlow72);
+        float fSlow75 = (fSlow73 / fSlow74);
+        float fSlow76 =
+            std::sqrt(std::max<float>(0.0f, ((zitarevmonodsp_faustpower2_f(fSlow73)
+                                              / zitarevmonodsp_faustpower2_f(fSlow74))
+                                             + -1.0f)));
+        float fSlow77 = (fSlow75 - fSlow76);
+        float fSlow78 = (fSlow71 * (fSlow76 + (1.0f - fSlow75)));
+        float fSlow79 = ((std::exp((fConst35 / fSlow20)) / fSlow71) + -1.0f);
+        float fSlow80 = std::exp((fConst40 / fSlow10));
+        float fSlow81 = zitarevmonodsp_faustpower2_f(fSlow80);
+        float fSlow82 = (1.0f - (fSlow81 * fSlow13));
+        float fSlow83 = (1.0f - fSlow81);
+        float fSlow84 = (fSlow82 / fSlow83);
+        float fSlow85 =
+            std::sqrt(std::max<float>(0.0f, ((zitarevmonodsp_faustpower2_f(fSlow82)
+                                              / zitarevmonodsp_faustpower2_f(fSlow83))
+                                             + -1.0f)));
+        float fSlow86 = (fSlow84 - fSlow85);
+        float fSlow87 = (fSlow80 * (fSlow85 + (1.0f - fSlow84)));
+        float fSlow88 = ((std::exp((fConst40 / fSlow20)) / fSlow80) + -1.0f);
+        float fSlow89 = (0.0f - (std::cos((fConst1 * fSlow6)) * (fSlow9 + 1.0f)));
+        float fSlow90 = (0.0f - (std::cos((fConst1 * fSlow2)) * (fSlow5 + 1.0f)));
+        for (int i = 0; (i < count); i = (i + 1)) {
+            float fTemp0          = float(input0[i]);
+            fVec0[(IOTA & 16383)] = fTemp0;
+            fRec0[0]              = (fSlow0 + (0.999000013f * fRec0[1]));
+            fRec1[0]              = (fSlow1 + (0.999000013f * fRec1[1]));
+            fRec15[0] =
+                (0.0f - (fSlow23 * ((fSlow24 * fRec15[1]) - (fRec11[1] + fRec11[2]))));
+            fRec14[0] =
+                ((fSlow18 * fRec14[1]) + (fSlow19 * (fRec11[1] + (fSlow21 * fRec15[0]))));
+            fVec1[(IOTA & 32767)] = ((0.353553385f * fRec14[0]) + 9.99999968e-21f);
+            float fTemp1          = (0.300000012f * fVec0[((IOTA - iSlow25) & 16383)]);
+            float fTemp2 =
+                (((0.600000024f * fRec12[1]) + fVec1[((IOTA - iConst6) & 32767)])
+                 - fTemp1);
+            fVec2[(IOTA & 2047)] = fTemp2;
+            fRec12[0]            = fVec2[((IOTA - iConst8) & 2047)];
+            float fRec13         = (0.0f - (0.600000024f * fTemp2));
+            fRec19[0] =
+                (0.0f - (fSlow23 * ((fSlow24 * fRec19[1]) - (fRec7[1] + fRec7[2]))));
+            fRec18[0] =
+                ((fSlow32 * fRec18[1]) + (fSlow33 * (fRec7[1] + (fSlow34 * fRec19[0]))));
+            fVec3[(IOTA & 32767)] = ((0.353553385f * fRec18[0]) + 9.99999968e-21f);
+            float fTemp3 =
+                (((0.600000024f * fRec16[1]) + fVec3[((IOTA - iConst12) & 32767)])
+                 - fTemp1);
+            fVec4[(IOTA & 4095)] = fTemp3;
+            fRec16[0]            = fVec4[((IOTA - iConst13) & 4095)];
+            float fRec17         = (0.0f - (0.600000024f * fTemp3));
+            fRec23[0] =
+                (0.0f - (fSlow23 * ((fSlow24 * fRec23[1]) - (fRec9[1] + fRec9[2]))));
+            fRec22[0] =
+                ((fSlow41 * fRec22[1]) + (fSlow42 * (fRec9[1] + (fSlow43 * fRec23[0]))));
+            fVec5[(IOTA & 16383)] = ((0.353553385f * fRec22[0]) + 9.99999968e-21f);
+            float fTemp4          = (fVec5[((IOTA - iConst17) & 16383)]
+                            + (fTemp1 + (0.600000024f * fRec20[1])));
+            fVec6[(IOTA & 4095)]  = fTemp4;
+            fRec20[0]             = fVec6[((IOTA - iConst18) & 4095)];
+            float fRec21          = (0.0f - (0.600000024f * fTemp4));
+            fRec27[0] =
+                (0.0f - (fSlow23 * ((fSlow24 * fRec27[1]) - (fRec5[1] + fRec5[2]))));
+            fRec26[0] =
+                ((fSlow50 * fRec26[1]) + (fSlow51 * (fRec5[1] + (fSlow52 * fRec27[0]))));
+            fVec7[(IOTA & 32767)] = ((0.353553385f * fRec26[0]) + 9.99999968e-21f);
+            float fTemp5          = (fVec7[((IOTA - iConst22) & 32767)]
+                            + (fTemp1 + (0.600000024f * fRec24[1])));
+            fVec8[(IOTA & 4095)]  = fTemp5;
+            fRec24[0]             = fVec8[((IOTA - iConst23) & 4095)];
+            float fRec25          = (0.0f - (0.600000024f * fTemp5));
+            fRec31[0] =
+                (0.0f - (fSlow23 * ((fSlow24 * fRec31[1]) - (fRec10[1] + fRec10[2]))));
+            fRec30[0] =
+                ((fSlow59 * fRec30[1]) + (fSlow60 * (fRec10[1] + (fSlow61 * fRec31[0]))));
+            fVec9[(IOTA & 16383)] = ((0.353553385f * fRec30[0]) + 9.99999968e-21f);
+            float fTemp6          = (fVec9[((IOTA - iConst27) & 16383)]
+                            - (fTemp1 + (0.600000024f * fRec28[1])));
+            fVec10[(IOTA & 2047)] = fTemp6;
+            fRec28[0]             = fVec10[((IOTA - iConst28) & 2047)];
+            float fRec29          = (0.600000024f * fTemp6);
+            fRec35[0] =
+                (0.0f - (fSlow23 * ((fSlow24 * fRec35[1]) - (fRec6[1] + fRec6[2]))));
+            fRec34[0] =
+                ((fSlow68 * fRec34[1]) + (fSlow69 * (fRec6[1] + (fSlow70 * fRec35[0]))));
+            fVec11[(IOTA & 16383)] = ((0.353553385f * fRec34[0]) + 9.99999968e-21f);
+            float fTemp7           = (fVec11[((IOTA - iConst32) & 16383)]
+                            - (fTemp1 + (0.600000024f * fRec32[1])));
+            fVec12[(IOTA & 4095)]  = fTemp7;
+            fRec32[0]              = fVec12[((IOTA - iConst33) & 4095)];
+            float fRec33           = (0.600000024f * fTemp7);
+            fRec39[0] =
+                (0.0f - (fSlow23 * ((fSlow24 * fRec39[1]) - (fRec8[1] + fRec8[2]))));
+            fRec38[0] =
+                ((fSlow77 * fRec38[1]) + (fSlow78 * (fRec8[1] + (fSlow79 * fRec39[0]))));
+            fVec13[(IOTA & 16383)] = ((0.353553385f * fRec38[0]) + 9.99999968e-21f);
+            float fTemp8           = ((fTemp1 + fVec13[((IOTA - iConst37) & 16383)])
+                            - (0.600000024f * fRec36[1]));
+            fVec14[(IOTA & 4095)]  = fTemp8;
+            fRec36[0]              = fVec14[((IOTA - iConst38) & 4095)];
+            float fRec37           = (0.600000024f * fTemp8);
+            fRec43[0] =
+                (0.0f - (fSlow23 * ((fSlow24 * fRec43[1]) - (fRec4[1] + fRec4[2]))));
+            fRec42[0] =
+                ((fSlow86 * fRec42[1]) + (fSlow87 * (fRec4[1] + (fSlow88 * fRec43[0]))));
+            fVec15[(IOTA & 16383)] = ((0.353553385f * fRec42[0]) + 9.99999968e-21f);
+            float fTemp9           = ((fVec15[((IOTA - iConst42) & 16383)] + fTemp1)
+                            - (0.600000024f * fRec40[1]));
+            fVec16[(IOTA & 2047)]  = fTemp9;
+            fRec40[0]              = fVec16[((IOTA - iConst43) & 2047)];
+            float fRec41           = (0.600000024f * fTemp9);
+            float fTemp10          = (fRec41 + fRec37);
+            float fTemp11          = (fRec29 + (fRec33 + fTemp10));
+            fRec4[0] =
+                (fRec12[1]
+                 + (fRec16[1]
+                    + (fRec20[1]
+                       + (fRec24[1]
+                          + (fRec28[1]
+                             + (fRec32[1]
+                                + (fRec36[1]
+                                   + (fRec40[1]
+                                      + (fRec13
+                                         + (fRec17
+                                            + (fRec21 + (fRec25 + fTemp11))))))))))));
+            fRec5[0] =
+                ((fRec28[1] + (fRec32[1] + (fRec36[1] + (fRec40[1] + fTemp11))))
+                 - (fRec12[1]
+                    + (fRec16[1]
+                       + (fRec20[1]
+                          + (fRec24[1] + (fRec13 + (fRec17 + (fRec25 + fRec21))))))));
+            float fTemp12 = (fRec33 + fRec29);
+            fRec6[0] =
+                ((fRec20[1]
+                  + (fRec24[1]
+                     + (fRec36[1] + (fRec40[1] + (fRec21 + (fRec25 + fTemp10))))))
+                 - (fRec12[1]
+                    + (fRec16[1]
+                       + (fRec28[1] + (fRec32[1] + (fRec13 + (fRec17 + fTemp12)))))));
+            fRec7[0] =
+                ((fRec12[1]
+                  + (fRec16[1]
+                     + (fRec36[1] + (fRec40[1] + (fRec13 + (fRec17 + fTemp10))))))
+                 - (fRec20[1]
+                    + (fRec24[1]
+                       + (fRec28[1] + (fRec32[1] + (fRec21 + (fRec25 + fTemp12)))))));
+            float fTemp13 = (fRec41 + fRec33);
+            float fTemp14 = (fRec37 + fRec29);
+            fRec8[0] =
+                ((fRec16[1]
+                  + (fRec24[1]
+                     + (fRec32[1] + (fRec40[1] + (fRec17 + (fRec25 + fTemp13))))))
+                 - (fRec12[1]
+                    + (fRec20[1]
+                       + (fRec28[1] + (fRec36[1] + (fRec13 + (fRec21 + fTemp14)))))));
+            fRec9[0] =
+                ((fRec12[1]
+                  + (fRec20[1]
+                     + (fRec32[1] + (fRec40[1] + (fRec13 + (fRec21 + fTemp13))))))
+                 - (fRec16[1]
+                    + (fRec24[1]
+                       + (fRec28[1] + (fRec36[1] + (fRec17 + (fRec25 + fTemp14)))))));
+            float fTemp15 = (fRec41 + fRec29);
+            float fTemp16 = (fRec37 + fRec33);
+            fRec10[0] =
+                ((fRec12[1]
+                  + (fRec24[1]
+                     + (fRec28[1] + (fRec40[1] + (fRec13 + (fRec25 + fTemp15))))))
+                 - (fRec16[1]
+                    + (fRec20[1]
+                       + (fRec32[1] + (fRec36[1] + (fRec17 + (fRec21 + fTemp16)))))));
+            fRec11[0] =
+                ((fRec16[1]
+                  + (fRec20[1]
+                     + (fRec28[1] + (fRec40[1] + (fRec17 + (fRec21 + fTemp15))))))
+                 - (fRec12[1]
+                    + (fRec24[1]
+                       + (fRec32[1] + (fRec36[1] + (fRec13 + (fRec25 + fTemp16)))))));
+            float fTemp17 = (0.370000005f * (fRec5[0] + fRec6[0]));
+            float fTemp18 = (fSlow89 * fRec3[1]);
+            fRec3[0]      = (fTemp17 - (fTemp18 + (fSlow9 * fRec3[2])));
+            float fTemp19 = (fSlow9 * fRec3[0]);
+            float fTemp20 =
+                (0.5f
+                 * ((fTemp19 + (fRec3[2] + (fTemp17 + fTemp18)))
+                    + (fSlow7 * ((fTemp19 + (fTemp18 + fRec3[2])) - fTemp17))));
+            float fTemp21 = (fSlow90 * fRec2[1]);
+            fRec2[0]      = (fTemp20 - (fTemp21 + (fSlow5 * fRec2[2])));
+            float fTemp22 = (fSlow5 * fRec2[0]);
+            float fTemp23 = (fTemp0 * (1.0f - fRec1[0]));
+            float fTemp24 = (0.370000005f * (fRec5[0] - fRec6[0]));
+            float fTemp25 = (fSlow89 * fRec45[1]);
+            fRec45[0]     = (fTemp24 - (fTemp25 + (fSlow9 * fRec45[2])));
+            float fTemp26 = (fSlow9 * fRec45[0]);
+            float fTemp27 =
+                (0.5f
+                 * ((fTemp26 + (fRec45[2] + (fTemp24 + fTemp25)))
+                    + (fSlow7 * ((fTemp26 + (fTemp25 + fRec45[2])) - fTemp24))));
+            float fTemp28 = (fSlow90 * fRec44[1]);
+            fRec44[0]     = (fTemp27 - (fTemp28 + (fSlow5 * fRec44[2])));
+            float fTemp29 = (fSlow5 * fRec44[0]);
+            output0[i]    = FAUSTFLOAT((
+                fRec0[0]
+                * (((0.5f
+                     * (fRec1[0]
+                        * ((fTemp22 + (fRec2[2] + (fTemp20 + fTemp21)))
+                           + (fSlow3 * ((fTemp22 + (fTemp21 + fRec2[2])) - fTemp20)))))
+                    + fTemp23)
+                   + (fTemp23
+                      + (0.5f
+                         * (fRec1[0]
+                            * ((fTemp29 + (fRec44[2] + (fTemp27 + fTemp28)))
+                               + (fSlow3
+                                  * ((fTemp29 + (fTemp28 + fRec44[2])) - fTemp27)))))))));
+            IOTA          = (IOTA + 1);
+            fRec0[1]      = fRec0[0];
+            fRec1[1]      = fRec1[0];
+            fRec15[1]     = fRec15[0];
+            fRec14[1]     = fRec14[0];
+            fRec12[1]     = fRec12[0];
+            fRec19[1]     = fRec19[0];
+            fRec18[1]     = fRec18[0];
+            fRec16[1]     = fRec16[0];
+            fRec23[1]     = fRec23[0];
+            fRec22[1]     = fRec22[0];
+            fRec20[1]     = fRec20[0];
+            fRec27[1]     = fRec27[0];
+            fRec26[1]     = fRec26[0];
+            fRec24[1]     = fRec24[0];
+            fRec31[1]     = fRec31[0];
+            fRec30[1]     = fRec30[0];
+            fRec28[1]     = fRec28[0];
+            fRec35[1]     = fRec35[0];
+            fRec34[1]     = fRec34[0];
+            fRec32[1]     = fRec32[0];
+            fRec39[1]     = fRec39[0];
+            fRec38[1]     = fRec38[0];
+            fRec36[1]     = fRec36[0];
+            fRec43[1]     = fRec43[0];
+            fRec42[1]     = fRec42[0];
+            fRec40[1]     = fRec40[0];
+            fRec4[2]      = fRec4[1];
+            fRec4[1]      = fRec4[0];
+            fRec5[2]      = fRec5[1];
+            fRec5[1]      = fRec5[0];
+            fRec6[2]      = fRec6[1];
+            fRec6[1]      = fRec6[0];
+            fRec7[2]      = fRec7[1];
+            fRec7[1]      = fRec7[0];
+            fRec8[2]      = fRec8[1];
+            fRec8[1]      = fRec8[0];
+            fRec9[2]      = fRec9[1];
+            fRec9[1]      = fRec9[0];
+            fRec10[2]     = fRec10[1];
+            fRec10[1]     = fRec10[0];
+            fRec11[2]     = fRec11[1];
+            fRec11[1]     = fRec11[0];
+            fRec3[2]      = fRec3[1];
+            fRec3[1]      = fRec3[0];
+            fRec2[2]      = fRec2[1];
+            fRec2[1]      = fRec2[0];
+            fRec45[2]     = fRec45[1];
+            fRec45[1]     = fRec45[0];
+            fRec44[2]     = fRec44[1];
+            fRec44[1]     = fRec44[0];
+        }
+    }
 };
 
 #endif


### PR DESCRIPTION
Everybody loves beautiful arranged code. But nobody wants to lose time indenting and remembering what the right style was in this project. So here is a .clang-format file. I tried to get a similar style that we have right now, but enhances readability.

A lot of IDE and texteditor are able to use .clang-format files. So most of us just have to tell our tools to use it. I used meson. If you setup the builddir with a .clang-format file in the root directory of the project, you get a clang-format target that you can start with `ninja clang-format`.

Although clang-format is able to reflow comments and most of the time it's beneficial, sometimes it gets a mess. So I turned it off for now. For two places in faust-src I turned clang-format off because I thought those are a kind of macro.

It broke the build first, because it reordered the #includes (so you find headers that are not self-contained). I had to change an uint into an unsigned int because of that. We might even avoid bugs with this in the future.

Are there some style decisions you don't like? 