### PR TITLE
Turn on clang-format comment reflow

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -55,7 +55,7 @@ BreakConstructorInitializers: BeforeComma
 BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
 ColumnLimit:     90
-CommentPragmas:  '^ IWYU pragma:'
+CommentPragmas: '( \| |\*--|<li>|@ref | @p | @param  |@returns |@warning |@ingroup |@author |@date |@related |@relates |@relatesalso |@deprecated |@image |@return |@brief |@attention |@copydoc |@addtogroup |@todo |@tparam |@see |@note |@skip |@skipline |@until |@line |@dontinclude |@include)'
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 4
@@ -145,7 +145,7 @@ RawStringFormats:
       - ParsePartialTestProto
     CanonicalDelimiter: ''
     BasedOnStyle:    google
-ReflowComments:  false
+ReflowComments:  true
 SortIncludes:    true
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false

--- a/src/CompressorPresets.h
+++ b/src/CompressorPresets.h
@@ -39,6 +39,8 @@ struct CompressorPresetList {
 };
 #endif
 
+// clang-format off
+
 /* Settings from http://www.anythingpeaceful.org/sonar/settings/comp.html
 
    Name     Thresh(dB) Att(ms) Rel(ms) Ratio:1 Gain(dB)    Comments
@@ -76,3 +78,5 @@ struct CompressorPresetList {
    Perc.       -10     10-20   50      3-6     3       Transient overdrive protection in mix
 
 */
+
+// clang-format on

--- a/src/UdpDataProtocol.cpp
+++ b/src/UdpDataProtocol.cpp
@@ -481,6 +481,8 @@ void UdpDataProtocol::run()
     // Anton Runov: making setRealtimeProcessPriority optional
     if (mUseRtPriority) { setRealtimeProcessPriority(); }
 
+
+    // clang-format off
     /////////////////////
     // to see thread priorities
     // sudo ps -eLo pri,rtprio,cls,pid,nice,cmd | grep -E 'jackd|jacktrip|rtc|RTPRI' | sort -r
@@ -540,6 +542,8 @@ void UdpDataProtocol::run()
     //         19      -  TS  4348   0 /usr/bin/jackd -dalsa -dhw:CODEC -r48000 -p128 -n2 -Xseq
 
     // jack puts its clients in FF at 5 points below itself
+    //
+    // clang-format off
 
     switch (mRunMode) {
     case RECEIVER: {


### PR DESCRIPTION
I've turned clang-format off for two bigger comments. The rest looked good to me. This doesn't include the reformatting of the codebase. So when we use clang-format, the code will continuously be reformatted as we push changes.