### PR TITLE
Change helpscreen wording for --broadcast argument

### DIFF
--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -710,7 +710,8 @@ void Settings::printUsage()
          << endl;
     cout << " --bufstrategy # (0, 1, 2)                Use alternative jitter buffer"
          << endl;
-    cout << " --broadcast <broadcast_queue>            Duplicates receive ports for each connected client with the specified broadcast_queue length. Broadcast outputs have higher latency but less packet loss." << endl;
+    cout << " --broadcast <broadcast_queue>            Duplicate receive ports with the specified broadcast_queue length. "
+                                                       "Broadcast outputs have higher latency but less packet loss.\n";
     cout << " --udprt                                  Use RT thread priority for "
             "network I/O"
          << endl;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -710,9 +710,7 @@ void Settings::printUsage()
          << endl;
     cout << " --bufstrategy # (0, 1, 2)                Use alternative jitter buffer"
          << endl;
-    cout << " --broadcast <broadcast_queue>            Turn on broadcast output ports "
-            "with extra queue (requires new jitter buffer)"
-         << endl;
+    cout << " --broadcast <broadcast_queue>            Duplicates receive ports for each connected client with the specified broadcast_queue length. Broadcast outputs have higher latency but less packet loss." << endl;
     cout << " --udprt                                  Use RT thread priority for "
             "network I/O"
          << endl;


### PR DESCRIPTION
Suggesting this new wording for --broadcast argument on help screen (changed in Settings.cpp): "Creates duplicate receive ports for each connected client that use the specified broadcast_queue length, to enable creating a broadcast output mix with added latency but less packet loss"