### PR TITLE
Ignore macOS .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 
 # build directory
 builddir/
+
+# macOS files
+.DS_Store


### PR DESCRIPTION
This PR adds `.DS_Store` to the list of ignored files in the repository.
These files are created on macOS automatically. We should ignore them so that they don't show up in git as files changed in the repository.