### PR TITLE
Fix Windows builds in GHA

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -1,5 +1,5 @@
 name: build
-on: [workflow_dispatch, pull_request]
+on: [push, pull_request]
 jobs:
   build:
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -13,11 +13,12 @@ jobs:
           - name: macOS
             runs-on: macos-10.15
           - name: Windows
-            runs-on: windows-latest
+            runs-on: windows-2019
 
     env:
       SRC_PATH: ${{ github.workspace }}/src
       BUILD_PATH: ${{ github.workspace }}/builddir
+      QT_VERSION: '5.15.2'
     steps:
       - uses: actions/checkout@v2
       - name: install dependencies for Linux
@@ -36,15 +37,37 @@ jobs:
           brew link qt5 --force
       - name: install dependencies for Windows
         if: runner.os == 'Windows'
-        uses: jurplel/install-qt-action@v2
         run: |
           choco install jack
-      - name: build
+      - name: Cache Qt
+        id: cache-qt
+        if: runner.os == 'Windows'
+        uses: actions/cache@v1
+        with:
+          path: ../Qt
+          key: ${{ runner.os }}-QtCache-${{ env.QT_VERSION }}
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v2
+        if: runner.os == 'Windows'
+        with:
+          version: ${{ env.QT_VERSION }}
+          arch: 'win64_mingw81'
+          cached: ${{ steps.cache-qt.outputs.cache-hit }}
+      - name: build on Linux / macOS
+        if: runner.os != 'Windows'
         env:
           DEVELOPER_DIR: '/Applications/Xcode_11.7.app/Contents/Developer' # specify XCode version on macOS
         run: |
           cd $SRC_PATH
           ./build
+      - name: build on Windows
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          mkdir $BUILD_PATH 
+          cd $BUILD_PATH
+          qmake -spec win32-g++ ../src/jacktrip.pro
+          mingw32-make release
       - name: upload artifacts
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
This PR fixes Windows builds in GHA.
Changes:
- Windows image set to a particular version, so it doesn't change by itself 
  - I'm not set on this, but this is consistent with current configuration on Linux and macOS
- uses mingw 8.1
- uses jack from chocolatey (as before) 
  - this is Jack 1.9.11, so before we consider using these builds for deployment this should probably be revisited; JT built against Jack 1.9.17 should be compatible with both old and new versions
- currently the resulting build does _not_ run on my machine when downloaded - it seems that it needs gcc libraries - not sure how this should be solved (but I think this PR is still valuable in the current form, and can be later updated for a functional build)
- I reverted the change in #230 since I couldn't get github actions to trigger on my fork; if desired I can remove that change from this PR