### PR TITLE
[Meson] Use rtaudio meson subproject instead of cmake

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
           meson --buildtype release $BUILD_PATH
           cd $BUILD_PATH
-          meson configure -Ddefault_library=static
+          meson configure -Ddefault_library=static -Drtaudio=enabled
           meson compile
       - name: build on Windows
         if: runner.os == 'Windows'

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           meson --buildtype release builddir
           cd builddir
-          meson configure -Ddefault_library=static
+          meson configure -Ddefault_library=static -Drtaudio=enabled
           meson compile
       - name: upload artifacts
         uses: actions/upload-artifact@v2

--- a/meson.build
+++ b/meson.build
@@ -86,9 +86,12 @@ if rtaudio_dep.found() == true
 endif
 
 if host_machine.system() == 'windows'
+	deps += compiler.find_library('ws2_32', required: true)
+endif
+
+if compiler.get_id() == 'msvc'
 	wingetopt = cmake.subproject('wingetopt')
 	deps += wingetopt.dependency('wingetopt')
-	deps += compiler.find_library('ws2_32', required: true)
 endif
 
 if host_machine.system() == 'darwin'

--- a/meson.build
+++ b/meson.build
@@ -78,22 +78,11 @@ src = [	'src/DataProtocol.cpp',
 	'src/SslServer.cpp',
 	'src/Auth.cpp']
 
-if not get_option('rtaudio').disabled()
+rtaudio_dep = dependency('rtaudio', required: get_option('rtaudio'))
+if rtaudio_dep.found() == true
 	defines += '-D__RT_AUDIO__'
-	rtaudio_dep = dependency('rtaudio', required: false)
-	deps += rtaudio_dep
-	if not rtaudio_dep.found()
-		opt_var = cmake.subproject_options()
-		opt_var.add_cmake_defines({'RTAUDIO_API_JACK': 'OFF'})
-		if not (host_machine.system() == 'windows')
-			opt_var.add_cmake_defines({'RTAUDIO_BUILD_SHARED_LIBS': 'OFF'})
-		endif
-		opt_var.set_install(false)
-		rtaudio = cmake.subproject('rtaudio', options: opt_var)
-		rtaudio_dep = rtaudio.dependency('rtaudio')
-		deps += rtaudio_dep
-	endif
 	src += 'src/RtAudioInterface.cpp'
+	deps += rtaudio_dep
 endif
 
 if host_machine.system() == 'windows'

--- a/subprojects/packagefiles/rtaudio/meson.build
+++ b/subprojects/packagefiles/rtaudio/meson.build
@@ -1,0 +1,73 @@
+project('rtaudio', 'cpp')
+
+src = ['RtAudio.cpp']
+incdir = include_directories('include')
+
+install_headers('RtAudio.h')
+
+compiler = meson.get_compiler('cpp')
+
+deps = []
+defines = []
+deps += dependency('threads')
+
+alsa_dep = dependency('alsa', required: get_option('alsa'))
+if alsa_dep.found()
+	defines += '-D__LINUX_ALSA__'
+	deps += alsa_dep
+endif
+
+jack_dep = dependency('jack', required: get_option('jack'))
+if jack_dep.found()
+	defines += '-D__UNIX_JACK__'
+	deps += jack_dep
+endif
+
+if get_option('oss') == true
+	defines += '-D__LINUX_OSS__'
+endif
+
+pulse_dep = dependency('libpulse', required: get_option('pulse'))
+if pulse_dep.found()
+	defines += '-D__LINUX_PULSE__'
+	deps += pulse_dep
+endif
+
+core_dep = dependency('appleframeworks', modules: ['CoreAudio', 'CoreFoundation'], required: get_option('core'))
+if core_dep.found()
+	defines += '-D__MACOSX_CORE__'
+	deps += core_dep
+endif
+
+dsound_dep = compiler.find_library('dsound', required: get_option('dsound'))
+if dsound_dep.found()
+	defines += '-D__WINDOWS_DS__'
+	deps += dsound_dep
+endif
+
+if get_option('wasapi') == true
+	deps += compiler.find_library('mfplat', required: true)
+	deps += compiler.find_library('mfuuid', required: true)
+	deps += compiler.find_library('ksuser', required: true)
+	deps += compiler.find_library('wmcodecdspuuid', required: true)
+	defines += '-D__WINDOWS_WASAPI__'
+endif
+
+if get_option('asio') == true
+	src += ['include/asio.cpp',
+		'include/asiolist.cpp',
+		'include/asiodrivers.cpp',
+		'include/iasiothiscallresolver.cpp']
+	defines += '-D__WINDOWS_ASIO__'
+endif
+
+
+if host_machine.system() == 'windows'
+	deps += compiler.find_library('ole32', required: true)
+	deps += compiler.find_library('winmm', required: true)
+endif
+
+rtaudio = library('rtaudio', src, include_directories: incdir, dependencies: deps)
+rtaudio_dep = declare_dependency(include_directories : '.',
+  link_with : rtaudio)
+meson.override_dependency('rtaudio', rtaudio_dep)

--- a/subprojects/packagefiles/rtaudio/meson_options.txt
+++ b/subprojects/packagefiles/rtaudio/meson_options.txt
@@ -1,0 +1,8 @@
+option('jack', type : 'feature', value : 'auto', description: 'Build with JACK Backend')
+option('alsa', type : 'feature', value : 'auto', description: 'Build with ALSA Backend')
+option('pulse', type : 'feature', value : 'auto', description: 'Build with Pulseaudio Backend')
+option('oss', type : 'boolean', value : 'false', description: 'Build with OSS Backend')
+option('core', type : 'feature', value : 'auto', description: 'Build with CoreAudio Backend')
+option('dsound', type : 'feature', value : 'auto', description: 'Build with DirectSound Backend')
+option('asio', type : 'boolean', value : 'false', description: 'Build with ASIO Backend')
+option('wasapi', type : 'boolean', value : 'false', description: 'Build with WASAPI Backend')

--- a/subprojects/rtaudio.wrap
+++ b/subprojects/rtaudio.wrap
@@ -1,6 +1,7 @@
 [wrap-git]
-url=https://github.com/ntonnaett/rtaudio.git
+url=https://github.com/thestk/rtaudio.git
 revision=head
+patch_directory=rtaudio
 
 [provide]
 dependency_names = rtaudio

--- a/subprojects/rtaudio.wrap
+++ b/subprojects/rtaudio.wrap
@@ -1,5 +1,5 @@
 [wrap-git]
-url=https://github.com/thestk/rtaudio.git
+url=https://github.com/ntonnaett/rtaudio.git
 revision=head
 
 [provide]


### PR DESCRIPTION
This uses a RtAudio subproject build with meson instead of cmake. With this I get rid of a lot of linking errors on Windows. Qt is linked dynamically.