### PR TITLE
RtAudio Support, Meson Wraps, MSVC Support, Skip Duplicate Builds

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -1,7 +1,22 @@
 name: build
 on: [push, pull_request]
 jobs:
+  skip-duplicates:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          # All of these options are optional, so you can remove them if you are happy with the defaults
+          concurrent_skipping: 'same_content'
+          skip_after_successful_duplicate: 'true'
+          paths_ignore: '["**/README.md", "**/INSTALL*"]'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
   build:
+    needs: skip-duplicates
+    if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' }}
     runs-on: ${{ matrix.runs-on }}
     name: ${{ matrix.name }}
     strategy:

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -84,14 +84,16 @@ jobs:
         env:
           DEVELOPER_DIR: '/Applications/Xcode_11.7.app/Contents/Developer' # specify XCode version on macOS
         run: |
-          meson $BUILD_PATH
+          meson --buildtype release $BUILD_PATH
           cd $BUILD_PATH
+          meson configure -Ddefault_library=static
           meson compile
       - name: build on Windows
         if: runner.os == 'Windows'
         run: |
-          meson setup builddir
+          meson --buildtype release builddir
           cd builddir
+          meson configure -Ddefault_library=static
           meson compile
       - name: upload artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -1,0 +1,101 @@
+name: meson-build
+on: [push, pull_request]
+jobs:
+  skip-duplicates:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          # All of these options are optional, so you can remove them if you are happy with the defaults
+          concurrent_skipping: 'same_content'
+          skip_after_successful_duplicate: 'true'
+          paths_ignore: '["**/README.md", "**/INSTALL*"]'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+  build:
+    needs: skip-duplicates
+    if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' }}
+    runs-on: ${{ matrix.runs-on }}
+    name: ${{ matrix.name }}
+    strategy:
+      fail-fast: false # don't abort if one of the build failse
+      matrix:
+        include:
+          - name: Linux
+            runs-on: ubuntu-20.04
+          - name: macOS
+            runs-on: macos-10.15
+          - name: Windows
+            runs-on: windows-2019
+
+    env:
+      SRC_PATH: ${{ github.workspace }}/src
+      BUILD_PATH: ${{ github.workspace }}/builddir
+      QT_VERSION: '5.15.2'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+      - name: install dependencies for Linux
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes libpulse-dev libasound2-dev libjack-dev qt5-default qt5-qmake qttools5-dev
+          python -m pip install --upgrade pip
+          pip install meson ninja
+      - name: install dependencies for macOS
+        if: runner.os == 'macOS'
+        env:
+          HOMEBREW_NO_ANALYTICS: 1
+          HOMEBREW_NO_AUTO_UPDATE: 1
+          HOMEBREW_NO_INSTALL_CLEANUP: 1
+        run: |
+          brew install qt5 jack meson
+          brew link qt5 --force
+      - name: install dependencies for Windows
+        if: runner.os == 'Windows'
+        run: |
+          choco install jack
+          python -m pip install --upgrade pip
+          pip install meson ninja
+      - name: Setup MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+        if: runner.os == 'Windows'
+      - name: Cache Qt
+        id: cache-qt
+        if: runner.os == 'Windows'
+        uses: actions/cache@v1
+        with:
+          path: ../Qt
+          key: ${{ runner.os }}-QtCacheMSVC-${{ env.QT_VERSION }}
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v2
+        if: runner.os == 'Windows'
+        with:
+          version: '5.15.2'
+          host: 'windows'
+          target: 'desktop'
+          arch: 'win64_msvc2019_64'
+          cached: ${{ steps.cache-qt.outputs.cache-hit }}
+      - name: build on Linux / macOS
+        if: runner.os != 'Windows'
+        env:
+          DEVELOPER_DIR: '/Applications/Xcode_11.7.app/Contents/Developer' # specify XCode version on macOS
+        run: |
+          meson $BUILD_PATH
+          cd $BUILD_PATH
+          meson compile
+      - name: build on Windows
+        if: runner.os == 'Windows'
+        run: |
+          meson setup builddir
+          cd builddir
+          meson compile
+      - name: upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: JackTrip-${{ matrix.name }} # version number could be added here
+          path: ${{ env.BUILD_PATH }}
+          retention-days: 30 # remove artifacts after 30 days

--- a/meson.build
+++ b/meson.build
@@ -1,17 +1,19 @@
-project('jacktrip', 'cpp', version: '1.2',
-		default_options: ['cpp_std=c++11'])
+project('jacktrip', 'cpp', version: '1.3.0',
+		default_options: ['cpp_std=c++17'])
 qt5 = import('qt5')
-qt5_dep = dependency('qt5', modules: ['Core', 'Network'])
-jack_dep = dependency('jack')
-thread_dep = dependency('threads')
+cmake = import('cmake')
 
-defines = []
+compiler = meson.get_compiler('cpp')
+
+defines = ['-DWAIRTOHUB']
 if host_machine.system() == 'linux'
 	defines += '-D__LINUX__'
 elif host_machine.system() == 'darwin'
 	defines += '-D__MAC_OSX__'
 elif host_machine.system() == 'windows'
 	defines += '-D__WIN_32__'
+	defines += '-D_WIN32_WINNT=0x0600'
+	defines += '-DNOMINMAX'
 endif
 
 moc_h = ['src/DataProtocol.h',
@@ -25,10 +27,10 @@ moc_h = ['src/DataProtocol.h',
 	'src/UdpHubListener.h']
 moc_files = qt5.preprocess(moc_headers : moc_h)
 
-src = ['src/DataProtocol.cpp',
-	'src/JMess.cpp',
+src = [	'src/DataProtocol.cpp',
 	'src/JackTrip.cpp',
 	'src/AudioTester.cpp',
+	'src/jacktrip_globals.cpp',
 	'src/jacktrip_globals.cpp',
 	'src/jacktrip_main.cpp',
 	'src/JackTripThread.cpp',
@@ -42,9 +44,41 @@ src = ['src/DataProtocol.cpp',
 	'src/UdpDataProtocol.cpp',
 	'src/UdpHubListener.cpp',
 	'src/AudioInterface.cpp',
-	'src/JackAudioInterface.cpp',
 	'src/Compressor.cpp',
 	'src/Limiter.cpp',
 	'src/Reverb.cpp']
 
-executable('jacktrip', src, moc_files, dependencies: [qt5_dep, jack_dep, thread_dep], cpp_args: defines, install: true )
+qt5_dep = dependency('qt5', modules: ['Core', 'Network'])
+jack_dep = dependency('jack', required: get_option('jack'))
+if not jack_dep.found()
+	defines += '-D__NO_JACK__'
+endif
+
+deps = [qt5_dep, jack_dep]
+
+if not get_option('rtaudio').disabled()
+	defines += '-D__RT_AUDIO__'
+	rtaudio_dep = dependency('rtaudio', required: false)
+	deps += rtaudio_dep
+	if not rtaudio_dep.found()
+		rtaudio = cmake.subproject('rtaudio')
+		rtaudio_dep = rtaudio.dependency('rtaudio')
+		deps += rtaudio_dep
+	endif
+	src += 'src/RtAudioInterface.cpp'
+endif
+
+if host_machine.system() == 'windows'
+	wingetopt = cmake.subproject('wingetopt')
+	deps += wingetopt.dependency('wingetopt')
+	deps += compiler.find_library('ws2_32', required: true)
+endif
+
+deps += dependency('threads')
+if jack_dep.found()
+src += 	['src/JackAudioInterface.cpp',
+	'src/JMess.cpp']
+endif
+
+
+executable('jacktrip', src, moc_files, dependencies: deps, cpp_args: defines, install: true )

--- a/meson.build
+++ b/meson.build
@@ -61,7 +61,9 @@ if not get_option('rtaudio').disabled()
 	rtaudio_dep = dependency('rtaudio', required: false)
 	deps += rtaudio_dep
 	if not rtaudio_dep.found()
-		rtaudio = cmake.subproject('rtaudio')
+		opt_var = cmake.subproject_options()
+		opt_var.add_cmake_defines({'RTAUDIO_API_JACK': 'OFF'})
+		rtaudio = cmake.subproject('rtaudio', options: opt_var)
 		rtaudio_dep = rtaudio.dependency('rtaudio')
 		deps += rtaudio_dep
 	endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,4 @@
+option('wair', type : 'feature', value : 'disabled', description: 'WAIR')
+option('rtaudio', type : 'feature', value : 'auto', description: 'Build with RtAudio Backend')
+option('jack', type : 'feature', value : 'auto', description: 'Build with Jack Backend')
+

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -156,7 +156,7 @@ JackTrip::~JackTrip()
 //*******************************************************************************
 void JackTrip::setupAudio(
 #ifdef WAIRTOHUB  // WAIR
-    __attribute__((unused)) int ID
+    [[maybe_unused]] int ID
 #endif  // endwhere
 )
 {

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -37,7 +37,9 @@
 
 #include "JackTrip.h"
 
+#ifndef __NO_JACK__
 #include "JackAudioInterface.h"
+#endif
 #include "JitterBuffer.h"
 #include "RingBufferWavetable.h"
 #include "UdpDataProtocol.h"

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -678,11 +678,11 @@ void JackTrip::receivedDataUDP()
     // IPv6 addition from fyfe
     // Get the datagram size to avoid problems with IPv6
     qint64 datagramSize = mUdpSockTemp.pendingDatagramSize();
-    char buf[datagramSize];
+    char *buf = new char[datagramSize];
     // set client address
     mUdpSockTemp.readDatagram(buf, datagramSize, &peerHostAddress, &peer_port);
     mUdpSockTemp.close();  // close the socket
-
+    delete[] buf;
     // Check for mapped IPv4->IPv6 addresses that look like ::ffff:x.x.x.x
     if (peerHostAddress.protocol() == QAbstractSocket::IPv6Protocol) {
         bool mappedIPv4;

--- a/src/JackTrip.h
+++ b/src/JackTrip.h
@@ -147,7 +147,7 @@ class JackTrip : public QObject
     /// \brief The class destructor
     virtual ~JackTrip();
 
-    static void sigIntHandler(__attribute__((unused)) int unused)
+    static void sigIntHandler(int /*unused*/)
     {
         std::cout << std::endl << "Shutting Down..." << std::endl;
         sSigInt = true;

--- a/src/JackTripWorker.cpp
+++ b/src/JackTripWorker.cpp
@@ -338,16 +338,17 @@ int JackTripWorker::setJackTripFromClientHeader(JackTrip& jacktrip)
         return -1;
     }
     int packet_size = UdpSockTemp.pendingDatagramSize();
-    char packet[packet_size];
-    UdpSockTemp.readDatagram(packet, packet_size);
+    int8_t* full_packet = new int8_t[packet_size];
+    UdpSockTemp.readDatagram(reinterpret_cast<char*>(full_packet), packet_size);
     UdpSockTemp.close();  // close the socket
-    int8_t* full_packet = reinterpret_cast<int8_t*>(packet);
 
     int PeerBufferSize     = jacktrip.getPeerBufferSize(full_packet);
     int PeerSamplingRate   = jacktrip.getPeerSamplingRate(full_packet);
     int PeerBitResolution  = jacktrip.getPeerBitResolution(full_packet);
     int PeerNumChannels    = jacktrip.getPeerNumChannels(full_packet);
     int PeerConnectionMode = jacktrip.getPeerConnectionMode(full_packet);
+    delete[] full_packet;
+    full_packet = nullptr;
 
     if (gVerboseFlag)
         cout << "--->JackTripWorker: getPeerBufferSize = " << PeerBufferSize << endl;

--- a/src/JackTripWorker.cpp
+++ b/src/JackTripWorker.cpp
@@ -37,8 +37,6 @@
 
 #include "JackTripWorker.h"
 
-#include <unistd.h>
-
 #include <QMutexLocker>
 #include <QTimer>
 #include <QWaitCondition>

--- a/src/PacketHeader.cpp
+++ b/src/PacketHeader.cpp
@@ -54,7 +54,7 @@ using std::endl;
 // for more info check: http://www.halcode.com/archives/2008/08/26/retrieving-system-time-gettimeofday/
 #if defined __WIN_32__
 #ifdef __cplusplus
-void GetSystemTimeAsFileTime(FILETIME*);
+// void GetSystemTimeAsFileTime(FILETIME*);
 inline int gettimeofday(struct timeval* p, void* tz /* IGNORED */)
 {
     union {
@@ -66,9 +66,6 @@ inline int gettimeofday(struct timeval* p, void* tz /* IGNORED */)
     p->tv_sec  = (long)((now.ns100 - (116444736000000000LL)) / 10000000LL);
     return 0;
 }
-#else
-/* Must be defined somewhere else */
-int gettimeofday(struct timeval* p, void* tz /* IGNORED */);
 #endif
 #endif
 

--- a/src/PacketHeader.cpp
+++ b/src/PacketHeader.cpp
@@ -37,7 +37,9 @@
 
 #include "PacketHeader.h"
 
+#if defined(__LINUX__) || defined(__MAC_OSX__)
 #include <sys/time.h>
+#endif
 
 #include <cstdlib>
 #include <iostream>

--- a/src/ProcessPlugin.h
+++ b/src/ProcessPlugin.h
@@ -38,8 +38,6 @@
 #ifndef __PROCESSPLUGIN_H__
 #define __PROCESSPLUGIN_H__
 
-#include <jack/jack.h>
-
 #include <QThread>
 
 /** \brief Interface for the process plugins to add to the JACK callback process in

--- a/src/RtAudioInterface.cpp
+++ b/src/RtAudioInterface.cpp
@@ -101,6 +101,7 @@ void RtAudioInterface::setup()
 #endif
     //linux only
     options.priority = 30;
+    options.streamName = gJackDefaultClientName.toStdString();
 
     unsigned int sampleRate   = getSampleRate();           //mSamplingRate;
     unsigned int bufferFrames = getBufferSizeInSamples();  //mBufferSize;

--- a/src/RtAudioInterface.cpp
+++ b/src/RtAudioInterface.cpp
@@ -100,7 +100,7 @@ void RtAudioInterface::setup()
     options.flags = options.flags | RTAUDIO_MINIMIZE_LATENCY;
 #endif
     //linux only
-    options.priority = 99;
+    options.priority = 30;
 
     unsigned int sampleRate   = getSampleRate();           //mSamplingRate;
     unsigned int bufferFrames = getBufferSizeInSamples();  //mBufferSize;

--- a/src/RtAudioInterface.cpp
+++ b/src/RtAudioInterface.cpp
@@ -79,7 +79,7 @@ void RtAudioInterface::setup()
     } else {
         RtAudio::DeviceInfo info;
         for (unsigned int i = 1; i < n_devices; ++i) {
-            info = audio.getDeviceInfo(i);
+            info = mRtAudio->getDeviceInfo(i);
             if (info.isDefaultInput == true) { deviceId_input = i; }
             if (info.isDefaultOutput == true) { deviceId_output = i; }
         }

--- a/src/RtAudioInterface.cpp
+++ b/src/RtAudioInterface.cpp
@@ -78,7 +78,7 @@ void RtAudioInterface::setup()
         std::exit(0);
     } else {
         RtAudio::DeviceInfo info;
-        for (unsigned int i = 1; i < n_devices; ++i) {
+        for (unsigned int i = 0; i < n_devices; ++i) {
             info = mRtAudio->getDeviceInfo(i);
             if (info.isDefaultInput == true) { deviceId_input = i; }
             if (info.isDefaultOutput == true) { deviceId_output = i; }

--- a/src/RtAudioInterface.cpp
+++ b/src/RtAudioInterface.cpp
@@ -69,16 +69,25 @@ void RtAudioInterface::setup()
     cout << "Settin Up Default RtAudio Interface" << endl;
     cout << gPrintSeparator << endl;
     mRtAudio = new RtAudio;
-    if (mRtAudio->getDeviceCount() < 1) {
-        cout << "No audio devices found!" << endl;
-        std::exit(0);
-    }
 
     uint32_t deviceId_input;
     uint32_t deviceId_output;
+
+    if (unsigned int n_devices = mRtAudio->getDeviceCount(); n_devices < 1) {
+        cout << "No audio devices found!" << endl;
+        std::exit(0);
+    } else {
+        RtAudio::DeviceInfo info;
+        for (unsigned int i = 1; i < n_devices; ++i) {
+            info = audio.getDeviceInfo(i);
+            if (info.isDefaultInput == true) { deviceId_input = i; }
+            if (info.isDefaultOutput == true) { deviceId_output = i; }
+        }
+    }
+
     // use default devices
-    deviceId_input  = mJackTrip->getDeviceID();
-    deviceId_output = mJackTrip->getDeviceID();
+    // deviceId_input  = mJackTrip->getDeviceID();
+    // deviceId_output = mJackTrip->getDeviceID();
 
     cout << "DEFAULT INPUT DEVICE  : " << endl;
     printDeviceInfo(deviceId_input);
@@ -94,17 +103,17 @@ void RtAudioInterface::setup()
     out_params.nChannels = getNumOutputChannels();
 
     RtAudio::StreamOptions options;
-    //The second flag affects linux and mac only
+    // The second flag affects linux and mac only
     options.flags = RTAUDIO_NONINTERLEAVED | RTAUDIO_SCHEDULE_REALTIME;
 #ifdef __WIN_32__
     options.flags = options.flags | RTAUDIO_MINIMIZE_LATENCY;
 #endif
-    //linux only
-    options.priority = 30;
+    // linux only
+    options.priority   = 30;
     options.streamName = gJackDefaultClientName.toStdString();
 
-    unsigned int sampleRate   = getSampleRate();           //mSamplingRate;
-    unsigned int bufferFrames = getBufferSizeInSamples();  //mBufferSize;
+    unsigned int sampleRate   = getSampleRate();           // mSamplingRate;
+    unsigned int bufferFrames = getBufferSizeInSamples();  // mBufferSize;
 
     try {
         // IMPORTANT NOTE: It's VERY important to remember to pass this
@@ -226,9 +235,10 @@ int RtAudioInterface::processCallback(jack_nframes_t nframes)
 */
 
 //*******************************************************************************
-//int RtAudioInterface::RtAudioCallback(void *outputBuffer, void *inputBuffer,
+// int RtAudioInterface::RtAudioCallback(void *outputBuffer, void *inputBuffer,
 //                                      unsigned int nFrames,
-//                                      double /*streamTime*/, RtAudioStreamStatus /*status*/)
+//                                      double /*streamTime*/, RtAudioStreamStatus
+//                                      /*status*/)
 //{
 /*
   mInBuffer[0] = (sample_t*) inputBuffer;
@@ -253,7 +263,8 @@ int RtAudioInterface::processCallback(jack_nframes_t nframes)
     //--------
     sample_t* tmp_sample = mOutBuffer[i]; //sample buffer for channel i
     for (unsigned int j = 0; j < nFrames; j++) {
-      //std::memcpy(&tmp_sample[j], &mOutputPacket[(i*mSizeInBytesPerChannel) + (j*4)], 4);
+      //std::memcpy(&tmp_sample[j], &mOutputPacket[(i*mSizeInBytesPerChannel) + (j*4)],
+  4);
       // Change the bit resolution on each sample
       //cout << tmp_sample[j] << endl;
       AudioInterface::fromBitToSampleConversion(&mOutputPacket[(i*getSizeInBytesPerChannel())
@@ -291,39 +302,39 @@ int RtAudioInterface::processCallback(jack_nframes_t nframes)
 
 */
 
-//mTestJackTrip->printTextTest();
+// mTestJackTrip->printTextTest();
 
-//if (mJackTrip != NULL)
+// if (mJackTrip != NULL)
 //  cout << "(mJackTrip != NULL)" << endl;
 
-//if (mJackTrip == NULL) { cout << " === JACKTRIPNULL === " << endl; }
+// if (mJackTrip == NULL) { cout << " === JACKTRIPNULL === " << endl; }
 
-//const int8_t* caca;
-//mJackTrip->sendNetworkPacket( mInputPacket );
+// const int8_t* caca;
+// mJackTrip->sendNetworkPacket( mInputPacket );
 
-//in_buffer = mInBuffer.data();
-//mInBuffer.data() = (float*) inputBuffer;
+// in_buffer = mInBuffer.data();
+// mInBuffer.data() = (float*) inputBuffer;
 
-//mInBuffer[0] = static_cast<float*>(outputBuffer);
-//mOutBuffer[0] = static_cast<sample_t*>(inputBuffer);
-//float* in_buffer = static_cast<float*>(inputBuffer);
-//float* out_buffer = static_cast<float*>(outputBuffer);
+// mInBuffer[0] = static_cast<float*>(outputBuffer);
+// mOutBuffer[0] = static_cast<sample_t*>(inputBuffer);
+// float* in_buffer = static_cast<float*>(inputBuffer);
+// float* out_buffer = static_cast<float*>(outputBuffer);
 
-//cout << "nFrames = ==================== = = = = = = = ======== " << this->getBufferSizeInSamples() << endl;
-//int8_t* input_packet = new int8_t[nFrames*2];
+// cout << "nFrames = ==================== = = = = = = = ======== " <<
+// this->getBufferSizeInSamples() << endl; int8_t* input_packet = new int8_t[nFrames*2];
 
-//tmp_sample = floor( (*input) * 32768.0 ); // 2^15 = 32768.0
+// tmp_sample = floor( (*input) * 32768.0 ); // 2^15 = 32768.0
 
-//JackAudioInterface::fromSampleToBitConversion(in_buffer, input_packet, BIT16);
-//for (int i = 0; i<nFrames; i++) {
+// JackAudioInterface::fromSampleToBitConversion(in_buffer, input_packet, BIT16);
+// for (int i = 0; i<nFrames; i++) {
 //  cout << in_buffer[i] << endl;
 //}
-//mJackTrip->sendNetworkPacket(input_packet);
-//cout << mJackTrip->getRingBuffersSlotSize() << endl;
-//delete[] input_packet;
+// mJackTrip->sendNetworkPacket(input_packet);
+// cout << mJackTrip->getRingBuffersSlotSize() << endl;
+// delete[] input_packet;
 
-//mOutputPacket = static_cast<int8_t*>(inputBuffer);
-//mInputPacket = static_cast<int8_t*>(outputBuffer);
+// mOutputPacket = static_cast<int8_t*>(inputBuffer);
+// mInputPacket = static_cast<int8_t*>(outputBuffer);
 
 // Allocate the Process Callback
 //-------------------------------------------------------------------
@@ -335,9 +346,8 @@ int RtAudioInterface::processCallback(jack_nframes_t nframes)
   for (int i = 0; i < getNumInputChannels(); i++) {
     sample_t* tmp_sample = mOutBuffer[i]; //sample buffer for channel i
     for (int j = 0; j < mBufferSize; j++) {
-      fromBitToSampleConversion(&mOutputPacket[(i*getSizeInBytesPerChannel()) + (j*BIT16)],
-                                &tmp_sample[j],
-                                BIT16);
+      fromBitToSampleConversion(&mOutputPacket[(i*getSizeInBytesPerChannel()) +
+  (j*BIT16)], &tmp_sample[j], BIT16);
     }
   }
   */
@@ -355,10 +365,10 @@ int RtAudioInterface::processCallback(jack_nframes_t nframes)
     //		mSizeInBytesPerChannel);
     //--------
     float* tmp_sample = in_buffer; //sample buffer for channel i
-    //sample_t* tmp_process_sample = mOutProcessBuffer[i]; //sample buffer from the output process
-    sample_t tmp_result;
-    for (int j = 0; j < mBufferSize; j++) {
-      //std::memcpy(&tmp_sample[j], &mOutputPacket[(i*mSizeInBytesPerChannel) + (j*4)], 4);
+    //sample_t* tmp_process_sample = mOutProcessBuffer[i]; //sample buffer from the output
+  process sample_t tmp_result; for (int j = 0; j < mBufferSize; j++) {
+      //std::memcpy(&tmp_sample[j], &mOutputPacket[(i*mSizeInBytesPerChannel) + (j*4)],
+  4);
       // Change the bit resolution on each sample
 
       // Add the input jack buffer to the buffer resulting from the output process
@@ -377,5 +387,5 @@ int RtAudioInterface::processCallback(jack_nframes_t nframes)
   //mInRingBuffer->insertSlotNonBlocking( mInputPacket );
   mJackTrip->sendNetworkPacket( mInputPacket );
   */
-//return 0;
+// return 0;
 //}

--- a/src/RtAudioInterface.cpp
+++ b/src/RtAudioInterface.cpp
@@ -74,10 +74,6 @@ void RtAudioInterface::setup()
         std::exit(0);
     }
 
-    // Get and print default devices
-    RtAudio::DeviceInfo info_input;
-    RtAudio::DeviceInfo info_output;
-
     uint32_t deviceId_input;
     uint32_t deviceId_output;
     // use default devices

--- a/src/RtAudioInterface.h
+++ b/src/RtAudioInterface.h
@@ -70,7 +70,7 @@ class RtAudioInterface : public AudioInterface
 
     //--------------SETTERS---------------------------------------------
     /// \brief This has no effect in RtAudio
-    virtual void setClientName(const char* /*ClientName*/) {}
+    virtual void setClientName(QString /*ClientName*/) {}
     //------------------------------------------------------------------
 
     //--------------GETTERS---------------------------------------------

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -859,7 +859,7 @@ JackTrip* Settings::getConfiguredJackTrip()
 
     // Set RtAudio
 #ifdef __RT_AUDIO__
-    if (!mUseJack) { mJackTrip->setAudiointerfaceMode(JackTrip::RTAUDIO); }
+    if (!mUseJack) { jackTrip->setAudiointerfaceMode(JackTrip::RTAUDIO); }
 #endif
 
     // Chanfe default Sampling Rate

--- a/src/UdpDataProtocol.cpp
+++ b/src/UdpDataProtocol.cpp
@@ -49,7 +49,6 @@
 #ifdef __WIN_32__
 //#include <winsock.h>
 #include <winsock2.h>  //cc need SD_SEND
-#include <ws2tcpip.h>  // for IPv6
 #endif
 #if defined(__LINUX__) || (__MAC_OSX__)
 #include <sys/fcntl.h>

--- a/src/UdpHubListener.cpp
+++ b/src/UdpHubListener.cpp
@@ -357,7 +357,7 @@ uint16_t UdpHubListener::readClientUdpPort(QTcpSocket* clientConnection,
     // --------------------------------
     uint16_t udp_port;
     qint64 size = sizeof(udp_port);
-    char port_buf[size];
+    char* port_buf = new char[size];
     clientConnection->read(port_buf, size);
     std::memcpy(&udp_port, port_buf, size);
 
@@ -367,6 +367,7 @@ uint16_t UdpHubListener::readClientUdpPort(QTcpSocket* clientConnection,
         clientName = QString::fromUtf8((const char*)name_buf);
     }
 
+    delete[] port_buf;
     return udp_port;
 }
 

--- a/src/UdpHubListener.cpp
+++ b/src/UdpHubListener.cpp
@@ -46,6 +46,10 @@
 #include <iostream>
 #include <stdexcept>
 
+#ifndef __NO_JACK__
+#include "JMess.h"
+#endif
+
 #include "JackTripWorker.h"
 #include "jacktrip_globals.h"
 
@@ -277,8 +281,9 @@ void UdpHubListener::receivedClientInfo(QTcpSocket* clientConnection)
 
     // qDebug() << "mPeerAddress" << mActiveAddress[id].address <<
     // mActiveAddress[id].port;
-
+#ifndef __NO_JACK__
     connectPatch(true);
+#endif
 }
 
 void UdpHubListener::stopCheck()
@@ -475,12 +480,14 @@ int UdpHubListener::releaseThread(int id)
 #ifdef WAIR  // wair
     if (isWAIR()) connectMesh(false);  // invoked with -Sw
 #endif                                 // endwhere
+#ifndef __NO_JACK__
     if (getHubPatch()) connectPatch(false);  // invoked with -p > 0
+#endif
     return 0;  /// \todo Check if we really need to return an argument here
 }
 
 #ifdef WAIR  // wair
-#include "JMess.h"
+#ifndef __NO_JACK__
 //*******************************************************************************
 void UdpHubListener::connectMesh(bool spawn)
 {
@@ -501,9 +508,10 @@ void UdpHubListener::enumerateRunningThreadIDs()
         if (!mActiveAddress[id].address.isEmpty()) { qDebug() << id; }
     }
 }
+#endif
 #endif  // endwhere
 
-#include "JMess.h"
+#ifndef __NO_JACK__
 void UdpHubListener::connectPatch(bool spawn)
 {
     if ((getHubPatch() == JackTrip::NOAUTO)
@@ -528,6 +536,7 @@ void UdpHubListener::connectPatch(bool spawn)
         tmp.connectSpawnedPorts(gDefaultNumInChannels, getHubPatch());
     // FIXME: need change to gDefaultNumInChannels if more than stereo
 }
+#endif
 
 void UdpHubListener::stopAllThreads()
 {

--- a/src/UdpHubListener.h
+++ b/src/UdpHubListener.h
@@ -86,7 +86,7 @@ class UdpHubListener : public QObject
         m_connectDefaultAudioPorts = connectDefaultAudioPorts;
     }
 
-    static void sigIntHandler(__attribute__((unused)) int unused)
+    static void sigIntHandler([[maybe_unused]] int unused)
     {
         std::cout << std::endl << "Shutting Down..." << std::endl;
         sSigInt = true;

--- a/src/UdpHubListener.h
+++ b/src/UdpHubListener.h
@@ -183,8 +183,9 @@ class UdpHubListener : public QObject
     void setWAIR(int b) { mWAIR = b; }
     bool isWAIR() { return mWAIR; }
 #endif  // endwhere
+#ifndef __NO_JACK__
     void connectPatch(bool spawn);
-
+#endif
    public:
     unsigned int mHubPatch;
     void setHubPatch(unsigned int p) { mHubPatch = p; }

--- a/src/jacktrip_globals.cpp
+++ b/src/jacktrip_globals.cpp
@@ -49,6 +49,10 @@
 #include <mach/thread_policy.h>
 #endif  //__MAC_OSX__
 
+#if defined(__WIN_32__)
+#include <windows.h>
+#include <processthreadsapi.h>
+#endif
 #include "jacktrip_globals.h"
 
 #if defined(__MAC_OSX__)

--- a/src/jacktrip_main.cpp
+++ b/src/jacktrip_main.cpp
@@ -46,8 +46,8 @@
 #include "UdpHubListener.h"
 #include "jacktrip_globals.h"
 
-void qtMessageHandler(__attribute__((unused)) QtMsgType type,
-                      __attribute__((unused)) const QMessageLogContext& context,
+void qtMessageHandler([[maybe_unused]] QtMsgType type,
+                      [[maybe_unused]] const QMessageLogContext& context,
                       const QString& msg)
 {
     std::cerr << msg.toStdString() << std::endl;

--- a/subprojects/rtaudio.wrap
+++ b/subprojects/rtaudio.wrap
@@ -1,0 +1,6 @@
+[wrap-git]
+url=https://github.com/thestk/rtaudio.git
+revision=head
+
+[provide]
+dependency_names = rtaudio

--- a/subprojects/wingetopt.wrap
+++ b/subprojects/wingetopt.wrap
@@ -1,0 +1,6 @@
+[wrap-git]
+url=https://github.com/alex85k/wingetopt.git
+revision=head
+
+[provide]
+dependency_names = wingetopt


### PR DESCRIPTION
- Meson gets RtAudio now if it's missing and builds it.
- RtAudio builds again (Jack disabled)
  - CoreAudio for MacOS
  - Alsa and Pulseaudio for Linux
  - WASAPI for Windows
- Fixed MSVC build and Github Actions builds with MSVC
  - uses meson wrap file for getopt (is POSIX API)
- Meson has options now: rtaudio, jack and wair
- Meson builds with C++17 as default
- There shouldn't be anything missing for meson in comparison to the jacktrip.pro file
- Skips duplicate Github Action builds
  - Before: 12 builds ((3 old, 3 meson) *2)
  - Now: 6 builds + 4 skip-duplicates (identifier jobs) + 2 skipped jobs