### PR TITLE
Different number of input and output channels

### DIFF
--- a/src/AudioInterface.cpp
+++ b/src/AudioInterface.cpp
@@ -71,7 +71,7 @@ AudioInterface::AudioInterface(JackTrip* jacktrip, int NumInChans, int NumOutCha
     , mProcessingAudio(false)
 {
 #ifndef WAIR
-    //cc
+    // cc
     // Initialize and assign memory for ProcessPlugins Buffers
     mInProcessBuffer.resize(mNumInChans);
     mOutProcessBuffer.resize(mNumOutChans);
@@ -236,8 +236,8 @@ void AudioInterface::callback(QVarLengthArray<sample_t*>& in_buffer,
     // 2) Dynamically allocate ProcessPlugin processes
     // -----------------------------------------------
     // The processing will be done in order of allocation
-    /// \todo Implement for more than one process plugin, now it just works propertely with one.
-    /// do it chaining outputs to inputs in the buffers. May need a tempo buffer
+    /// \todo Implement for more than one process plugin, now it just works propertely
+    /// with one. do it chaining outputs to inputs in the buffers. May need a tempo buffer
 
 #ifndef WAIR  // NOT WAIR:
     for (int i = 0; i < mProcessPluginsFromNetwork.size(); i++) {
@@ -322,7 +322,7 @@ void AudioInterface::callback(QVarLengthArray<sample_t*>& in_buffer,
         }
         for (int i = 0; i < mNumNetRevChans; i++) {
             sample_t* mix_sample = out_buffer[i % mNumOutChans];
-            sample_t* tmp_sample = mNetInBuffer[i];  //mNetInBuffer
+            sample_t* tmp_sample = mNetInBuffer[i];  // mNetInBuffer
             for (int j = 0; j < (int)n_frames; j++) { mix_sample[j] += tmp_sample[j]; }
         }  // nib6 to aob2
 #else  // AP
@@ -365,10 +365,10 @@ void AudioInterface::callback(QVarLengthArray<sample_t*>& in_buffer,
   int* error;
   mode = celt_mode_create(48000, 2, 64, error);
   */
-    //celt_mode_create(48000, 2, 64, NULL);
-    //unsigned char* compressed;
-    //CELTEncoder* celtEncoder;
-    //celt_encode_float(celtEncoder, mInBuffer, NULL, compressed, );
+    // celt_mode_create(48000, 2, 64, NULL);
+    // unsigned char* compressed;
+    // CELTEncoder* celtEncoder;
+    // celt_encode_float(celtEncoder, mInBuffer, NULL, compressed, );
 
     ///********************************************************
     ///********************************************************
@@ -385,14 +385,14 @@ void AudioInterface::broadcastCallback(QVarLengthArray<sample_t*>& mon_buffer,
     mJackTrip->receiveBroadcastPacket(mAudioOutputPacket);
     // Extract separate channels to send to Jack
     for (int i = 0; i < mNumOutChans; i++) {
-        sample_t* tmp_sample = mon_buffer[i];  //sample buffer for channel i
+        sample_t* tmp_sample = mon_buffer[i];  // sample buffer for channel i
         for (unsigned int j = 0; j < n_frames; j++) {
             // Change the bit resolution on each sample
             fromBitToSampleConversion(
                 // use interleaved channel layout
                 //&mOutputPacket[(i*mSizeInBytesPerChannel) + (j*mBitResolutionMode)],
                 &mAudioOutputPacket[(j * mBitResolutionMode * mNumOutChans)
-                               + (i * mBitResolutionMode)],
+                                    + (i * mBitResolutionMode)],
                 &tmp_sample[j], mBitResolutionMode);
         }
     }
@@ -415,7 +415,7 @@ void AudioInterface::computeProcessFromNetwork(QVarLengthArray<sample_t*>& out_b
     if (mNumNetRevChans)
         // Extract separate channels
         for (int i = 0; i < mNumNetRevChans; i++) {
-            sample_t* tmp_sample = mNetInBuffer[i];  //sample buffer for channel i
+            sample_t* tmp_sample = mNetInBuffer[i];  // sample buffer for channel i
             for (unsigned int j = 0; j < n_frames; j++) {
                 // Change the bit resolution on each sample
                 fromBitToSampleConversion(
@@ -433,17 +433,17 @@ void AudioInterface::computeProcessFromNetwork(QVarLengthArray<sample_t*>& out_b
         for (int i = 0; i < mNumOutChans; i++) {
             //--------
             // This should be faster for 32 bits
-            //std::memcpy(mOutBuffer[i], &mOutputPacket[i*mSizeInBytesPerChannel],
+            // std::memcpy(mOutBuffer[i], &mOutputPacket[i*mSizeInBytesPerChannel],
             //         mSizeInBytesPerChannel);
             //--------
-            sample_t* tmp_sample = out_buffer[i];  //sample buffer for channel i
+            sample_t* tmp_sample = out_buffer[i];  // sample buffer for channel i
             for (unsigned int j = 0; j < n_frames; j++) {
                 // Change the bit resolution on each sample
                 fromBitToSampleConversion(
                     // use interleaved channel layout
                     //&mOutputPacket[(i*mSizeInBytesPerChannel) + (j*mBitResolutionMode)],
                     &mAudioOutputPacket[(j * mBitResolutionMode * mNumOutChans)
-                                   + (i * mBitResolutionMode)],
+                                        + (i * mBitResolutionMode)],
                     &tmp_sample[j], mBitResolutionMode);
             }
         }
@@ -461,13 +461,14 @@ void AudioInterface::computeProcessToNetwork(QVarLengthArray<sample_t*>& in_buff
     if (mNumNetRevChans)
         for (int i = 0; i < mNumNetRevChans; i++) {
             sample_t* tmp_sample =
-                in_buffer[i % mNumInChans];  //sample buffer for channel i
+                in_buffer[i % mNumInChans];  // sample buffer for channel i
             sample_t* tmp_process_sample =
-                mInProcessBuffer[i];  //sample buffer from the output process
+                mInProcessBuffer[i];  // sample buffer from the output process
             sample_t tmp_result;
             for (unsigned int j = 0; j < n_frames; j++) {
                 // Change the bit resolution on each sample
-                // Add the input jack buffer to the buffer resulting from the output process
+                // Add the input jack buffer to the buffer resulting from the output
+                // process
 #define INGAIN \
     (0.9999)  // 0.9999 because 1.0 can saturate the fixed pt rounding on output
 #define COMBGAIN (1.0)
@@ -487,23 +488,24 @@ void AudioInterface::computeProcessToNetwork(QVarLengthArray<sample_t*>& in_buff
         for (int i = 0; i < mNumInChans; i++) {
             //--------
             // This should be faster for 32 bits
-            //std::memcpy(&mInputPacket[i*mSizeInBytesPerChannel], mInBuffer[i],
+            // std::memcpy(&mInputPacket[i*mSizeInBytesPerChannel], mInBuffer[i],
             //         mSizeInBytesPerChannel);
             //--------
-            sample_t* tmp_sample = in_buffer[i];  //sample buffer for channel i
+            sample_t* tmp_sample = in_buffer[i];  // sample buffer for channel i
             sample_t* tmp_process_sample =
-                mInProcessBuffer[i];  //sample buffer from the output process
+                mInProcessBuffer[i];  // sample buffer from the output process
             sample_t tmp_result;
             for (unsigned int j = 0; j < n_frames; j++) {
                 // Change the bit resolution on each sample
-                // Add the input jack buffer to the buffer resulting from the output process
+                // Add the input jack buffer to the buffer resulting from the output
+                // process
                 tmp_result = tmp_sample[j] + tmp_process_sample[j];
                 fromSampleToBitConversion(
                     &tmp_result,
                     // use interleaved channel layout
                     //&mInputPacket[(i*mSizeInBytesPerChannel) + (j*mBitResolutionMode)],
                     &mAudioInputPacket[(j * mBitResolutionMode * mNumInChans)
-                                  + (i * mBitResolutionMode)],
+                                       + (i * mBitResolutionMode)],
                     mBitResolutionMode);
             }
         }
@@ -551,7 +553,7 @@ void AudioInterface::fromSampleToBitConversion(
         // Then we compute the remainder error, and quantize that part into an 8bit number
         // Note that this remainder is always positive, so we use an unsigned integer
         tmp_sample8 = floor(
-            (tmp_sample - tmp_sample16)  //this is a positive number, between 0.0-1.0
+            (tmp_sample - tmp_sample16)  // this is a positive number, between 0.0-1.0
             * 256.0);
         tmp_u8 = static_cast<uint8_t>(tmp_sample8);
 

--- a/src/AudioInterface.cpp
+++ b/src/AudioInterface.cpp
@@ -113,12 +113,12 @@ AudioInterface::~AudioInterface()
 #endif  // endwhere
 
     for (int i = 0; i < mProcessPluginsFromNetwork.size(); i++) {
-        delete mProcessPluginsFromNetwork[i];
+        delete[] mProcessPluginsFromNetwork[i];
     }
     for (int i = 0; i < mProcessPluginsToNetwork.size(); i++) {
-        delete mProcessPluginsToNetwork[i];
+        delete[] mProcessPluginsToNetwork[i];
     }
-    for (int i = 0; i < mNumInChans; i++) { delete mInBufCopy[i]; }
+    for (int i = 0; i < mNumInChans; i++) { delete[] mInBufCopy[i]; }
 }
 
 //*******************************************************************************

--- a/src/AudioInterface.cpp
+++ b/src/AudioInterface.cpp
@@ -502,7 +502,7 @@ void AudioInterface::computeProcessToNetwork(QVarLengthArray<sample_t*>& in_buff
                     &tmp_result,
                     // use interleaved channel layout
                     //&mInputPacket[(i*mSizeInBytesPerChannel) + (j*mBitResolutionMode)],
-                    &mInputPacket[(j * mBitResolutionMode * mNumOutChans)
+                    &mAudioInputPacket[(j * mBitResolutionMode * mNumInChans)
                                   + (i * mBitResolutionMode)],
                     mBitResolutionMode);
             }

--- a/src/AudioInterface.cpp
+++ b/src/AudioInterface.cpp
@@ -463,7 +463,7 @@ void AudioInterface::computeProcessToNetwork(QVarLengthArray<sample_t*>& in_buff
             sample_t* tmp_sample =
                 in_buffer[i % mNumInChans];  //sample buffer for channel i
             sample_t* tmp_process_sample =
-                mOutProcessBuffer[i];  //sample buffer from the output process
+                mInProcessBuffer[i];  //sample buffer from the output process
             sample_t tmp_result;
             for (unsigned int j = 0; j < n_frames; j++) {
                 // Change the bit resolution on each sample
@@ -492,7 +492,7 @@ void AudioInterface::computeProcessToNetwork(QVarLengthArray<sample_t*>& in_buff
             //--------
             sample_t* tmp_sample = in_buffer[i];  //sample buffer for channel i
             sample_t* tmp_process_sample =
-                mOutProcessBuffer[i];  //sample buffer from the output process
+                mInProcessBuffer[i];  //sample buffer from the output process
             sample_t tmp_result;
             for (unsigned int j = 0; j < n_frames; j++) {
                 // Change the bit resolution on each sample

--- a/src/AudioInterface.h
+++ b/src/AudioInterface.h
@@ -239,9 +239,9 @@ class AudioInterface
     QVarLengthArray<sample_t*>
         mOutProcessBuffer;  ///< Vector of Output buffers/channel for ProcessPlugin
     int8_t*
-        mInputPacket;  ///< Packet containing all the channels to read from the RingBuffer
+        mAudioInputPacket;  ///< Packet containing all the channels to read from the RingBuffer
     int8_t*
-        mOutputPacket;  ///< Packet containing all the channels to send to the RingBuffer
+        mAudioOutputPacket;  ///< Packet containing all the channels to send to the RingBuffer
     bool mLoopBack;
     AudioTester* mAudioTesterP{nullptr};
 

--- a/src/AudioInterface.h
+++ b/src/AudioInterface.h
@@ -49,7 +49,7 @@
 // Forward declarations
 class JackTrip;
 
-//using namespace JackTripNamespace;
+// using namespace JackTripNamespace;
 
 /** \brief Base Class that provides an interface with audio
  */
@@ -77,11 +77,11 @@ class AudioInterface
     };
 
     /** \brief The class constructor
-   * \param jacktrip Pointer to the JackTrip class that connects all classes (mediator)
-   * \param NumInChans Number of Input Channels
-   * \param NumOutChans Number of Output Channels
-   * \param AudioBitResolution Audio Sample Resolutions in bits
-   */
+     * \param jacktrip Pointer to the JackTrip class that connects all classes (mediator)
+     * \param NumInChans Number of Input Channels
+     * \param NumOutChans Number of Output Channels
+     * \param AudioBitResolution Audio Sample Resolutions in bits
+     */
     AudioInterface(
         JackTrip* jacktrip, int NumInChans, int NumOutChans,
 #ifdef WAIR  // wair
@@ -92,12 +92,12 @@ class AudioInterface
     virtual ~AudioInterface();
 
     /** \brief Setup the client. This function should be called just before
-    *
-    * starting the audio processes, it will setup the audio client with
-    * the class parameters, like Sampling Rate,
-    * Packet Size, Bit Resolution, etc... Sub-classes should also call the parent
-    * method to ensure correct inizialization.
-    */
+     *
+     * starting the audio processes, it will setup the audio client with
+     * the class parameters, like Sampling Rate,
+     * Packet Size, Bit Resolution, etc... Sub-classes should also call the parent
+     * method to ensure correct inizialization.
+     */
     virtual void setup();
     /// \brief Tell the audio server that we are ready to roll. The
     /// process-callback will start running. This runs on its own thread.
@@ -117,46 +117,46 @@ class AudioInterface
                                    unsigned int n_frames);
     virtual void callback(QVarLengthArray<sample_t*>& in_buffer,
                           QVarLengthArray<sample_t*>& out_buffer, unsigned int n_frames);
-    /** \brief appendProcessPluginToNetwork(): Append a ProcessPlugin for outgoing audio. 
-   * The processing order equals order they were appended.
-   * This processing is in the JackTrip client before sending to the network.
-   * \param plugin a ProcessPlugin smart pointer. Create the object instance
-   * using something like:\n
-   * <tt>std::tr1::shared_ptr<ProcessPluginName> loopback(new ProcessPluginName);</tt>
-   */
+    /** \brief appendProcessPluginToNetwork(): Append a ProcessPlugin for outgoing audio.
+     * The processing order equals order they were appended.
+     * This processing is in the JackTrip client before sending to the network.
+     * \param plugin a ProcessPlugin smart pointer. Create the object instance
+     * using something like:\n
+     * <tt>std::tr1::shared_ptr<ProcessPluginName> loopback(new ProcessPluginName);</tt>
+     */
     virtual void appendProcessPluginToNetwork(ProcessPlugin* plugin);
     /** \brief appendProcessPluginFromNetwork():
-   * Same as appendProcessPluginToNetwork() except that these plugins operate
-   * on the audio received from the network (typically from a JackTrip server).
-   * The complete processing chain then looks like this:
-   * audio -> JACK -> JackTrip client -> processPlugin to network
-   *               -> remote JackTrip server
-   *               -> JackTrip client -> processPlugin from network -> JACK -> audio
-   */
+     * Same as appendProcessPluginToNetwork() except that these plugins operate
+     * on the audio received from the network (typically from a JackTrip server).
+     * The complete processing chain then looks like this:
+     * audio -> JACK -> JackTrip client -> processPlugin to network
+     *               -> remote JackTrip server
+     *               -> JackTrip client -> processPlugin from network -> JACK -> audio
+     */
     virtual void appendProcessPluginFromNetwork(ProcessPlugin* plugin);
     /** \brief initPlugins():
-   * Initialize all ProcessPlugin modules.
-   * The audio sampling rate (mSampleRate) must be set at this time.
-   */
+     * Initialize all ProcessPlugin modules.
+     * The audio sampling rate (mSampleRate) must be set at this time.
+     */
     void initPlugins();
     virtual void connectDefaultPorts() = 0;
     /** \brief Convert a 32bit number (sample_t) into one of the bit resolution
-   * supported (audioBitResolutionT).
-   *
-   * The result is stored in an int_8 array of the
-   * appropriate size to hold the value. The caller is responsible to allocate
-   * enough space to store the result.
-   */
+     * supported (audioBitResolutionT).
+     *
+     * The result is stored in an int_8 array of the
+     * appropriate size to hold the value. The caller is responsible to allocate
+     * enough space to store the result.
+     */
     static void fromSampleToBitConversion(
         const sample_t* const input, int8_t* output,
         const AudioInterface::audioBitResolutionT targetBitResolution);
     /** \brief Convert a audioBitResolutionT bit resolution number into a
-   * 32bit number (sample_t)
-   *
-   * The result is stored in an sample_t array of the
-   * appropriate size to hold the value. The caller is responsible to allocate
-   * enough space to store the result.
-   */
+     * 32bit number (sample_t)
+     *
+     * The result is stored in an sample_t array of the
+     * appropriate size to hold the value. The caller is responsible to allocate
+     * enough space to store the result.
+     */
     static void fromBitToSampleConversion(
         const int8_t* const input, sample_t* output,
         const AudioInterface::audioBitResolutionT sourceBitResolution);
@@ -191,15 +191,15 @@ class AudioInterface
     /// \return  AudioInterface::samplingRateT enum type
     virtual samplingRateT getSampleRateType() const;
     /** \brief Get the Audio Bit Resolution, in bits
-   *
-   * This is one of the audioBitResolutionT set in construction
-   */
+     *
+     * This is one of the audioBitResolutionT set in construction
+     */
     virtual int getAudioBitResolution() const { return mAudioBitResolution; }
     /** \brief Helper function to get the sample rate (in Hz) for a
-   * JackAudioInterface::samplingRateT
-   * \param rate_type  JackAudioInterface::samplingRateT enum type
-   * \return Sample Rate in Hz
-   */
+     * JackAudioInterface::samplingRateT
+     * \param rate_type  JackAudioInterface::samplingRateT enum type
+     * \return Sample Rate in Hz
+     */
     static int getSampleRateFromType(samplingRateT rate_type);
     //------------------------------------------------------------------
 
@@ -237,11 +237,11 @@ class AudioInterface
     QVarLengthArray<sample_t*>
         mInProcessBuffer;  ///< Vector of Input buffers/channel for ProcessPlugin
     QVarLengthArray<sample_t*>
-        mOutProcessBuffer;  ///< Vector of Output buffers/channel for ProcessPlugin
-    int8_t*
-        mAudioInputPacket;  ///< Packet containing all the channels to read from the RingBuffer
-    int8_t*
-        mAudioOutputPacket;  ///< Packet containing all the channels to send to the RingBuffer
+        mOutProcessBuffer;       ///< Vector of Output buffers/channel for ProcessPlugin
+    int8_t* mAudioInputPacket;   ///< Packet containing all the channels to read from the
+                                 ///< RingBuffer
+    int8_t* mAudioOutputPacket;  ///< Packet containing all the channels to send to the
+                                 ///< RingBuffer
     bool mLoopBack;
     AudioTester* mAudioTesterP{nullptr};
 

--- a/src/JackAudioInterface.cpp
+++ b/src/JackAudioInterface.cpp
@@ -184,7 +184,7 @@ void JackAudioInterface::createChannels()
 
     //Create Output Ports
     mOutPorts.resize(mNumOutChans);
-    for (int i = 0; i < mNumInChans; i++) {
+    for (int i = 0; i < mNumOutChans; i++) {
         QString outName;
         QTextStream(&outName) << "receive_" << i + 1;
         mOutPorts[i] = jack_port_register(mClient, outName.toLatin1(),
@@ -212,6 +212,7 @@ uint32_t JackAudioInterface::getSampleRate() const
 //*******************************************************************************
 uint32_t JackAudioInterface::getBufferSizeInSamples() const
 {
+    // This is the maximum buffer size… Should only be used before the client gets activated
     return jack_get_buffer_size(mClient);
 }
 

--- a/src/JackAudioInterface.cpp
+++ b/src/JackAudioInterface.cpp
@@ -212,7 +212,6 @@ uint32_t JackAudioInterface::getSampleRate() const
 //*******************************************************************************
 uint32_t JackAudioInterface::getBufferSizeInSamples() const
 {
-    // This is the maximum buffer size… Should only be used before the client gets activated
     return jack_get_buffer_size(mClient);
 }
 

--- a/src/JackAudioInterface.cpp
+++ b/src/JackAudioInterface.cpp
@@ -179,7 +179,7 @@ void JackAudioInterface::createChannels()
         QString inName;
         QTextStream(&inName) << "send_" << i + 1;
         mInPorts[i] = jack_port_register(mClient, inName.toLatin1(),
-                                         JACK_DEFAULT_AUDIO_TYPE, JackPortIsInput, 0);
+                                         JACK_DEFAULT_AUDIO_TYPE, JackPortIsTerminal, 0);
     }
 
     //Create Output Ports
@@ -188,17 +188,17 @@ void JackAudioInterface::createChannels()
         QString outName;
         QTextStream(&outName) << "receive_" << i + 1;
         mOutPorts[i] = jack_port_register(mClient, outName.toLatin1(),
-                                          JACK_DEFAULT_AUDIO_TYPE, JackPortIsOutput, 0);
+                                          JACK_DEFAULT_AUDIO_TYPE, JackPortIsTerminal, 0);
     }
     //Create Broadcast Ports
     if (mBroadcast) {
         mBroadcastPorts.resize(mNumOutChans);
-        for (int i = 0; i < mNumInChans; i++) {
+        for (int i = 0; i < mNumOutChans; i++) {
             QString outName;
             QTextStream(&outName) << "broadcast_" << i + 1;
             mBroadcastPorts[i] =
                 jack_port_register(mClient, outName.toLatin1(), JACK_DEFAULT_AUDIO_TYPE,
-                                   JackPortIsOutput, 0);
+                                   JackPortIsTerminal, 0);
         }
     }
 }

--- a/src/JackAudioInterface.cpp
+++ b/src/JackAudioInterface.cpp
@@ -79,7 +79,7 @@ JackAudioInterface::JackAudioInterface(
     mNumNetRevChans(NumNetRevChans)
     ,
 #endif  // endwhere
-    //mAudioBitResolution(AudioBitResolution*8),
+    // mAudioBitResolution(AudioBitResolution*8),
     mBitResolutionMode(AudioBitResolution)
     , mClient(NULL)
     , mClientName(ClientName)
@@ -105,14 +105,14 @@ void JackAudioInterface::setupClient()
     QByteArray clientName = mClientName.toUtf8();
 //    const char* server_name = NULL;
 #ifdef __MAC_OSX__
-    //Jack seems to have an issue with client names over 27 bytes in OS X
+    // Jack seems to have an issue with client names over 27 bytes in OS X
     int maxSize = 27;
 #else
     int maxSize = jack_client_name_size();
 #endif
     if (clientName.length() > maxSize) {
         int length = maxSize;
-        //Make sure we don't cut mid multi-byte character.
+        // Make sure we don't cut mid multi-byte character.
         while ((length > 0) && ((clientName.at(length) & 0xc0) == 0x80)) { length--; }
         clientName.truncate(length);
     }
@@ -130,7 +130,8 @@ void JackAudioInterface::setupClient()
 //#ifndef WAIR // WAIR
 //        mClient = jack_client_open (client_name, options, &status, server_name);
 //#else
-//        mClient = jack_client_open (client_name, JackUseExactName, &status, server_name);
+//        mClient = jack_client_open (client_name, JackUseExactName, &status,
+//        server_name);
 //#endif // endwhere
 #ifndef WAIR  // WAIR
         mClient = jack_client_open(clientName.constData(), options, &status);
@@ -140,14 +141,14 @@ void JackAudioInterface::setupClient()
     }
 
     if (mClient == NULL) {
-        //fprintf (stderr, "jack_client_open() failed, "
+        // fprintf (stderr, "jack_client_open() failed, "
         //	     "status = 0x%2.0x\n", status);
         if (status & JackServerFailed) {
             fprintf(stderr, "Unable to connect to JACK server\n");
-            //std::cerr << "ERROR: Maybe the JACK server is not running?" << std::endl;
-            //std::cerr << gPrintSeparator << std::endl;
+            // std::cerr << "ERROR: Maybe the JACK server is not running?" << std::endl;
+            // std::cerr << gPrintSeparator << std::endl;
         }
-        //std::exit(1);
+        // std::exit(1);
         throw std::runtime_error("Maybe the JACK server is not running?");
     }
     if (status & JackServerStarted) { fprintf(stderr, "JACK server started\n"); }
@@ -173,24 +174,26 @@ void JackAudioInterface::setupClient()
 //*******************************************************************************
 void JackAudioInterface::createChannels()
 {
-    //Create Input Ports
+    // Create Input Ports
     mInPorts.resize(mNumInChans);
     for (int i = 0; i < mNumInChans; i++) {
         QString inName;
         QTextStream(&inName) << "send_" << i + 1;
-        mInPorts[i] = jack_port_register(mClient, inName.toLatin1(),
-                                         JACK_DEFAULT_AUDIO_TYPE, JackPortIsInput | JackPortIsTerminal, 0);
+        mInPorts[i] =
+            jack_port_register(mClient, inName.toLatin1(), JACK_DEFAULT_AUDIO_TYPE,
+                               JackPortIsInput | JackPortIsTerminal, 0);
     }
 
-    //Create Output Ports
+    // Create Output Ports
     mOutPorts.resize(mNumOutChans);
     for (int i = 0; i < mNumOutChans; i++) {
         QString outName;
         QTextStream(&outName) << "receive_" << i + 1;
-        mOutPorts[i] = jack_port_register(mClient, outName.toLatin1(),
-                                          JACK_DEFAULT_AUDIO_TYPE, JackPortIsOutput | JackPortIsTerminal, 0);
+        mOutPorts[i] =
+            jack_port_register(mClient, outName.toLatin1(), JACK_DEFAULT_AUDIO_TYPE,
+                               JackPortIsOutput | JackPortIsTerminal, 0);
     }
-    //Create Broadcast Ports
+    // Create Broadcast Ports
     if (mBroadcast) {
         mBroadcastPorts.resize(mNumOutChans);
         for (int i = 0; i < mNumOutChans; i++) {
@@ -227,22 +230,22 @@ void JackAudioInterface::setProcessCallback()
     std::cout << "Setting JACK Process Callback..." << std::endl;
     if (int code = jack_set_process_callback(
             mClient, JackAudioInterface::wrapperProcessCallback, this)) {
-        //std::cerr << "Could not set the process callback" << std::endl;
-        //return(code);
+        // std::cerr << "Could not set the process callback" << std::endl;
+        // return(code);
         (void)code;  // to avoid compiler warnings
         throw std::runtime_error("Could not set the Jack process callback");
-        //std::exit(1);
+        // std::exit(1);
     }
     std::cout << "SUCCESS" << std::endl;
     std::cout << gPrintSeparator << std::endl;
-    //return(0);
+    // return(0);
 }
 
 //*******************************************************************************
 int JackAudioInterface::startProcess() const
 {
-    //Tell the JACK server that we are ready to roll.  Our
-    //process() callback will start running now.
+    // Tell the JACK server that we are ready to roll.  Our
+    // process() callback will start running now.
     if (int code = (jack_activate(mClient))) {
         std::cerr << "Cannot activate client" << std::endl;
         return (code);
@@ -265,12 +268,12 @@ int JackAudioInterface::stopProcess() const
 //*******************************************************************************
 void JackAudioInterface::jackShutdown(void*)
 {
-    //std::cout << "The Jack Server was shut down!" << std::endl;
+    // std::cout << "The Jack Server was shut down!" << std::endl;
     JackTrip::sJackStopped = true;
     std::cout << "The Jack Server was shut down!" << std::endl;
-    //throw std::runtime_error("The Jack Server was shut down!");
-    //std::cout << "Exiting program..." << std::endl;
-    //std::exit(1);
+    // throw std::runtime_error("The Jack Server was shut down!");
+    // std::cout << "Exiting program..." << std::endl;
+    // std::exit(1);
 }
 
 //*******************************************************************************
@@ -285,7 +288,8 @@ int JackAudioInterface::processCallback(jack_nframes_t nframes)
     // Get input and output buffers from JACK
     //-------------------------------------------------------------------
     for (int i = 0; i < mNumInChans; i++) {
-        // Input Ports are READ ONLY and change as needed (no locks) - make a copy for debugging
+        // Input Ports are READ ONLY and change as needed (no locks) - make a copy for
+        // debugging
         mInBuffer[i] = (sample_t*)jack_port_get_buffer(mInPorts[i], nframes);
     }
     for (int i = 0; i < mNumOutChans; i++) {
@@ -296,8 +300,8 @@ int JackAudioInterface::processCallback(jack_nframes_t nframes)
     // TEST: Loopback
     // To test, uncomment and send audio to client input. The same audio
     // should come out as output in the first channel
-    //memcpy (mOutBuffer[0], mInBuffer[0], sizeof(sample_t) * nframes);
-    //memcpy (mOutBuffer[1], mInBuffer[1], sizeof(sample_t) * nframes);
+    // memcpy (mOutBuffer[0], mInBuffer[0], sizeof(sample_t) * nframes);
+    // memcpy (mOutBuffer[1], mInBuffer[1], sizeof(sample_t) * nframes);
     //-------------------------------------------------------------------
 
     AudioInterface::callback(mInBuffer, mOutBuffer, nframes);
@@ -356,168 +360,3 @@ void JackAudioInterface::connectDefaultPorts()
         std::free(ports);
     }
 }
-
-// OLD CODE (some moved to parent class AudioInterface.cpp)
-// ==============================================================================
-
-//*******************************************************************************
-/*
-int JackAudioInterface::processCallback(jack_nframes_t nframes)
-{
-  // Get input and output buffers from JACK
-  //-------------------------------------------------------------------
-  for (int i = 0; i < mNumInChans; i++) {
-    // Input Ports are READ ONLY
-    mInBuffer[i] = (sample_t*) jack_port_get_buffer(mInPorts[i], nframes);
-  }
-  for (int i = 0; i < mNumOutChans; i++) {
-    // Output Ports are WRITABLE
-    mOutBuffer[i] = (sample_t*) jack_port_get_buffer(mOutPorts[i], nframes);
-  }
-  //-------------------------------------------------------------------
-  // TEST: Loopback
-  // To test, uncomment and send audio to client input. The same audio
-  // should come out as output in the first channel
-  //memcpy (mOutBuffer[0], mInBuffer[0], sizeof(sample_t) * nframes);
-  //memcpy (mOutBuffer[1], mInBuffer[1], sizeof(sample_t) * nframes);
-  //-------------------------------------------------------------------
-
-  // Allocate the Process Callback
-  //-------------------------------------------------------------------
-  // 1) First, process incoming packets
-  // ----------------------------------
-  computeNetworkProcessFromNetwork();
-
-
-  // 2) Dynamically allocate ProcessPlugin processes
-  // -----------------------------------------------
-  // The processing will be done in order of allocation
-
-  ///\todo Implement for more than one process plugin, now it just works propertely with one.
-  /// do it chaining outputs to inputs in the buffers. May need a tempo buffer
-  for (int i = 0; i < mNumInChans; i++) {
-    std::memset(mInProcessBuffer[i], 0, sizeof(sample_t) * nframes);
-    std::memcpy(mInProcessBuffer[i], mOutBuffer[i], sizeof(sample_t) * nframes);
-  }
-  for (int i = 0; i < mNumOutChans; i++) {
-    std::memset(mOutProcessBuffer[i], 0, sizeof(sample_t) * nframes);
-  }
-
-  for (int i = 0; i < mProcessPlugins.size(); i++) {
-    //mProcessPlugins[i]->compute(nframes, mOutBuffer.data(), mInBuffer.data());
-    mProcessPlugins[i]->compute(nframes, mInProcessBuffer.data(), mOutProcessBuffer.data());
-  }
-
-
-  // 3) Finally, send packets to peer
-  // --------------------------------
-  computeNetworkProcessToNetwork();
-*/
-///************PROTORYPE FOR CELT**************************
-///********************************************************
-/*
-  CELTMode* mode;
-  int* error;
-  mode = celt_mode_create(48000, 2, 64, error);
-  */
-//celt_mode_create(48000, 2, 64, NULL);
-//unsigned char* compressed;
-//CELTEncoder* celtEncoder;
-//celt_encode_float(celtEncoder, mInBuffer, NULL, compressed, );
-
-///********************************************************
-///********************************************************
-//  return 0;
-//}
-
-//*******************************************************************************
-/*
-void JackAudioInterface::setRingBuffers
-(const std::tr1::shared_ptr<RingBuffer> InRingBuffer,
- const std::tr1::shared_ptr<RingBuffer> OutRingBuffer)
-{
-  mInRingBuffer = InRingBuffer;
-  mOutRingBuffer = OutRingBuffer;
-}
-*/
-
-//*******************************************************************************
-// Before sending and reading to Jack, we have to round to the sample resolution
-// that the program is using. Jack uses 32 bits (gJackBitResolution in globals.h)
-// by default
-/*
-void JackAudioInterface::computeNetworkProcessFromNetwork()
-{
-  /// \todo cast *mInBuffer[i] to the bit resolution
-  //cout << mNumFrames << endl;
-  // Output Process (from NETWORK to JACK)
-  // ----------------------------------------------------------------
-  // Read Audio buffer from RingBuffer (read from incoming packets)
-  //mOutRingBuffer->readSlotNonBlocking( mOutputPacket );
-  mJackTrip->receiveNetworkPacket( mOutputPacket );
-
-  // Extract separate channels to send to Jack
-  for (int i = 0; i < mNumOutChans; i++) {
-    //--------
-    // This should be faster for 32 bits
-    //std::memcpy(mOutBuffer[i], &mOutputPacket[i*mSizeInBytesPerChannel],
-    //		mSizeInBytesPerChannel);
-    //--------
-    sample_t* tmp_sample = mOutBuffer[i]; //sample buffer for channel i
-    for (int j = 0; j < mNumFrames; j++) {
-      //std::memcpy(&tmp_sample[j], &mOutputPacket[(i*mSizeInBytesPerChannel) + (j*4)], 4);
-      // Change the bit resolution on each sample
-      //cout << tmp_sample[j] << endl;
-      fromBitToSampleConversion(&mOutputPacket[(i*mSizeInBytesPerChannel)
-                 + (j*mBitResolutionMode)],
-        &tmp_sample[j],
-        mBitResolutionMode);
-    }
-  }
-}
-*/
-
-//*******************************************************************************
-/*
-void JackAudioInterface::computeNetworkProcessToNetwork()
-{
-  // Input Process (from JACK to NETWORK)
-  // ----------------------------------------------------------------
-  // Concatenate  all the channels from jack to form packet
-  for (int i = 0; i < mNumInChans; i++) {
-    //--------
-    // This should be faster for 32 bits
-    //std::memcpy(&mInputPacket[i*mSizeInBytesPerChannel], mInBuffer[i],
-    //		mSizeInBytesPerChannel);
-    //--------
-    sample_t* tmp_sample = mInBuffer[i]; //sample buffer for channel i
-    sample_t* tmp_process_sample = mOutProcessBuffer[i]; //sample buffer from the output process
-    sample_t tmp_result;
-    for (int j = 0; j < mNumFrames; j++) {
-      //std::memcpy(&tmp_sample[j], &mOutputPacket[(i*mSizeInBytesPerChannel) + (j*4)], 4);
-      // Change the bit resolution on each sample
-
-      // Add the input jack buffer to the buffer resulting from the output process
-      tmp_result = tmp_sample[j] + tmp_process_sample[j];
-      fromSampleToBitConversion(&tmp_result,
-        &mInputPacket[(i*mSizeInBytesPerChannel)
-                + (j*mBitResolutionMode)],
-        mBitResolutionMode);
-    }
-  }
-  // Send Audio buffer to RingBuffer (these goes out as outgoing packets)
-  //mInRingBuffer->insertSlotNonBlocking( mInputPacket );
-  mJackTrip->sendNetworkPacket( mInputPacket );
-}
-*/
-
-//*******************************************************************************
-/*
-//void JackAudioInterface::appendProcessPlugin(const std::tr1::shared_ptr<ProcessPlugin> plugin)
-void JackAudioInterface::appendProcessPlugin(ProcessPlugin* plugin)
-{
-  /// \todo check that channels in ProcessPlugins are less or same that jack channels
-  if ( plugin->getNumInputs() ) {}
-  mProcessPlugins.append(plugin);
-}
-*/

--- a/src/JackAudioInterface.cpp
+++ b/src/JackAudioInterface.cpp
@@ -179,7 +179,7 @@ void JackAudioInterface::createChannels()
         QString inName;
         QTextStream(&inName) << "send_" << i + 1;
         mInPorts[i] = jack_port_register(mClient, inName.toLatin1(),
-                                         JACK_DEFAULT_AUDIO_TYPE, JackPortIsTerminal, 0);
+                                         JACK_DEFAULT_AUDIO_TYPE, JackPortIsInput | JackPortIsTerminal, 0);
     }
 
     //Create Output Ports
@@ -188,7 +188,7 @@ void JackAudioInterface::createChannels()
         QString outName;
         QTextStream(&outName) << "receive_" << i + 1;
         mOutPorts[i] = jack_port_register(mClient, outName.toLatin1(),
-                                          JACK_DEFAULT_AUDIO_TYPE, JackPortIsTerminal, 0);
+                                          JACK_DEFAULT_AUDIO_TYPE, JackPortIsOutput | JackPortIsTerminal, 0);
     }
     //Create Broadcast Ports
     if (mBroadcast) {

--- a/src/JackAudioInterface.h
+++ b/src/JackAudioInterface.h
@@ -51,23 +51,24 @@
 #include "ProcessPlugin.h"
 #include "jacktrip_types.h"
 
-//class JackTrip; //forward declaration
+// class JackTrip; //forward declaration
 
 /** \brief Class that provides an interface with the Jack Audio Server
  *
  * \todo implement srate_callback
- * \todo automatically starts jack with buffer and sample rate settings specified by the user
+ * \todo automatically starts jack with buffer and sample rate settings specified by the
+ * user
  */
 class JackAudioInterface : public AudioInterface
 {
    public:
     /** \brief The class constructor
-   * \param jacktrip Pointer to the JackTrip class that connects all classes (mediator)
-   * \param NumInChans Number of Input Channels
-   * \param NumOutChans Number of Output Channels
-   * \param AudioBitResolution Audio Sample Resolutions in bits
-   * \param ClientName Client name in Jack
-   */
+     * \param jacktrip Pointer to the JackTrip class that connects all classes (mediator)
+     * \param NumInChans Number of Input Channels
+     * \param NumOutChans Number of Output Channels
+     * \param AudioBitResolution Audio Sample Resolutions in bits
+     * \param ClientName Client name in Jack
+     */
     JackAudioInterface(
         JackTrip* jacktrip, int NumInChans, int NumOutChans,
 #ifdef WAIR  // wair
@@ -81,13 +82,13 @@ class JackAudioInterface : public AudioInterface
     /// \brief Setup the client
     virtual void setup();
     /** \brief Tell the JACK server that we are ready to roll. The
-   * process-callback will start running. This runs on its own thread.
-   * \return 0 on success, otherwise a non-zero error code
-   */
+     * process-callback will start running. This runs on its own thread.
+     * \return 0 on success, otherwise a non-zero error code
+     */
     virtual int startProcess() const;
     /** \brief Stops the process-callback thread
-   * \return 0 on success, otherwise a non-zero error code
-   */
+     * \return 0 on success, otherwise a non-zero error code
+     */
     virtual int stopProcess() const;
     /// \brief Connect the default ports, capture to sends, and receives to playback
     void connectDefaultPorts();
@@ -124,46 +125,45 @@ class JackAudioInterface : public AudioInterface
 
    private:
     /** \brief Private method to setup a client of the Jack server.
-   * \exception std::runtime_error Can't start Jack
-   *
-   * This method is called by the class constructors. It does the following:\n
-   *  - Connects to the JACK server
-   *  - Sets the shutdown process callback
-   *  - Creates the appropriate number of input and output channels
-   */
+     * \exception std::runtime_error Can't start Jack
+     *
+     * This method is called by the class constructors. It does the following:\n
+     *  - Connects to the JACK server
+     *  - Sets the shutdown process callback
+     *  - Creates the appropriate number of input and output channels
+     */
     void setupClient();
     /// \brief Creates input and output channels in the Jack client
     void createChannels();
     /** \brief JACK calls this shutdown_callback if the server ever shuts down or
-   * decides to disconnect the client.
-   */
+     * decides to disconnect the client.
+     */
     static void jackShutdown(void*);
     /** \brief Set the process callback of the member function processCallback.
-   * This process will be called by the JACK server whenever there is work to be done.
-   */
+     * This process will be called by the JACK server whenever there is work to be done.
+     */
     void setProcessCallback();
     /** \brief JACK process callback
-   *
-   * This is the function to be called to process audio. This function is
-   * of the type JackProcessCallback, which is defined as:\n
-   * <tt>typedef int(* JackProcessCallback)(jack_nframes_t nframes, void *arg)</tt>
-   * \n
-   * See
-   * http://jackaudio.org/files/docs/html/types_8h.html#4923142208a8e7dacf00ca7a10681d2b
-   * for more details
-   */
+     *
+     * This is the function to be called to process audio. This function is
+     * of the type JackProcessCallback, which is defined as:\n
+     * <tt>typedef int(* JackProcessCallback)(jack_nframes_t nframes, void *arg)</tt>
+     * \n
+     * See
+     * http://jackaudio.org/files/docs/html/types_8h.html#4923142208a8e7dacf00ca7a10681d2b
+     * for more details
+     */
     int processCallback(jack_nframes_t nframes);
     /** \brief Wrapper to cast the member processCallback to a static function pointer
-   * that can be used with <tt>jack_set_process_callback</tt>
-   *
-   * <tt>jack_set_process_callback</tt> needs a static member function pointer. A normal
-   * member function won't work because a <b><i>this</i></b> pointer is passed under the scenes.
-   * That's why we
-   * need to cast the member funcion processCallback to the static function
-   * wrapperProcessCallback. The callback is then set as:\n
-   * <tt>jack_set_process_callback(mClient, JackAudioInterface::wrapperProcessCallback,
-   *                              this)</tt>
-   */
+     * that can be used with <tt>jack_set_process_callback</tt>
+     *
+     * <tt>jack_set_process_callback</tt> needs a static member function pointer. A normal
+     * member function won't work because a <b><i>this</i></b> pointer is passed under the
+     * scenes. That's why we need to cast the member funcion processCallback to the static
+     * function wrapperProcessCallback. The callback is then set as:\n
+     * <tt>jack_set_process_callback(mClient, JackAudioInterface::wrapperProcessCallback,
+     *                              this)</tt>
+     */
     // reference : http://article.gmane.org/gmane.comp.audio.jackit/12873
     static int wrapperProcessCallback(jack_nframes_t nframes, void* arg);
 
@@ -173,7 +173,7 @@ class JackAudioInterface : public AudioInterface
     int mNumNetRevChans;  ///<  Number of Network Audio Channels (network comb filters
 #endif                    // endwhere
     int mNumFrames;  ///< Buffer block size, in samples
-    //int mAudioBitResolution; ///< Bit resolution in audio samples
+    // int mAudioBitResolution; ///< Bit resolution in audio samples
     AudioInterface::audioBitResolutionT
         mBitResolutionMode;  ///< Bit resolution (audioBitResolutionT) mode
 

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -325,7 +325,7 @@ void JackTrip::setupRingBuffers()
     // Create RingBuffers with the apprioprate size
     /// \todo Make all this operations cleaner
     // int total_audio_packet_size = getTotalAudioPacketSizeInBytes();
-    int input_slot_size = getInputRingBuffersSlotSize();
+    int input_slot_size  = getInputRingBuffersSlotSize();
     int output_slot_size = getOutputRingBuffersSlotSize();
     if (0 <= mBufferStrategy) {
         mUnderRunMode = ZEROS;
@@ -335,8 +335,10 @@ void JackTrip::setupRingBuffers()
 
     switch (mUnderRunMode) {
     case WAVETABLE:
-        mSendRingBuffer = new RingBufferWavetable(input_slot_size, gDefaultOutputQueueLength);
-        mReceiveRingBuffer = new RingBufferWavetable(output_slot_size, mBufferQueueLength);
+        mSendRingBuffer =
+            new RingBufferWavetable(input_slot_size, gDefaultOutputQueueLength);
+        mReceiveRingBuffer =
+            new RingBufferWavetable(output_slot_size, mBufferQueueLength);
         /*
     mSendRingBuffer = new RingBufferWavetable(mAudioInterface->getSizeInBytesPerChannel()
     * mNumChans, gDefaultOutputQueueLength); mReceiveRingBuffer = new
@@ -1053,12 +1055,14 @@ void JackTrip::putHeaderInPacket(int8_t* full_packet, int8_t* audio_packet)
 //*******************************************************************************
 int JackTrip::getSendPacketSizeInBytes() const
 {
-    return (getTotalAudioInputPacketSizeInBytes() + mPacketHeader->getHeaderSizeInBytes());
+    return (getTotalAudioInputPacketSizeInBytes()
+            + mPacketHeader->getHeaderSizeInBytes());
 }
 
 int JackTrip::getReceivePacketSizeInBytes() const
 {
-    return (getTotalAudioOutputPacketSizeInBytes() + mPacketHeader->getHeaderSizeInBytes());
+    return (getTotalAudioOutputPacketSizeInBytes()
+            + mPacketHeader->getHeaderSizeInBytes());
 }
 
 //*******************************************************************************

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -174,11 +174,12 @@ void JackTrip::setupAudio(
         if (gVerboseFlag)
             std::cout << "  JackTrip:setupAudio before new JackAudioInterface"
                       << std::endl;
-        mAudioInterface = new JackAudioInterface(this, mNumAudioChansIn, mNumAudioChansOut,
+        mAudioInterface =
+            new JackAudioInterface(this, mNumAudioChansIn, mNumAudioChansOut,
 #ifdef WAIR  // wair
-                                                 mNumNetRevChans,
+                                   mNumNetRevChans,
 #endif  // endwhere
-                                                 mAudioBitResolution);
+                                   mAudioBitResolution);
 
 #ifdef WAIRTOHUB  // WAIR
         QString VARIABLE_AUDIO_NAME = WAIR_AUDIO_NAME;  // legacy for WAIR
@@ -215,8 +216,8 @@ void JackTrip::setupAudio(
 #ifdef __NO_JACK__  /// \todo FIX THIS REPETITION OF CODE
 #ifdef __RT_AUDIO__
         cout << "Warning: using non jack version, RtAudio will be used instead" << endl;
-        mAudioInterface =
-            new RtAudioInterface(this, mNumAudioChansIn, mNumAudioChansOut, mAudioBitResolution);
+        mAudioInterface = new RtAudioInterface(this, mNumAudioChansIn, mNumAudioChansOut,
+                                               mAudioBitResolution);
         mAudioInterface->setSampleRate(mSampleRate);
         mAudioInterface->setDeviceID(mDeviceID);
         mAudioInterface->setBufferSizeInSamples(mAudioBufferSize);
@@ -225,8 +226,8 @@ void JackTrip::setupAudio(
 #endif
     } else if (mAudiointerfaceMode == JackTrip::RTAUDIO) {
 #ifdef __RT_AUDIO__
-        mAudioInterface =
-            new RtAudioInterface(this, mNumAudioChansIn, mNumAudioChansOut, mAudioBitResolution);
+        mAudioInterface = new RtAudioInterface(this, mNumAudioChansIn, mNumAudioChansOut,
+                                               mAudioBitResolution);
         mAudioInterface->setSampleRate(mSampleRate);
         mAudioInterface->setDeviceID(mDeviceID);
         mAudioInterface->setBufferSizeInSamples(mAudioBufferSize);
@@ -341,9 +342,11 @@ void JackTrip::setupRingBuffers()
             new RingBufferWavetable(audio_output_slot_size, mBufferQueueLength);
         break;
     case ZEROS:
-        mSendRingBuffer = new RingBuffer(audio_input_slot_size, gDefaultOutputQueueLength);
+        mSendRingBuffer =
+            new RingBuffer(audio_input_slot_size, gDefaultOutputQueueLength);
         if (0 > mBufferStrategy) {
-            mReceiveRingBuffer = new RingBuffer(audio_output_slot_size, mBufferQueueLength);
+            mReceiveRingBuffer =
+                new RingBuffer(audio_output_slot_size, mBufferQueueLength);
         } else {
             cout << "Using JitterBuffer strategy " << mBufferStrategy << endl;
             if (0 > mBufferQueueLength) {

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -1027,7 +1027,20 @@ void JackTrip::createHeader(const DataProtocol::packetHeaderTypeT headertype)
 }
 
 //*******************************************************************************
-void JackTrip::putHeaderInPacket(int8_t* full_packet, int8_t* audio_packet)
+void JackTrip::putHeaderInIncomingPacket(int8_t* full_packet, int8_t* audio_packet)
+{
+    mPacketHeader->fillHeaderCommonFromAudio();
+    mPacketHeader->putHeaderInPacket(full_packet);
+
+    int8_t* audio_part;
+    audio_part = full_packet + mPacketHeader->getHeaderSizeInBytes();
+    // std::memcpy(audio_part, audio_packet, mAudioInterface->getBufferSizeInBytes());
+    // std::memcpy(audio_part, audio_packet, mAudioInterface->getSizeInBytesPerChannel() *
+    // mNumChans);
+    std::memcpy(audio_part, audio_packet, getTotalAudioOutputPacketSizeInBytes());
+}
+
+void JackTrip::putHeaderInOutgoingPacket(int8_t* full_packet, int8_t* audio_packet)
 {
     mPacketHeader->fillHeaderCommonFromAudio();
     mPacketHeader->putHeaderInPacket(full_packet);

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -60,8 +60,9 @@
 using std::cout;
 using std::endl;
 
-//the following function has to remain outside the Jacktrip class definition
-//its purpose is to close the app when control c is hit by the user in rtaudio/asio4all mode
+// the following function has to remain outside the Jacktrip class definition
+// its purpose is to close the app when control c is hit by the user in rtaudio/asio4all
+// mode
 /*if defined __WIN_32__
 void sigint_handler(int sig)
 {
@@ -143,7 +144,7 @@ JackTrip::JackTrip(jacktripModeT JacktripMode, dataProtocolT DataProtocolType,
 //*******************************************************************************
 JackTrip::~JackTrip()
 {
-    //wait();
+    // wait();
     delete mDataProtocolSender;
     delete mDataProtocolReceiver;
     delete mAudioInterface;
@@ -182,12 +183,12 @@ void JackTrip::setupAudio(
 
 #ifdef WAIRTOHUB  // WAIR
         QString VARIABLE_AUDIO_NAME = WAIR_AUDIO_NAME;  // legacy for WAIR
-        //Set our Jack client name if we're a hub server or a custom name hasn't been set
+        // Set our Jack client name if we're a hub server or a custom name hasn't been set
         if (!mPeerAddress.isEmpty()
             && (mJackClientName.constData() == gJackDefaultClientName.constData())) {
             mJackClientName = QString(mPeerAddress).replace(":", "_");
         }
-        //std::cout  << "WAIR ID " << ID << " jacktrip client name set to=" <<
+        // std::cout  << "WAIR ID " << ID << " jacktrip client name set to=" <<
         //              mJackClientName.toStdString() << std::endl;
 
 #endif  // endwhere
@@ -235,7 +236,8 @@ void JackTrip::setupAudio(
     }
 
     mAudioInterface->setLoopBack(mLoopBack);
-    if (mAudioTesterP) {  // if we're a hub server, this will be a nullptr - MAJOR REFACTOR NEEDED, in my opinion
+    if (mAudioTesterP) {  // if we're a hub server, this will be a nullptr - MAJOR
+                          // REFACTOR NEEDED, in my opinion
         mAudioTesterP->setSampleRate(mSampleRate);
     }
     mAudioInterface->setAudioTesterP(mAudioTesterP);
@@ -263,7 +265,7 @@ void JackTrip::setupAudio(
 //*******************************************************************************
 void JackTrip::closeAudio()
 {
-    //mAudioInterface->close();
+    // mAudioInterface->close();
     if (mAudioInterface != NULL) {
         mAudioInterface->stopProcess();
         delete mAudioInterface;
@@ -283,7 +285,7 @@ void JackTrip::setupDataProtocol()
         QThread::usleep(100);
         mDataProtocolSender =
             new UdpDataProtocol(this, DataProtocol::SENDER,
-                                //mSenderPeerPort, mSenderBindPort,
+                                // mSenderPeerPort, mSenderBindPort,
                                 mSenderBindPort, mSenderPeerPort, mRedundancy);
         mDataProtocolReceiver =
             new UdpDataProtocol(this, DataProtocol::RECEIVER, mReceiverBindPort,
@@ -312,9 +314,9 @@ void JackTrip::setupDataProtocol()
     }
 
     // Set Audio Packet Size
-    //mDataProtocolSender->setAudioPacketSize
+    // mDataProtocolSender->setAudioPacketSize
     //  (mAudioInterface->getSizeInBytesPerChannel() * mNumChans);
-    //mDataProtocolReceiver->setAudioPacketSize
+    // mDataProtocolReceiver->setAudioPacketSize
     //  (mAudioInterface->getSizeInBytesPerChannel() * mNumChans);
     mDataProtocolSender->setAudioPacketSize(getTotalAudioPacketSizeInBytes());
     mDataProtocolReceiver->setAudioPacketSize(getTotalAudioPacketSizeInBytes());
@@ -325,7 +327,7 @@ void JackTrip::setupRingBuffers()
 {
     // Create RingBuffers with the apprioprate size
     /// \todo Make all this operations cleaner
-    //int total_audio_packet_size = getTotalAudioPacketSizeInBytes();
+    // int total_audio_packet_size = getTotalAudioPacketSizeInBytes();
     int slot_size = getRingBuffersSlotSize();
     if (0 <= mBufferStrategy) {
         mUnderRunMode = ZEROS;
@@ -338,9 +340,9 @@ void JackTrip::setupRingBuffers()
         mSendRingBuffer = new RingBufferWavetable(slot_size, gDefaultOutputQueueLength);
         mReceiveRingBuffer = new RingBufferWavetable(slot_size, mBufferQueueLength);
         /*
-    mSendRingBuffer = new RingBufferWavetable(mAudioInterface->getSizeInBytesPerChannel() * mNumChans,
-                gDefaultOutputQueueLength);
-    mReceiveRingBuffer = new RingBufferWavetable(mAudioInterface->getSizeInBytesPerChannel() * mNumChans,
+    mSendRingBuffer = new RingBufferWavetable(mAudioInterface->getSizeInBytesPerChannel()
+    * mNumChans, gDefaultOutputQueueLength); mReceiveRingBuffer = new
+    RingBufferWavetable(mAudioInterface->getSizeInBytesPerChannel() * mNumChans,
              mBufferQueueLength);
              */
         break;
@@ -358,9 +360,9 @@ void JackTrip::setupRingBuffers()
                 mBroadcastQueueLength, mNumChans, mAudioBitResolution);
         }
         /*
-    mSendRingBuffer = new RingBuffer(mAudioInterface->getSizeInBytesPerChannel() * mNumChans,
-             gDefaultOutputQueueLength);
-    mReceiveRingBuffer = new RingBuffer(mAudioInterface->getSizeInBytesPerChannel() * mNumChans,
+    mSendRingBuffer = new RingBuffer(mAudioInterface->getSizeInBytesPerChannel() *
+    mNumChans, gDefaultOutputQueueLength); mReceiveRingBuffer = new
+    RingBuffer(mAudioInterface->getSizeInBytesPerChannel() * mNumChans,
           mBufferQueueLength);
           */
         break;
@@ -378,7 +380,7 @@ void JackTrip::appendProcessPluginToNetwork(ProcessPlugin* plugin)
 {
     if (plugin) {
         mProcessPluginsToNetwork.append(plugin);  // ownership transferred
-        //mAudioInterface->appendProcessPluginToNetwork(plugin);
+        // mAudioInterface->appendProcessPluginToNetwork(plugin);
     }
 }
 
@@ -387,7 +389,7 @@ void JackTrip::appendProcessPluginFromNetwork(ProcessPlugin* plugin)
 {
     if (plugin) {
         mProcessPluginsFromNetwork.append(plugin);  // ownership transferred
-        //mAudioInterface->appendProcessPluginFromNetwork(plugin);
+        // mAudioInterface->appendProcessPluginFromNetwork(plugin);
     }
 }
 
@@ -397,7 +399,7 @@ void JackTrip::startProcess(
     int ID
 #endif  // endwhere
 )
-{  //signal that catches ctrl c in rtaudio-asio mode
+{  // signal that catches ctrl c in rtaudio-asio mode
     /*#if defined (__WIN_32__)
     if (signal(SIGINT, sigint_handler) == SIG_ERR) {
         perror("signal");
@@ -413,8 +415,9 @@ void JackTrip::startProcess(
             << "  JackTrip:startProcess before checkIfPortIsBinded(mReceiverBindPort)"
             << std::endl;
 #if defined __WIN_32__
-        //cc fixed windows crash with this print statement!
-        //qDebug() << "before mJackTrip->startProcess" << mReceiverBindPort<< mSenderBindPort;
+        // cc fixed windows crash with this print statement!
+        // qDebug() << "before mJackTrip->startProcess" << mReceiverBindPort<<
+        // mSenderBindPort;
 #endif
     checkIfPortIsBinded(mReceiverBindPort);
     if (gVerboseFlag)
@@ -430,7 +433,8 @@ void JackTrip::startProcess(
         ID
 #endif  // endwhere
     );
-    //cc redundant with instance creator  createHeader(mPacketHeaderType); next line fixme
+    // cc redundant with instance creator  createHeader(mPacketHeaderType); next line
+    // fixme
     createHeader(mPacketHeaderType);
     setupDataProtocol();
     setupRingBuffers();
@@ -440,7 +444,7 @@ void JackTrip::startProcess(
                      &JackTrip::slotStopProcessesDueToError, Qt::QueuedConnection);
     QObject::connect(mDataProtocolReceiver, SIGNAL(signalReceivedConnectionFromPeer()),
                      this, SLOT(slotReceivedConnectionFromPeer()), Qt::QueuedConnection);
-    //QObject::connect(this, SIGNAL(signalUdpTimeOut()),
+    // QObject::connect(this, SIGNAL(signalUdpTimeOut()),
     //                 this, SLOT(slotStopProcesses()), Qt::QueuedConnection);
     QObject::connect((UdpDataProtocol*)mDataProtocolReceiver,
                      &UdpDataProtocol::signalUdpWaitingTooLong, this,
@@ -450,7 +454,7 @@ void JackTrip::startProcess(
     QObject::connect(mDataProtocolReceiver, &DataProtocol::signalCeaseTransmission, this,
                      &JackTrip::slotStopProcessesDueToError, Qt::QueuedConnection);
 
-    //QObject::connect(mDataProtocolSender, SIGNAL(signalError(const char*)),
+    // QObject::connect(mDataProtocolSender, SIGNAL(signalError(const char*)),
     //                 this, SLOT(slotStopProcesses()), Qt::QueuedConnection);
     QObject::connect(mDataProtocolReceiver, SIGNAL(signalError(const char*)), this,
                      SLOT(slotStopProcesses()), Qt::QueuedConnection);
@@ -526,9 +530,8 @@ void JackTrip::completeConnection()
     /*
      * changed order so that audio starts after receiver and sender
      * because UdpDataProtocol:run0 before setRealtimeProcessPriority()
-     * causes an audio hiccup from jack JackPosixSemaphore::TimedWait err = Interrupted system call
-     * new QThread::msleep(1);
-     * to allow sender to start
+     * causes an audio hiccup from jack JackPosixSemaphore::TimedWait err = Interrupted
+     * system call new QThread::msleep(1); to allow sender to start
      */
     QThread::msleep(1);
     if (gVerboseFlag) std::cout << "step 5" << std::endl;
@@ -546,7 +549,7 @@ void JackTrip::completeConnection()
 
     if (mConnectDefaultAudioPorts) { mAudioInterface->connectDefaultPorts(); }
 
-    //Start our IO stat timer
+    // Start our IO stat timer
     if (mIOStatTimeout > 0) {
         cout << "STATS" << mIOStatTimeout << endl;
         if (!mIOStatStream.isNull()) {
@@ -603,16 +606,16 @@ void JackTrip::receivedConnectionTCP()
     std::memcpy(port_buf, &mReceiverBindPort, sizeof(mReceiverBindPort));
     std::memset(port_buf + sizeof(mReceiverBindPort), 0, gMaxRemoteNameLength);
     if (!mRemoteClientName.isEmpty()) {
-        //If our remote client name is set, send it too.
+        // If our remote client name is set, send it too.
         QByteArray name = mRemoteClientName.toUtf8();
         // Find a clean place to truncate if we're over length.
         // (Make sure we're not in the middle of a multi-byte characetr.)
         int length = name.length();
-        //Need to take the final null terminator into account here.
+        // Need to take the final null terminator into account here.
         if (length > gMaxRemoteNameLength - 1) {
             length = gMaxRemoteNameLength - 1;
             while ((length > 0) && ((name.at(length) & 0xc0) == 0x80)) {
-                //We're in the middle of a multi-byte character. Work back.
+                // We're in the middle of a multi-byte character. Work back.
                 length--;
             }
         }
@@ -625,7 +628,7 @@ void JackTrip::receivedConnectionTCP()
         mTcpClient.waitForBytesWritten(-1);
     }*/
     if (gVerboseFlag) cout << "Port " << mReceiverBindPort << " sent to Server" << endl;
-    //Continued in receivedDataTCP slot
+    // Continued in receivedDataTCP slot
 }
 
 void JackTrip::receivedDataTCP()
@@ -642,15 +645,15 @@ void JackTrip::receivedDataTCP()
     uint32_t udp_port;
     int size = sizeof(udp_port);
     char port_buf[sizeof(mReceiverBindPort)];
-    //char port_buf[size];
+    // char port_buf[size];
     mTcpClient.read(port_buf, size);
     std::memcpy(&udp_port, port_buf, size);
-    //cout << "Received UDP Port Number: " << udp_port << endl;
+    // cout << "Received UDP Port Number: " << udp_port << endl;
 
     // Close the TCP Socket
     // --------------------
     mTcpClient.close();  // Close the socket
-    //cout << "TCP Socket Closed!" << endl;
+    // cout << "TCP Socket Closed!" << endl;
     if (gVerboseFlag) cout << "Connection Successful!" << endl;
 
     // Set with the received UDP port
@@ -668,7 +671,7 @@ void JackTrip::receivedDataTCP()
 
 void JackTrip::receivedDataUDP()
 {
-    //Stop our timer.
+    // Stop our timer.
     mTimeoutTimer.stop();
 
     QHostAddress peerHostAddress;
@@ -725,7 +728,7 @@ void JackTrip::receivedDataUDP()
 void JackTrip::udpTimerTick()
 {
     if (mStopped || sSigInt || sJackStopped) {
-        //Stop everything.
+        // Stop everything.
         mUdpSockTemp.close();
         mTimeoutTimer.stop();
         stop();
@@ -744,7 +747,7 @@ void JackTrip::udpTimerTick()
 void JackTrip::tcpTimerTick()
 {
     if (mStopped || sSigInt || sJackStopped) {
-        //Stop everything.
+        // Stop everything.
         mTcpClient.close();
         mTimeoutTimer.stop();
         stop();
@@ -763,7 +766,7 @@ void JackTrip::tcpTimerTick()
 void JackTrip::stop(QString errorMessage)
 {
     mStopped = true;
-    //Make sure we're only run once
+    // Make sure we're only run once
     if (mHasShutdown) { return; }
     mHasShutdown = true;
     std::cout << "Stopping JackTrip..." << std::endl;
@@ -777,7 +780,7 @@ void JackTrip::stop(QString errorMessage)
     mDataProtocolReceiver->wait();
 
     // Stop the audio processes
-    //mAudioInterface->stopProcess();
+    // mAudioInterface->stopProcess();
     closeAudio();
 
     cout << "JackTrip Processes STOPPED!" << endl;
@@ -824,9 +827,10 @@ int JackTrip::serverStart(bool timeout, int udpTimeout)  // udpTimeout unused
         if (gVerboseFlag)
             std::cout << "WARNING: SERVER mode: Peer Address was set but will be deleted."
                       << endl;
-        //throw std::invalid_argument("Peer Address has to be set if you run in CLIENT mode");
+        // throw std::invalid_argument("Peer Address has to be set if you run in CLIENT
+        // mode");
         mPeerAddress.clear();
-        //return;
+        // return;
     }
 
     // Get the client address when it connects
@@ -864,8 +868,8 @@ int JackTrip::serverStart(bool timeout, int udpTimeout)  // udpTimeout unused
 //*******************************************************************************
 int JackTrip::clientPingToServerStart()
 {
-    //mConnectionMode = JackTrip::KSTRONG;
-    //mConnectionMode = JackTrip::JAMTEST;
+    // mConnectionMode = JackTrip::KSTRONG;
+    // mConnectionMode = JackTrip::JAMTEST;
 
     // Set Peer (server in this case) address
     // --------------------------------------
@@ -892,7 +896,7 @@ int JackTrip::clientPingToServerStart()
     connect(&mTcpClient, &QTcpSocket::readyRead, this, &JackTrip::receivedDataTCP);
     connect(&mTcpClient, &QTcpSocket::connected, this, &JackTrip::receivedConnectionTCP);
     mElapsedTime = 0;
-    mEndTime     = 5000;  //Timeout after 5 seconds.
+    mEndTime     = 5000;  // Timeout after 5 seconds.
     mTimeoutTimer.setInterval(mSleepTime);
     connect(&mTimeoutTimer, &QTimer::timeout, this, &JackTrip::tcpTimerTick);
     mTimeoutTimer.start();
@@ -930,7 +934,8 @@ int JackTrip::clientPingToServerStart()
   if ( !UdpSockTemp.bind(QHostAddress::Any,
                          mReceiverBindPort,
                          QUdpSocket::ShareAddress) ) {
-    //throw std::runtime_error("Could not bind PingToServer UDP socket. It may be already binded.");
+    //throw std::runtime_error("Could not bind PingToServer UDP socket. It may be already
+  binded.");
   }
 
   // Listen to server response
@@ -970,8 +975,8 @@ throw(std::runtime_error)
   struct sockaddr_in local_addr;
   ::bzero(&local_addr, sizeof(local_addr));
   local_addr.sin_family = AF_INET; //AF_INET: IPv4 Protocol
-  local_addr.sin_addr.s_addr = htonl(INADDR_ANY); //INADDR_ANY: let the kernel decide the active address
-  local_addr.sin_port = htons(bind_port); //set bind port
+  local_addr.sin_addr.s_addr = htonl(INADDR_ANY); //INADDR_ANY: let the kernel decide the
+active address local_addr.sin_port = htons(bind_port); //set bind port
 
   // Set socket to be reusable, this is platform dependent
   int one = 1;
@@ -994,8 +999,8 @@ throw(std::runtime_error)
   struct sockaddr_in peer_addr;
   bzero(&peer_addr, sizeof(peer_addr));
   peer_addr.sin_family = AF_INET; //AF_INET: IPv4 Protocol
-  peer_addr.sin_addr.s_addr = htonl(INADDR_ANY); //INADDR_ANY: let the kernel decide the active address
-  peer_addr.sin_port = htons(peer_port); //set local port
+  peer_addr.sin_addr.s_addr = htonl(INADDR_ANY); //INADDR_ANY: let the kernel decide the
+active address peer_addr.sin_port = htons(peer_port); //set local port
   // Connect the socket and issue a Write shutdown (to make it a
   // reader socket only)
   if ( (::inet_pton(AF_INET, PeerHostAddress.toString().toLatin1().constData(),
@@ -1016,7 +1021,7 @@ throw(std::runtime_error)
 //*******************************************************************************
 void JackTrip::createHeader(const DataProtocol::packetHeaderTypeT headertype)
 {
-    delete mPacketHeader;  //Just in case it has already been allocated
+    delete mPacketHeader;  // Just in case it has already been allocated
     switch (headertype) {
     case DataProtocol::DEFAULT:
         mPacketHeader = new DefaultHeader(this);
@@ -1041,17 +1046,19 @@ void JackTrip::putHeaderInPacket(int8_t* full_packet, int8_t* audio_packet)
 
     int8_t* audio_part;
     audio_part = full_packet + mPacketHeader->getHeaderSizeInBytes();
-    //std::memcpy(audio_part, audio_packet, mAudioInterface->getBufferSizeInBytes());
-    //std::memcpy(audio_part, audio_packet, mAudioInterface->getSizeInBytesPerChannel() * mNumChans);
+    // std::memcpy(audio_part, audio_packet, mAudioInterface->getBufferSizeInBytes());
+    // std::memcpy(audio_part, audio_packet, mAudioInterface->getSizeInBytesPerChannel() *
+    // mNumChans);
     std::memcpy(audio_part, audio_packet, getTotalAudioPacketSizeInBytes());
 }
 
 //*******************************************************************************
 int JackTrip::getPacketSizeInBytes()
 {
-    //return (mAudioInterface->getBufferSizeInBytes() + mPacketHeader->getHeaderSizeInBytes());
-    //return (mAudioInterface->getSizeInBytesPerChannel() * mNumChans  +
-    //mPacketHeader->getHeaderSizeInBytes());
+    // return (mAudioInterface->getBufferSizeInBytes() +
+    // mPacketHeader->getHeaderSizeInBytes()); return
+    // (mAudioInterface->getSizeInBytesPerChannel() * mNumChans  +
+    // mPacketHeader->getHeaderSizeInBytes());
     return (getTotalAudioPacketSizeInBytes() + mPacketHeader->getHeaderSizeInBytes());
 }
 
@@ -1060,8 +1067,9 @@ void JackTrip::parseAudioPacket(int8_t* full_packet, int8_t* audio_packet)
 {
     int8_t* audio_part;
     audio_part = full_packet + mPacketHeader->getHeaderSizeInBytes();
-    //std::memcpy(audio_packet, audio_part, mAudioInterface->getBufferSizeInBytes());
-    //std::memcpy(audio_packet, audio_part, mAudioInterface->getSizeInBytesPerChannel() * mNumChans);
+    // std::memcpy(audio_packet, audio_part, mAudioInterface->getBufferSizeInBytes());
+    // std::memcpy(audio_packet, audio_part, mAudioInterface->getSizeInBytesPerChannel() *
+    // mNumChans);
     std::memcpy(audio_packet, audio_part, getTotalAudioPacketSizeInBytes());
 }
 
@@ -1076,7 +1084,8 @@ void JackTrip::checkIfPortIsBinded(int port)
 {
     QUdpSocket UdpSockTemp;  // Create socket to wait for client
     // Bind the socket
-    //cc        if ( !UdpSockTemp.bind(QHostAddress::AnyIPv4, port, QUdpSocket::DontShareAddress) )
+    // cc        if ( !UdpSockTemp.bind(QHostAddress::AnyIPv4, port,
+    // QUdpSocket::DontShareAddress) )
     if (!UdpSockTemp.bind(QHostAddress::Any, port, QUdpSocket::DontShareAddress)) {
         UdpSockTemp.close();  // close the socket
         throw std::runtime_error(

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -117,7 +117,6 @@ JackTrip::JackTrip(jacktripModeT JacktripMode, dataProtocolT DataProtocolType,
     , mTcpServerPort(tcp_peer_port)
     , mRedundancy(redundancy)
     , mJackClientName(gJackDefaultClientName)
-    , mConnectionMode(JackTrip::NORMAL)
     , mTimeoutTimer(this)
     , mSleepTime(100)
     , mElapsedTime(0)

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -74,7 +74,7 @@ bool JackTrip::sJackStopped = false;
 
 //*******************************************************************************
 JackTrip::JackTrip(jacktripModeT JacktripMode, dataProtocolT DataProtocolType,
-                   int NumChans,
+                   int NumChansIn, int NumChansOut,
 #ifdef WAIR  // WAIR
                    int NumNetRevChans,
 #endif  // endwhere
@@ -88,13 +88,12 @@ JackTrip::JackTrip(jacktripModeT JacktripMode, dataProtocolT DataProtocolType,
     , mDataProtocol(DataProtocolType)
     , mPacketHeaderType(PacketHeaderType)
     , mAudiointerfaceMode(JackTrip::JACK)
-    , mNumChans(NumChans)
-    ,
+    , mNumChansIn(NumChansIn)
+    , mNumChansOut(NumChansOut)
 #ifdef WAIR  // WAIR
-    mNumNetRevChans(NumNetRevChans)
-    ,
+    , mNumNetRevChans(NumNetRevChans)
 #endif  // endwhere
-    mBufferQueueLength(BufferQueueLength)
+    , mBufferQueueLength(BufferQueueLength)
     , mBufferStrategy(1)
     , mBroadcastQueueLength(0)
     , mSampleRate(gDefaultSampleRate)
@@ -175,7 +174,7 @@ void JackTrip::setupAudio(
         if (gVerboseFlag)
             std::cout << "  JackTrip:setupAudio before new JackAudioInterface"
                       << std::endl;
-        mAudioInterface = new JackAudioInterface(this, mNumChans, mNumChans,
+        mAudioInterface = new JackAudioInterface(this, mNumChansIn, mNumChansOut,
 #ifdef WAIR  // wair
                                                  mNumNetRevChans,
 #endif  // endwhere
@@ -217,7 +216,7 @@ void JackTrip::setupAudio(
 #ifdef __RT_AUDIO__
         cout << "Warning: using non jack version, RtAudio will be used instead" << endl;
         mAudioInterface =
-            new RtAudioInterface(this, mNumChans, mNumChans, mAudioBitResolution);
+            new RtAudioInterface(this, mNumChansIn, mNumChansOut, mAudioBitResolution);
         mAudioInterface->setSampleRate(mSampleRate);
         mAudioInterface->setDeviceID(mDeviceID);
         mAudioInterface->setBufferSizeInSamples(mAudioBufferSize);
@@ -227,7 +226,7 @@ void JackTrip::setupAudio(
     } else if (mAudiointerfaceMode == JackTrip::RTAUDIO) {
 #ifdef __RT_AUDIO__
         mAudioInterface =
-            new RtAudioInterface(this, mNumChans, mNumChans, mAudioBitResolution);
+            new RtAudioInterface(this, mNumChansIn, mNumChansOut, mAudioBitResolution);
         mAudioInterface->setSampleRate(mSampleRate);
         mAudioInterface->setDeviceID(mDeviceID);
         mAudioInterface->setBufferSizeInSamples(mAudioBufferSize);

--- a/src/JackTrip.h
+++ b/src/JackTrip.h
@@ -132,7 +132,7 @@ class JackTrip : public QObject
      */
     JackTrip(
         jacktripModeT JacktripMode = CLIENT, dataProtocolT DataProtocolType = UDP,
-        int NumChans = gDefaultNumInChannels,
+        int NumChansIn = gDefaultNumInChannels, int NumChansOut = gDefaultNumInChannels,
 #ifdef WAIR  // wair
         int NumNetRevChans = 0,
 #endif  // endwhere
@@ -261,8 +261,10 @@ class JackTrip : public QObject
     {
         mRemoteClientName = remoteClientName;
     }
-    /// \brief Set the number of audio channels
-    virtual void setNumChannels(int num_chans) { mNumChans = num_chans; }
+    /// \brief Set the number of audio input channels
+    virtual void setNumInputChannels(int num_chans) { mNumChansIn = num_chans; }
+    /// \brief Set the number of audio output channels
+    virtual void setNumOutputChannels(int num_chans) { mNumChansOut = num_chans; }
 
     virtual void setIOStatTimeout(int timeout) { mIOStatTimeout = timeout; }
     virtual void setIOStatStream(QSharedPointer<std::ofstream> statStream)
@@ -407,13 +409,14 @@ class JackTrip : public QObject
     }
     unsigned int getNumInputChannels() const
     {
-        return mNumChans; /*return mAudioInterface->getNumInputChannels();*/
+        return mNumChansIn; /*return mAudioInterface->getNumInputChannels();*/
     }
     unsigned int getNumOutputChannels() const
     {
-        return mNumChans; /*return mAudioInterface->getNumOutputChannels();*/
+        return mNumChansOut; /*return mAudioInterface->getNumOutputChannels();*/
     }
-    unsigned int getNumChannels() const
+
+    [[deprecated]] unsigned int getNumChannels() const
     {
         if (getNumInputChannels() == getNumOutputChannels()) {
             return getNumInputChannels();
@@ -575,8 +578,9 @@ class JackTrip : public QObject
     DataProtocol::packetHeaderTypeT mPacketHeaderType;  ///< Packet Header Type
     JackTrip::audiointerfaceModeT mAudiointerfaceMode;
 
-    int mNumChans;  ///< Number of Channels (inputs = outputs)
-#ifdef WAIR         // WAIR
+    int mNumChansIn;   ///< Number of Input Channels
+    int mNumChansOut;  ///< Number of Output Channels
+#ifdef WAIR            // WAIR
     int mNumNetRevChans;  ///< Number of Network Audio Channels (net comb filters)
 #endif                    // endwhere
     int mBufferQueueLength;  ///< Audio Buffer from network queue length

--- a/src/JackTrip.h
+++ b/src/JackTrip.h
@@ -313,8 +313,14 @@ class JackTrip : public QObject
         mPacketHeader = PacketHeader;
     }
 
-    virtual int getInputRingBuffersSlotSize() { return getTotalAudioInputPacketSizeInBytes(); }
-    virtual int getOutputRingBuffersSlotSize() { return getTotalAudioOutputPacketSizeInBytes(); }
+    virtual int getInputRingBuffersSlotSize()
+    {
+        return getTotalAudioInputPacketSizeInBytes();
+    }
+    virtual int getOutputRingBuffersSlotSize()
+    {
+        return getTotalAudioOutputPacketSizeInBytes();
+    }
 
     virtual void setAudiointerfaceMode(JackTrip::audiointerfaceModeT audiointerface_mode)
     {

--- a/src/JackTrip.h
+++ b/src/JackTrip.h
@@ -262,9 +262,9 @@ class JackTrip : public QObject
         mRemoteClientName = remoteClientName;
     }
     /// \brief Set the number of audio input channels
-    virtual void setNumInputChannels(int num_chans) { mNumChansIn = num_chans; }
+    virtual void setNumInputChannels(int num_chans) { mNumAudioChansIn = num_chans; }
     /// \brief Set the number of audio output channels
-    virtual void setNumOutputChannels(int num_chans) { mNumChansOut = num_chans; }
+    virtual void setNumOutputChannels(int num_chans) { mNumAudioChansOut = num_chans; }
 
     virtual void setIOStatTimeout(int timeout) { mIOStatTimeout = timeout; }
     virtual void setIOStatStream(QSharedPointer<std::ofstream> statStream)
@@ -410,11 +410,11 @@ class JackTrip : public QObject
     }
     unsigned int getNumInputChannels() const
     {
-        return mNumChansIn; /*return mAudioInterface->getNumInputChannels();*/
+        return mNumAudioChansIn; /*return mAudioInterface->getNumInputChannels();*/
     }
     unsigned int getNumOutputChannels() const
     {
-        return mNumChansOut; /*return mAudioInterface->getNumOutputChannels();*/
+        return mNumAudioChansOut; /*return mAudioInterface->getNumOutputChannels();*/
     }
 
     virtual void checkPeerSettings(int8_t* full_packet);
@@ -468,7 +468,7 @@ class JackTrip : public QObject
             return mAudioInterface->getSizeInBytesPerChannel() * mNumNetRevChans;
         else  // not wair
 #endif        // endwhere
-            return mAudioInterface->getSizeInBytesPerChannel() * mNumChansIn;
+            return mAudioInterface->getSizeInBytesPerChannel() * mNumAudioChansIn;
     }
 
     int getTotalAudioOutputPacketSizeInBytes() const
@@ -478,7 +478,7 @@ class JackTrip : public QObject
             return mAudioInterface->getSizeInBytesPerChannel() * mNumNetRevChans;
         else  // not wair
 #endif        // endwhere
-            return mAudioInterface->getSizeInBytesPerChannel() * mNumChansOut;
+            return mAudioInterface->getSizeInBytesPerChannel() * mNumAudioChansOut;
     }
     //@}
     //------------------------------------------------------------------------------------
@@ -581,8 +581,8 @@ class JackTrip : public QObject
     DataProtocol::packetHeaderTypeT mPacketHeaderType;  ///< Packet Header Type
     JackTrip::audiointerfaceModeT mAudiointerfaceMode;
 
-    int mNumChansIn;   ///< Number of Input Channels
-    int mNumChansOut;  ///< Number of Output Channels
+    int mNumAudioChansIn;   ///< Number of Audio Input Channels
+    int mNumAudioChansOut;  ///< Number of Audio Output Channels
 #ifdef WAIR            // WAIR
     int mNumNetRevChans;  ///< Number of Network Audio Channels (net comb filters)
 #endif                    // endwhere

--- a/src/JackTrip.h
+++ b/src/JackTrip.h
@@ -101,11 +101,11 @@ class JackTrip : public QObject
     };
 
     /// \brief Enum for Connection Mode (in packet header)
-    enum connectionModeT {
+/*    enum connectionModeT {
         NORMAL,   ///< Normal Mode
         KSTRONG,  ///< Karplus Strong
         JAMTEST   ///< Karplus Strong
-    };
+    }; */
 
     /// \brief Enum for Hub Server Audio Connection Mode (connections to hub server are
     /// automatically patched in Jack)
@@ -331,11 +331,13 @@ class JackTrip : public QObject
     void setDeviceID(uint32_t device_id) { mDeviceID = device_id; }
     void setAudioBufferSizeInSamples(uint32_t buf_size) { mAudioBufferSize = buf_size; }
 
+         /*
     JackTrip::connectionModeT getConnectionMode() const { return mConnectionMode; }
     void setConnectionMode(JackTrip::connectionModeT connection_mode)
     {
         mConnectionMode = connection_mode;
     }
+          */
 
     JackTrip::hubConnectionModeT getHubConnectionModeT() const
     {
@@ -417,14 +419,6 @@ class JackTrip : public QObject
         return mNumChansOut; /*return mAudioInterface->getNumOutputChannels();*/
     }
 
-    [[deprecated]] unsigned int getNumChannels() const
-    {
-        if (getNumInputChannels() == getNumOutputChannels()) {
-            return getNumInputChannels();
-        } else {
-            return 0;
-        }
-    }
     virtual void checkPeerSettings(int8_t* full_packet);
     void increaseSequenceNumber() { mPacketHeader->increaseSequenceNumber(); }
     int getSequenceNumber() const { return mPacketHeader->getSequenceNumber(); }
@@ -454,14 +448,14 @@ class JackTrip : public QObject
         return mPacketHeader->getPeerBitResolution(full_packet);
     }
 
-    uint8_t getPeerNumChannels(int8_t* full_packet) const
+    uint8_t getPeerNumIncomingChannels(int8_t* full_packet) const
     {
-        return mPacketHeader->getPeerNumChannels(full_packet);
+        return mPacketHeader->getPeerNumIncomingChannels(full_packet);
     }
 
-    uint8_t getPeerConnectionMode(int8_t* full_packet) const
+    uint8_t getPeerNumOutgoingChannels(int8_t* full_packet) const
     {
-        return mPacketHeader->getPeerConnectionMode(full_packet);
+        return mPacketHeader->getPeerNumOutgoingChannels(full_packet);
     }
 
     size_t getSizeInBytesPerChannel() const
@@ -628,7 +622,7 @@ class JackTrip : public QObject
     QString mJackClientName;    ///< JackAudio Client Name
     QString mRemoteClientName;  ///< Remote JackAudio Client Name for hub client mode
 
-    JackTrip::connectionModeT mConnectionMode;  ///< Connection Mode
+    // JackTrip::connectionModeT mConnectionMode;  ///< Connection Mode
     JackTrip::hubConnectionModeT
         mHubConnectionModeT;  ///< Hub Server Jack Audio Patch Connection Mode
 

--- a/src/JackTrip.h
+++ b/src/JackTrip.h
@@ -454,7 +454,12 @@ class JackTrip : public QObject
 
     uint8_t getPeerNumOutgoingChannels(int8_t* full_packet) const
     {
-        return mPacketHeader->getPeerNumOutgoingChannels(full_packet);
+        if (0 == mPacketHeader->getPeerNumOutgoingChannels(full_packet)) {
+          return mPacketHeader->getPeerNumIncomingChannels(full_packet);
+        } else {
+          return mPacketHeader->getPeerNumOutgoingChannels(full_packet);
+        }
+
     }
 
     size_t getSizeInBytesPerChannel() const

--- a/src/JackTrip.h
+++ b/src/JackTrip.h
@@ -101,11 +101,11 @@ class JackTrip : public QObject
     };
 
     /// \brief Enum for Connection Mode (in packet header)
-/*    enum connectionModeT {
+    enum connectionModeT {
         NORMAL,   ///< Normal Mode
         KSTRONG,  ///< Karplus Strong
         JAMTEST   ///< Karplus Strong
-    }; */
+    };
 
     /// \brief Enum for Hub Server Audio Connection Mode (connections to hub server are
     /// automatically patched in Jack)
@@ -336,14 +336,6 @@ class JackTrip : public QObject
     void setSampleRate(uint32_t sample_rate) { mSampleRate = sample_rate; }
     void setDeviceID(uint32_t device_id) { mDeviceID = device_id; }
     void setAudioBufferSizeInSamples(uint32_t buf_size) { mAudioBufferSize = buf_size; }
-
-         /*
-    JackTrip::connectionModeT getConnectionMode() const { return mConnectionMode; }
-    void setConnectionMode(JackTrip::connectionModeT connection_mode)
-    {
-        mConnectionMode = connection_mode;
-    }
-          */
 
     JackTrip::hubConnectionModeT getHubConnectionModeT() const
     {

--- a/src/JackTrip.h
+++ b/src/JackTrip.h
@@ -584,7 +584,7 @@ class JackTrip : public QObject
 
     int mNumAudioChansIn;   ///< Number of Audio Input Channels
     int mNumAudioChansOut;  ///< Number of Audio Output Channels
-#ifdef WAIR            // WAIR
+#ifdef WAIR                 // WAIR
     int mNumNetRevChans;  ///< Number of Network Audio Channels (net comb filters)
 #endif                    // endwhere
     int mBufferQueueLength;  ///< Audio Buffer from network queue length

--- a/src/JackTrip.h
+++ b/src/JackTrip.h
@@ -313,7 +313,8 @@ class JackTrip : public QObject
         mPacketHeader = PacketHeader;
     }
 
-    virtual int getRingBuffersSlotSize() { return getTotalAudioPacketSizeInBytes(); }
+    virtual int getInputRingBuffersSlotSize() { return getTotalAudioInputPacketSizeInBytes(); }
+    virtual int getOutputRingBuffersSlotSize() { return getTotalAudioOutputPacketSizeInBytes(); }
 
     virtual void setAudiointerfaceMode(JackTrip::audiointerfaceModeT audiointerface_mode)
     {
@@ -362,8 +363,8 @@ class JackTrip : public QObject
     /// \todo Document all these functions
     virtual void createHeader(const DataProtocol::packetHeaderTypeT headertype);
     void putHeaderInPacket(int8_t* full_packet, int8_t* audio_packet);
-    virtual int getPacketSizeInBytes();
-    void parseAudioPacket(int8_t* full_packet, int8_t* audio_packet);
+    int getSendPacketSizeInBytes() const;
+    int getReceivePacketSizeInBytes() const;
     virtual void sendNetworkPacket(const int8_t* ptrToSlot)
     {
         mSendRingBuffer->insertSlotNonBlocking(ptrToSlot, 0, 0);
@@ -468,14 +469,24 @@ class JackTrip : public QObject
         return mAudioInterface->getSizeInBytesPerChannel();
     }
     int getHeaderSizeInBytes() const { return mPacketHeader->getHeaderSizeInBytes(); }
-    virtual int getTotalAudioPacketSizeInBytes() const
+    int getTotalAudioInputPacketSizeInBytes() const
     {
 #ifdef WAIR  // WAIR
         if (mNumNetRevChans)
             return mAudioInterface->getSizeInBytesPerChannel() * mNumNetRevChans;
         else  // not wair
 #endif        // endwhere
-            return mAudioInterface->getSizeInBytesPerChannel() * mNumChans;
+            return mAudioInterface->getSizeInBytesPerChannel() * mNumChansIn;
+    }
+
+    int getTotalAudioOutputPacketSizeInBytes() const
+    {
+#ifdef WAIR  // WAIR
+        if (mNumNetRevChans)
+            return mAudioInterface->getSizeInBytesPerChannel() * mNumNetRevChans;
+        else  // not wair
+#endif        // endwhere
+            return mAudioInterface->getSizeInBytesPerChannel() * mNumChansOut;
     }
     //@}
     //------------------------------------------------------------------------------------

--- a/src/JackTrip.h
+++ b/src/JackTrip.h
@@ -362,7 +362,8 @@ class JackTrip : public QObject
     //@{
     /// \todo Document all these functions
     virtual void createHeader(const DataProtocol::packetHeaderTypeT headertype);
-    void putHeaderInPacket(int8_t* full_packet, int8_t* audio_packet);
+    void putHeaderInIncomingPacket(int8_t* full_packet, int8_t* audio_packet);
+    void putHeaderInOutgoingPacket(int8_t* full_packet, int8_t* audio_packet);
     int getSendPacketSizeInBytes() const;
     int getReceivePacketSizeInBytes() const;
     virtual void sendNetworkPacket(const int8_t* ptrToSlot)

--- a/src/JackTripWorker.cpp
+++ b/src/JackTripWorker.cpp
@@ -360,7 +360,7 @@ int JackTripWorker::setJackTripFromClientHeader(JackTrip& jacktrip)
         cout << "--->JackTripWorker: getPeerConnectionMode = " << PeerConnectionMode
              << endl;
 
-    jacktrip.setNumChannels(PeerNumChannels);
+    jacktrip.setNumOutputChannels(PeerNumChannels);
     return PeerConnectionMode;
 }
 

--- a/src/JackTripWorker.cpp
+++ b/src/JackTripWorker.cpp
@@ -134,7 +134,8 @@ void JackTripWorker::run()
         // Create and setup JackTrip Object
         // JackTrip jacktrip(JackTrip::SERVER, JackTrip::UDP, mNumChans, 2);
         if (gVerboseFlag)
-            cout << "---> JackTripWorker: Creating jacktrip objects..." << "\n";
+            cout << "---> JackTripWorker: Creating jacktrip objects..."
+                 << "\n";
 
 #ifdef WAIR  // WAIR
             // forces    BufferQueueLength to 2
@@ -165,7 +166,8 @@ void JackTripWorker::run()
 #ifdef WAIR  // WAIR
         // Add Plugins
         if (mWAIR) {
-            cout << "Running in WAIR Mode..." << "\n";
+            cout << "Running in WAIR Mode..."
+                 << "\n";
             cout << gPrintSeparator << "\n";
             switch (mNumNetRevChans) {
             case 16:  // freeverb
@@ -340,20 +342,22 @@ int JackTripWorker::setJackTripFromClientHeader(JackTrip& jacktrip)
     UdpSockTemp.readDatagram(reinterpret_cast<char*>(full_packet), packet_size);
     UdpSockTemp.close();  // close the socket
 
-    int PeerBufferSize     = jacktrip.getPeerBufferSize(full_packet);
-    int PeerSamplingRate   = jacktrip.getPeerSamplingRate(full_packet);
-    int PeerBitResolution  = jacktrip.getPeerBitResolution(full_packet);
-    int PeerNumIncomingChannels    = jacktrip.getPeerNumIncomingChannels(full_packet);
-    int PeerNumOutgoingChannels    = jacktrip.getPeerNumOutgoingChannels(full_packet);
+    int PeerBufferSize          = jacktrip.getPeerBufferSize(full_packet);
+    int PeerSamplingRate        = jacktrip.getPeerSamplingRate(full_packet);
+    int PeerBitResolution       = jacktrip.getPeerBitResolution(full_packet);
+    int PeerNumIncomingChannels = jacktrip.getPeerNumIncomingChannels(full_packet);
+    int PeerNumOutgoingChannels = jacktrip.getPeerNumOutgoingChannels(full_packet);
     delete[] full_packet;
     full_packet = nullptr;
 
     if (gVerboseFlag) {
-        std::cout << "--->JackTripWorker: getPeerBufferSize = " << PeerBufferSize << "\n"
-             << "--->JackTripWorker: getPeerSamplingRate = " << PeerSamplingRate << "\n"
-             << "--->JackTripWorker: getPeerBitResolution = " << PeerBitResolution << "\n"
-             << "--->JackTripWorker: PeerNumIncomingChannels = " << PeerNumIncomingChannels << "\n"
-             << "--->JackTripWorker: PeerNumOutgoingChannels = " << PeerNumOutgoingChannels << "\n";
+        cout << "JackTripWorker: getPeerBufferSize       = " << PeerBufferSize << "\n"
+             << "JackTripWorker: getPeerSamplingRate     = " << PeerSamplingRate << "\n"
+             << "JackTripWorker: getPeerBitResolution    = " << PeerBitResolution << "\n"
+             << "JackTripWorker: PeerNumIncomingChannels = " << PeerNumIncomingChannels
+             << "\n"
+             << "JackTripWorker: PeerNumOutgoingChannels = " << PeerNumOutgoingChannels
+             << "\n";
     }
 
     jacktrip.setNumInputChannels(PeerNumIncomingChannels);

--- a/src/JackTripWorker.cpp
+++ b/src/JackTripWorker.cpp
@@ -41,6 +41,7 @@
 #include <QTimer>
 #include <QWaitCondition>
 #include <iostream>
+#include <limits>
 
 #include "JackTrip.h"
 #include "UdpHubListener.h"
@@ -340,9 +341,13 @@ int JackTripWorker::setJackTripFromClientHeader(JackTrip& jacktrip)
     // Only the first Mode was used (NORMAL == 0). If this field is set to 0, we
     // can assume the peer is using an old version, and the last field doesn't reflect the
     // number of Outgoing Channels.
+    // The maximum of this field will be used as 0.
     if (JackTrip::NORMAL == PeerNumOutgoingChannels) {
         jacktrip.setNumInputChannels(PeerNumIncomingChannels);
         jacktrip.setNumOutputChannels(PeerNumIncomingChannels);
+    } else if (std::numeric_limits<uint8_t>::max() == PeerNumOutgoingChannels) {
+        jacktrip.setNumInputChannels(PeerNumIncomingChannels);
+        jacktrip.setNumOutputChannels(0);
     } else {
         jacktrip.setNumInputChannels(PeerNumIncomingChannels);
         jacktrip.setNumOutputChannels(PeerNumOutgoingChannels);

--- a/src/JackTripWorker.cpp
+++ b/src/JackTripWorker.cpp
@@ -61,34 +61,11 @@ using std::endl;
 JackTripWorker::JackTripWorker(UdpHubListener* udphublistener, int BufferQueueLength,
                                JackTrip::underrunModeT UnderRunMode, QString clientName)
     : mUdpHubListener(udphublistener)
-    , m_connectDefaultAudioPorts(false)
     , mBufferQueueLength(BufferQueueLength)
     , mUnderRunMode(UnderRunMode)
     , mClientName(clientName)
-    , mSpawning(false)
-    , mID(0)
-    , mNumChans(1)
-    , mIOStatTimeout(0)
-#ifdef WAIR  // wair
-    , mNumNetRevChans(0)
-    , mWAIR(false)
-#endif  // endwhere
 {
     setAutoDelete(false);  // stick around after calling run()
-    // mNetks = new NetKS;
-    // mNetks->play();
-    mBufferStrategy      = 1;
-    mBroadcastQueue      = 0;
-    mSimulatedLossRate   = 0.0;
-    mSimulatedJitterRate = 0.0;
-    mSimulatedDelayRel   = 0.0;
-    mUseRtUdpPriority    = false;
-}
-
-//*******************************************************************************
-JackTripWorker::~JackTripWorker()
-{
-    // delete mUdpHubListener;
 }
 
 //*******************************************************************************

--- a/src/JackTripWorker.cpp
+++ b/src/JackTripWorker.cpp
@@ -70,14 +70,13 @@ JackTripWorker::JackTripWorker(UdpHubListener* udphublistener, int BufferQueueLe
 
 //*******************************************************************************
 void JackTripWorker::setJackTrip(int id, QString client_address, uint16_t server_port,
-                                 uint16_t client_port,
-                                 bool connectDefaultAudioPorts)
+                                 uint16_t client_port, bool connectDefaultAudioPorts)
 {
     {  // Start Spawning, so lock mSpawning
         QMutexLocker locker(&mMutex);
         mSpawning = true;
     }
-    mID = id;
+    mID                        = id;
     mClientAddress             = client_address;
     mServerPort                = server_port;
     mClientPort                = client_port;

--- a/src/JackTripWorker.cpp
+++ b/src/JackTripWorker.cpp
@@ -70,7 +70,7 @@ JackTripWorker::JackTripWorker(UdpHubListener* udphublistener, int BufferQueueLe
 
 //*******************************************************************************
 void JackTripWorker::setJackTrip(int id, QString client_address, uint16_t server_port,
-                                 uint16_t client_port, int num_channels,
+                                 uint16_t client_port,
                                  bool connectDefaultAudioPorts)
 {
     {  // Start Spawning, so lock mSpawning
@@ -78,12 +78,9 @@ void JackTripWorker::setJackTrip(int id, QString client_address, uint16_t server
         mSpawning = true;
     }
     mID = id;
-    // Set the jacktrip address and ports
-    // mClientAddress.setAddress(client_address);
     mClientAddress             = client_address;
     mServerPort                = server_port;
     mClientPort                = client_port;
-    mNumChans                  = num_channels;
     m_connectDefaultAudioPorts = connectDefaultAudioPorts;
 }
 
@@ -132,11 +129,11 @@ void JackTripWorker::run()
         //        qDebug() << "is WAIR?" <<  tmp ;
         qDebug() << "mNumNetRevChans" << mNumNetRevChans;
 
-        JackTrip jacktrip(JackTrip::SERVERPINGSERVER, JackTrip::UDP, mNumChans,
+        JackTrip jacktrip(JackTrip::SERVERPINGSERVER, JackTrip::UDP, 1, 1,
                           mNumNetRevChans, FORCEBUFFERQ);
         JackTrip* mJackTrip = &jacktrip;
 #else  // endwhere
-        JackTrip jacktrip(JackTrip::SERVERPINGSERVER, JackTrip::UDP, mNumChans,
+        JackTrip jacktrip(JackTrip::SERVERPINGSERVER, JackTrip::UDP, 1, 1,
                           mBufferQueueLength);
 #endif  // not wair
 
@@ -214,8 +211,8 @@ void JackTripWorker::run()
 
         if (gVerboseFlag)
             cout << "---> JackTripWorker: setJackTripFromClientHeader..." << endl;
-        int PeerConnectionMode = setJackTripFromClientHeader(jacktrip);
-        if (PeerConnectionMode == -1) {
+
+        if (-1 == setJackTripFromClientHeader(jacktrip)) {
             mUdpHubListener->releaseThread(mID);
             {
                 QMutexLocker locker(&mMutex);
@@ -319,6 +316,9 @@ int JackTripWorker::setJackTripFromClientHeader(JackTrip& jacktrip)
     UdpSockTemp.readDatagram(reinterpret_cast<char*>(full_packet), packet_size);
     UdpSockTemp.close();  // close the socket
 
+    // TODO Why is this a pointer to int8_t?
+    int8_t* full_packet = reinterpret_cast<int8_t*>(packet);
+
     int PeerBufferSize          = jacktrip.getPeerBufferSize(full_packet);
     int PeerSamplingRate        = jacktrip.getPeerSamplingRate(full_packet);
     int PeerBitResolution       = jacktrip.getPeerBitResolution(full_packet);
@@ -337,9 +337,19 @@ int JackTripWorker::setJackTripFromClientHeader(JackTrip& jacktrip)
              << "\n";
     }
 
-    jacktrip.setNumInputChannels(PeerNumIncomingChannels);
-    jacktrip.setNumOutputChannels(PeerNumOutgoingChannels);
-    return 0;
+    // The header field for NumOutgoingChannels was used for the ConnectionMode.
+    // Only the first Mode was used (NORMAL == 0). If this field is set to 0, we
+    // can assume the peer is using an old version, and the last field doesn't reflect the
+    // number of Outgoing Channels.
+    if (JackTrip::NORMAL == PeerNumOutgoingChannels) {
+        jacktrip.setNumInputChannels(PeerNumIncomingChannels);
+        jacktrip.setNumOutputChannels(PeerNumIncomingChannels);
+    } else {
+        jacktrip.setNumInputChannels(PeerNumIncomingChannels);
+        jacktrip.setNumOutputChannels(PeerNumOutgoingChannels);
+    }
+
+    return PeerNumOutgoingChannels;
 }
 
 //*******************************************************************************

--- a/src/JackTripWorker.cpp
+++ b/src/JackTripWorker.cpp
@@ -316,9 +316,6 @@ int JackTripWorker::setJackTripFromClientHeader(JackTrip& jacktrip)
     UdpSockTemp.readDatagram(reinterpret_cast<char*>(full_packet), packet_size);
     UdpSockTemp.close();  // close the socket
 
-    // TODO Why is this a pointer to int8_t?
-    int8_t* full_packet = reinterpret_cast<int8_t*>(packet);
-
     int PeerBufferSize          = jacktrip.getPeerBufferSize(full_packet);
     int PeerSamplingRate        = jacktrip.getPeerSamplingRate(full_packet);
     int PeerBitResolution       = jacktrip.getPeerBitResolution(full_packet);

--- a/src/JackTripWorker.cpp
+++ b/src/JackTripWorker.cpp
@@ -134,7 +134,7 @@ void JackTripWorker::run()
         // Create and setup JackTrip Object
         // JackTrip jacktrip(JackTrip::SERVER, JackTrip::UDP, mNumChans, 2);
         if (gVerboseFlag)
-            cout << "---> JackTripWorker: Creating jacktrip objects..." << endl;
+            cout << "---> JackTripWorker: Creating jacktrip objects..." << "\n";
 
 #ifdef WAIR  // WAIR
             // forces    BufferQueueLength to 2
@@ -165,8 +165,8 @@ void JackTripWorker::run()
 #ifdef WAIR  // WAIR
         // Add Plugins
         if (mWAIR) {
-            cout << "Running in WAIR Mode..." << endl;
-            cout << gPrintSeparator << std::endl;
+            cout << "Running in WAIR Mode..." << "\n";
+            cout << gPrintSeparator << "\n";
             switch (mNumNetRevChans) {
             case 16:  // freeverb
                 mJackTrip->appendProcessPluginFromNetwork(
@@ -343,25 +343,22 @@ int JackTripWorker::setJackTripFromClientHeader(JackTrip& jacktrip)
     int PeerBufferSize     = jacktrip.getPeerBufferSize(full_packet);
     int PeerSamplingRate   = jacktrip.getPeerSamplingRate(full_packet);
     int PeerBitResolution  = jacktrip.getPeerBitResolution(full_packet);
-    int PeerNumChannels    = jacktrip.getPeerNumChannels(full_packet);
-    int PeerConnectionMode = jacktrip.getPeerConnectionMode(full_packet);
+    int PeerNumIncomingChannels    = jacktrip.getPeerNumIncomingChannels(full_packet);
+    int PeerNumOutgoingChannels    = jacktrip.getPeerNumOutgoingChannels(full_packet);
     delete[] full_packet;
     full_packet = nullptr;
 
-    if (gVerboseFlag)
-        cout << "--->JackTripWorker: getPeerBufferSize = " << PeerBufferSize << endl;
-    if (gVerboseFlag)
-        cout << "--->JackTripWorker: getPeerSamplingRate = " << PeerSamplingRate << endl;
-    if (gVerboseFlag)
-        cout << "--->JackTripWorker: getPeerBitResolution = " << PeerBitResolution
-             << endl;
-    cout << "--->JackTripWorker: PeerNumChannels = " << PeerNumChannels << endl;
-    if (gVerboseFlag)
-        cout << "--->JackTripWorker: getPeerConnectionMode = " << PeerConnectionMode
-             << endl;
+    if (gVerboseFlag) {
+        std::cout << "--->JackTripWorker: getPeerBufferSize = " << PeerBufferSize << "\n"
+             << "--->JackTripWorker: getPeerSamplingRate = " << PeerSamplingRate << "\n"
+             << "--->JackTripWorker: getPeerBitResolution = " << PeerBitResolution << "\n"
+             << "--->JackTripWorker: PeerNumIncomingChannels = " << PeerNumIncomingChannels << "\n"
+             << "--->JackTripWorker: PeerNumOutgoingChannels = " << PeerNumOutgoingChannels << "\n";
+    }
 
-    jacktrip.setNumOutputChannels(PeerNumChannels);
-    return PeerConnectionMode;
+    jacktrip.setNumInputChannels(PeerNumIncomingChannels);
+    jacktrip.setNumOutputChannels(PeerNumOutgoingChannels);
+    return 0;
 }
 
 //*******************************************************************************

--- a/src/JackTripWorker.h
+++ b/src/JackTripWorker.h
@@ -87,8 +87,7 @@ class JackTripWorker
     /// \param id ID number
     /// \param address
     void setJackTrip(int id, QString client_address, uint16_t server_port,
-                     uint16_t client_port,
-                     bool connectDefaultAudioPorts);
+                     uint16_t client_port, bool connectDefaultAudioPorts);
     /// Stop and remove thread from pool
     void stopThread();
     int getID() { return mID; }
@@ -139,20 +138,20 @@ class JackTripWorker
     volatile bool mSpawning = false;
     QMutex mMutex;  ///< Mutex to protect mSpawning
 
-    int mID = 0;        ///< ID thread number
+    int mID = 0;  ///< ID thread number
 
-    int mBufferStrategy = 1;
-    int mBroadcastQueue = 0;
-    double mSimulatedLossRate = 0.0;
+    int mBufferStrategy         = 1;
+    int mBroadcastQueue         = 0;
+    double mSimulatedLossRate   = 0.0;
     double mSimulatedJitterRate = 0.0;
-    double mSimulatedDelayRel = 0.0;
-    bool mUseRtUdpPriority = false;
+    double mSimulatedDelayRel   = 0.0;
+    bool mUseRtUdpPriority      = false;
 
     int mIOStatTimeout = 0;
     QSharedPointer<std::ofstream> mIOStatStream;
 #ifdef WAIR  // wair
     int mNumNetRevChans = 0;  ///< Number of Net Channels = net combs
-    bool mWAIR = false;
+    bool mWAIR          = false;
 #endif  // endwhere
 };
 

--- a/src/JackTripWorker.h
+++ b/src/JackTripWorker.h
@@ -87,7 +87,7 @@ class JackTripWorker
     /// \param id ID number
     /// \param address
     void setJackTrip(int id, QString client_address, uint16_t server_port,
-                     uint16_t client_port, int num_channels,
+                     uint16_t client_port,
                      bool connectDefaultAudioPorts);
     /// Stop and remove thread from pool
     void stopThread();

--- a/src/JackTripWorker.h
+++ b/src/JackTripWorker.h
@@ -75,7 +75,7 @@ class JackTripWorker
                    JackTrip::underrunModeT UnderRunMode = JackTrip::WAVETABLE,
                    QString clientName                   = "");
     /// \brief The class destructor
-    virtual ~JackTripWorker();
+    ~JackTripWorker() = default;
 
     /// \brief Implements the Thread Loop.
     /// To start the thread, call start() ( DO NOT CALL run() ).
@@ -119,13 +119,12 @@ class JackTripWorker
 
    private:
     int setJackTripFromClientHeader(JackTrip& jacktrip);
-    // JackTrip::connectionModeT getConnectionModeFromHeader();
 
     UdpHubListener* mUdpHubListener;  ///< Hub Listener Socket
     // QHostAddress mClientAddress; ///< Client Address
     QString mClientAddress;
     uint16_t mServerPort;  ///< Server Ephemeral Incomming Port to use with Client
-    bool m_connectDefaultAudioPorts;
+    bool m_connectDefaultAudioPorts = false;
 
     /// Client Outgoing Port. By convention, the receving port will be <tt>mClientPort
     /// -1</tt>
@@ -137,24 +136,23 @@ class JackTripWorker
 
     /// Thread spawning internal lock.
     /// If true, the prototype is working on creating (spawning) a new thread
-    volatile bool mSpawning;
+    volatile bool mSpawning = false;
     QMutex mMutex;  ///< Mutex to protect mSpawning
 
-    int mID;        ///< ID thread number
-    int mNumChans;  ///< Number of Channels
+    int mID = 0;        ///< ID thread number
 
-    int mBufferStrategy;
-    int mBroadcastQueue;
-    double mSimulatedLossRate;
-    double mSimulatedJitterRate;
-    double mSimulatedDelayRel;
-    bool mUseRtUdpPriority;
+    int mBufferStrategy = 1;
+    int mBroadcastQueue = 0;
+    double mSimulatedLossRate = 0.0;
+    double mSimulatedJitterRate = 0.0;
+    double mSimulatedDelayRel = 0.0;
+    bool mUseRtUdpPriority = false;
 
-    int mIOStatTimeout;
+    int mIOStatTimeout = 0;
     QSharedPointer<std::ofstream> mIOStatStream;
 #ifdef WAIR  // wair
-    int mNumNetRevChans;  ///< Number of Net Channels = net combs
-    bool mWAIR;
+    int mNumNetRevChans = 0;  ///< Number of Net Channels = net combs
+    bool mWAIR = false;
 #endif  // endwhere
 };
 

--- a/src/JackTripWorker.h
+++ b/src/JackTripWorker.h
@@ -119,7 +119,7 @@ class JackTripWorker
 
    private:
     int setJackTripFromClientHeader(JackTrip& jacktrip);
-    JackTrip::connectionModeT getConnectionModeFromHeader();
+    // JackTrip::connectionModeT getConnectionModeFromHeader();
 
     UdpHubListener* mUdpHubListener;  ///< Hub Listener Socket
     // QHostAddress mClientAddress; ///< Client Address

--- a/src/PacketHeader.cpp
+++ b/src/PacketHeader.cpp
@@ -43,6 +43,7 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <limits>
 #include <stdexcept>
 
 #include "JackTrip.h"
@@ -110,7 +111,13 @@ void DefaultHeader::fillHeaderCommonFromAudio()
     mHeader.SamplingRate               = mJackTrip->getSampleRateType();
     mHeader.BitResolution              = mJackTrip->getAudioBitResolution();
     mHeader.NumIncomingChannelsFromNet = mJackTrip->getNumOutputChannels();
-    mHeader.NumOutgoingChannelsToNet   = mJackTrip->getNumInputChannels();
+
+    if(0 == mJackTrip->getNumInputChannels()) {
+        mHeader.NumOutgoingChannelsToNet   = std::numeric_limits<uint8_t>::max();
+    } else {
+        mHeader.NumOutgoingChannelsToNet   = mJackTrip->getNumInputChannels();
+    }
+
 }
 
 //***********************************************************************

--- a/src/PacketHeader.cpp
+++ b/src/PacketHeader.cpp
@@ -50,8 +50,9 @@
 using std::cout;
 using std::endl;
 
-// below is the gettimeofday definition for windows: this function is not defined in sys/time.h as it is in unix
-// for more info check: http://www.halcode.com/archives/2008/08/26/retrieving-system-time-gettimeofday/
+// below is the gettimeofday definition for windows: this function is not defined in
+// sys/time.h as it is in unix for more info check:
+// http://www.halcode.com/archives/2008/08/26/retrieving-system-time-gettimeofday/
 #if defined __WIN_32__
 #ifdef __cplusplus
 // void GetSystemTimeAsFileTime(FILETIME*);
@@ -92,24 +93,24 @@ uint64_t PacketHeader::usecTime()
 DefaultHeader::DefaultHeader(JackTrip* jacktrip)
     : PacketHeader(jacktrip), mJackTrip(jacktrip)
 {
-    mHeader.TimeStamp     = 0;
-    mHeader.SeqNumber     = 0;
-    mHeader.BufferSize    = 0;
-    mHeader.SamplingRate  = 0;
-    mHeader.BitResolution = 0;
-    mHeader.NumIncomingChannelsFromNet    = 0;
-    mHeader.NumOutgoingChannelsToNet = 0;
+    mHeader.TimeStamp                  = 0;
+    mHeader.SeqNumber                  = 0;
+    mHeader.BufferSize                 = 0;
+    mHeader.SamplingRate               = 0;
+    mHeader.BitResolution              = 0;
+    mHeader.NumIncomingChannelsFromNet = 0;
+    mHeader.NumOutgoingChannelsToNet   = 0;
 }
 
 //***********************************************************************
 void DefaultHeader::fillHeaderCommonFromAudio()
 {
-    mHeader.TimeStamp      = PacketHeader::usecTime();
-    mHeader.BufferSize     = mJackTrip->getBufferSizeInSamples();
-    mHeader.SamplingRate   = mJackTrip->getSampleRateType();
-    mHeader.BitResolution  = mJackTrip->getAudioBitResolution();
-    mHeader.NumIncomingChannelsFromNet    = mJackTrip->getNumOutputChannels();
-    mHeader.NumOutgoingChannelsToNet = mJackTrip->getNumInputChannels();
+    mHeader.TimeStamp                  = PacketHeader::usecTime();
+    mHeader.BufferSize                 = mJackTrip->getBufferSizeInSamples();
+    mHeader.SamplingRate               = mJackTrip->getSampleRateType();
+    mHeader.BitResolution              = mJackTrip->getAudioBitResolution();
+    mHeader.NumIncomingChannelsFromNet = mJackTrip->getNumOutputChannels();
+    mHeader.NumOutgoingChannelsToNet   = mJackTrip->getNumInputChannels();
 }
 
 //***********************************************************************
@@ -125,9 +126,9 @@ void DefaultHeader::checkPeerSettings(int8_t* full_packet)
         std::cerr << "WARNING: Peer Buffer Size is  : " << peer_header->BufferSize
                   << endl;
         std::cerr << "         Local Buffer Size is : " << mHeader.BufferSize << endl;
-        //std::cerr << "Make sure both machines use same buffer size" << endl;
-        //std::cerr << gPrintSeparator << endl;
-        //error = true;
+        // std::cerr << "Make sure both machines use same buffer size" << endl;
+        // std::cerr << gPrintSeparator << endl;
+        // error = true;
     }
 
     // Check Sampling Rate
@@ -159,9 +160,9 @@ void DefaultHeader::checkPeerSettings(int8_t* full_packet)
 
     // Exit program if error
     if (error) {
-        //std::cerr << "Exiting program..." << endl;
-        //std::exit(1);
-        //throw std::logic_error("Local and Peer Settings don't match");
+        // std::cerr << "Exiting program..." << endl;
+        // std::exit(1);
+        // throw std::logic_error("Local and Peer Settings don't match");
         emit signalError("Local and Peer Settings don't match");
     }
     /// \todo Check number of channels and other parameters
@@ -176,14 +177,15 @@ void DefaultHeader::printHeader() const
     // Get the sample rate in Hz form the AudioInterface::samplingRateT
     int sample_rate = AudioInterface::getSampleRateFromType(
         static_cast<AudioInterface::samplingRateT>(mHeader.SamplingRate));
+    // clang-format off
     cout << "Sampling Rate               = " << sample_rate << "\n"
             "Audio Bit Resolutions       = " << static_cast<int>(mHeader.BitResolution) << "\n"
-            "Number of Incoming Channels = " << static_cast<int>(mHeader.NumIncomingChannelsFromNet ) << "\n"
-            "Number of Incoming Channels = " << static_cast<int>(mHeader.NumIncomingChannelsFromNet ) << "\n"
+            "Number of Incoming Channels = " << static_cast<int>(mHeader.NumIncomingChannelsFromNet) << "\n"
+            "Number of Incoming Channels = " << static_cast<int>(mHeader.NumIncomingChannelsFromNet) << "\n"
             "Sequence Number             = " << static_cast<int>(mHeader.SeqNumber) << "\n"
-            "Time Stamp                  = " << mHeader.TimeStamp << "\n";
-    cout << gPrintSeparator << endl;
-    //cout << sizeof(mHeader) << endl;
+            "Time Stamp                  = " << mHeader.TimeStamp << "\n"
+            << gPrintSeparator << "\n";
+    // clang-format on
 }
 
 //***********************************************************************
@@ -259,11 +261,13 @@ void JamLinkHeader::fillHeaderCommonFromAudio()
     // Check number of channels
     int num_inchannels = mJackTrip->getNumInputChannels();
     if (num_inchannels != 1) {
-        //std::cerr << "ERROR: JamLink only support ONE channel. Run JackTrip using only one channel"
+        // std::cerr << "ERROR: JamLink only support ONE channel. Run JackTrip using only
+        // one channel"
         //	      << endl;
-        //std::exit(1);
-        //std::cerr << "WARINING: JamLink only support ONE channel. Run JackTrip using only one channel" << endl;
-        //throw std::logic_error("JamLink only support ONE channel. Run JackTrip using only one channel");
+        // std::exit(1);
+        // std::cerr << "WARINING: JamLink only support ONE channel. Run JackTrip using
+        // only one channel" << endl; throw std::logic_error("JamLink only support ONE
+        // channel. Run JackTrip using only one channel");
         emit signalError(
             "JamLink only support ONE channel. Run JackTrip using only one channel");
     }
@@ -271,8 +275,9 @@ void JamLinkHeader::fillHeaderCommonFromAudio()
     // Sampling Rate
     int rate_type = mJackTrip->getSampleRateType();
     if (rate_type != AudioInterface::SR48) {
-        //std::cerr << "WARINING: JamLink only support 48kHz for communication with JackTrip at the moment." << endl;
-        //throw std::logic_error("ERROR: JamLink only support 48kHz for communication with JackTrip at the moment.");
+        // std::cerr << "WARINING: JamLink only support 48kHz for communication with
+        // JackTrip at the moment." << endl; throw std::logic_error("ERROR: JamLink only
+        // support 48kHz for communication with JackTrip at the moment.");
         emit signalError(
             "ERROR: JamLink only support 48kHz for communication with JackTrip at the "
             "moment.");
@@ -281,8 +286,9 @@ void JamLinkHeader::fillHeaderCommonFromAudio()
     // Check Buffer Size
     int buf_size = mJackTrip->getBufferSizeInSamples();
     if (buf_size != 64) {
-        //std::cerr << "WARINING: JamLink only support 64 buffer size for communication with JackTrip at the moment." << endl;
-        //throw std::logic_error("ERROR: JamLink only support 64 buffer size for communication with JackTrip at the moment.");
+        // std::cerr << "WARINING: JamLink only support 64 buffer size for communication
+        // with JackTrip at the moment." << endl; throw std::logic_error("ERROR: JamLink
+        // only support 64 buffer size for communication with JackTrip at the moment.");
         emit signalError(
             "ERROR: JamLink only support 64 buffer size for communication with JackTrip "
             "at the moment.");
@@ -303,9 +309,9 @@ void JamLinkHeader::fillHeaderCommonFromAudio()
         mHeader.Common = (mHeader.Common | ETX_22KHZ);
         break;
     default:
-        //std::cerr << "ERROR: Sample rate not supported by JamLink" << endl;
-        //std::exit(1);
-        //throw std::out_of_range("Sample rate not supported by JamLink");
+        // std::cerr << "ERROR: Sample rate not supported by JamLink" << endl;
+        // std::exit(1);
+        // throw std::out_of_range("Sample rate not supported by JamLink");
         emit signalError("Sample rate not supported by JamLink.");
         break;
     }

--- a/src/PacketHeader.cpp
+++ b/src/PacketHeader.cpp
@@ -187,7 +187,7 @@ void DefaultHeader::printHeader() const
     cout << "Sampling Rate               = " << sample_rate << "\n"
             "Audio Bit Resolutions       = " << static_cast<int>(mHeader.BitResolution) << "\n"
             "Number of Incoming Channels = " << static_cast<int>(mHeader.NumIncomingChannelsFromNet) << "\n"
-            "Number of Incoming Channels = " << static_cast<int>(mHeader.NumIncomingChannelsFromNet) << "\n"
+            "Number of Outgoing Channels = " << static_cast<int>(mHeader.NumOutgoingChannelsToNet) << "\n"
             "Sequence Number             = " << static_cast<int>(mHeader.SeqNumber) << "\n"
             "Time Stamp                  = " << mHeader.TimeStamp << "\n"
             << gPrintSeparator << "\n";

--- a/src/PacketHeader.cpp
+++ b/src/PacketHeader.cpp
@@ -112,7 +112,9 @@ void DefaultHeader::fillHeaderCommonFromAudio()
     mHeader.BitResolution              = mJackTrip->getAudioBitResolution();
     mHeader.NumIncomingChannelsFromNet = mJackTrip->getNumOutputChannels();
 
-    if (0 == mJackTrip->getNumInputChannels()) {
+    if (mJackTrip->getNumInputChannels() == mJackTrip->getNumOutputChannels()) {
+        mHeader.NumOutgoingChannelsToNet = 0;
+    } else if (0 == mJackTrip->getNumInputChannels()) {
         mHeader.NumOutgoingChannelsToNet = std::numeric_limits<uint8_t>::max();
     } else {
         mHeader.NumOutgoingChannelsToNet = mJackTrip->getNumInputChannels();

--- a/src/PacketHeader.cpp
+++ b/src/PacketHeader.cpp
@@ -112,12 +112,11 @@ void DefaultHeader::fillHeaderCommonFromAudio()
     mHeader.BitResolution              = mJackTrip->getAudioBitResolution();
     mHeader.NumIncomingChannelsFromNet = mJackTrip->getNumOutputChannels();
 
-    if(0 == mJackTrip->getNumInputChannels()) {
-        mHeader.NumOutgoingChannelsToNet   = std::numeric_limits<uint8_t>::max();
+    if (0 == mJackTrip->getNumInputChannels()) {
+        mHeader.NumOutgoingChannelsToNet = std::numeric_limits<uint8_t>::max();
     } else {
-        mHeader.NumOutgoingChannelsToNet   = mJackTrip->getNumInputChannels();
+        mHeader.NumOutgoingChannelsToNet = mJackTrip->getNumInputChannels();
     }
-
 }
 
 //***********************************************************************

--- a/src/PacketHeader.cpp
+++ b/src/PacketHeader.cpp
@@ -97,10 +97,8 @@ DefaultHeader::DefaultHeader(JackTrip* jacktrip)
     mHeader.BufferSize    = 0;
     mHeader.SamplingRate  = 0;
     mHeader.BitResolution = 0;
-    //mHeader.NumInChannels = 0;
-    //mHeader.NumOutChannels = 0;
-    mHeader.NumChannels    = 0;
-    mHeader.ConnectionMode = 0;
+    mHeader.NumIncomingChannelsFromNet    = 0;
+    mHeader.NumOutgoingChannelsToNet = 0;
 }
 
 //***********************************************************************
@@ -110,9 +108,8 @@ void DefaultHeader::fillHeaderCommonFromAudio()
     mHeader.BufferSize     = mJackTrip->getBufferSizeInSamples();
     mHeader.SamplingRate   = mJackTrip->getSampleRateType();
     mHeader.BitResolution  = mJackTrip->getAudioBitResolution();
-    mHeader.NumChannels    = mJackTrip->getNumChannels();
-    mHeader.ConnectionMode = static_cast<int>(mJackTrip->getConnectionMode());
-    //printHeader();
+    mHeader.NumIncomingChannelsFromNet    = mJackTrip->getNumOutputChannels();
+    mHeader.NumOutgoingChannelsToNet = mJackTrip->getNumInputChannels();
 }
 
 //***********************************************************************
@@ -179,17 +176,12 @@ void DefaultHeader::printHeader() const
     // Get the sample rate in Hz form the AudioInterface::samplingRateT
     int sample_rate = AudioInterface::getSampleRateFromType(
         static_cast<AudioInterface::samplingRateT>(mHeader.SamplingRate));
-    cout << "Sampling Rate             = " << sample_rate << endl;
-    cout << "Audio Bit Resolutions     = " << static_cast<int>(mHeader.BitResolution)
-         << endl;
-    //cout << "Number of Input Channels  = " << static_cast<int>(mHeader.NumInChannels) << endl;
-    //cout << "Number of Output Channels = " << static_cast<int>(mHeader.NumOutChannels) << endl;
-    cout << "Number of Channels        = " << static_cast<int>(mHeader.NumChannels)
-         << endl;
-    cout << "Sequence Number           = " << static_cast<int>(mHeader.SeqNumber) << endl;
-    cout << "Time Stamp                = " << mHeader.TimeStamp << endl;
-    cout << "Connection Mode           = " << static_cast<int>(mHeader.ConnectionMode)
-         << endl;
+    cout << "Sampling Rate               = " << sample_rate << "\n"
+            "Audio Bit Resolutions       = " << static_cast<int>(mHeader.BitResolution) << "\n"
+            "Number of Incoming Channels = " << static_cast<int>(mHeader.NumIncomingChannelsFromNet ) << "\n"
+            "Number of Incoming Channels = " << static_cast<int>(mHeader.NumIncomingChannelsFromNet ) << "\n"
+            "Sequence Number             = " << static_cast<int>(mHeader.SeqNumber) << "\n"
+            "Time Stamp                  = " << mHeader.TimeStamp << "\n";
     cout << gPrintSeparator << endl;
     //cout << sizeof(mHeader) << endl;
 }
@@ -235,19 +227,18 @@ uint8_t DefaultHeader::getPeerBitResolution(int8_t* full_packet) const
 }
 
 //***********************************************************************
-uint8_t DefaultHeader::getPeerNumChannels(int8_t* full_packet) const
+uint8_t DefaultHeader::getPeerNumIncomingChannels(int8_t* full_packet) const
 {
     DefaultHeaderStruct* peer_header;
     peer_header = reinterpret_cast<DefaultHeaderStruct*>(full_packet);
-    return peer_header->NumChannels;
+    return peer_header->NumIncomingChannelsFromNet;
 }
 
-//***********************************************************************
-uint8_t DefaultHeader::getPeerConnectionMode(int8_t* full_packet) const
+uint8_t DefaultHeader::getPeerNumOutgoingChannels(int8_t* full_packet) const
 {
     DefaultHeaderStruct* peer_header;
     peer_header = reinterpret_cast<DefaultHeaderStruct*>(full_packet);
-    return static_cast<uint8_t>(peer_header->ConnectionMode);
+    return peer_header->NumOutgoingChannelsToNet;
 }
 
 //#######################################################################

--- a/src/PacketHeader.h
+++ b/src/PacketHeader.h
@@ -62,11 +62,11 @@ struct DefaultHeaderStruct : public HeaderStruct {
     uint8_t SamplingRate;   ///< Sampling Rate in JackAudioInterface::samplingRateT
     uint8_t BitResolution;  ///< Audio Bit Resolution
     uint8_t NumIncomingChannelsFromNet;  ///< Number of incoming Channels from the network
-    uint8_t NumOutgoingChannelsToNet; ///< Number of outgoing Channels to the network
+    uint8_t NumOutgoingChannelsToNet;    ///< Number of outgoing Channels to the network
 };
 
 //---------------------------------------------------------
-//JamLink UDP Header:
+// JamLink UDP Header:
 /************************************************************************/
 /* values for the UDP stream type                                       */
 /* streamType is a 16-bit value at the head of each UDP stream          */
@@ -81,7 +81,7 @@ const unsigned short ETX_XTND   = (1 << 14);
 const unsigned short ETX_STEREO = (1 << 13);
 const unsigned short ETX_MONO   = (0 << 13);
 const unsigned short ETX_16BIT  = (0 << 12);
-//inline unsigned short ETX_RATE_MASK(const unsigned short a) { a&(0x7<<9); }
+// inline unsigned short ETX_RATE_MASK(const unsigned short a) { a&(0x7<<9); }
 const unsigned short ETX_48KHZ = (0 << 9);
 const unsigned short ETX_44KHZ = (1 << 9);
 const unsigned short ETX_32KHZ = (2 << 9);
@@ -91,7 +91,7 @@ const unsigned short ETX_16KHZ = (5 << 9);
 const unsigned short ETX_11KHZ = (6 << 9);
 const unsigned short ETX_8KHZ  = (7 << 9);
 // able to express up to 512 SPP
-//inline unsigned short  ETX_SPP(const unsigned short a) { (a&0x01FF); }
+// inline unsigned short  ETX_SPP(const unsigned short a) { (a&0x01FF); }
 
 /// \brief JamLink Header Struct
 struct JamLinkHeaderStuct : public HeaderStruct {
@@ -128,13 +128,13 @@ class PacketHeader : public QObject
 //    virtual void parseHeader()                          = 0;
     virtual void checkPeerSettings(int8_t* full_packet) = 0;
 
-    virtual uint64_t getPeerTimeStamp(int8_t* full_packet) const      = 0;
-    virtual uint16_t getPeerSequenceNumber(int8_t* full_packet) const = 0;
-    virtual uint16_t getPeerBufferSize(int8_t* full_packet) const     = 0;
-    virtual uint8_t getPeerSamplingRate(int8_t* full_packet) const    = 0;
-    virtual uint8_t getPeerBitResolution(int8_t* full_packet) const   = 0;
-    virtual uint8_t getPeerNumIncomingChannels(int8_t* full_packet) const     = 0;
-    virtual uint8_t getPeerNumOutgoingChannels(int8_t* full_packet) const     = 0;
+    virtual uint64_t getPeerTimeStamp(int8_t* full_packet) const          = 0;
+    virtual uint16_t getPeerSequenceNumber(int8_t* full_packet) const     = 0;
+    virtual uint16_t getPeerBufferSize(int8_t* full_packet) const         = 0;
+    virtual uint8_t getPeerSamplingRate(int8_t* full_packet) const        = 0;
+    virtual uint8_t getPeerBitResolution(int8_t* full_packet) const       = 0;
+    virtual uint8_t getPeerNumIncomingChannels(int8_t* full_packet) const = 0;
+    virtual uint8_t getPeerNumOutgoingChannels(int8_t* full_packet) const = 0;
 
     /// \brief Increase sequence number for counter, a 16bit number
     virtual void increaseSequenceNumber() { mSeqNumber++; }
@@ -184,8 +184,14 @@ class DefaultHeader : public PacketHeader
         putHeaderInPacketBaseClass(full_packet, mHeader);
     }
     void printHeader() const;
-    uint8_t getNumIncomingChannelsFromNet() const { return mHeader.NumIncomingChannelsFromNet; }
-    uint8_t getNumOutgoingChannelsToNet() const { return mHeader.NumOutgoingChannelsToNet; }
+    uint8_t getNumIncomingChannelsFromNet() const
+    {
+        return mHeader.NumIncomingChannelsFromNet;
+    }
+    uint8_t getNumOutgoingChannelsToNet() const
+    {
+        return mHeader.NumOutgoingChannelsToNet;
+    }
     virtual uint64_t getPeerTimeStamp(int8_t* full_packet) const;
     virtual uint16_t getPeerSequenceNumber(int8_t* full_packet) const;
     virtual uint16_t getPeerBufferSize(int8_t* full_packet) const;

--- a/src/PacketHeader.h
+++ b/src/PacketHeader.h
@@ -61,11 +61,8 @@ struct DefaultHeaderStruct : public HeaderStruct {
     uint16_t BufferSize;    ///< Buffer Size in Samples
     uint8_t SamplingRate;   ///< Sampling Rate in JackAudioInterface::samplingRateT
     uint8_t BitResolution;  ///< Audio Bit Resolution
-    //uint8_t  NumInChannels; ///< Number of Input Channels
-    //uint8_t  NumOutChannels; ///<  Number of Output Channels
-    uint8_t
-        NumChannels;  ///< Number of Channels, we assume input and outputs are the same
-    uint8_t ConnectionMode;
+    uint8_t NumIncomingChannelsFromNet;  ///< Number of incoming Channels from the network
+    uint8_t NumOutgoingChannelsToNet; ///< Number of outgoing Channels to the network
 };
 
 //---------------------------------------------------------
@@ -128,7 +125,7 @@ class PacketHeader : public QObject
     virtual void fillHeaderCommonFromAudio() = 0;
     /// \brief Parse the packet header and take appropriate measures (like change settings, or
     /// quit the program if peer settings don't match)
-    virtual void parseHeader()                          = 0;
+//    virtual void parseHeader()                          = 0;
     virtual void checkPeerSettings(int8_t* full_packet) = 0;
 
     virtual uint64_t getPeerTimeStamp(int8_t* full_packet) const      = 0;
@@ -136,8 +133,8 @@ class PacketHeader : public QObject
     virtual uint16_t getPeerBufferSize(int8_t* full_packet) const     = 0;
     virtual uint8_t getPeerSamplingRate(int8_t* full_packet) const    = 0;
     virtual uint8_t getPeerBitResolution(int8_t* full_packet) const   = 0;
-    virtual uint8_t getPeerNumChannels(int8_t* full_packet) const     = 0;
-    virtual uint8_t getPeerConnectionMode(int8_t* full_packet) const  = 0;
+    virtual uint8_t getPeerNumIncomingChannels(int8_t* full_packet) const     = 0;
+    virtual uint8_t getPeerNumOutgoingChannels(int8_t* full_packet) const     = 0;
 
     /// \brief Increase sequence number for counter, a 16bit number
     virtual void increaseSequenceNumber() { mSeqNumber++; }
@@ -177,7 +174,7 @@ class DefaultHeader : public PacketHeader
     virtual ~DefaultHeader() {}
 
     virtual void fillHeaderCommonFromAudio();
-    virtual void parseHeader() {}
+//    virtual void parseHeader() {}
     virtual void checkPeerSettings(int8_t* full_packet);
     virtual void increaseSequenceNumber() { mHeader.SeqNumber++; }
     virtual uint16_t getSequenceNumber() const { return mHeader.SeqNumber; }
@@ -187,16 +184,15 @@ class DefaultHeader : public PacketHeader
         putHeaderInPacketBaseClass(full_packet, mHeader);
     }
     void printHeader() const;
-    uint8_t getConnectionMode() const { return mHeader.ConnectionMode; }
-    uint8_t getNumChannels() const { return mHeader.NumChannels; }
-
+    uint8_t getNumIncomingChannelsFromNet() const { return mHeader.NumIncomingChannelsFromNet; }
+    uint8_t getNumOutgoingChannelsToNet() const { return mHeader.NumOutgoingChannelsToNet; }
     virtual uint64_t getPeerTimeStamp(int8_t* full_packet) const;
     virtual uint16_t getPeerSequenceNumber(int8_t* full_packet) const;
     virtual uint16_t getPeerBufferSize(int8_t* full_packet) const;
     virtual uint8_t getPeerSamplingRate(int8_t* full_packet) const;
     virtual uint8_t getPeerBitResolution(int8_t* full_packet) const;
-    virtual uint8_t getPeerNumChannels(int8_t* full_packet) const;
-    virtual uint8_t getPeerConnectionMode(int8_t* full_packet) const;
+    uint8_t getPeerNumIncomingChannels(int8_t* full_packet) const override;
+    uint8_t getPeerNumOutgoingChannels(int8_t* full_packet) const override;
 
    private:
     DefaultHeaderStruct mHeader;  ///< Default Header Struct
@@ -224,8 +220,8 @@ class JamLinkHeader : public PacketHeader
     virtual uint16_t getPeerBufferSize(int8_t* /*full_packet*/) const { return 0; }
     virtual uint8_t getPeerSamplingRate(int8_t* /*full_packet*/) const { return 0; }
     virtual uint8_t getPeerBitResolution(int8_t* /*full_packet*/) const { return 0; }
-    virtual uint8_t getPeerNumChannels(int8_t* /*full_packet*/) const { return 0; }
-    virtual uint8_t getPeerConnectionMode(int8_t* /*full_packet*/) const { return 0; }
+    uint8_t getPeerNumIncomingChannels(int8_t* full_packet) const override { return 0; }
+    uint8_t getPeerNumOutgoingChannels(int8_t* full_packet) const override { return 0; }
 
     virtual void increaseSequenceNumber() {}
     virtual int getHeaderSizeInBytes() const { return sizeof(mHeader); }
@@ -262,8 +258,8 @@ class EmptyHeader : public PacketHeader
     virtual uint16_t getPeerBufferSize(int8_t* /*full_packet*/) const { return 0; }
     virtual uint8_t getPeerSamplingRate(int8_t* /*full_packet*/) const { return 0; }
     virtual uint8_t getPeerBitResolution(int8_t* /*full_packet*/) const { return 0; }
-    virtual uint8_t getPeerNumChannels(int8_t* /*full_packet*/) const { return 0; }
-    virtual uint8_t getPeerConnectionMode(int8_t* /*full_packet*/) const { return 0; }
+    uint8_t getPeerNumIncomingChannels(int8_t* full_packet) const override { return 0; }
+    uint8_t getPeerNumOutgoingChannels(int8_t* full_packet) const override { return 0; }
 
     virtual void putHeaderInPacket(int8_t* /*full_packet*/) {}
 

--- a/src/PacketHeader.h
+++ b/src/PacketHeader.h
@@ -122,10 +122,7 @@ class PacketHeader : public QObject
     static uint64_t usecTime();
     /// \todo Implement this using a JackTrip Method (Mediator) member instead of the
     /// reference to JackAudio
-    virtual void fillHeaderCommonFromAudio() = 0;
-    /// \brief Parse the packet header and take appropriate measures (like change settings, or
-    /// quit the program if peer settings don't match)
-//    virtual void parseHeader()                          = 0;
+    virtual void fillHeaderCommonFromAudio()            = 0;
     virtual void checkPeerSettings(int8_t* full_packet) = 0;
 
     virtual uint64_t getPeerTimeStamp(int8_t* full_packet) const          = 0;
@@ -174,7 +171,6 @@ class DefaultHeader : public PacketHeader
     virtual ~DefaultHeader() {}
 
     virtual void fillHeaderCommonFromAudio();
-//    virtual void parseHeader() {}
     virtual void checkPeerSettings(int8_t* full_packet);
     virtual void increaseSequenceNumber() { mHeader.SeqNumber++; }
     virtual uint16_t getSequenceNumber() const { return mHeader.SeqNumber; }
@@ -218,7 +214,6 @@ class JamLinkHeader : public PacketHeader
     virtual ~JamLinkHeader() {}
 
     virtual void fillHeaderCommonFromAudio();
-    virtual void parseHeader() {}
     virtual void checkPeerSettings(int8_t* /*full_packet*/) {}
 
     virtual uint64_t getPeerTimeStamp(int8_t* /*full_packet*/) const { return 0; }
@@ -254,7 +249,6 @@ class EmptyHeader : public PacketHeader
     virtual ~EmptyHeader() {}
 
     virtual void fillHeaderCommonFromAudio() {}
-    virtual void parseHeader() {}
     virtual void checkPeerSettings(int8_t* /*full_packet*/) {}
     virtual void increaseSequenceNumber() {}
     virtual int getHeaderSizeInBytes() const { return 0; }

--- a/src/RingBuffer.cpp
+++ b/src/RingBuffer.cpp
@@ -62,13 +62,13 @@ RingBuffer::RingBuffer(int SlotSize, int NumSlots)
     if (0 < mTotalSize) {
         mRingBuffer   = new int8_t[mTotalSize];
         mLastReadSlot = new int8_t[mSlotSize];
-        //QMutexLocker locker(&mMutex); // lock the mutex
+        // QMutexLocker locker(&mMutex); // lock the mutex
 
         // Verify if there's enough space to for the buffers
         if ((mRingBuffer == NULL) || (mLastReadSlot == NULL)) {
-            //std::cerr << "ERROR: RingBuffer out of memory!" << endl;
-            //std::cerr << "Exiting program..." << endl;
-            //std::exit(1);
+            // std::cerr << "ERROR: RingBuffer out of memory!" << endl;
+            // std::cerr << "Exiting program..." << endl;
+            // std::exit(1);
             throw std::length_error("RingBuffer out of memory!");
         }
 
@@ -125,7 +125,7 @@ void RingBuffer::insertSlotBlocking(const int8_t* ptrToSlot)
     // Check if there is space available to write a slot
     // If the Ringbuffer is full, it waits for the bufferIsNotFull condition
     while (mFullSlots == mNumSlots) {
-        //std::cout << "OUPUT OVERFLOW BLOCKING" << std::endl;
+        // std::cout << "OUPUT OVERFLOW BLOCKING" << std::endl;
         mBufferIsNotFull.wait(&mMutex);
     }
 
@@ -133,7 +133,7 @@ void RingBuffer::insertSlotBlocking(const int8_t* ptrToSlot)
     std::memcpy(mRingBuffer + mWritePosition, ptrToSlot, mSlotSize);
     // Update write position
     mWritePosition = (mWritePosition + mSlotSize) % mTotalSize;
-    mFullSlots++;  //update full slots
+    mFullSlots++;  // update full slots
     // Wake threads waitng for bufferIsNotFull condition
     mBufferIsNotEmpty.wakeAll();
 }
@@ -147,7 +147,7 @@ void RingBuffer::readSlotBlocking(int8_t* ptrToReadSlot)
     // Check if there are slots available to read
     // If the Ringbuffer is empty, it waits for the bufferIsNotEmpty condition
     while (mFullSlots == 0) {
-        //std::cerr << "READ UNDER-RUN BLOCKING before" << endl;
+        // std::cerr << "READ UNDER-RUN BLOCKING before" << endl;
         mBufferIsNotEmpty.wait(&mMutex, 200);
         if (JackTrip::sJackStopped) { return; }
     }
@@ -157,8 +157,9 @@ void RingBuffer::readSlotBlocking(int8_t* ptrToReadSlot)
     // Always save memory of the last read slot
     std::memcpy(mLastReadSlot, mRingBuffer + mReadPosition, mSlotSize);
     // Update write position
-    mReadPosition = (mReadPosition + mSlotSize) % mTotalSize;
-    mFullSlots--;  //update full slots
+    mReadPosition =
+        (0 == mTotalSize) ? mReadPosition : (mReadPosition + mSlotSize) % mTotalSize;
+    mFullSlots--;  // update full slots
     // Wake threads waitng for bufferIsNotFull condition
     mBufferIsNotFull.wakeAll();
 }
@@ -185,7 +186,7 @@ bool RingBuffer::insertSlotNonBlocking(const int8_t* ptrToSlot, int len, int los
     /// \todo It may be better here to insert the slot anyways,
     /// instead of not writing anything
     if (mFullSlots == mNumSlots) {
-        //std::cout << "OUPUT OVERFLOW NON BLOCKING = " << mNumSlots << std::endl;
+        // std::cout << "OUPUT OVERFLOW NON BLOCKING = " << mNumSlots << std::endl;
         overflowReset();
         return true;
     }
@@ -194,7 +195,7 @@ bool RingBuffer::insertSlotNonBlocking(const int8_t* ptrToSlot, int len, int los
     std::memcpy(mRingBuffer + mWritePosition, ptrToSlot, mSlotSize);
     // Update write position
     mWritePosition = (mWritePosition + mSlotSize) % mTotalSize;
-    mFullSlots++;  //update full slots
+    mFullSlots++;  // update full slots
     // Wake threads waitng for bufferIsNotFull condition
     mBufferIsNotEmpty.wakeAll();
     return true;
@@ -215,8 +216,8 @@ void RingBuffer::readSlotNonBlocking(int8_t* ptrToReadSlot)
     // If the Ringbuffer is empty, it returns a buffer of zeros and rests the buffer
     if (mFullSlots <= 0) {
         // Returns a buffer of zeros if there's nothing to read
-        //std::cerr << "READ UNDER-RUN NON BLOCKING = " << mNumSlots << endl;
-        //std::memset(ptrToReadSlot, 0, mSlotSize);
+        // std::cerr << "READ UNDER-RUN NON BLOCKING = " << mNumSlots << endl;
+        // std::memset(ptrToReadSlot, 0, mSlotSize);
         setUnderrunReadSlot(ptrToReadSlot);
         underrunReset();
         return;
@@ -228,7 +229,7 @@ void RingBuffer::readSlotNonBlocking(int8_t* ptrToReadSlot)
     std::memcpy(mLastReadSlot, mRingBuffer + mReadPosition, mSlotSize);
     // Update write position
     mReadPosition = (mReadPosition + mSlotSize) % mTotalSize;
-    mFullSlots--;  //update full slots
+    mFullSlots--;  // update full slots
     // Wake threads waitng for bufferIsNotFull condition
     mBufferIsNotFull.wakeAll();
 }
@@ -257,10 +258,11 @@ void RingBuffer::setMemoryInReadSlotWithLastReadSlot(int8_t* ptrToReadSlot)
 void RingBuffer::underrunReset()
 {
     // Advance the write pointer 1/2 the ring buffer
-    //mWritePosition = ( mReadPosition + ( (mNumSlots/2) * mSlotSize ) ) % mTotalSize;
-    //mWritePosition = ( mWritePosition + ( (mNumSlots/2) * mSlotSize ) ) % mTotalSize;
-    //mFullSlots += mNumSlots/2;
-    // There's nothing new to read, so we clear the whole buffer (Set the entire buffer to 0)
+    // mWritePosition = ( mReadPosition + ( (mNumSlots/2) * mSlotSize ) ) % mTotalSize;
+    // mWritePosition = ( mWritePosition + ( (mNumSlots/2) * mSlotSize ) ) % mTotalSize;
+    // mFullSlots += mNumSlots/2;
+    // There's nothing new to read, so we clear the whole buffer (Set the entire buffer to
+    // 0)
     std::memset(mRingBuffer, 0, mTotalSize);
     ++mUnderrunsNew;
 }
@@ -270,7 +272,7 @@ void RingBuffer::underrunReset()
 void RingBuffer::overflowReset()
 {
     // Advance the read pointer 1/2 the ring buffer
-    //mReadPosition = ( mWritePosition + ( (mNumSlots/2) * mSlotSize ) ) % mTotalSize;
+    // mReadPosition = ( mWritePosition + ( (mNumSlots/2) * mSlotSize ) ) % mTotalSize;
     int d         = mNumSlots / 2;
     mReadPosition = (mReadPosition + (d * mSlotSize)) % mTotalSize;
     mFullSlots -= d;

--- a/src/RingBuffer.cpp
+++ b/src/RingBuffer.cpp
@@ -62,7 +62,7 @@ RingBuffer::RingBuffer(int SlotSize, int NumSlots)
     if (0 < mTotalSize) {
         mRingBuffer   = new int8_t[mTotalSize];
         mLastReadSlot = new int8_t[mSlotSize];
-        std::memset(mRingBuffer, 0, mTotalSize);  // set buffer to 0
+        std::memset(mRingBuffer, 0, mTotalSize);   // set buffer to 0
         std::memset(mLastReadSlot, 0, mSlotSize);  // set buffer to 0
 
         mWritePosition = ((NumSlots / 2) * SlotSize) % mTotalSize;

--- a/src/RingBuffer.cpp
+++ b/src/RingBuffer.cpp
@@ -62,29 +62,9 @@ RingBuffer::RingBuffer(int SlotSize, int NumSlots)
     if (0 < mTotalSize) {
         mRingBuffer   = new int8_t[mTotalSize];
         mLastReadSlot = new int8_t[mSlotSize];
-        // QMutexLocker locker(&mMutex); // lock the mutex
-
-        // Verify if there's enough space to for the buffers
-        if ((mRingBuffer == NULL) || (mLastReadSlot == NULL)) {
-            // std::cerr << "ERROR: RingBuffer out of memory!" << endl;
-            // std::cerr << "Exiting program..." << endl;
-            // std::exit(1);
-            throw std::length_error("RingBuffer out of memory!");
-        }
-
-        // Set the buffers to zeros
-        /*
-      for (int i=0; i<mTotalSize; i++) {
-        mRingBuffer[i] = 0;    // Initialize all elements to zero.
-      }
-      */
         std::memset(mRingBuffer, 0, mTotalSize);  // set buffer to 0
-        /*
-      for (int i=0; i<mSlotSize; i++) {
-        mLastReadSlot[i] = 0;    // Initialize all elements to zero.
-      }
-      */
         std::memset(mLastReadSlot, 0, mSlotSize);  // set buffer to 0
+
         mWritePosition = ((NumSlots / 2) * SlotSize) % mTotalSize;
     }
 

--- a/src/RingBuffer.h
+++ b/src/RingBuffer.h
@@ -45,10 +45,10 @@
 
 #include "jacktrip_types.h"
 
-//using namespace JackTripNamespace;
+// using namespace JackTripNamespace;
 
-/** \brief Provides a ring-buffer (or circular-buffer) that can be written to and read from
- * asynchronously (blocking) or synchronously (non-blocking).
+/** \brief Provides a ring-buffer (or circular-buffer) that can be written to and read
+ * from asynchronously (blocking) or synchronously (non-blocking).
  *
  * The RingBuffer is an array of \b NumSlots slots of memory
  * each of which is of size \b SlotSize bytes (8-bits). Slots can be read and
@@ -58,45 +58,45 @@ class RingBuffer
 {
    public:
     /** \brief The class constructor
-   * \param SlotSize Size of one slot in bytes
-   * \param NumSlots Number of slots
-   */
+     * \param SlotSize Size of one slot in bytes
+     * \param NumSlots Number of slots
+     */
     RingBuffer(int SlotSize, int NumSlots);
 
     /** \brief The class destructor
-   */
+     */
     virtual ~RingBuffer();
 
-    /** \brief Insert a slot into the RingBuffer from ptrToSlot. This method will block until
-   * there's space in the buffer.
-   *
-   * The caller is responsible to make sure sizeof(WriteSlot) = SlotSize. This
-   * method should be use when the caller can block against its output, like
-   * sending/receiving UDP packets. It shouldn't be used by audio. For that, use the
-   * insertSlotNonBlocking.
-   * \param ptrToSlot Pointer to slot to insert into the RingBuffer
-   */
+    /** \brief Insert a slot into the RingBuffer from ptrToSlot. This method will block
+     * until there's space in the buffer.
+     *
+     * The caller is responsible to make sure sizeof(WriteSlot) = SlotSize. This
+     * method should be use when the caller can block against its output, like
+     * sending/receiving UDP packets. It shouldn't be used by audio. For that, use the
+     * insertSlotNonBlocking.
+     * \param ptrToSlot Pointer to slot to insert into the RingBuffer
+     */
     void insertSlotBlocking(const int8_t* ptrToSlot);
 
-    /** \brief Read a slot from the RingBuffer into ptrToReadSlot. This method will block until
-   * there's space in the buffer.
-   *
-   * The caller is responsible to make sure sizeof(ptrToReadSlot) = SlotSize. This
-   * method should be use when the caller can block against its input, like
-   * sending/receiving UDP packets. It shouldn't be used by audio. For that, use the
-   * readSlotNonBlocking.
-   * \param ptrToReadSlot Pointer to read slot from the RingBuffer
-   */
+    /** \brief Read a slot from the RingBuffer into ptrToReadSlot. This method will block
+     * until there's space in the buffer.
+     *
+     * The caller is responsible to make sure sizeof(ptrToReadSlot) = SlotSize. This
+     * method should be use when the caller can block against its input, like
+     * sending/receiving UDP packets. It shouldn't be used by audio. For that, use the
+     * readSlotNonBlocking.
+     * \param ptrToReadSlot Pointer to read slot from the RingBuffer
+     */
     void readSlotBlocking(int8_t* ptrToReadSlot);
 
     /** \brief Same as insertSlotBlocking but non-blocking (asynchronous)
-   * \param ptrToSlot Pointer to slot to insert into the RingBuffer
-   */
+     * \param ptrToSlot Pointer to slot to insert into the RingBuffer
+     */
     virtual bool insertSlotNonBlocking(const int8_t* ptrToSlot, int len, int lostLen);
 
     /** \brief Same as readSlotBlocking but non-blocking (asynchronous)
-   * \param ptrToReadSlot Pointer to read slot from the RingBuffer
-   */
+     * \param ptrToReadSlot Pointer to read slot from the RingBuffer
+     */
     virtual void readSlotNonBlocking(int8_t* ptrToReadSlot);
     virtual void readBroadcastSlot(int8_t* ptrToReadSlot);
 
@@ -120,17 +120,17 @@ class RingBuffer
 
    protected:
     /** \brief Sets the memory in the Read Slot when uderrun occurs. By default,
-   * this sets it to 0. Override this method in a subclass for a different behavior.
-   * \param ptrToReadSlot Pointer to read slot from the RingBuffer
-   */
+     * this sets it to 0. Override this method in a subclass for a different behavior.
+     * \param ptrToReadSlot Pointer to read slot from the RingBuffer
+     */
     virtual void setUnderrunReadSlot(int8_t* ptrToReadSlot);
 
     /** \brief Uses the last read slot to set the memory in the Read Slot.
-   *
-   * The last read slot is the last packet that arrived, so if no new packets are received,
-   * it keeps looping the same packet.
-   * \param ptrToReadSlot Pointer to read slot from the RingBuffer
-   */
+     *
+     * The last read slot is the last packet that arrived, so if no new packets are
+     * received, it keeps looping the same packet. \param ptrToReadSlot Pointer to read
+     * slot from the RingBuffer
+     */
     virtual void setMemoryInReadSlotWithLastReadSlot(int8_t* ptrToReadSlot);
 
     /// \brief Resets the ring buffer for reads under-runs non-blocking

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -167,28 +167,31 @@ void Settings::parseInput(int argc, char** argv)
            != -1)
         switch (ch) {
         case OPT_NUMINCOMING:
-            if(0 < atoi(optarg)){
+            if (0 < atoi(optarg)) {
                 mNumAudioOutputChans = atoi(optarg);
             } else {
-                std::cerr << "--numincoming ERROR: Number of channels must be greater than 0\n";
+                std::cerr
+                    << "--numincoming ERROR: Number of channels must be greater than 0\n";
                 std::exit(1);
             }
             break;
         case OPT_NUMOUTGOING:
-            if(0 < atoi(optarg)){
-            mNumAudioInputChans = atoi(optarg);
+            if (0 < atoi(optarg)) {
+                mNumAudioInputChans = atoi(optarg);
             } else {
-                std::cerr << "--numoutgoing ERROR: Number of channels must be greater than 0\n";
+                std::cerr
+                    << "--numoutgoing ERROR: Number of channels must be greater than 0\n";
                 std::exit(1);
             }
             break;
         case 'n':  // Number of input and output channels
             //-------------------------------------------------------
-            if(0 < atoi(optarg)) {
-            mNumAudioInputChans  = atoi(optarg);
-            mNumAudioOutputChans = atoi(optarg);
+            if (0 < atoi(optarg)) {
+                mNumAudioInputChans  = atoi(optarg);
+                mNumAudioOutputChans = atoi(optarg);
             } else {
-                std::cerr << "-n --numchannels ERROR: Number of channels must be greater than 0\n";
+                std::cerr << "-n --numchannels ERROR: Number of channels must be greater "
+                             "than 0\n";
                 std::exit(1);
             }
             break;
@@ -538,15 +541,15 @@ void Settings::parseInput(int argc, char** argv)
         std::exit(1);
     }
 
-    if(true == mAudioTester.getEnabled()) {
-    assert(mNumAudioInputChans > 0);
-    mAudioTester.setSendChannel(mNumAudioInputChans
-                                - 1);  // use last channel for latency testing
-    // Originally, testing only in the last channel was adopted
-    // because channel 0 ("left") was a clap track on CCRMA loopback
-    // servers.  Now, however, we also do it in order to easily keep
-    // effects in all but the last channel, enabling silent testing
-    // in the last channel in parallel with normal operation of the others.
+    if (true == mAudioTester.getEnabled()) {
+        assert(mNumAudioInputChans > 0);
+        mAudioTester.setSendChannel(mNumAudioInputChans
+                                    - 1);  // use last channel for latency testing
+        // Originally, testing only in the last channel was adopted
+        // because channel 0 ("left") was a clap track on CCRMA loopback
+        // servers.  Now, however, we also do it in order to easily keep
+        // effects in all but the last channel, enabling silent testing
+        // in the last channel in parallel with normal operation of the others.
     }
     // Exit if options are incompatible
     //----------------------------------------------------------------------------

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -866,11 +866,11 @@ JackTrip* Settings::getConfiguredJackTrip()
     // Allocate audio effects in client, if any:
     int nReservedChans =
         mAudioTester.getEnabled() ? 1 : 0;  // no fx allowed on tester channel
-    // FIXME: Does outgoing mean send to the network?
+
     std::vector<ProcessPlugin*> outgoingEffects =
         mEffects.allocateOutgoingEffects(mNumChansIn - nReservedChans);
     for (auto p : outgoingEffects) { jackTrip->appendProcessPluginToNetwork(p); }
-    // FIXME: Does incoming mean receive from the network?
+
     std::vector<ProcessPlugin*> incomingEffects =
         mEffects.allocateIncomingEffects(mNumChansOut - nReservedChans);
     for (auto p : incomingEffects) { jackTrip->appendProcessPluginFromNetwork(p); }
@@ -882,7 +882,7 @@ JackTrip* Settings::getConfiguredJackTrip()
         switch (mNumNetRevChans) {
         case 16: {
             jackTrip->appendProcessPluginFromNetwork(
-                new ap8x2(mNumChans));  // plugin slot 0
+                new ap8x2(mNumChansOut));  // plugin slot 0
             /////////////////////////////////////////////////////////
             Stk16* plugin = new Stk16(mNumNetRevChans);
             plugin->Stk16::initCombClient(mClientAddCombLen, mClientRoomSize);

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -799,18 +799,6 @@ JackTrip* Settings::getConfiguredJackTrip()
         jackTrip->setPeerAddress(mPeerAddress);
     }
 
-    //        if(mLocalAddress!=QString()) // default
-    //            mJackTrip->setLocalAddress(QHostAddress(mLocalAddress.toLatin1().data()));
-    //        else
-    //            mJackTrip->setLocalAddress(QHostAddress::Any);
-
-    // Set Ports - Done in constructor now.
-    // cout << "SETTING ALL PORTS" << endl;
-    /*if (gVerboseFlag) std::cout << "Settings:startJackTrip before
-    mJackTrip->setBindPorts" << std::endl; jackTrip->setBindPorts(mBindPortNum); if
-    (gVerboseFlag) std::cout << "Settings:startJackTrip before mJackTrip->setPeerPorts" <<
-    std::endl; jackTrip->setPeerPorts(mPeerPortNum);*/
-
     // Set in JamLink Mode
     if (mJamLink) {
         cout << "Running in JamLink Mode..." << endl;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -69,7 +69,9 @@ enum JTLongOptIDS {
     OPT_SIMJITTER,
     OPT_BROADCAST,
     OPT_RTUDPPRIORITY,
-    OPT_APPENDTHREADID
+    OPT_APPENDTHREADID,
+    OPT_NUMINCOMING,
+    OPT_NUMOUTGOING
 };
 
 //*******************************************************************************
@@ -91,6 +93,8 @@ void Settings::parseInput(int argc, char** argv)
         // These options don't set a flag.
         {"numchannels", required_argument, NULL,
          'n'},  // Number of input and output channels
+        {"numincoming", required_argument, NULL, OPT_NUMINCOMING}, // Number of incoming channels
+        {"numoutgoing", required_argument, NULL, OPT_NUMOUTGOING}, // Number of outgoing channels
 #ifdef WAIR     // WAIR
         {"wair", no_argument, NULL, 'w'},  // Run in LAIR mode, sets numnetrevchannels
         {"addcombfilterlength", required_argument, NULL,
@@ -160,6 +164,12 @@ void Settings::parseInput(int argc, char** argv)
                 NULL))
            != -1)
         switch (ch) {
+        case OPT_NUMINCOMING:
+            mNumChansOut = atoi(optarg);
+            break;
+        case OPT_NUMOUTGOING:
+            mNumChansIn = atoi(optarg);
+            break;
         case 'n':  // Number of input and output channels
             //-------------------------------------------------------
             mNumChansIn = atoi(optarg);
@@ -577,6 +587,8 @@ void Settings::printUsage()
     cout << " -n, --numchannels #                      Number of Input and Output "
             "Channels (default: "
          << 2 << ")" << endl;
+    cout << "     --numincoming #                      Number of incoming Channels from the network\n";
+    cout << "     --numoutgoing #                      Number of incoming Channels from the network\n";
 #ifdef WAIR  // WAIR
     cout << " -w, --wair                               Run in WAIR Mode" << endl;
     cout << " -N, --addcombfilterlength #              comb length adjustment for WAIR "

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -73,50 +73,6 @@ enum JTLongOptIDS {
 };
 
 //*******************************************************************************
-Settings::Settings()
-    : mJackTripMode(JackTrip::SERVER)
-    , mDataProtocol(JackTrip::UDP)
-    , mBufferQueueLength(gDefaultQueueLength)
-    , mAudioBitResolution(AudioInterface::BIT16)
-    , mBindPortNum(gDefaultPort)
-    , mPeerPortNum(gDefaultPort)
-    , mServerUdpPortNum(0)
-    , mUnderrunMode(JackTrip::WAVETABLE)
-    , mStopOnTimeout(false)
-    , mBufferStrategy(1)
-    , mLoopBack(false)
-    ,
-#ifdef WAIR  // WAIR
-    mNumNetRevChans(0)
-    , mWAIR(false)
-    ,
-#endif  // endwhere
-    mJamLink(false)
-    , mEmptyHeader(false)
-    , mJackTripServer(false)
-    , mLocalAddress(gDefaultLocalAddress)
-    , mRedundancy(1)
-    , mUseJack(true)
-    , mChanfeDefaultSR(false)
-    , mChanfeDefaultID(0)
-    , mChanfeDefaultBS(false)
-    , mHubConnectionMode(JackTrip::SERVERTOCLIENT)
-    , mConnectDefaultAudioPorts(true)
-    , mIOStatTimeout(0)
-    , mEffects(false)
-    ,  // outgoing limiter OFF by default
-    mSimulatedLossRate(0.0)
-    , mSimulatedJitterRate(0.0)
-    , mSimulatedDelayRel(0.0)
-    , mBroadcastQueue(0)
-    , mUseRtUdpPriority(false)
-{
-}
-
-//*******************************************************************************
-Settings::~Settings() = default;
-
-//*******************************************************************************
 void Settings::parseInput(int argc, char** argv)
 {
     // Always use decimal point for floating point numbers

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -523,6 +523,7 @@ void Settings::parseInput(int argc, char** argv)
         std::exit(1);
     }
 
+    if(true == mAudioTester.getEnabled()) {
     assert(mNumAudioInputChans > 0);
     mAudioTester.setSendChannel(mNumAudioInputChans
                                 - 1);  // use last channel for latency testing
@@ -531,7 +532,7 @@ void Settings::parseInput(int argc, char** argv)
     // servers.  Now, however, we also do it in order to easily keep
     // effects in all but the last channel, enabling silent testing
     // in the last channel in parallel with normal operation of the others.
-
+    }
     // Exit if options are incompatible
     //----------------------------------------------------------------------------
     bool haveSomeServerMode = not((mJackTripMode == JackTrip::CLIENT)

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -593,7 +593,7 @@ void Settings::printUsage()
          << 2 << ")" << endl;
     cout << "     --numincoming #                      Number of incoming Channels from "
             "the network\n";
-    cout << "     --numoutgoing #                      Number of incoming Channels from "
+    cout << "     --numoutgoing #                      Number of outgoing Channels to "
             "the network\n";
 #ifdef WAIR  // WAIR
     cout << " -w, --wair                               Run in WAIR Mode" << endl;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -69,9 +69,9 @@ enum JTLongOptIDS {
     OPT_SIMJITTER,
     OPT_BROADCAST,
     OPT_RTUDPPRIORITY,
-    OPT_APPENDTHREADID,
-    OPT_NUMINCOMING,
-    OPT_NUMOUTGOING
+    OPT_NUMRECEIVE,
+    OPT_NUMSEND,
+    OPT_APPENDTHREADID
 };
 
 //*******************************************************************************
@@ -93,10 +93,10 @@ void Settings::parseInput(int argc, char** argv)
         // These options don't set a flag.
         {"numchannels", required_argument, NULL,
          'n'},  // Number of input and output channels
-        {"numincoming", required_argument, NULL,
-         OPT_NUMINCOMING},  // Number of incoming channels
-        {"numoutgoing", required_argument, NULL,
-         OPT_NUMOUTGOING},  // Number of outgoing channels
+        {"numreceive", required_argument, NULL,
+         OPT_NUMRECEIVE},  // Number of incoming channels
+        {"numsend", required_argument, NULL,
+         OPT_NUMSEND},  // Number of outgoing channels
 #ifdef WAIR                 // WAIR
         {"wair", no_argument, NULL, 'w'},  // Run in LAIR mode, sets numnetrevchannels
         {"addcombfilterlength", required_argument, NULL,
@@ -166,21 +166,21 @@ void Settings::parseInput(int argc, char** argv)
                 NULL))
            != -1)
         switch (ch) {
-        case OPT_NUMINCOMING:
+        case OPT_NUMRECEIVE:
             if (0 < atoi(optarg)) {
                 mNumAudioOutputChans = atoi(optarg);
             } else {
                 std::cerr
-                    << "--numincoming ERROR: Number of channels must be greater than 0\n";
+                    << "--numreceive ERROR: Number of channels must be greater than 0\n";
                 std::exit(1);
             }
             break;
-        case OPT_NUMOUTGOING:
+        case OPT_NUMSEND:
             if (0 < atoi(optarg)) {
                 mNumAudioInputChans = atoi(optarg);
             } else {
                 std::cerr
-                    << "--numoutgoing ERROR: Number of channels must be greater than 0\n";
+                    << "--numsend ERROR: Number of channels must be greater than 0\n";
                 std::exit(1);
             }
             break;
@@ -609,9 +609,9 @@ void Settings::printUsage()
     cout << " -n, --numchannels #                      Number of Input and Output "
             "Channels (# greater than 0, default: "
          << 2 << ")" << endl;
-    cout << "     --numincoming #                      Number of incoming Channels from "
+    cout << "     --numreceive #                       Number of receive Channels from "
             "the network (# greater than 0)\n";
-    cout << "     --numoutgoing #                      Number of outgoing Channels to "
+    cout << "     --numsend #                          Number of send Channels to "
             "the network (# greater than 0)\n";
 #ifdef WAIR  // WAIR
     cout << " -w, --wair                               Run in WAIR Mode" << endl;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -165,15 +165,15 @@ void Settings::parseInput(int argc, char** argv)
            != -1)
         switch (ch) {
         case OPT_NUMINCOMING:
-            mNumChansOut = atoi(optarg);
+            mNumAudioOutputChans = atoi(optarg);
             break;
         case OPT_NUMOUTGOING:
-            mNumChansIn = atoi(optarg);
+            mNumAudioInputChans = atoi(optarg);
             break;
         case 'n':  // Number of input and output channels
             //-------------------------------------------------------
-            mNumChansIn = atoi(optarg);
-            mNumChansOut = atoi(optarg);
+            mNumAudioInputChans = atoi(optarg);
+            mNumAudioOutputChans = atoi(optarg);
             break;
         case 'U':  // UDP Bind Port
             mServerUdpPortNum = atoi(optarg);
@@ -521,8 +521,8 @@ void Settings::parseInput(int argc, char** argv)
         std::exit(1);
     }
 
-    assert(mNumChansIn > 0);
-    mAudioTester.setSendChannel(mNumChansIn - 1);  // use last channel for latency testing
+    assert(mNumAudioInputChans > 0);
+    mAudioTester.setSendChannel(mNumAudioInputChans - 1);  // use last channel for latency testing
     // Originally, testing only in the last channel was adopted
     // because channel 0 ("left") was a clap track on CCRMA loopback
     // servers.  Now, however, we also do it in order to easily keep
@@ -764,7 +764,7 @@ JackTrip* Settings::getConfiguredJackTrip()
     if (gVerboseFlag)
         std::cout << "Settings:startJackTrip before new JackTrip" << std::endl;
     JackTrip* jackTrip = new JackTrip(
-        mJackTripMode, mDataProtocol, mNumChansIn, mNumChansOut,
+        mJackTripMode, mDataProtocol, mNumAudioInputChans, mNumAudioOutputChans,
 #ifdef WAIR  // wair
         mNumNetRevChans,
 #endif  // endwhere
@@ -880,11 +880,11 @@ JackTrip* Settings::getConfiguredJackTrip()
         mAudioTester.getEnabled() ? 1 : 0;  // no fx allowed on tester channel
 
     std::vector<ProcessPlugin*> outgoingEffects =
-        mEffects.allocateOutgoingEffects(mNumChansIn - nReservedChans);
+        mEffects.allocateOutgoingEffects(mNumAudioInputChans - nReservedChans);
     for (auto p : outgoingEffects) { jackTrip->appendProcessPluginToNetwork(p); }
 
     std::vector<ProcessPlugin*> incomingEffects =
-        mEffects.allocateIncomingEffects(mNumChansOut - nReservedChans);
+        mEffects.allocateIncomingEffects(mNumAudioOutputChans - nReservedChans);
     for (auto p : incomingEffects) { jackTrip->appendProcessPluginFromNetwork(p); }
 
 #ifdef WAIR  // WAIR

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -93,9 +93,9 @@ void Settings::parseInput(int argc, char** argv)
         // These options don't set a flag.
         {"numchannels", required_argument, NULL,
          'n'},  // Number of input and output channels
-        {"numreceive", required_argument, NULL,
+        {"receivechannels", required_argument, NULL,
          OPT_NUMRECEIVE},  // Number of incoming channels
-        {"numsend", required_argument, NULL,
+        {"sendchannels", required_argument, NULL,
          OPT_NUMSEND},  // Number of outgoing channels
 #ifdef WAIR                 // WAIR
         {"wair", no_argument, NULL, 'w'},  // Run in LAIR mode, sets numnetrevchannels
@@ -171,7 +171,7 @@ void Settings::parseInput(int argc, char** argv)
                 mNumAudioOutputChans = atoi(optarg);
             } else {
                 std::cerr
-                    << "--numreceive ERROR: Number of channels must be greater than 0\n";
+                    << "--receivechannels ERROR: Number of channels must be greater than 0\n";
                 std::exit(1);
             }
             break;
@@ -180,7 +180,7 @@ void Settings::parseInput(int argc, char** argv)
                 mNumAudioInputChans = atoi(optarg);
             } else {
                 std::cerr
-                    << "--numsend ERROR: Number of channels must be greater than 0\n";
+                    << "--sendchannels ERROR: Number of channels must be greater than 0\n";
                 std::exit(1);
             }
             break;
@@ -609,9 +609,9 @@ void Settings::printUsage()
     cout << " -n, --numchannels #                      Number of Input and Output "
             "Channels (# greater than 0, default: "
          << 2 << ")" << endl;
-    cout << "     --numreceive #                       Number of receive Channels from "
+    cout << "     --receivechannels #                       Number of receive Channels from "
             "the network (# greater than 0)\n";
-    cout << "     --numsend #                          Number of send Channels to "
+    cout << "     --sendchannels #                          Number of send Channels to "
             "the network (# greater than 0)\n";
 #ifdef WAIR  // WAIR
     cout << " -w, --wair                               Run in WAIR Mode" << endl;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -167,15 +167,30 @@ void Settings::parseInput(int argc, char** argv)
            != -1)
         switch (ch) {
         case OPT_NUMINCOMING:
-            mNumAudioOutputChans = atoi(optarg);
+            if(0 < atoi(optarg)){
+                mNumAudioOutputChans = atoi(optarg);
+            } else {
+                std::cerr << "--numincoming ERROR: Number of channels must be greater than 0\n";
+                std::exit(1);
+            }
             break;
         case OPT_NUMOUTGOING:
+            if(0 < atoi(optarg)){
             mNumAudioInputChans = atoi(optarg);
+            } else {
+                std::cerr << "--numoutgoing ERROR: Number of channels must be greater than 0\n";
+                std::exit(1);
+            }
             break;
         case 'n':  // Number of input and output channels
             //-------------------------------------------------------
+            if(0 < atoi(optarg)) {
             mNumAudioInputChans  = atoi(optarg);
             mNumAudioOutputChans = atoi(optarg);
+            } else {
+                std::cerr << "-n --numchannels ERROR: Number of channels must be greater than 0\n";
+                std::exit(1);
+            }
             break;
         case 'U':  // UDP Bind Port
             mServerUdpPortNum = atoi(optarg);
@@ -589,12 +604,12 @@ void Settings::printUsage()
     cout << endl;
     cout << "OPTIONAL ARGUMENTS: " << endl;
     cout << " -n, --numchannels #                      Number of Input and Output "
-            "Channels (default: "
+            "Channels (# greater than 0, default: "
          << 2 << ")" << endl;
     cout << "     --numincoming #                      Number of incoming Channels from "
-            "the network\n";
+            "the network (# greater than 0)\n";
     cout << "     --numoutgoing #                      Number of outgoing Channels to "
-            "the network\n";
+            "the network (# greater than 0)\n";
 #ifdef WAIR  // WAIR
     cout << " -w, --wair                               Run in WAIR Mode" << endl;
     cout << " -N, --addcombfilterlength #              comb length adjustment for WAIR "

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -93,9 +93,11 @@ void Settings::parseInput(int argc, char** argv)
         // These options don't set a flag.
         {"numchannels", required_argument, NULL,
          'n'},  // Number of input and output channels
-        {"numincoming", required_argument, NULL, OPT_NUMINCOMING}, // Number of incoming channels
-        {"numoutgoing", required_argument, NULL, OPT_NUMOUTGOING}, // Number of outgoing channels
-#ifdef WAIR     // WAIR
+        {"numincoming", required_argument, NULL,
+         OPT_NUMINCOMING},  // Number of incoming channels
+        {"numoutgoing", required_argument, NULL,
+         OPT_NUMOUTGOING},  // Number of outgoing channels
+#ifdef WAIR                 // WAIR
         {"wair", no_argument, NULL, 'w'},  // Run in LAIR mode, sets numnetrevchannels
         {"addcombfilterlength", required_argument, NULL,
          'N'},                                                 // added comb filter length
@@ -172,7 +174,7 @@ void Settings::parseInput(int argc, char** argv)
             break;
         case 'n':  // Number of input and output channels
             //-------------------------------------------------------
-            mNumAudioInputChans = atoi(optarg);
+            mNumAudioInputChans  = atoi(optarg);
             mNumAudioOutputChans = atoi(optarg);
             break;
         case 'U':  // UDP Bind Port
@@ -522,7 +524,8 @@ void Settings::parseInput(int argc, char** argv)
     }
 
     assert(mNumAudioInputChans > 0);
-    mAudioTester.setSendChannel(mNumAudioInputChans - 1);  // use last channel for latency testing
+    mAudioTester.setSendChannel(mNumAudioInputChans
+                                - 1);  // use last channel for latency testing
     // Originally, testing only in the last channel was adopted
     // because channel 0 ("left") was a clap track on CCRMA loopback
     // servers.  Now, however, we also do it in order to easily keep
@@ -587,8 +590,10 @@ void Settings::printUsage()
     cout << " -n, --numchannels #                      Number of Input and Output "
             "Channels (default: "
          << 2 << ")" << endl;
-    cout << "     --numincoming #                      Number of incoming Channels from the network\n";
-    cout << "     --numoutgoing #                      Number of incoming Channels from the network\n";
+    cout << "     --numincoming #                      Number of incoming Channels from "
+            "the network\n";
+    cout << "     --numoutgoing #                      Number of incoming Channels from "
+            "the network\n";
 #ifdef WAIR  // WAIR
     cout << " -w, --wair                               Run in WAIR Mode" << endl;
     cout << " -N, --addcombfilterlength #              comb length adjustment for WAIR "

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -76,8 +76,8 @@ class Settings : public QObject
    private:
     JackTrip::jacktripModeT mJackTripMode = JackTrip::SERVER;  ///< JackTrip::jacktripModeT
     JackTrip::dataProtocolT mDataProtocol = JackTrip::UDP;  ///< Data Protocol
-    int mNumChansIn = 2;                          ///< Number of Input Channels
-    int mNumChansOut = 2;                          ///< Number of Output Channels
+    int mNumAudioInputChans = 2;                          ///< Number of Input Channels
+    int mNumAudioOutputChans = 2;                          ///< Number of Output Channels
     int mBufferQueueLength = gDefaultQueueLength;                 ///< Audio Buffer from network queue length
     AudioInterface::audioBitResolutionT mAudioBitResolution = AudioInterface::BIT16;
     QString mPeerAddress;  ///< Peer Address to use in jacktripModeT::CLIENT Mode

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -78,7 +78,8 @@ class Settings : public QObject
    private:
     JackTrip::jacktripModeT mJackTripMode;  ///< JackTrip::jacktripModeT
     JackTrip::dataProtocolT mDataProtocol;  ///< Data Protocol
-    int mNumChans;                          ///< Number of Channels (inputs = outputs)
+    int mNumChansIn = 2;                          ///< Number of Input Channels
+    int mNumChansOut = 2;                          ///< Number of Output Channels
     int mBufferQueueLength;                 ///< Audio Buffer from network queue length
     AudioInterface::audioBitResolutionT mAudioBitResolution;
     QString mPeerAddress;  ///< Peer Address to use in jacktripModeT::CLIENT Mode

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -60,7 +60,6 @@ class Settings : public QObject
     Q_OBJECT;
 
    public:
-
     /// \brief Parses command line input
     void parseInput(int argc, char** argv);
 
@@ -74,15 +73,17 @@ class Settings : public QObject
     bool isHubServer() { return mJackTripServer; }
 
    private:
-    JackTrip::jacktripModeT mJackTripMode = JackTrip::SERVER;  ///< JackTrip::jacktripModeT
+    JackTrip::jacktripModeT mJackTripMode =
+        JackTrip::SERVER;                                   ///< JackTrip::jacktripModeT
     JackTrip::dataProtocolT mDataProtocol = JackTrip::UDP;  ///< Data Protocol
-    int mNumAudioInputChans = 2;                          ///< Number of Input Channels
-    int mNumAudioOutputChans = 2;                          ///< Number of Output Channels
-    int mBufferQueueLength = gDefaultQueueLength;                 ///< Audio Buffer from network queue length
+    int mNumAudioInputChans               = 2;              ///< Number of Input Channels
+    int mNumAudioOutputChans              = 2;              ///< Number of Output Channels
+    int mBufferQueueLength =
+        gDefaultQueueLength;  ///< Audio Buffer from network queue length
     AudioInterface::audioBitResolutionT mAudioBitResolution = AudioInterface::BIT16;
     QString mPeerAddress;  ///< Peer Address to use in jacktripModeT::CLIENT Mode
-    int mBindPortNum = gDefaultPort;      ///< Bind Port Number
-    int mPeerPortNum = gDefaultPort;      ///< Peer Port Number
+    int mBindPortNum      = gDefaultPort;  ///< Bind Port Number
+    int mPeerPortNum      = gDefaultPort;  ///< Peer Port Number
     int mServerUdpPortNum = 0;
     QString mClientName;  ///< JackClient Name
     QString mRemoteClientName;
@@ -92,35 +93,35 @@ class Settings : public QObject
     int mBufferStrategy{1};
 
 #ifdef WAIR  // wair
-    int mNumNetRevChans = 0;     ///< Number of Network Audio Channels (net comb filters)
-    int mClientAddCombLen;   ///< cmd line adjustment of net comb
-    double mClientRoomSize;  ///< freeverb room size
-    bool mWAIR = false;              ///< WAIR mode
-#endif                       // endwhere
+    int mNumNetRevChans = 0;  ///< Number of Network Audio Channels (net comb filters)
+    int mClientAddCombLen;    ///< cmd line adjustment of net comb
+    double mClientRoomSize;   ///< freeverb room size
+    bool mWAIR = false;       ///< WAIR mode
+#endif                        // endwhere
 
-    bool mLoopBack = false;            ///< Loop-back mode
-    bool mJamLink = false;             ///< JamLink mode
-    bool mEmptyHeader = false;         ///< EmptyHeader mode
-    bool mJackTripServer = false;      ///< JackTrip Server mode
-    QString mLocalAddress = gDefaultLocalAddress;     ///< Local Address
-    unsigned int mRedundancy = 1;  ///< Redundancy factor for data in the network
-    bool mUseJack = true;             ///< Use or not JackAduio
-    bool mChanfeDefaultSR = false;     ///< Change Default Sampling Rate
-    bool mChanfeDefaultID = 0;     ///< Change Default device ID
-    bool mChanfeDefaultBS = false;     ///< Change Default Buffer Size
+    bool mLoopBack           = false;                 ///< Loop-back mode
+    bool mJamLink            = false;                 ///< JamLink mode
+    bool mEmptyHeader        = false;                 ///< EmptyHeader mode
+    bool mJackTripServer     = false;                 ///< JackTrip Server mode
+    QString mLocalAddress    = gDefaultLocalAddress;  ///< Local Address
+    unsigned int mRedundancy = 1;      ///< Redundancy factor for data in the network
+    bool mUseJack            = true;   ///< Use or not JackAduio
+    bool mChanfeDefaultSR    = false;  ///< Change Default Sampling Rate
+    bool mChanfeDefaultID    = 0;      ///< Change Default device ID
+    bool mChanfeDefaultBS    = false;  ///< Change Default Buffer Size
     unsigned int mSampleRate;
     unsigned int mDeviceID;
     unsigned int mAudioBufferSize;
     unsigned int mHubConnectionMode = JackTrip::SERVERTOCLIENT;
-    bool mConnectDefaultAudioPorts = true;  ///< Connect or not jack audio ports
-    int mIOStatTimeout = 0;
+    bool mConnectDefaultAudioPorts  = true;  ///< Connect or not jack audio ports
+    int mIOStatTimeout              = 0;
     QSharedPointer<std::ofstream> mIOStatStream;
-    Effects mEffects = false; // outgoing limiter OFF by default
-    double mSimulatedLossRate = 0.0;
+    Effects mEffects            = false;  // outgoing limiter OFF by default
+    double mSimulatedLossRate   = 0.0;
     double mSimulatedJitterRate = 0.0;
-    double mSimulatedDelayRel = 0.0;
-    int mBroadcastQueue = 0;
-    bool mUseRtUdpPriority = false;
+    double mSimulatedDelayRel   = 0.0;
+    int mBroadcastQueue         = 0;
+    bool mUseRtUdpPriority      = false;
     AudioTester mAudioTester;
 };
 

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -60,8 +60,6 @@ class Settings : public QObject
     Q_OBJECT;
 
    public:
-    Settings();
-    virtual ~Settings();
 
     /// \brief Parses command line input
     void parseInput(int argc, char** argv);
@@ -76,53 +74,53 @@ class Settings : public QObject
     bool isHubServer() { return mJackTripServer; }
 
    private:
-    JackTrip::jacktripModeT mJackTripMode;  ///< JackTrip::jacktripModeT
-    JackTrip::dataProtocolT mDataProtocol;  ///< Data Protocol
+    JackTrip::jacktripModeT mJackTripMode = JackTrip::SERVER;  ///< JackTrip::jacktripModeT
+    JackTrip::dataProtocolT mDataProtocol = JackTrip::UDP;  ///< Data Protocol
     int mNumChansIn = 2;                          ///< Number of Input Channels
     int mNumChansOut = 2;                          ///< Number of Output Channels
-    int mBufferQueueLength;                 ///< Audio Buffer from network queue length
-    AudioInterface::audioBitResolutionT mAudioBitResolution;
+    int mBufferQueueLength = gDefaultQueueLength;                 ///< Audio Buffer from network queue length
+    AudioInterface::audioBitResolutionT mAudioBitResolution = AudioInterface::BIT16;
     QString mPeerAddress;  ///< Peer Address to use in jacktripModeT::CLIENT Mode
-    int mBindPortNum;      ///< Bind Port Number
-    int mPeerPortNum;      ///< Peer Port Number
-    int mServerUdpPortNum;
+    int mBindPortNum = gDefaultPort;      ///< Bind Port Number
+    int mPeerPortNum = gDefaultPort;      ///< Peer Port Number
+    int mServerUdpPortNum = 0;
     QString mClientName;  ///< JackClient Name
     QString mRemoteClientName;
     bool mAppendThreadID{false};
-    JackTrip::underrunModeT mUnderrunMode;  ///< Underrun mode
-    bool mStopOnTimeout;  /// < Stop jacktrip after 10 second network timeout
-    int mBufferStrategy;
+    JackTrip::underrunModeT mUnderrunMode{JackTrip::WAVETABLE};  ///< Underrun mode
+    bool mStopOnTimeout{false};  /// < Stop jacktrip after 10 second network timeout
+    int mBufferStrategy{1};
 
 #ifdef WAIR  // wair
-    int mNumNetRevChans;     ///< Number of Network Audio Channels (net comb filters)
+    int mNumNetRevChans = 0;     ///< Number of Network Audio Channels (net comb filters)
     int mClientAddCombLen;   ///< cmd line adjustment of net comb
     double mClientRoomSize;  ///< freeverb room size
-    bool mWAIR;              ///< WAIR mode
+    bool mWAIR = false;              ///< WAIR mode
 #endif                       // endwhere
 
-    bool mLoopBack;            ///< Loop-back mode
-    bool mJamLink;             ///< JamLink mode
-    bool mEmptyHeader;         ///< EmptyHeader mode
-    bool mJackTripServer;      ///< JackTrip Server mode
-    QString mLocalAddress;     ///< Local Address
-    unsigned int mRedundancy;  ///< Redundancy factor for data in the network
-    bool mUseJack;             ///< Use or not JackAduio
-    bool mChanfeDefaultSR;     ///< Change Default Sampling Rate
-    bool mChanfeDefaultID;     ///< Change Default device ID
-    bool mChanfeDefaultBS;     ///< Change Default Buffer Size
+    bool mLoopBack = false;            ///< Loop-back mode
+    bool mJamLink = false;             ///< JamLink mode
+    bool mEmptyHeader = false;         ///< EmptyHeader mode
+    bool mJackTripServer = false;      ///< JackTrip Server mode
+    QString mLocalAddress = gDefaultLocalAddress;     ///< Local Address
+    unsigned int mRedundancy = 1;  ///< Redundancy factor for data in the network
+    bool mUseJack = true;             ///< Use or not JackAduio
+    bool mChanfeDefaultSR = false;     ///< Change Default Sampling Rate
+    bool mChanfeDefaultID = 0;     ///< Change Default device ID
+    bool mChanfeDefaultBS = false;     ///< Change Default Buffer Size
     unsigned int mSampleRate;
     unsigned int mDeviceID;
     unsigned int mAudioBufferSize;
-    unsigned int mHubConnectionMode;
-    bool mConnectDefaultAudioPorts;  ///< Connect or not jack audio ports
-    int mIOStatTimeout;
+    unsigned int mHubConnectionMode = JackTrip::SERVERTOCLIENT;
+    bool mConnectDefaultAudioPorts = true;  ///< Connect or not jack audio ports
+    int mIOStatTimeout = 0;
     QSharedPointer<std::ofstream> mIOStatStream;
-    Effects mEffects;
-    double mSimulatedLossRate;
-    double mSimulatedJitterRate;
-    double mSimulatedDelayRel;
-    int mBroadcastQueue;
-    bool mUseRtUdpPriority;
+    Effects mEffects = false; // outgoing limiter OFF by default
+    double mSimulatedLossRate = 0.0;
+    double mSimulatedJitterRate = 0.0;
+    double mSimulatedDelayRel = 0.0;
+    int mBroadcastQueue = 0;
+    bool mUseRtUdpPriority = false;
     AudioTester mAudioTester;
 };
 

--- a/src/UdpDataProtocol.cpp
+++ b/src/UdpDataProtocol.cpp
@@ -454,11 +454,11 @@ void UdpDataProtocol::run()
 
     int full_packet_size;
     mSmplSize = mJackTrip->getAudioBitResolution() / 8;
-    
+
     if (mRunMode == RECEIVER) {
         mChans           = mJackTrip->getNumOutputChannels();
         full_packet_size = mJackTrip->getReceivePacketSizeInBytes();
-        mFullPacket = new int8_t[full_packet_size];
+        mFullPacket      = new int8_t[full_packet_size];
         std::memset(mFullPacket, 0, full_packet_size);  // set buffer to 0
         // Put header in first packet
         mJackTrip->putHeaderInIncomingPacket(mFullPacket, mAudioPacket);
@@ -466,7 +466,7 @@ void UdpDataProtocol::run()
     } else {
         mChans           = mJackTrip->getNumInputChannels();
         full_packet_size = mJackTrip->getSendPacketSizeInBytes();
-        mFullPacket = new int8_t[full_packet_size];
+        mFullPacket      = new int8_t[full_packet_size];
         std::memset(mFullPacket, 0, full_packet_size);  // set buffer to 0
         // Put header in first packet
         mJackTrip->putHeaderInOutgoingPacket(mFullPacket, mAudioPacket);

--- a/src/UdpDataProtocol.cpp
+++ b/src/UdpDataProtocol.cpp
@@ -843,7 +843,7 @@ void UdpDataProtocol::sendPacketRedundancy(int8_t* full_redundant_packet,
 {
     mJackTrip->readAudioBuffer(mAudioPacket);
     int8_t* src = mAudioPacket;
-    if (1 != mChans) {
+    if (1 < mChans) {
         // Convert internal interleaved layout to non-interleaved
         int N       = getAudioPacketSizeInBites() / mChans / mSmplSize;
         int8_t* dst = mBuffer.data();

--- a/src/UdpDataProtocol.cpp
+++ b/src/UdpDataProtocol.cpp
@@ -648,16 +648,6 @@ void UdpDataProtocol::run()
         std::memset(full_redundant_packet, 0,
                     full_redundant_packet_size);  // Initialize to 0
         while (!mStopped && !JackTrip::sSigInt && !JackTrip::sJackStopped) {
-            // OLD CODE WITHOUT REDUNDANCY -----------------------------------------------------
-            /*
-        // We block until there's stuff available to read
-        mJackTrip->readAudioBuffer( mAudioPacket );
-        mJackTrip->putHeaderInPacket(mFullPacket, mAudioPacket);
-        // This will send the packet immediately
-        //int bytes_sent = sendPacket( reinterpret_cast<char*>(mFullPacket), full_packet_size);
-        sendPacket( UdpSocket, PeerAddress, reinterpret_cast<char*>(mFullPacket), full_packet_size);
-        */
-            //----------------------------------------------------------------------------------
             sendPacketRedundancy(full_redundant_packet, full_redundant_packet_size,
                                  full_packet_size);
         }

--- a/src/UdpDataProtocol.cpp
+++ b/src/UdpDataProtocol.cpp
@@ -456,8 +456,8 @@ void UdpDataProtocol::run()
     mSmplSize = mJackTrip->getAudioBitResolution() / 8;
 
     if (mRunMode == RECEIVER) {
-        mChans           = mJackTrip->getNumOutputChannels();
-        if(0 == mChans) return;
+        mChans = mJackTrip->getNumOutputChannels();
+        if (0 == mChans) return;
         full_packet_size = mJackTrip->getReceivePacketSizeInBytes();
         mFullPacket      = new int8_t[full_packet_size];
         std::memset(mFullPacket, 0, full_packet_size);  // set buffer to 0
@@ -465,8 +465,8 @@ void UdpDataProtocol::run()
         mJackTrip->putHeaderInIncomingPacket(mFullPacket, mAudioPacket);
 
     } else {
-        mChans           = mJackTrip->getNumInputChannels();
-        if(0 == mChans) return;
+        mChans = mJackTrip->getNumInputChannels();
+        if (0 == mChans) return;
         full_packet_size = mJackTrip->getSendPacketSizeInBytes();
         mFullPacket      = new int8_t[full_packet_size];
         std::memset(mFullPacket, 0, full_packet_size);  // set buffer to 0

--- a/src/UdpDataProtocol.cpp
+++ b/src/UdpDataProtocol.cpp
@@ -458,7 +458,7 @@ void UdpDataProtocol::run()
         full_packet_size = mJackTrip->getReceivePacketSizeInBytes();
     } else {
         mChans           = mJackTrip->getNumInputChannels();
-        full_packet_size = mJackTrip->getReceivePacketSizeInBytes();
+        full_packet_size = mJackTrip->getSendPacketSizeInBytes();
     }
     mSmplSize = mJackTrip->getAudioBitResolution() / 8;
 

--- a/src/UdpDataProtocol.cpp
+++ b/src/UdpDataProtocol.cpp
@@ -446,18 +446,25 @@ void UdpDataProtocol::run()
                   << " before Setup Audio Packet buffer, Full Packet buffer, Redundancy "
                      "Variables"
                   << std::endl;
+    
+
     // Setup Audio Packet buffer
     size_t audio_packet_size = getAudioPacketSizeInBites();
     //cout << "audio_packet_size: " << audio_packet_size << endl;
     mAudioPacket = new int8_t[audio_packet_size];
     std::memset(mAudioPacket, 0, audio_packet_size);  // set buffer to 0
     mBuffer.resize(audio_packet_size, 0);
-    mChans    = mJackTrip->getNumChannels();
-    mSmplSize = mJackTrip->getAudioBitResolution() / 8;
+    
+    int full_packet_size;
+    if(mRunMode == RECEIVER) {
+        mChans    = mJackTrip->getNumOutputChannels();
+        full_packet_size = mJackTrip->getReceivePacketSizeInBytes();
+    } else {
+        mChans    = mJackTrip->getNumInputChannels();
+        full_packet_size = mJackTrip->getReceivePacketSizeInBytes();
+    }
+    mSmplSize = mJackTrip->getAudioBitResolution() / 8;    
 
-    // Setup Full Packet buffer
-    int full_packet_size = mJackTrip->getPacketSizeInBytes();
-    //cout << "full_packet_size: " << full_packet_size << endl;
     mFullPacket = new int8_t[full_packet_size];
     std::memset(mFullPacket, 0, full_packet_size);  // set buffer to 0
 

--- a/src/UdpDataProtocol.cpp
+++ b/src/UdpDataProtocol.cpp
@@ -457,6 +457,7 @@ void UdpDataProtocol::run()
 
     if (mRunMode == RECEIVER) {
         mChans           = mJackTrip->getNumOutputChannels();
+        if(0 == mChans) return;
         full_packet_size = mJackTrip->getReceivePacketSizeInBytes();
         mFullPacket      = new int8_t[full_packet_size];
         std::memset(mFullPacket, 0, full_packet_size);  // set buffer to 0
@@ -465,6 +466,7 @@ void UdpDataProtocol::run()
 
     } else {
         mChans           = mJackTrip->getNumInputChannels();
+        if(0 == mChans) return;
         full_packet_size = mJackTrip->getSendPacketSizeInBytes();
         mFullPacket      = new int8_t[full_packet_size];
         std::memset(mFullPacket, 0, full_packet_size);  // set buffer to 0

--- a/src/UdpDataProtocol.cpp
+++ b/src/UdpDataProtocol.cpp
@@ -580,7 +580,7 @@ void UdpDataProtocol::run()
                       << " before mJackTrip->checkPeerSettings()" << std::endl;
         mJackTrip->checkPeerSettings(full_redundant_packet);
 
-        int peer_chans   = mJackTrip->getPeerNumChannels(full_redundant_packet);
+        int peer_chans   = mJackTrip->getPeerNumOutgoingChannels(full_redundant_packet);
         full_packet_size = mJackTrip->getHeaderSizeInBytes()
                            + mJackTrip->getPeerBufferSize(full_redundant_packet)
                                  * peer_chans * mSmplSize;
@@ -780,7 +780,7 @@ void UdpDataProtocol::receivePacketRedundancy(
     mRevivedCount += redun_last_index;
     //cout << endl;
 
-    int peer_chans    = mJackTrip->getPeerNumChannels(full_redundant_packet);
+    int peer_chans    = mJackTrip->getPeerNumOutgoingChannels(full_redundant_packet);
     int N             = mJackTrip->getPeerBufferSize(full_redundant_packet);
     int host_buf_size = N * mChans * mSmplSize;
     int hdr_size      = mJackTrip->getHeaderSizeInBytes();

--- a/src/UdpDataProtocol.h
+++ b/src/UdpDataProtocol.h
@@ -54,8 +54,8 @@
  * The class has a <tt>bind port</tt> and a <tt>peer port</tt>. The meaning of these
  * depends on the runModeT. If it's a SENDER, <tt>bind port</tt> is the source port and
  * <tt>peer port</tt> is the destination port for each UDP packet. If it's a RECEIVER,
- * the <tt>bind port</tt> destination port (for incoming packets) and the <tt>peer port</tt>
- * is the source port.
+ * the <tt>bind port</tt> destination port (for incoming packets) and the <tt>peer
+ * port</tt> is the source port.
  *
  * The SENDER and RECEIVER socket can share the same port/address pair (for compatibility
  * with the JamLink boxes). This is achieved setting
@@ -69,22 +69,24 @@ class UdpDataProtocol : public DataProtocol
 
    public:
     /** \brief The class constructor
-   * \param jacktrip Pointer to the JackTrip class that connects all classes (mediator)
-   * \param runmode Sets the run mode, use either SENDER or RECEIVER
-   * \param bind_port Port number to bind for this socket (this is the receive or send port depending on the runmode)
-   * \param peer_port Peer port number (this is the receive or send port depending on the runmode)
-   * \param udp_redundancy_factor Number of redundant packets
-   */
+     * \param jacktrip Pointer to the JackTrip class that connects all classes (mediator)
+     * \param runmode Sets the run mode, use either SENDER or RECEIVER
+     * \param bind_port Port number to bind for this socket (this is the receive or send
+     * port depending on the runmode)
+     * \param peer_port Peer port number (this is the receive or send port depending on
+     * the runmode)
+     * \param udp_redundancy_factor Number of redundant packets
+     */
     UdpDataProtocol(JackTrip* jacktrip, const runModeT runmode, int bind_port,
                     int peer_port, unsigned int udp_redundancy_factor = 1);
 
     /** \brief The class destructor
-   */
+     */
     virtual ~UdpDataProtocol();
 
     /** \brief Set the Peer address to connect to
-   * \param peerHostOrIP IPv4 number or host name
-   */
+     * \param peerHostOrIP IPv4 number or host name
+     */
     void setPeerAddress(const char* peerHostOrIP);
 
 #if defined(__WIN_32__)
@@ -94,40 +96,40 @@ class UdpDataProtocol : public DataProtocol
 #endif
 
     /** \brief Receives a packet. It blocks until a packet is received
-   *
-   * This function makes sure we recieve a complete packet
-   * of size n
-   * \param buf Buffer to store the recieved packet
-   * \param n size of packet to receive
-   * \return number of bytes read, -1 on error
-   */
-    //virtual int receivePacket(char* buf, const size_t n);
+     *
+     * This function makes sure we recieve a complete packet
+     * of size n
+     * \param buf Buffer to store the recieved packet
+     * \param n size of packet to receive
+     * \return number of bytes read, -1 on error
+     */
+    // virtual int receivePacket(char* buf, const size_t n);
     virtual int receivePacket(char* buf, const size_t n);
 
     /** \brief Sends a packet
-   *
-   * This function meakes sure we send a complete packet
-   * of size n
-   * \param buf Buffer to send
-   * \param n size of packet to receive
-   * \return number of bytes read, -1 on error
-   */
+     *
+     * This function meakes sure we send a complete packet
+     * of size n
+     * \param buf Buffer to send
+     * \param n size of packet to receive
+     * \return number of bytes read, -1 on error
+     */
     virtual int sendPacket(const char* buf, const size_t n);
 
     /** \brief Obtains the peer address from the first UDP packet received. This address
-   * is used by the SERVER mode to connect back to the client.
-   * \param peerHostAddress QHostAddress to store the peer address
-   * \param port Receiving port
-   */
+     * is used by the SERVER mode to connect back to the client.
+     * \param peerHostAddress QHostAddress to store the peer address
+     * \param port Receiving port
+     */
     virtual void getPeerAddressFromFirstPacket(QHostAddress& peerHostAddress,
                                                uint16_t& port);
 
     /** \brief Sets the bind port number
-    */
+     */
     void setBindPort(int port) { mBindPort = port; }
 
     /** \brief Sets the peer port number
-    */
+     */
     void setPeerPort(int port)
     {
         mPeerPort            = port;
@@ -136,10 +138,10 @@ class UdpDataProtocol : public DataProtocol
     }
 
     /** \brief Implements the Thread Loop. To start the thread, call start()
-   * ( DO NOT CALL run() )
-   *
-   * This function creats and binds all the socket and start the connection loop thread.
-   */
+     * ( DO NOT CALL run() )
+     *
+     * This function creats and binds all the socket and start the connection loop thread.
+     */
     virtual void run();
 
     virtual bool getStats(PktStat* stat);
@@ -150,15 +152,16 @@ class UdpDataProtocol : public DataProtocol
 
    signals:
 
-    /// \brief Signals when waiting every 10 milliseconds, with the total wait on wait_msec
+    /// \brief Signals when waiting every 10 milliseconds, with the total wait on
+    /// wait_msec
     /// \param wait_msec Total wait in milliseconds
     void signalWaitingTooLong(int wait_msec);
     void signalUdpWaitingTooLong();
 
-    //private:
+    // private:
    protected:
     /** \brief Binds the UDP socket to the available address and specified port
-   */
+     */
 #if defined(__WIN_32__)
     SOCKET bindSocket();
 #else
@@ -166,25 +169,25 @@ class UdpDataProtocol : public DataProtocol
 #endif
 
     /** \brief This function blocks until data is available for reading in the
-   * socket. The function will timeout after timeout_msec microseconds.
-   *
-   * This function is intended to replace QAbstractSocket::waitForReadyRead which has
-   * some problems with multithreading.
-   *
-   * \return returns true if there is data available for reading;
-   * otherwise it returns false (if an error occurred or the operation timed out)
-   */
+     * socket. The function will timeout after timeout_msec microseconds.
+     *
+     * This function is intended to replace QAbstractSocket::waitForReadyRead which has
+     * some problems with multithreading.
+     *
+     * \return returns true if there is data available for reading;
+     * otherwise it returns false (if an error occurred or the operation timed out)
+     */
     void waitForReady(int timeout_msec);
 
     /** \brief Redundancy algorythm at the receiving end
-    */
+     */
     virtual void receivePacketRedundancy(int8_t* full_redundant_packet,
                                          int full_redundant_packet_size,
                                          int full_packet_size, uint16_t& current_seq_num,
                                          uint16_t& last_seq_num, uint16_t& newer_seq_num);
 
     /** \brief Redundancy algorythm at the sender's end
-    */
+     */
     virtual void sendPacketRedundancy(int8_t* full_redundant_packet,
                                       int full_redundant_packet_size,
                                       int full_packet_size);

--- a/src/UdpHubListener.cpp
+++ b/src/UdpHubListener.cpp
@@ -62,12 +62,12 @@ bool UdpHubListener::sSigInt = false;
 UdpHubListener::UdpHubListener(int server_port, int server_udp_port)
     : mTcpServer(this)
     , mServerPort(server_port)
-    , mServerUdpPort(server_udp_port)  //final udp base port number
+    , mServerUdpPort(server_udp_port)  // final udp base port number
     , mStopped(false)
 #ifdef WAIR  // wair
     , mWAIR(false)
 #endif  // endwhere
-    ,mTotalRunningThreads(0)
+    , mTotalRunningThreads(0)
     , mHubPatchDescriptions({"server-to-clients", "client loopback",
                              "client fan out/in but not loopback", "reserved for TUB",
                              "full mix", "no auto patching"})
@@ -254,9 +254,9 @@ void UdpHubListener::receivedClientInfo(QTcpSocket* clientConnection)
     cout << "JackTrip HUB SERVER: Spawning JackTripWorker..." << endl;
     {
         QMutexLocker lock(&mMutex);
-        mJTWorkers->at(id)->setJackTrip(
-            id, mActiveAddress[id].address, server_udp_port, mActiveAddress[id].port,
-            m_connectDefaultAudioPorts);
+        mJTWorkers->at(id)->setJackTrip(id, mActiveAddress[id].address, server_udp_port,
+                                        mActiveAddress[id].port,
+                                        m_connectDefaultAudioPorts);
 
         // qDebug() << "mPeerAddress" << id <<  mActiveAddress[id].address <<
         // mActiveAddress[id].port;
@@ -277,6 +277,7 @@ void UdpHubListener::receivedClientInfo(QTcpSocket* clientConnection)
 
     // qDebug() << "mPeerAddress" << mActiveAddress[id].address <<
     // mActiveAddress[id].port;
+
 #ifndef __NO_JACK__
     connectPatch(true);
 #endif

--- a/src/UdpHubListener.cpp
+++ b/src/UdpHubListener.cpp
@@ -259,7 +259,7 @@ void UdpHubListener::receivedClientInfo(QTcpSocket* clientConnection)
     {
         QMutexLocker lock(&mMutex);
         mJTWorkers->at(id)->setJackTrip(
-            id, mActiveAddress[id].address, server_udp_port, mActiveAddress[id].port, 1,
+            id, mActiveAddress[id].address, server_udp_port, mActiveAddress[id].port,
             m_connectDefaultAudioPorts);  /// \todo temp default to 1 channel
 
         // qDebug() << "mPeerAddress" << id <<  mActiveAddress[id].address <<

--- a/src/UdpHubListener.cpp
+++ b/src/UdpHubListener.cpp
@@ -60,18 +60,14 @@ bool UdpHubListener::sSigInt = false;
 
 //*******************************************************************************
 UdpHubListener::UdpHubListener(int server_port, int server_udp_port)
-    :  // mJTWorker(NULL),
-    mTcpServer(this)
+    : mTcpServer(this)
     , mServerPort(server_port)
-    , mServerUdpPort(server_udp_port)
-    ,  // final udp base port number
-    mStopped(false)
-    ,
+    , mServerUdpPort(server_udp_port)  //final udp base port number
+    , mStopped(false)
 #ifdef WAIR  // wair
-    mWAIR(false)
-    ,
+    , mWAIR(false)
 #endif  // endwhere
-    mTotalRunningThreads(0)
+    ,mTotalRunningThreads(0)
     , mHubPatchDescriptions({"server-to-clients", "client loopback",
                              "client fan out/in but not loopback", "reserved for TUB",
                              "full mix", "no auto patching"})
@@ -260,7 +256,7 @@ void UdpHubListener::receivedClientInfo(QTcpSocket* clientConnection)
         QMutexLocker lock(&mMutex);
         mJTWorkers->at(id)->setJackTrip(
             id, mActiveAddress[id].address, server_udp_port, mActiveAddress[id].port,
-            m_connectDefaultAudioPorts);  /// \todo temp default to 1 channel
+            m_connectDefaultAudioPorts);
 
         // qDebug() << "mPeerAddress" << id <<  mActiveAddress[id].address <<
         // mActiveAddress[id].port;
@@ -296,56 +292,6 @@ void UdpHubListener::stopCheck()
         emit signalStopped();
     }
 }
-
-/* From Old Runloop code
-  // Create objects on the stack
-  QUdpSocket HubUdpSocket;
-  QHostAddress PeerAddress;
-  uint16_t peer_port; // Ougoing Peer port, in case they're not using the default
-
-  // Bind the socket to the well known port
-  bindUdpSocket(HubUdpSocket, mServerPort);
-
-  char buf[1];
-  cout << "Server Listening in UDP Port: " << mServerPort << endl;
-  cout << "Waiting for client..." << endl;
-  cout << "=======================================================" << endl;
-  while ( !mStopped )
-  {
-    //cout << "WAITING........................." << endl;
-    while ( HubUdpSocket.hasPendingDatagrams() )
-    {
-      cout << "Received request from Client!" << endl;
-      // Get Client IP Address and outgoing port from packet
-      int rv = HubUdpSocket.readDatagram(buf, 1, &PeerAddress, &peer_port);
-      cout << "Peer Port in Server ==== " << peer_port << endl;
-      if (rv < 0) { std::cerr << "ERROR: Bad UDP packet read..." << endl; }
-
-      /// \todo Get number of channels in the client from header
-
-      // check by comparing 32-bit addresses
-      /// \todo Add the port number in the comparison
-      cout << "peer_portpeer_portpeer_port === " << peer_port << endl;
-      int id = isNewAddress(PeerAddress.toIPv4Address(), peer_port);
-
-      //cout << "IDIDIDIDIDDID === " << id << endl;
-
-      // If the address is new, create a new thread in the pool
-      if (id >= 0) // old address is -1
-      {
-        // redirect port and spawn listener
-        sendToPoolPrototype(id);
-        // wait until one is complete before another spawns
-        while (mJTWorker->isSpawning()) { QThread::msleep(10); }
-        mTotalRunningThreads++;
-        cout << "Total Running Threads:  " << mTotalRunningThreads << endl;
-        cout << "=======================================================" << endl;
-      }
-      //cout << "ENDDDDDDDDDDDDDDDDDd === " << id << endl;
-    }
-    QThread::msleep(100);
-  }
-  */
 
 //*******************************************************************************
 // Returns 0 on error
@@ -393,18 +339,6 @@ int UdpHubListener::sendUdpPort(QTcpSocket* clientConnection, int udp_port)
     return 1;
     // cout << "Port sent to Client" << endl;
 }
-
-//*******************************************************************************
-/*
-void UdpHubListener::sendToPoolPrototype(int id)
-{
-  mJTWorker->setJackTrip(id, mActiveAddress[id][0],
-                         mBasePort+(2*id), mActiveAddress[id][1],
-                         1); /// \todo temp default to 1 channel
-  mThreadPool.start(mJTWorker, QThread::TimeCriticalPriority); //send one thread to the
-pool
-}
-*/
 
 //*******************************************************************************
 void UdpHubListener::bindUdpSocket(QUdpSocket& udpsocket, int port)

--- a/src/jacktrip_main.cpp
+++ b/src/jacktrip_main.cpp
@@ -39,8 +39,8 @@
 
 #include <QCoreApplication>
 #include <QLoggingCategory>
-#include <memory>
 #include <iostream>
+#include <memory>
 
 #include "Settings.h"
 #include "UdpHubListener.h"
@@ -56,7 +56,7 @@ void qtMessageHandler([[maybe_unused]] QtMsgType type,
 #if defined(__LINUX__) || (__MAC_OSX__)
 static int setupUnixSignalHandler(void (*handler)(int))
 {
-    //Setup our SIGINT handler.
+    // Setup our SIGINT handler.
     struct sigaction sigInt;
     sigInt.sa_handler = handler;
     sigemptyset(&sigInt.sa_mask);
@@ -106,7 +106,7 @@ int main(int argc, char* argv[])
         Settings settings;
         settings.parseInput(argc, argv);
 
-        //Either start our hub server or our jacktrip process as appropriate.
+        // Either start our hub server or our jacktrip process as appropriate.
         if (settings.isHubServer()) {
             udpHub.reset(settings.getConfiguredHubServer());
             if (gVerboseFlag)

--- a/src/jacktrip_main.cpp
+++ b/src/jacktrip_main.cpp
@@ -39,7 +39,7 @@
 
 #include <QCoreApplication>
 #include <QLoggingCategory>
-#include <QScopedPointer>
+#include <memory>
 #include <iostream>
 
 #include "Settings.h"
@@ -96,8 +96,8 @@ BOOL WINAPI windowsCtrlHandler(DWORD fdwCtrlType)
 int main(int argc, char* argv[])
 {
     QCoreApplication app(argc, argv);
-    QScopedPointer<JackTrip> jackTrip;
-    QScopedPointer<UdpHubListener> udpHub;
+    std::unique_ptr<JackTrip> jackTrip;
+    std::unique_ptr<UdpHubListener> udpHub;
 
     QLoggingCategory::setFilterRules(QStringLiteral("*.debug=true"));
     qInstallMessageHandler(qtMessageHandler);
@@ -111,9 +111,9 @@ int main(int argc, char* argv[])
             udpHub.reset(settings.getConfiguredHubServer());
             if (gVerboseFlag)
                 std::cout << "Settings:startJackTrip before udphub->start" << std::endl;
-            QObject::connect(udpHub.data(), &UdpHubListener::signalStopped, &app,
+            QObject::connect(udpHub.get(), &UdpHubListener::signalStopped, &app,
                              &QCoreApplication::quit, Qt::QueuedConnection);
-            QObject::connect(udpHub.data(), &UdpHubListener::signalError, &app,
+            QObject::connect(udpHub.get(), &UdpHubListener::signalError, &app,
                              &QCoreApplication::quit, Qt::QueuedConnection);
 #if defined(__LINUX__) || (__MAC_OSX__)
             setupUnixSignalHandler(UdpHubListener::sigIntHandler);
@@ -127,9 +127,9 @@ int main(int argc, char* argv[])
             if (gVerboseFlag)
                 std::cout << "Settings:startJackTrip before mJackTrip->startProcess"
                           << std::endl;
-            QObject::connect(jackTrip.data(), &JackTrip::signalProcessesStopped, &app,
+            QObject::connect(jackTrip.get(), &JackTrip::signalProcessesStopped, &app,
                              &QCoreApplication::quit, Qt::QueuedConnection);
-            QObject::connect(jackTrip.data(), &JackTrip::signalError, &app,
+            QObject::connect(jackTrip.get(), &JackTrip::signalError, &app,
                              &QCoreApplication::quit, Qt::QueuedConnection);
 #if defined(__LINUX__) || (__MAC_OSX__)
             setupUnixSignalHandler(JackTrip::sigIntHandler);


### PR DESCRIPTION
The special case of 0 channels will not be part of this PR. It was already broken. We check now that number of channels won't be set to 0.

## Todo
- [x] Split mNumChans in mNumChansIn and mNumChansOut
- [x] Use connectionMode field in DefaultHeader for the second NumChans
- [x]  Use JackTrip::NORMAL as identifier for old clients
- [x]  Use UINT8MAX as identifier for 0 outgoing channels
- [x] JackTripWorker
- [x] Add long options for separate number of incoming and outgoing channels
- [x] Hub Mode: Client tells server number of channels
- [x] P2P Mode: Both sides have to set the number of channels
    - [x] set on both side (jacktrip -s --numincoming #1 --numoutgoing #2 // jacktrip -c ip --numincoming #2 --numoutgoing #1) 
- [x] Checks for 0 channels

Resolves #78 