### PR TITLE
Check for static qt on windows

### DIFF
--- a/macos/assemble_app.sh
+++ b/macos/assemble_app.sh
@@ -63,8 +63,8 @@ sed -i '' "s/%BUNDLENAME%/$APPNAME/" "$APPNAME.app/Contents/Info.plist"
 sed -i '' "s/%BUNDLEID%/$BUNDLE_ID/" "$APPNAME.app/Contents/Info.plist"
 
 # The qt bin folder needs to be in your PATH for this script to work.
-STATIC_CHECK=$(otool -L ../builddir/jacktrip | grep QtCore)
-if [ ! -z "$STATIC_CHECK" ]; then
+DYNAMIC_QT=$(otool -L ../builddir/jacktrip | grep QtCore)
+if [ ! -z "$DYNAMIC_QT" ]; then
     [ -z $(which macdeployqt) ] && { echo "The Qt bin folder needs to be in your PATH for this script to work."; exit 1; }
     if [ ! -z "$CERTIFICATE" ]; then
         macdeployqt "$APPNAME.app" -codesign="$CERTIFICATE"

--- a/win/build_installer.bat
+++ b/win/build_installer.bat
@@ -1,11 +1,12 @@
 @echo off
-
-set QTBINPATH=C:\Qt\5.15.2\mingw81_64\bin
-set QTLIBPATH=C:\Qt\Tools\mingw810_64\bin
-set WIXPATH=C:\Program Files (x86)\WiX Toolset v3.11\bin
-set SSLPATH=C:\Qt\Tools\OpenSSL\Win_x64\bin
-
 setlocal EnableDelayedExpansion
+
+if not defined QTBINPATH (set QTBINPATH=C:\Qt\5.15.2\mingw81_64\bin)
+if not defined QTLIBPATH (set QTLIBPATH=C:\Qt\Tools\mingw810_64\bin)
+if not defined WIXPATH (set WIXPATH=C:\Program Files ^(x86^)\WiX Toolset v3.11\bin)
+if not defined SSLPATH (set SSLPATH=C:\Qt\Tools\OpenSSL\Win_x64\bin)
+
+set PATH=%PATH%;%WIXPATH%
 del deploy /s /q
 rmdir deploy /s /q
 mkdir deploy
@@ -14,13 +15,15 @@ copy dialog.bmp deploy\
 copy license.rtf deploy\
 copy ..\builddir\jacktrip.exe deploy\
 cd deploy
-set PATH=%PATH%;%WIXPATH%;%QTBINPATH%
-windeployqt jacktrip.exe
-copy "%QTLIBPATH%\libgcc_s_seh-1.dll" .\
-copy "%QTLIBPATH%\libstdc++-6.dll" .\
-copy "%QTLIBPATH%\libwinpthread-1.dll" .\
-copy "%SSLPATH%\libcrypto-1_1-x64.dll" .\
-copy "%SSLPATH%\libssl-1_1-x64.dll" .\
+for /f "tokens=*" %%a in ('%QTLIBPATH%\objdump -p jacktrip.exe ^| findstr Qt5Core.dll') do set STATIC_CHECK=%%a
+if defined STATIC_CHECK (
+	%QTBINPATH%\windeployqt jacktrip.exe
+	copy "%QTLIBPATH%\libgcc_s_seh-1.dll" .\
+	copy "%QTLIBPATH%\libstdc++-6.dll" .\
+	copy "%QTLIBPATH%\libwinpthread-1.dll" .\
+	copy "%SSLPATH%\libcrypto-1_1-x64.dll" .\
+	copy "%SSLPATH%\libssl-1_1-x64.dll" .\
+)
 .\jacktrip --test-gui
 if %ERRORLEVEL% NEQ 0 (
 	echo "You need to build jacktrip with gui support to build the installer."

--- a/win/build_installer.bat
+++ b/win/build_installer.bat
@@ -15,8 +15,8 @@ copy dialog.bmp deploy\
 copy license.rtf deploy\
 copy ..\builddir\jacktrip.exe deploy\
 cd deploy
-for /f "tokens=*" %%a in ('%QTLIBPATH%\objdump -p jacktrip.exe ^| findstr Qt5Core.dll') do set STATIC_CHECK=%%a
-if defined STATIC_CHECK (
+for /f "tokens=*" %%a in ('%QTLIBPATH%\objdump -p jacktrip.exe ^| findstr Qt5Core.dll') do set DYNAMIC_QT=%%a
+if defined DYNAMIC_QT (
 	%QTBINPATH%\windeployqt jacktrip.exe
 	copy "%QTLIBPATH%\libgcc_s_seh-1.dll" .\
 	copy "%QTLIBPATH%\libstdc++-6.dll" .\


### PR DESCRIPTION
Checks to see if jacktrip has been built using static qt on windows and only sets path variables if they are not already set.

The script currently assumes the qt mingw tools are installed. If building with msvc, we'll need to copy different compiler dlls into the package, and possibly use dumpbin instead of objdump for the static qt test.