### PR TITLE
Qmake: use pkg-config for Jack

### DIFF
--- a/jacktrip.pro
+++ b/jacktrip.pro
@@ -42,10 +42,12 @@ INCLUDEPATH += faust-src-lair/stk
 # wair needs stk, can be had from linux this way
 # INCLUDEPATH+=/usr/include/stk
 # LIBS += -L/usr/local/lib -ljack -lstk -lm
-  LIBS += -L/usr/local/lib -ljack -lm
+  LIBS += -L/usr/local/lib -lm
   nojack {
     message(Building NONJACK)
-    LIBS -= -ljack
+  } else {
+    CONFIG += link_pkgconfig
+    PKGCONFIG += jack
   }
 }
 


### PR DESCRIPTION
This should allow for linking to jack in various locations, particularly for building with pipewire.