### PR TITLE
Build static Qt in GHA on macOS and Windows

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -25,16 +25,30 @@ jobs:
         include:
           - name: Linux
             runs-on: ubuntu-18.04
+            qmake-spec: linux-g++
+            make-cmd: make
+
           - name: macOS
             runs-on: macos-10.15
+            qmake-spec: macx-clang
+            make-cmd: make
+
           - name: macOS-static
             runs-on: macos-10.15
+            qmake-spec: macx-clang
+            make-cmd: make
             static: true
+
           - name: Windows
             runs-on: windows-2019
+            qmake-spec: win32-g++
+            make-cmd: mingw32-make
+
           - name: Windows-static
-            static: true
             runs-on: windows-2019
+            qmake-spec: win32-g++
+            make-cmd: mingw32-make
+            static: true
 
     env:
       SRC_PATH: ${{ github.workspace }}/src
@@ -122,29 +136,18 @@ jobs:
           mingw32-make -j4
           echo "installing Qt"
           mingw32-make install
-      - name: build JackTrip on Linux / macOS
-        if: runner.os != 'Windows'
-        run: |
-          cd $SRC_PATH
-          if [[ "${{ matrix.static }}" == true ]]; then 
-            export PATH=$QT_STATIC_BUILD_PATH/bin:$PATH
-            ./build static
-          else
-            ./build
-          fi
-      - name: build JackTrip on Windows
-        if: runner.os == 'Windows'
+      - name: build JackTrip
         shell: bash
         run: |
           mkdir $BUILD_PATH 
           cd $BUILD_PATH
+          CONFIG_STRING=
           if [[ "${{ matrix.static }}" == true ]]; then 
             export PATH=$QT_STATIC_BUILD_PATH/bin:$PATH
-            qmake -spec win32-g++ -config static ../src/jacktrip.pro
-          else
-            qmake -spec win32-g++ ../src/jacktrip.pro
+            CONFIG_STRING="-config static" $CONFIG_STRING
           fi
-          mingw32-make release
+          qmake -spec ${{ matrix.qmake-spec }} $CONFIG_STRING ../src/jacktrip.pro
+          ${{ matrix.make-cmd }} release
       - name: upload artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -27,6 +27,9 @@ jobs:
             runs-on: ubuntu-18.04
           - name: macOS
             runs-on: macos-10.15
+          - name: macOS-static
+            runs-on: macos-10.15
+            static: true
           - name: Windows
             runs-on: windows-2019
 
@@ -34,6 +37,11 @@ jobs:
       SRC_PATH: ${{ github.workspace }}/src
       BUILD_PATH: ${{ github.workspace }}/builddir
       QT_VERSION: '5.15.2'
+      DEVELOPER_DIR: '/Applications/Xcode_11.7.app/Contents/Developer' # specify XCode version on macOS
+      QT_SRC_URL: 'https://download.qt.io/official_releases/qt/5.15/5.15.2/single/qt-everywhere-src-5.15.2.tar.xz'
+      QT_SRC_PATH: ${{ github.workspace }}/../qt-static-src
+      QT_STATIC_BUILD_PATH: ${{ github.workspace }}/../qt-static
+      QT_STATIC_CACHE_KEY: '5.15.2_v01'
     steps:
       - uses: actions/checkout@v2
       - name: install dependencies for Linux
@@ -48,8 +56,11 @@ jobs:
           HOMEBREW_NO_AUTO_UPDATE: 1
           HOMEBREW_NO_INSTALL_CLEANUP: 1
         run: |
-          brew install qt5 jack
-          brew link qt5 --force
+          brew install jack
+          if [[ "${{ matrix.static }}" != true ]]; then 
+            brew install qt5
+            brew link qt5 --force
+          fi
       - name: install dependencies for Windows
         if: runner.os == 'Windows'
         run: |
@@ -68,13 +79,41 @@ jobs:
           version: ${{ env.QT_VERSION }}
           arch: 'win64_mingw81'
           cached: ${{ steps.cache-qt.outputs.cache-hit }}
+      - name: cache static Qt
+        id: cache-static-qt
+        if: matrix.static == true
+        uses: actions/cache@v1
+        with:
+          path: ${{ env.QT_STATIC_BUILD_PATH }}
+          key: ${{ runner.os }}-QtStaticCache-${{ env.QT_STATIC_CACHE_KEY }}
+      - name: build static Qt
+        if: matrix.static == true && '!steps.cache-static-qt.outputs.cache-hit'
+        run: |
+          mkdir $QT_STATIC_BUILD_PATH
+          echo "Downloading Qt source"
+          curl -L $QT_SRC_URL -o qt.tar.xz
+          echo "Unpacking Qt source"
+          tar -xf qt.tar.xz
+          # move qt to a known location
+          mv qt-everywhere* $QT_SRC_PATH
+          # configure
+          "$QT_SRC_PATH/configure" -static -release -ltcg -optimize-size -no-pch -prefix "$QT_STATIC_BUILD_PATH" -skip webengine -skip qt3d -skip qtactiveqt -skip qtandroidextras -skip qtcharts -skip qtdatavis3d -skip qtdeclarative -skip qtdoc -skip qtgamepad -skip qtgraphicaleffects -skip qtimageformats -skip qtlocation -skip qtlottie -skip qtmultimedia -skip qtpurchasing -skip qtquick3d -skip qtpurchasing -skip qtquickcontrols -skip qtquickcontrols2 -skip qtquicktimeline -skip qtremoteobjects -skip qtscript -skip qtsensors -skip qtserialbus -skip qtserialport -skip qtspeech -skip qtsvg -skip qttools -skip qtvirtualkeyboard -skip qtwayland -skip qtwebchannel -skip qtwebengine -skip qtwebglplugin -skip qtwebsockets -skip qtwebview -skip qtxmlpatterns -nomake tools -nomake tests -nomake examples -opensource -confirm-license
+          # build
+          echo "building Qt"
+          make -j4
+          # install
+          echo "installing Qt"
+          make install
       - name: build on Linux / macOS
         if: runner.os != 'Windows'
-        env:
-          DEVELOPER_DIR: '/Applications/Xcode_11.7.app/Contents/Developer' # specify XCode version on macOS
         run: |
           cd $SRC_PATH
-          ./build
+          if [[ "${{ matrix.static }}" == true ]]; then 
+            export PATH=$QT_STATIC_BUILD_PATH/bin:$PATH
+            ./build static
+          else
+            ./build
+          fi
       - name: build on Windows
         if: runner.os == 'Windows'
         shell: bash

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -32,6 +32,9 @@ jobs:
             static: true
           - name: Windows
             runs-on: windows-2019
+          - name: Windows-static
+            static: true
+            runs-on: windows-2019
 
     env:
       SRC_PATH: ${{ github.workspace }}/src
@@ -41,7 +44,8 @@ jobs:
       QT_SRC_URL: 'https://download.qt.io/official_releases/qt/5.15/5.15.2/single/qt-everywhere-src-5.15.2.tar.xz'
       QT_SRC_PATH: ${{ github.workspace }}/../qt-static-src
       QT_STATIC_BUILD_PATH: ${{ github.workspace }}/../qt-static
-      QT_STATIC_CACHE_KEY: '5.15.2_v01'
+      QT_STATIC_CACHE_KEY: '5.15.2_v01' # update this to force rebuilding static Qt
+      QT_STATIC_OPTIONS: '-static -release -optimize-size -no-pch -nomake tools -nomake tests -nomake examples -opensource -confirm-license -skip webengine -skip qt3d -skip qtactiveqt -skip qtandroidextras -skip qtcharts -skip qtdatavis3d -skip qtdeclarative -skip qtdoc -skip qtgamepad -skip qtgraphicaleffects -skip qtimageformats -skip qtlocation -skip qtlottie -skip qtmultimedia -skip qtpurchasing -skip qtquick3d -skip qtpurchasing -skip qtquickcontrols -skip qtquickcontrols2 -skip qtquicktimeline -skip qtremoteobjects -skip qtscript -skip qtsensors -skip qtserialbus -skip qtserialport -skip qtspeech -skip qtsvg -skip qttools -skip qtvirtualkeyboard -skip qtwayland -skip qtwebchannel -skip qtwebengine -skip qtwebglplugin -skip qtwebsockets -skip qtwebview -skip qtxmlpatterns' # common for all platforms
     steps:
       - uses: actions/checkout@v2
       - name: install dependencies for Linux
@@ -65,16 +69,16 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           choco install jack --version=1.9.17
-      - name: Cache Qt
+      - name: cache Qt
         id: cache-qt
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && matrix.static != true
         uses: actions/cache@v1
         with:
           path: ../Qt
           key: ${{ runner.os }}-QtCache-${{ env.QT_VERSION }}
-      - name: Install Qt
+      - name: install Qt
         uses: jurplel/install-qt-action@v2
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && matrix.static != true
         with:
           version: ${{ env.QT_VERSION }}
           arch: 'win64_mingw81'
@@ -86,25 +90,39 @@ jobs:
         with:
           path: ${{ env.QT_STATIC_BUILD_PATH }}
           key: ${{ runner.os }}-QtStaticCache-${{ env.QT_STATIC_CACHE_KEY }}
-      - name: build static Qt
-        if: matrix.static == true && '!steps.cache-static-qt.outputs.cache-hit'
+      - name: download Qt sources
+        if: matrix.static == true && steps.cache-static-qt.outputs.cache-hit != 'true'
+        shell: bash
         run: |
-          mkdir $QT_STATIC_BUILD_PATH
           echo "Downloading Qt source"
           curl -L $QT_SRC_URL -o qt.tar.xz
           echo "Unpacking Qt source"
           tar -xf qt.tar.xz
           # move qt to a known location
           mv qt-everywhere* $QT_SRC_PATH
+      - name: build static Qt on Linux / macOS
+        if: matrix.static == true && steps.cache-static-qt.outputs.cache-hit != 'true' && runner.os != 'Windows'
+        run: |
+          mkdir $QT_STATIC_BUILD_PATH
           # configure
-          "$QT_SRC_PATH/configure" -static -release -ltcg -optimize-size -no-pch -prefix "$QT_STATIC_BUILD_PATH" -skip webengine -skip qt3d -skip qtactiveqt -skip qtandroidextras -skip qtcharts -skip qtdatavis3d -skip qtdeclarative -skip qtdoc -skip qtgamepad -skip qtgraphicaleffects -skip qtimageformats -skip qtlocation -skip qtlottie -skip qtmultimedia -skip qtpurchasing -skip qtquick3d -skip qtpurchasing -skip qtquickcontrols -skip qtquickcontrols2 -skip qtquicktimeline -skip qtremoteobjects -skip qtscript -skip qtsensors -skip qtserialbus -skip qtserialport -skip qtspeech -skip qtsvg -skip qttools -skip qtvirtualkeyboard -skip qtwayland -skip qtwebchannel -skip qtwebengine -skip qtwebglplugin -skip qtwebsockets -skip qtwebview -skip qtxmlpatterns -nomake tools -nomake tests -nomake examples -opensource -confirm-license
+          "$QT_SRC_PATH/configure" -ltcg -prefix "$QT_STATIC_BUILD_PATH" $QT_STATIC_OPTIONS
           # build
           echo "building Qt"
           make -j4
           # install
           echo "installing Qt"
           make install
-      - name: build on Linux / macOS
+      - name: build static Qt on Windows
+        if: matrix.static == true && steps.cache-static-qt.outputs.cache-hit != 'true' && runner.os == 'Windows'
+        shell: cmd
+        run: |
+          mkdir %QT_STATIC_BUILD_PATH%
+          call "%QT_SRC_PATH%/configure.bat" -static-runtime -opengl desktop -platform win32-g++ -prefix "%QT_STATIC_BUILD_PATH%" %QT_STATIC_OPTIONS%
+          echo "building Qt"
+          mingw32-make -j4
+          echo "installing Qt"
+          mingw32-make install
+      - name: build JackTrip on Linux / macOS
         if: runner.os != 'Windows'
         run: |
           cd $SRC_PATH
@@ -114,13 +132,18 @@ jobs:
           else
             ./build
           fi
-      - name: build on Windows
+      - name: build JackTrip on Windows
         if: runner.os == 'Windows'
         shell: bash
         run: |
           mkdir $BUILD_PATH 
           cd $BUILD_PATH
-          qmake -spec win32-g++ ../src/jacktrip.pro
+          if [[ "${{ matrix.static }}" == true ]]; then 
+            export PATH=$QT_STATIC_BUILD_PATH/bin:$PATH
+            qmake -spec win32-g++ -config static ../src/jacktrip.pro
+          else
+            qmake -spec win32-g++ ../src/jacktrip.pro
+          fi
           mingw32-make release
       - name: upload artifacts
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
I've added static Qt builds to our GHA - qmake only for now.

Thanks @wholenotes for all the pointers. I've also found [this page](https://retifrav.github.io/blog/2018/02/17/build-qt-statically/) to be helpful, especially for the Windows build.

Here are some notes:
- Qt is built once and then cached
- initial build takes a long time (almost an hour), but subsequent builds for a given branch are fast, see [this job on my fork](https://github.com/dyfer/jacktrip/runs/2210027958?check_suite_focus=true)
- I used the latest Qt5 - 5.15.2; on Windows that probably doesn't matter (it supports Windows 7 and later). On macOS this probably means that we support only macOS 10.13 and later; I think previous JT releases used older Qt and thus might've supported older OSs (?). We could change the Qt version that we use, or even build two versions (the latter is probably an overkill?)
- on Windows Qt is built using `mingw32`, like JT; in the process of working on this I also got the [MSVC build working, linked here for reference](https://github.com/dyfer/jacktrip/blob/mp/static-qt-msvc/.github/workflows/jacktrip.yml#L115)
- ~~[this change](https://github.com/jacktrip/jacktrip/compare/dev...dyfer:mp/static-qt-gha?expand=1#diff-12d8f0d8ae7fbe32ec242aac7bb0b0402495ff5553c089cfcef9576b2ad836ceR116) seemed like a good idea, but I'm not sure if it's correct, could someone confirm?~~ I've tested [Windows build without this change](https://github.com/dyfer/jacktrip/actions/runs/730676824) - it still worked fine and had no external dependencies aside from libjack and system libraries. In that case I removed this change from my PR.
- macOS Qt building step is labeled `Linux / macOS`, since according to the website linked earlier the same commands should work on Linux; I have not tried building static Qt on Linux though
- I've set the qt build to [skip numerous modules](https://github.com/jacktrip/jacktrip/pull/257/files#diff-400b21146a0aa3667e1c8f1d95c364ac50306b03359d195bff0e90725ecaabf8R62), which I don't think we're using anyway. This of course can be further changed/tweaked if we need in the future. The [cache key](https://github.com/jacktrip/jacktrip/pull/257/files#diff-400b21146a0aa3667e1c8f1d95c364ac50306b03359d195bff0e90725ecaabf8R61) needs to be updated to trigger rebuilding Qt.