### PR TITLE
INSTALL.txt: remove qjackctl reference

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -50,7 +50,6 @@ If you don't have Homebrew, install it:
 /bin/bash -c "$(curl -fsSLhttps://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 To install git if you don't have it:
 brew install git
-brew install qjackctl
 Install and link qt5:
 brew install qt5
 brew link qt5 --force


### PR DESCRIPTION
I believe that we shouldn't suggest installing qjackctl with homebrew. AFAIU this will also pull jack1 from homebrew (which might cause trouble) and we already suggest installing current jack2 (which is good). Jack2 does provide qjackctl with the regular download.
IMO this should go to both `main` and `dev`, but definitely to `main` as this is the default branch - I'm not sure what's the best workflow procedure for this in the JT repo....?