### PR TITLE
Update build script, create win/mac installers and mac application bundle

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -45,7 +45,7 @@ jobs:
             static: true
             binary-path: jacktrip # relative to builddir
             app-bundle: true
-            bundle-installer-path: macos/JackTrip.app # relative to base (repo) directory
+            bundle-installer-path: bundle # relative to builddir
 
           # - name: Windows-dynamic
           #   runs-on: windows-2019
@@ -189,6 +189,8 @@ jobs:
           fi
           cd macos
           ./assemble_app.sh
+          mkdir -p $BUILD_PATH/${{ matrix.bundle-installer-path }}
+          cp -R JackTrip.app $BUILD_PATH/${{ matrix.bundle-installer-path }}
       - name: upload artifacts
         uses: actions/upload-artifact@v2
         if: matrix.binary-path
@@ -200,4 +202,4 @@ jobs:
         if: matrix.app-bundle == true || matrix.installer == true
         with:
           name: JackTrip-${{ matrix.name }}-${{ matrix.suffix }} # version number could be added here
-          path: ${{ github.workspace }}/${{ matrix.bundle-installer-path }}
+          path: ${{ env.BUILD_PATH }}/${{ matrix.bundle-installer-path }}

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -200,14 +200,30 @@ jobs:
             CONFIG_STRING="nogui $CONFIG_STRING"
           fi
           ./build $CONFIG_STRING
-      - name: create app bundle
-        if: runner.os == 'macOS' && matrix.bundle-path
+      - name: create app bundle and installer on macOS
+        if: runner.os == 'macOS' && (matrix.bundle-path || matrix.installer-path)
         run: |
-          if [[ "${{ matrix.static }}" == true ]]; then 
-            export PATH=$QT_STATIC_BUILD_PATH/bin:$PATH
-          else
-            export PATH=`brew --prefix qt5`/bin:$PATH
+          CONFIG=
+          if [[ -n "${{ matrix.installer-path }}" ]]; then 
+            CONFIG="-i $CONFIG"
           fi
+          cd macos
+          ./assemble_app.sh $CONFIG
+          if [[ -n ${{ matrix.bundle-path }} ]]; then
+            mkdir -p $BUILD_PATH/${{ matrix.bundle-path }}
+            cp -R *.app $BUILD_PATH/${{ matrix.bundle-path }}
+          fi
+          if [[ -n ${{ matrix.installer-path }} ]]; then
+            mkdir -p $BUILD_PATH/${{ matrix.installer-path }}
+            cp -R package/build/* $BUILD_PATH/${{ matrix.installer-path }}
+          fi
+        run: |
+          CONFIG=
+          if [[ -n "${{ matrix.installer-path }}" ]]; then 
+            CONFIG="-i $CONFIG"
+          fi
+          cd macos
+          ./assemble_app.sh $CONFIG
       - name: upload jacktrip binary
         uses: actions/upload-artifact@v2
         if: matrix.jacktrip-path

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -27,6 +27,11 @@ jobs:
             runs-on: ubuntu-18.04
             binary-path: jacktrip
 
+          - name: Linux-nogui
+            runs-on: ubuntu-18.04
+            binary-path: jacktrip
+            nogui: true
+
           - name: macOS
             runs-on: macos-10.15
             rtaudio: true
@@ -191,6 +196,7 @@ jobs:
           ./assemble_app.sh
       - name: upload artifacts
         uses: actions/upload-artifact@v2
+        if: matrix.binary-path
         with:
           name: JackTrip-${{ matrix.name }} # version number could be added here
           path: ${{ env.BUILD_PATH }}/${{ matrix.binary-path }}

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -23,19 +23,15 @@ jobs:
       fail-fast: false # don't abort if one of the build failse
       matrix:
         include:
-          - name: Linux
+          - name: Linux-x64
             runs-on: ubuntu-18.04
+            static: true
             binary-path: jacktrip
 
-          - name: Linux-nogui
+          - name: Linux-x64-dynamic-nogui
             runs-on: ubuntu-18.04
             binary-path: jacktrip
             nogui: true
-
-          - name: macOS
-            runs-on: macos-10.15
-            rtaudio: true
-            binary-path: jacktrip
 
           # - name: macOS-dynamic
           #   runs-on: macos-10.15
@@ -51,10 +47,10 @@ jobs:
             app-bundle: true
             bundle-installer-path: ../macos/JackTrip.app # also relative to builddir
 
-          - name: Windows
-            runs-on: windows-2019
-            rtaudio: true
-            binary-path: release/jacktrip.exe
+          # - name: Windows-dynamic
+          #   runs-on: windows-2019
+          #   rtaudio: true
+          #   binary-path: release/jacktrip.exe
 
           - name: Windows-x64
             # suffix: installer

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -16,7 +16,7 @@ jobs:
           do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
   build:
     needs: skip-duplicates
-    if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' }}
+    if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' }} || ${{ github.ref == 'refs/heads/dev' }}
     runs-on: ${{ matrix.runs-on }}
     name: ${{ matrix.name }}
     strategy:

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -32,21 +32,31 @@ jobs:
             rtaudio: true
             binary-path: jacktrip
 
-          - name: macOS-static
+          # - name: macOS-dynamic
+          #   runs-on: macos-10.15
+          #   rtaudio: true
+          #   binary-path: jacktrip
+
+          - name: macOS-x64
+            suffix: app
             runs-on: macos-10.15
             rtaudio: true
             static: true
             binary-path: jacktrip
+            app-bundle: true
+            bundle-installer-path: ../macos/JackTrip.app # also relative to builddir
 
           - name: Windows
             runs-on: windows-2019
             rtaudio: true
             binary-path: release/jacktrip.exe
 
-          - name: Windows-static
+          - name: Windows-x64
+            # suffix: installer
             runs-on: windows-2019
             rtaudio: true
             static: true
+            # installer: true
             binary-path: release/jacktrip.exe
 
     env:
@@ -169,9 +179,24 @@ jobs:
             CONFIG_STRING="nogui $CONFIG_STRING"
           fi
           ./build $CONFIG_STRING
+      - name: create app bundle
+        if: runner.os == 'macOS' && matrix.app-bundle == true
+        run: |
+          if [[ "${{ matrix.static }}" == true ]]; then 
+            export PATH=$QT_STATIC_BUILD_PATH/bin:$PATH
+          else
+            export PATH=`brew --prefix qt5`/bin:$PATH
+          fi
+          cd macos
+          ./assemble_app.sh
       - name: upload artifacts
         uses: actions/upload-artifact@v2
         with:
           name: JackTrip-${{ matrix.name }} # version number could be added here
           path: ${{ env.BUILD_PATH }}/${{ matrix.binary-path }}
-          retention-days: 30 # remove artifacts after 30 days
+      - name: upload app bundle / installer
+        uses: actions/upload-artifact@v2
+        if: matrix.app-bundle == true || matrix.installer == true
+        with:
+          name: JackTrip-${{ matrix.name }}-${{ matrix.suffix }} # version number could be added here
+          path: ${{ env.BUILD_PATH }}/${{ matrix.bundle-installer-path }}

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -26,31 +26,30 @@ jobs:
           - name: Linux-x64
             runs-on: ubuntu-18.04
             static: true
-            binary-path: jacktrip
+            jacktrip-path: jacktrip
 
           - name: Linux-x64-dynamic-nogui
             runs-on: ubuntu-18.04
-            binary-path: jacktrip
+            jacktrip-path: jacktrip
             nogui: true
 
           # - name: macOS-dynamic
           #   runs-on: macos-10.15
           #   rtaudio: true
-          #   binary-path: jacktrip
+          #   jacktrip-path: jacktrip
 
           - name: macOS-x64
-            suffix: app
             runs-on: macos-10.15
             rtaudio: true
             static: true
-            binary-path: jacktrip # relative to builddir
-            app-bundle: true
-            bundle-installer-path: bundle # relative to builddir
+            jacktrip-path: jacktrip # relative to build path; triggers artifact upload for jacktrip binary
+            bundle-path: bundle # relative to build path; triggers application bundle creation and upload (macOS)
+            installer-path: installer # relative to build path; triggers installer creation and upload
 
           # - name: Windows-dynamic
           #   runs-on: windows-2019
           #   rtaudio: true
-          #   binary-path: release/jacktrip.exe
+          #   jacktrip-path: release/jacktrip.exe
 
           - name: Windows-x64
             # suffix: installer
@@ -58,7 +57,7 @@ jobs:
             rtaudio: true
             static: true
             # installer: true
-            binary-path: release/jacktrip.exe
+            jacktrip-path: release/jacktrip.exe
 
     env:
       BUILD_PATH: ${{ github.workspace }}/builddir
@@ -180,7 +179,7 @@ jobs:
           fi
           ./build $CONFIG_STRING
       - name: create app bundle
-        if: runner.os == 'macOS' && matrix.app-bundle == true
+        if: runner.os == 'macOS' && matrix.bundle-path
         run: |
           if [[ "${{ matrix.static }}" == true ]]; then 
             export PATH=$QT_STATIC_BUILD_PATH/bin:$PATH
@@ -189,17 +188,23 @@ jobs:
           fi
           cd macos
           ./assemble_app.sh
-          mkdir -p $BUILD_PATH/${{ matrix.bundle-installer-path }}
-          cp -R JackTrip.app $BUILD_PATH/${{ matrix.bundle-installer-path }}
+          mkdir -p $BUILD_PATH/${{ matrix.bundle-path }}
+          cp -R JackTrip.app $BUILD_PATH/${{ matrix.bundle-path }}
       - name: upload artifacts
         uses: actions/upload-artifact@v2
-        if: matrix.binary-path
+        if: matrix.jacktrip-path
         with:
           name: JackTrip-${{ matrix.name }} # version number could be added here
-          path: ${{ env.BUILD_PATH }}/${{ matrix.binary-path }}
-      - name: upload app bundle / installer
+          path: ${{ env.BUILD_PATH }}/${{ matrix.jacktrip-path }}
+      - name: upload application bundle
         uses: actions/upload-artifact@v2
-        if: matrix.app-bundle == true || matrix.installer == true
+        if: matrix.bundle-path
         with:
-          name: JackTrip-${{ matrix.name }}-${{ matrix.suffix }} # version number could be added here
-          path: ${{ env.BUILD_PATH }}/${{ matrix.bundle-installer-path }}
+          name: JackTrip-${{ matrix.name }}-application # version number could be added here
+          path: ${{ env.BUILD_PATH }}/${{ matrix.bundle-path }}
+      - name: upload installer
+        uses: actions/upload-artifact@v2
+        if: matrix.installer-path
+        with:
+          name: JackTrip-${{ matrix.name }}-installer # version number could be added here
+          path: ${{ env.BUILD_PATH }}/${{ matrix.installer-path }}

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -25,32 +25,22 @@ jobs:
         include:
           - name: Linux
             runs-on: ubuntu-18.04
-            qmake-spec: linux-g++
-            make-cmd: make
 
           - name: macOS
             runs-on: macos-10.15
-            qmake-spec: macx-clang
-            make-cmd: make
             rtaudio: true
 
           - name: macOS-static
             runs-on: macos-10.15
-            qmake-spec: macx-clang
-            make-cmd: make
             rtaudio: true
             static: true
 
           - name: Windows
             runs-on: windows-2019
-            qmake-spec: win32-g++
-            make-cmd: mingw32-make
             rtaudio: true
 
           - name: Windows-static
             runs-on: windows-2019
-            qmake-spec: win32-g++
-            make-cmd: mingw32-make
             rtaudio: true
             static: true
 
@@ -159,18 +149,21 @@ jobs:
       - name: build JackTrip
         shell: bash
         run: |
-          mkdir $BUILD_PATH 
-          cd $BUILD_PATH
-          CONFIG_STRING=
+          CONFIG_STRING="noclean"
           if [[ "${{ matrix.static }}" == true ]]; then 
             export PATH=$QT_STATIC_BUILD_PATH/bin:$PATH
-            CONFIG_STRING="-config static $CONFIG_STRING"
+            CONFIG_STRING="static $CONFIG_STRING"
           fi
           if [[ "${{ matrix.rtaudio }}" == true ]]; then 
-            CONFIG_STRING="-config rtaudio $CONFIG_STRING"
+            CONFIG_STRING="rtaudio $CONFIG_STRING"
           fi
-          qmake -spec ${{ matrix.qmake-spec }} $CONFIG_STRING ../jacktrip.pro
-          ${{ matrix.make-cmd }} release
+          if [[ "${{ matrix.nojack }}" == true ]]; then 
+            CONFIG_STRING="nojack $CONFIG_STRING"
+          fi
+          if [[ "${{ matrix.nogui }}" == true ]]; then 
+            CONFIG_STRING="nogui $CONFIG_STRING"
+          fi
+          ./build $CONFIG_STRING
       - name: upload artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -58,6 +58,7 @@ jobs:
             static: true
             # installer: true
             jacktrip-path: release/jacktrip.exe
+            installer-path: installer # relative to build path; triggers installer creation and upload
 
     env:
       BUILD_PATH: ${{ github.workspace }}/builddir
@@ -217,13 +218,14 @@ jobs:
             mkdir -p $BUILD_PATH/${{ matrix.installer-path }}
             cp -R package/build/* $BUILD_PATH/${{ matrix.installer-path }}
           fi
+      - name: create installer on Windows
+        if: runner.os == 'Windows' && matrix.installer-path
+        shell: cmd
         run: |
-          CONFIG=
-          if [[ -n "${{ matrix.installer-path }}" ]]; then 
-            CONFIG="-i $CONFIG"
-          fi
-          cd macos
-          ./assemble_app.sh $CONFIG
+          cd win
+          call "build_installer.bat"
+          bash -c "mkdir -p $BUILD_PATH/${{ matrix.installer-path }}"
+          bash -c "cp deploy/*.msi $BUILD_PATH/${{ matrix.installer-path }}"
       - name: upload jacktrip binary
         uses: actions/upload-artifact@v2
         if: matrix.jacktrip-path

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -163,12 +163,21 @@ jobs:
           mingw32-make -j4
           echo "installing Qt"
           mingw32-make install
+      - name: set Qt environment variables
+        shell: bash
+        run: |
+          if [[ "${{ matrix.static }}" == true ]]; then 
+            echo "$QT_STATIC_BUILD_PATH/bin" >> $GITHUB_PATH
+          elif [[ "${{ runner.os }}" == "macOS" ]]; then
+            echo "`brew --prefix qt5`/bin" >> $GITHUB_PATH
+          else
+            echo "$Qt5_DIR/bin" >> $GITHUB_PATH
+          fi
       - name: build JackTrip
         shell: bash
         run: |
           CONFIG_STRING="noclean"
           if [[ "${{ matrix.static }}" == true ]]; then 
-            export PATH=$QT_STATIC_BUILD_PATH/bin:$PATH
             CONFIG_STRING="static $CONFIG_STRING"
           fi
           if [[ "${{ matrix.rtaudio }}" == true ]]; then 

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -96,6 +96,9 @@ jobs:
             brew install rt-audio
             rm -f `brew --prefix rt-audio`/lib/*.dylib # remove the dynamic library, we want static only
           fi
+          if [[ -n ${{ matrix.installer-path }} ]]; then
+            brew install packages
+          fi
       - name: install dependencies for Windows
         if: runner.os == 'Windows'
         shell: bash

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -189,11 +189,7 @@ jobs:
           else
             export PATH=`brew --prefix qt5`/bin:$PATH
           fi
-          cd macos
-          ./assemble_app.sh
-          mkdir -p $BUILD_PATH/${{ matrix.bundle-path }}
-          cp -R JackTrip.app $BUILD_PATH/${{ matrix.bundle-path }}
-      - name: upload artifacts
+      - name: upload jacktrip binary
         uses: actions/upload-artifact@v2
         if: matrix.jacktrip-path
         with:

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -25,24 +25,29 @@ jobs:
         include:
           - name: Linux
             runs-on: ubuntu-18.04
+            binary-path: jacktrip
 
           - name: macOS
             runs-on: macos-10.15
             rtaudio: true
+            binary-path: jacktrip
 
           - name: macOS-static
             runs-on: macos-10.15
             rtaudio: true
             static: true
+            binary-path: jacktrip
 
           - name: Windows
             runs-on: windows-2019
             rtaudio: true
+            binary-path: release/jacktrip.exe
 
           - name: Windows-static
             runs-on: windows-2019
             rtaudio: true
             static: true
+            binary-path: release/jacktrip.exe
 
     env:
       SRC_PATH: ${{ github.workspace }}/src
@@ -168,5 +173,5 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: JackTrip-${{ matrix.name }} # version number could be added here
-          path: ${{ env.BUILD_PATH }}
+          path: ${{ env.BUILD_PATH }}/${{ matrix.binary-path }}
           retention-days: 30 # remove artifacts after 30 days

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -61,7 +61,6 @@ jobs:
             binary-path: release/jacktrip.exe
 
     env:
-      SRC_PATH: ${{ github.workspace }}/src
       BUILD_PATH: ${{ github.workspace }}/builddir
       QT_VERSION: '5.15.2'
       DEVELOPER_DIR: '/Applications/Xcode_11.7.app/Contents/Developer' # specify XCode version on macOS

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -43,9 +43,9 @@ jobs:
             runs-on: macos-10.15
             rtaudio: true
             static: true
-            binary-path: jacktrip
+            binary-path: jacktrip # relative to builddir
             app-bundle: true
-            bundle-installer-path: ../macos/JackTrip.app # also relative to builddir
+            bundle-installer-path: macos/JackTrip.app # relative to base (repo) directory
 
           # - name: Windows-dynamic
           #   runs-on: windows-2019
@@ -201,4 +201,4 @@ jobs:
         if: matrix.app-bundle == true || matrix.installer == true
         with:
           name: JackTrip-${{ matrix.name }}-${{ matrix.suffix }} # version number could be added here
-          path: ${{ env.BUILD_PATH }}/${{ matrix.bundle-installer-path }}
+          path: ${{ github.workspace }}/${{ matrix.bundle-installer-path }}

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -71,6 +71,16 @@ jobs:
       
     steps:
       - uses: actions/checkout@v2
+      - name: set version string for artifacts
+        shell: bash
+        id: set-version
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          else
+            VERSION=$GITHUB_SHA
+          fi
+          echo "::set-output name=version::$VERSION"
       - name: install dependencies for Linux
         if: runner.os == 'Linux'
         run: |
@@ -202,17 +212,17 @@ jobs:
         uses: actions/upload-artifact@v2
         if: matrix.jacktrip-path
         with:
-          name: JackTrip-${{ matrix.name }} # version number could be added here
+          name: JackTrip-${{ steps.set-version.outputs.version }}-${{ matrix.name }}
           path: ${{ env.BUILD_PATH }}/${{ matrix.jacktrip-path }}
       - name: upload application bundle
         uses: actions/upload-artifact@v2
         if: matrix.bundle-path
         with:
-          name: JackTrip-${{ matrix.name }}-application # version number could be added here
+          name: JackTrip-${{ steps.set-version.outputs.version }}-${{ matrix.name }}-application
           path: ${{ env.BUILD_PATH }}/${{ matrix.bundle-path }}
       - name: upload installer
         uses: actions/upload-artifact@v2
         if: matrix.installer-path
         with:
-          name: JackTrip-${{ matrix.name }}-installer # version number could be added here
+          name: JackTrip-${{ steps.set-version.outputs.version }}-${{ matrix.name }}-installer
           path: ${{ env.BUILD_PATH }}/${{ matrix.installer-path }}

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ site/
 # macOS files
 .DS_Store
 
-# app bundle
+# app bundle and installer
 macos/*.app
+macos/package/build

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ site/
 
 # macOS files
 .DS_Store
+
+# app bundle
+macos/*.app

--- a/build
+++ b/build
@@ -1,30 +1,101 @@
 #!/bin/bash
 ## Created by Juan-Pablo Caceres
 
+# Parse command line options
+clean=1
+CONFIG=
+UNKNOWN_OPTIONS=
+HELP_STR="usage:\n
+./build [noclean nojack rtaudio nogui static [-config static]]\n\n
+options:\n
+noclean - do not run \"make clean\" first\n
+nojack - build without jack\n
+rtaudio - build with rtaudio\n
+nogui - build without the gui\n
+static - build with static libraries\n
+"
+while [[ "$#" -gt 0 ]]; do
+  if [[ -z "$UNKNOWN_OPTIONS" ]]; then
+    case $1 in
+      noclean) clean=0 ;;
+      nojack)
+      echo "Building without jack"
+      CONFIG="-config nojack $CONFIG" 
+      ;;
+      rtaudio) 
+      echo "Building with rtaudio"
+      CONFIG="-config rtaudio $CONFIG" 
+      ;;
+      nogui)
+      echo "Building without the gui"
+      CONFIG="-config nogui $CONFIG" 
+      ;;
+      static)
+      echo "Building with static libraries"
+      CONFIG="-config static $CONFIG" 
+      ;;
+      -h|--help) 
+      echo -e $HELP_STR; exit 
+      ;;
+      *) UNKNOWN_OPTIONS="$UNKNOWN_OPTIONS $1" ;;
+    esac
+    shift
+  else
+    case $1 in
+      *) UNKNOWN_OPTIONS="$UNKNOWN_OPTIONS $1" ;;
+    esac
+    shift
+  fi
+done
+
 # Check for Platform
 platform='unknown'
 unamestr=`uname`
 if [[ "$unamestr" == 'Linux' ]]; then
-    echo "Building on Linux"
-    platform='linux'
+  echo "Building on Linux"
+  platform='linux'
 elif [[ "$unamestr" == 'Darwin' ]]; then
-    echo "Building on Mac OS X"
-    platform='macosx'
+  echo "Building on macOS"
+  platform='macosx'
+elif [[ "$unamestr" == 'MINGW'* ]]; then
+  echo "Building on Windows (MinGW)"
+  platform='mingw'
 fi
 
 # Set qmake command name
 if [[ $platform == 'linux' ]]; then
-    if hash qmake-qt5 2>/dev/null; then
-	echo "Using qmake-qt5"
-	QCMD=qmake-qt5
-    elif hash qmake 2>/dev/null; then #in case qt was compiled by user
-	echo "Using qmake"
-	QCMD=qmake
-    fi
-    QSPEC=linux-g++
+  if hash qmake-qt5 2>/dev/null; then
+    echo "Using qmake-qt5"
+    QCMD=qmake-qt5
+  elif hash qmake 2>/dev/null; then #in case qt was compiled by user
+  echo "Using qmake"
+  QCMD=qmake
+fi
+QSPEC=linux-g++
+MCMD=make
 elif [[ $platform == 'macosx' ]]; then
-    QCMD=qmake
-    QSPEC=macx-clang
+  QCMD=qmake
+  QSPEC=macx-clang
+  # if qmake is not in path, try homebrew qt5
+  if ! command -v $QCMD &> /dev/null; then
+    # echo "qmake not found in \$PATH, searching for homebrew qt5"
+    QT_PREFIX=`brew --prefix qt5`
+    if [[ -n $QT_PREFIX ]]; then
+      QCMD="$QT_PREFIX/bin/$QCMD"
+      echo "Using qmake at $QCMD"
+    else
+      echo "Homebrew installation of qt5 not found"
+      exit
+    fi
+  fi
+  MCMD=make
+elif [[ $platform == 'mingw' ]]; then
+  QCMD=qmake
+  QSPEC=win32-g++
+  MCMD=mingw32-make
+elif [[ $platform == 'unknown' ]]; then
+  echo "Unregonized platform, exiting"
+  exit
 fi
 
 # Create our build directory
@@ -32,15 +103,11 @@ mkdir -p builddir
 cd builddir
 
 # Build
-if [[ $1 == 'nojack' ]]; then
-    echo "Building without Jack"
-    $QCMD -spec $QSPEC -config nojack ../jacktrip.pro
-    make clean
-    $QCMD -spec $QSPEC -config nojack ../jacktrip.pro
-    make release
-else
-    $QCMD -spec $QSPEC ../jacktrip.pro $@
-    make clean
-    $QCMD -spec $QSPEC ../jacktrip.pro $@
-    make release
+echo "qmake command:"
+echo "$QCMD -spec $QSPEC $CONFIG ../jacktrip.pro" $UNKNOWN_OPTIONS
+if [[ $clean == 1 ]]; then
+  $QCMD -spec $QSPEC $CONFIG ../jacktrip.pro $UNKNOWN_OPTIONS
+  $MCMD clean
 fi
+$QCMD -spec $QSPEC $CONFIG ../jacktrip.pro $UNKNOWN_OPTIONS
+$MCMD release

--- a/macos/package/JackTrip.pkgproj_template
+++ b/macos/package/JackTrip.pkgproj_template
@@ -854,13 +854,6 @@
 				<key>PATH_TYPE</key>
 				<integer>1</integer>
 			</dict>
-			<key>CERTIFICATE</key>
-			<dict>
-				<key>NAME</key>
-				<string>Developer ID Installer: Aaron Wyatt (2U5GEXWGZZ)</string>
-				<key>PATH</key>
-				<string>/Users/psiborg/Library/Keychains/login.keychain</string>
-			</dict>
 			<key>EXCLUDED_FILES</key>
 			<array>
 				<dict>

--- a/win/files_static.wxs
+++ b/win/files_static.wxs
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <Fragment>
+        <DirectoryRef Id="INSTALLDIR">
+            <Component Id="cmpE6579DC78E167F46AB23E0BE3EAA58CE" Guid="27BFCC7D-F4A8-4F71-8A2B-00A8BC74B106">
+                <File Id="fil5E6E1243EAE085FE802B6D64690357B0" KeyPath="yes" Source="SourceDir\jacktrip.exe" />
+                <Shortcut Id="startmenuJackTrip" Directory="ProgramMenuDir" Name="JackTrip"
+                    WorkingDirectory="INSTALLDIR" Icon="jacktrip.exe" IconIndex="0" Advertise="yes" />
+            </Component>
+        </DirectoryRef>
+    </Fragment>
+    <Fragment>
+        <ComponentGroup Id="jacktrip">
+            <ComponentRef Id="cmpE6579DC78E167F46AB23E0BE3EAA58CE" />
+        </ComponentGroup>
+    </Fragment>
+</Wix>


### PR DESCRIPTION
I've updated the qmake build script and added creating macOS bundle to GitHub Actions (qmake build).

~~I've made following changes that I'd like to get feedback on (particularly @psiborg112 ):~~
- ~~In the bundle creation script, I changed `QJackTrip` to `JackTrip`. IIUC this is consistent with what we decided on the app name. Is that OK @psiborg112 ?~~
- ~~I've also renamed folder `os x` to `macos`; I'm happy to revert that change if you don't like it, please let me know.~~

The above changes were done outside of this PR.

I've also removed dynamic builds for macOS and Windows, and added a new Linux build with `nogui` option (also I plan to use that for running tests later). I think I'd also like to switch the main Linux build to static, just so it can be easily used for testing etc.

I've updated build artifacts so just the binary is uploaded, instead of the whole directory.

Any and all feed back welcome!

EDIT: 
Current list of changes:
- [x] Updated qmake build script
  - [x] takes command line options `./build [noclean nojack rtaudio nogui static [-config static]]`
  - [x] works also on Windows with MinGW
- [x] removed (commented out) dynamic Windows/macOS builds
- [x] added static Linux build
- [x] ~~renamed `os x` to `macos` folder~~ done in #303
- [x] ~~renamed `qjacktrip` to `jacktrip` in `win` and `macos` folders (**looking for confirmation from everyone whether this is what we want**)~~ done in #303 and #308
- [x] ~~added building Qt tools in static Qt build to get `macdeployqt`/`windeployqt` (BUT maybe we don't need it? see below)~~
- [x] added app bundle creation on macOS
- [x] added installer creation on macOS (no signing!)
- [x] added installer creation on Windows
- [x] ~~did not use provided scripts for creating bundle/installer~~ I used updated scripts for creating bundle and installer
- [x] ~~I did not use `macdeployqt`/`windeployqt` - I don't think we need that for static builds, do we?~~
  - ~~now that we are building app bundle / installer, we could consider dynamic builds as well... but a single static binary is nice~~ now handled by the scripts
- [x] Windows: I modified the installer's list (`files_static.wxs`)
  - [x] tested windows installer
- [x] macOS: I modified installer file removing Aaron's certificate
- [x] Added version string to the artifacts: it's commit SHA (long) for non-tagged build, and a tag name for tagged builds (releases)
  - [ ] Question: would we want to shorten the SHA to first 7 digits, like e.g. on the [commit list](https://github.com/jacktrip/jacktrip/commits/dev) in github?
- [ ] Question (@psiborg112): **can macOS binaries be signed after being packaged into an installer?** 

### Here's the current [artifact list](https://github.com/jacktrip/jacktrip/actions/runs/887636201#artifacts) from this PR.