### PR TITLE
Build with rtaudio

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -32,22 +32,26 @@ jobs:
             runs-on: macos-10.15
             qmake-spec: macx-clang
             make-cmd: make
+            rtaudio: true
 
           - name: macOS-static
             runs-on: macos-10.15
             qmake-spec: macx-clang
             make-cmd: make
+            rtaudio: true
             static: true
 
           - name: Windows
             runs-on: windows-2019
             qmake-spec: win32-g++
             make-cmd: mingw32-make
+            rtaudio: true
 
           - name: Windows-static
             runs-on: windows-2019
             qmake-spec: win32-g++
             make-cmd: mingw32-make
+            rtaudio: true
             static: true
 
     env:
@@ -79,10 +83,20 @@ jobs:
             brew install qt5
             brew link qt5 --force
           fi
+          if [[ "${{ matrix.rtaudio }}" == true ]]; then 
+            brew install rt-audio
+            rm -f `brew --prefix rt-audio`/lib/*.dylib # remove the dynamic library, we want static only
+          fi
       - name: install dependencies for Windows
         if: runner.os == 'Windows'
+        shell: bash
         run: |
           choco install jack --version=1.9.17
+          if [[ "${{ matrix.rtaudio }}" == true ]]; then 
+            choco install pkgconfiglite
+            vcpkg install rtaudio --triplet=x64-mingw-static
+            echo "PKG_CONFIG_PATH=$VCPKG_INSTALLATION_ROOT\installed\x64-mingw-static\lib\pkgconfig" >> $GITHUB_ENV
+          fi
       - name: cache Qt
         id: cache-qt
         if: runner.os == 'Windows' && matrix.static != true
@@ -144,7 +158,10 @@ jobs:
           CONFIG_STRING=
           if [[ "${{ matrix.static }}" == true ]]; then 
             export PATH=$QT_STATIC_BUILD_PATH/bin:$PATH
-            CONFIG_STRING="-config static" $CONFIG_STRING
+            CONFIG_STRING="-config static $CONFIG_STRING"
+          fi
+          if [[ "${{ matrix.rtaudio }}" == true ]]; then 
+            CONFIG_STRING="-config rtaudio $CONFIG_STRING"
           fi
           qmake -spec ${{ matrix.qmake-spec }} $CONFIG_STRING ../src/jacktrip.pro
           ${{ matrix.make-cmd }} release


### PR DESCRIPTION
I've added rtaudio static to our build system for macOS and Windows. RtAudio support is added to `qmake` with `-config rtaudio` flag.

Have not tested extensively - it just builds and runs for now. There seem to be no external dependencies (i.e. static library seems to be properly used).

I've removed some dead code in `jacktrip.pro` file from previously included rtaudio in the source. I'm using rt-audio from vcpkg and pkg-config to get the include paths and linker flags, so this means that windows builds with rtaudio will require installing pkg-config and rtaudio separately. I'd be happy to add that to the docs in another PR. (Building without rtaudio is still possible and doesn't require either library).

On Windows, I had a problem adding proper linker flags - it seems that we need to link the main app with Windows libraries when using rtaudio (not sure if it's supposed to be like that - shouldn't the static library be linked to these already?) Anyway, the problem was that the additional linker flags need to come _after_ `-lrtaudio`, but when using `pkg-config` in `qmake`, linker flags from pkg-config are added _after_ linker flags specified manually. Thus on Windows I added linker flags including `-lrtaudio` (so `-lrtaudio` ends up being used [twice](https://github.com/dyfer/jacktrip/runs/2471276875?check_suite_focus=true#step:12:1012)) which was needed for successful linking.