### PR TITLE
Build rtaudio subproject statically (except for Windows)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -64,6 +64,7 @@ if not get_option('rtaudio').disabled()
 		opt_var = cmake.subproject_options()
 		opt_var.add_cmake_defines({'RTAUDIO_API_JACK': 'OFF',
 					'RTAUDIO_BUILD_SHARED_LIBS': 'OFF'})
+		opt_var.set_install(false)
 		rtaudio = cmake.subproject('rtaudio', options: opt_var)
 		rtaudio_dep = rtaudio.dependency('rtaudio')
 		deps += rtaudio_dep

--- a/meson.build
+++ b/meson.build
@@ -62,7 +62,8 @@ if not get_option('rtaudio').disabled()
 	deps += rtaudio_dep
 	if not rtaudio_dep.found()
 		opt_var = cmake.subproject_options()
-		opt_var.add_cmake_defines({'RTAUDIO_API_JACK': 'OFF'})
+		opt_var.add_cmake_defines({'RTAUDIO_API_JACK': 'OFF',
+					'RTAUDIO_BUILD_SHARED_LIBS': 'OFF'})
 		rtaudio = cmake.subproject('rtaudio', options: opt_var)
 		rtaudio_dep = rtaudio.dependency('rtaudio')
 		deps += rtaudio_dep

--- a/meson.build
+++ b/meson.build
@@ -62,8 +62,10 @@ if not get_option('rtaudio').disabled()
 	deps += rtaudio_dep
 	if not rtaudio_dep.found()
 		opt_var = cmake.subproject_options()
-		opt_var.add_cmake_defines({'RTAUDIO_API_JACK': 'OFF',
-					'RTAUDIO_BUILD_SHARED_LIBS': 'OFF'})
+		opt_var.add_cmake_defines({'RTAUDIO_API_JACK': 'OFF'})
+		if not (host_machine.system() == 'windows')
+			opt_var.add_cmake_defines({'RTAUDIO_BUILD_SHARED_LIBS': 'OFF'})
+		endif
 		opt_var.set_install(false)
 		rtaudio = cmake.subproject('rtaudio', options: opt_var)
 		rtaudio_dep = rtaudio.dependency('rtaudio')


### PR DESCRIPTION
This should always compile rtaudio statically when it is a subproject.