### PR TITLE
Use Jack 1.9.17 in GHA, update qmake file for Jack 1.9.17 (Windows)

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -38,7 +38,7 @@ jobs:
       - name: install dependencies for Windows
         if: runner.os == 'Windows'
         run: |
-          choco install jack
+          choco install jack --version=1.9.17
       - name: Cache Qt
         id: cache-qt
         if: runner.os == 'Windows'

--- a/src/jacktrip.pro
+++ b/src/jacktrip.pro
@@ -97,9 +97,21 @@ win32 {
   message(Building on win32)
 #cc  CONFIG += x86 console
   CONFIG += c++11 console
-  INCLUDEPATH += "C:\Program Files (x86)\Jack\includes"
-  LIBS += "C:\Program Files (x86)\Jack\lib\libjack64.lib"
-  LIBS += "C:\Program Files (x86)\Jack\lib\libjackserver64.lib"
+  exists("C:\Program Files\JACK2") {
+    message("using Jack in C:\Program Files\JACK2")
+    INCLUDEPATH += "C:\Program Files\JACK2\include"
+    LIBS += "C:\Program Files\JACK2\lib\libjack64.lib"
+    LIBS += "C:\Program Files\JACK2\lib\libjackserver64.lib"
+  } else {
+    exists("C:\Program Files (x86)\Jack") {
+      message("using Jack in C:\Program Files (x86)\Jack")
+      INCLUDEPATH += "C:\Program Files (x86)\Jack\includes"
+      LIBS += "C:\Program Files (x86)\Jack\lib\libjack64.lib"
+      LIBS += "C:\Program Files (x86)\Jack\lib\libjackserver64.lib"
+    } else {
+      message("Jack library not found")
+    }
+  }
 #cc  QMAKE_CXXFLAGS += -D__WINDOWS_ASIO__ #-D__UNIX_JACK__ #RtAudio Flags
   #QMAKE_LFLAGS += -static -static-libgcc -static-libstdc++ -lpthread
   LIBS += -lWs2_32 #cc -lOle32 #needed by rtaudio/asio


### PR DESCRIPTION
I tried switching jack version on windows to 1.9.17 in GitHub Actions. This also required updating include and lib paths in the `jacktrip.pro` file.

Right now I'm checking for existence of both "new" and "old" Jack locations on windows and using the one that's found. If there is a better way to do this, I'd be happy to learn.

Previously we discussed pkg-config with Nils. I now think we shouldn't rely on it, at least for qmake build, as it's an additional dependency that needs to be installed on windows. Again, I wonder if there's a better way to search multiple library locations in plain qmake config. 

I've also tried [building](https://github.com/dyfer/jacktrip/runs/1989751578) with this change using the [old version](https://github.com/dyfer/jacktrip/runs/1989751578?check_suite_focus=true#step:5:14009) and it seems [fine](https://github.com/dyfer/jacktrip/runs/1989751578?check_suite_focus=true#step:9:22).

I also think this should go into main before the next release.