### PR TITLE
Check location of binary (windows install script)

### DIFF
--- a/win/build_installer.bat
+++ b/win/build_installer.bat
@@ -13,7 +13,8 @@ mkdir deploy
 copy files.wxs deploy\
 copy dialog.bmp deploy\
 copy license.rtf deploy\
-copy ..\builddir\jacktrip.exe deploy\
+if exist ..\builddir\release\jacktrip.exe (set JACKTRIP=..\builddir\release\jacktrip.exe) else (set JACKTRIP=..\builddir\jacktrip.exe)
+copy %JACKTRIP% deploy\
 cd deploy
 for /f "tokens=*" %%a in ('%QTLIBPATH%\objdump -p jacktrip.exe ^| findstr Qt5Core.dll') do set DYNAMIC_QT=%%a
 if defined DYNAMIC_QT (


### PR DESCRIPTION
Just realised that qmake builds in builddir\release by default on windows. (Using cmake via kdevelop myself, so the binary is in builddir.) Have the script check which to use.