### PR TITLE
GitHub Actions: use jack 1.9.16 on macOS

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -74,7 +74,11 @@ jobs:
           HOMEBREW_NO_AUTO_UPDATE: 1
           HOMEBREW_NO_INSTALL_CLEANUP: 1
         run: |
-          brew install jack
+          # brew install jack
+          # instead of using homebrew, install jack 1.9.16 from the installer, which should provide compatibility with both jackosx and the newer jack2
+          curl -L https://github.com/jackaudio/jack2-releases/releases/download/v1.9.16/jack2-macOS-v1.9.16.tar.gz -o jack2.tar.gz
+          tar -xf jack2.tar.gz
+          sudo installer -pkg jack2-osx-1.9.16.pkg -target /
           if [[ "${{ matrix.static }}" != true ]]; then 
             brew install qt5
             brew link qt5 --force


### PR DESCRIPTION
Currently there is jack 1.9.17 available in homebrew. Linking against this version prevents from running with jackosx, due to difference in library name (no API conflicts), see https://github.com/jackaudio/jack2/issues/738
Linking against Jack 1.9.16 should make JackTrip compatible with both JackOSX and the newer Jack2.

EDIT: 1.3.0 release of JT is linked against Jack 1.9.16 since this was the version that was in homebrew at the time of releasing.