### PR TITLE
[Dev] Fix regression in remote client name handling

### DIFF
--- a/src/UdpHubListener.cpp
+++ b/src/UdpHubListener.cpp
@@ -348,7 +348,11 @@ uint16_t UdpHubListener::readClientUdpPort(QTcpSocket* clientConnection, QString
     char port_buf[size];
     clientConnection->read(port_buf, size);
     std::memcpy(&udp_port, port_buf, size);
-    
+
+    // Read and discard the next two bytes so that we're properly aligned
+    // to read any jack client name request.
+    clientConnection->read(port_buf, size);
+
     if (clientConnection->bytesAvailable() == gMaxRemoteNameLength) {
         char name_buf[gMaxRemoteNameLength];
         clientConnection->read(name_buf, gMaxRemoteNameLength);


### PR DESCRIPTION
Now that the port is only being read as a 16 bit integer by the hub server, the requested remote client name isn't being read properly. We need to discard the two bytes that come before it.