### PR TITLE
Hardcode Derived Class Names of ProcessPlugins

### DIFF
--- a/src/Compressor.h
+++ b/src/Compressor.h
@@ -132,6 +132,7 @@ class Compressor : public ProcessPlugin
     int getNumInputs() override { return (mNumChannels); }
     int getNumOutputs() override { return (mNumChannels); }
     void compute(int nframes, float** inputs, float** outputs) override;
+    const char* getName() const override { return "Compressor"; }
 
    private:
     float fs;

--- a/src/Limiter.h
+++ b/src/Limiter.h
@@ -125,6 +125,7 @@ class Limiter : public ProcessPlugin
     int getNumInputs() override { return (mNumChannels); }
     int getNumOutputs() override { return (mNumChannels); }
     void compute(int nframes, float** inputs, float** outputs) override;
+    const char* getName() const override { return "Limiter"; }
 
     void setWarningAmplitude(double wa)
     {  // setting to 0 turns off warnings

--- a/src/NetKS.h
+++ b/src/NetKS.h
@@ -133,6 +133,8 @@ class NetKS : public ProcessPlugin
         }
     }
 
+    const char* getName() const override { return "NetKS"; }
+
     //============================================================================
 };
 

--- a/src/ProcessPlugin.h
+++ b/src/ProcessPlugin.h
@@ -63,13 +63,7 @@ class ProcessPlugin : public QThread
 
     //virtual void buildUserInterface(UI* interface) = 0;
 
-    virtual char* getName()
-    {
-        char* pluginName{
-            const_cast<char*>(typeid(*this).name())};  // get name of DERIVED class
-        while (isdigit(*pluginName)) { pluginName++; }
-        return pluginName;
-    }
+    virtual const char* getName() const = 0; // get name of DERIVED class
 
     /** \brief Do proper Initialization of members and class instances. By default this
    * initializes the Sampling Frequency. If a class instance depends on the
@@ -79,8 +73,7 @@ class ProcessPlugin : public QThread
     {
         fSamplingFreq = samplingRate;
         if (verbose) {
-            char* derivedClassName = getName();
-            printf("%s: init(%d)\n", derivedClassName, samplingRate);
+            printf("%s: init(%d)\n", getName(), samplingRate);
         }
     }
     virtual bool getInited() { return inited; }

--- a/src/Reverb.h
+++ b/src/Reverb.h
@@ -146,7 +146,7 @@ class Reverb : public ProcessPlugin
     int getNumInputs() override { return (mNumInChannels); }
     int getNumOutputs() override { return (mNumOutChannels); }
     void compute(int nframes, float** inputs, float** outputs) override;
-
+    const char* getName() const override { return "Reverb"; }
    private:
     float fs;
     int mNumInChannels;


### PR DESCRIPTION
Fixes #246 
It's hardcoding the names of ProcessPlugin's derived classes.