### PR TITLE
gha mkdocs: run only on the main repo

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -12,6 +12,7 @@ jobs:
   build:
     name: Deploy docs
     runs-on: ubuntu-latest
+    if: github.repository == 'jacktrip/jacktrip'
     steps:
       - name: Checkout main
         uses: actions/checkout@v2


### PR DESCRIPTION
I think this should work :) - I don't think we want to make it run on forks (i.e. I don't have GH pages activated on my fork and I wouldn't want a copy of the main JT pages there anyway).
If we wanted, we could make it configurable per repository (fork) but I don't think that's needed - let me know if you think otherwise.