### PR TITLE
Fix and optimize some for loops

### DIFF
--- a/src/AudioInterface.cpp
+++ b/src/AudioInterface.cpp
@@ -651,10 +651,10 @@ void AudioInterface::initPlugins()
     if (nPlugins > 0) {
         std::cout << "Initializing Faust plugins (have " << nPlugins
                   << ") at sampling rate " << mSampleRate << "\n";
-        for (ProcessPlugin* plugin : mProcessPluginsFromNetwork) {
+        for (ProcessPlugin* plugin : qAsConst(mProcessPluginsFromNetwork)) {
             plugin->init(mSampleRate);
         }
-        for (ProcessPlugin* plugin : mProcessPluginsToNetwork) {
+        for (ProcessPlugin* plugin : qAsConst(mProcessPluginsToNetwork)) {
             plugin->init(mSampleRate);
         }
     }

--- a/src/compressordsp.h
+++ b/src/compressordsp.h
@@ -1381,7 +1381,7 @@ class APIUI
     {
         std::map<const char*, const char*> res;
         std::map<std::string, std::string> metadata = fMetaData[p];
-        for (auto it : metadata) { res[it.first.c_str()] = it.second.c_str(); }
+        for (const auto& it : metadata) { res[it.first.c_str()] = it.second.c_str(); }
         return res;
     }
 

--- a/src/freeverbdsp.h
+++ b/src/freeverbdsp.h
@@ -1381,7 +1381,7 @@ class APIUI
     {
         std::map<const char*, const char*> res;
         std::map<std::string, std::string> metadata = fMetaData[p];
-        for (auto it : metadata) { res[it.first.c_str()] = it.second.c_str(); }
+        for (const auto& it : metadata) { res[it.first.c_str()] = it.second.c_str(); }
         return res;
     }
 

--- a/src/limiterdsp.h
+++ b/src/limiterdsp.h
@@ -1378,7 +1378,7 @@ class APIUI
     {
         std::map<const char*, const char*> res;
         std::map<std::string, std::string> metadata = fMetaData[p];
-        for (auto it : metadata) { res[it.first.c_str()] = it.second.c_str(); }
+        for (const auto& it : metadata) { res[it.first.c_str()] = it.second.c_str(); }
         return res;
     }
 


### PR DESCRIPTION
Qt containers might lose their head if they are used in range based for loops. Consting the iterators with qAsConst helps.

Some range based for loops did some unnecessary copies.