### PR TITLE
Add Clang-Tidy: Modernize deprecated headers, use range-based for loops

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,1 @@
+Checks: '-*,modernize-deprecated-headers'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,1 +1,1 @@
-Checks: '-*,modernize-deprecated-headers'
+Checks: '-*,modernize-deprecated-headers,modernize-loop-convert'

--- a/src/AudioInterface.cpp
+++ b/src/AudioInterface.cpp
@@ -37,7 +37,7 @@
 
 #include "AudioInterface.h"
 
-#include <assert.h>
+#include <cassert>
 
 #include <cmath>
 #include <iostream>

--- a/src/AudioInterface.cpp
+++ b/src/AudioInterface.cpp
@@ -112,11 +112,11 @@ AudioInterface::~AudioInterface()
     for (int i = 0; i < aCnt; i++) { delete[] mAPInBuffer[i]; }
 #endif  // endwhere
 
-    for (int i = 0; i < mProcessPluginsFromNetwork.size(); i++) {
-        delete[] mProcessPluginsFromNetwork[i];
+    for (auto & i : mProcessPluginsFromNetwork) {
+        delete[] i;
     }
-    for (int i = 0; i < mProcessPluginsToNetwork.size(); i++) {
-        delete[] mProcessPluginsToNetwork[i];
+    for (auto & i : mProcessPluginsToNetwork) {
+        delete[] i;
     }
     for (int i = 0; i < mNumInChans; i++) { delete[] mInBufCopy[i]; }
 }
@@ -240,8 +240,7 @@ void AudioInterface::callback(QVarLengthArray<sample_t*>& in_buffer,
     /// with one. do it chaining outputs to inputs in the buffers. May need a tempo buffer
 
 #ifndef WAIR  // NOT WAIR:
-    for (int i = 0; i < mProcessPluginsFromNetwork.size(); i++) {
-        ProcessPlugin* p = mProcessPluginsFromNetwork[i];
+    for (auto* p : qAsConst(mProcessPluginsFromNetwork)) {
         if (p->getInited()) {
             p->compute(n_frames, out_buffer.data(), out_buffer.data());
         }

--- a/src/AudioTester.cpp
+++ b/src/AudioTester.cpp
@@ -38,7 +38,7 @@
 
 #include "AudioTester.h"
 
-#include <assert.h>
+#include <cassert>
 
 // Called 1st in Audiointerface.cpp
 void AudioTester::lookForReturnPulse(QVarLengthArray<sample_t*>& out_buffer,

--- a/src/Effects.h
+++ b/src/Effects.h
@@ -37,7 +37,7 @@
 
 #pragma once
 
-#include <assert.h>
+#include <cassert>
 
 #include <vector>
 

--- a/src/JMess.cpp
+++ b/src/JMess.cpp
@@ -363,10 +363,7 @@ void JMess::disconnectAll()
 
     this->setConnectedPorts();
 
-    for (QVector<QVector<QString> >::iterator it = mConnectedPorts.begin();
-         it != mConnectedPorts.end(); ++it) {
-        OutputInput = *it;
-
+    for (auto & OutputInput : mConnectedPorts) {
         if (jack_disconnect(mClient, OutputInput[0].toUtf8(), OutputInput[1].toUtf8())) {
             cerr << "WARNING: port: " << qPrintable(OutputInput[0])
                  << "and port: " << qPrintable(OutputInput[1])

--- a/src/JMess.h
+++ b/src/JMess.h
@@ -32,7 +32,7 @@
 #ifndef __JMESS_H
 #define __JMESS_H
 
-#include <errno.h>
+#include <cerrno>
 
 #include <QIODevice>
 #include <QString>

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -543,11 +543,11 @@ void JackTrip::completeConnection()
     if (gVerboseFlag)
         std::cout << "  JackTrip:startProcess before mAudioInterface->startProcess"
                   << std::endl;
-    for (int i = 0; i < mProcessPluginsFromNetwork.size(); ++i) {
-        mAudioInterface->appendProcessPluginFromNetwork(mProcessPluginsFromNetwork[i]);
+    for (auto & i : mProcessPluginsFromNetwork) {
+        mAudioInterface->appendProcessPluginFromNetwork(i);
     }
-    for (int i = 0; i < mProcessPluginsToNetwork.size(); ++i) {
-        mAudioInterface->appendProcessPluginToNetwork(mProcessPluginsToNetwork[i]);
+    for (auto & i : mProcessPluginsToNetwork) {
+        mAudioInterface->appendProcessPluginToNetwork(i);
     }
     mAudioInterface->initPlugins();   // mSampleRate known now, which plugins require
     mAudioInterface->startProcess();  // Tell JACK server we are ready for audio flow now

--- a/src/Limiter.h
+++ b/src/Limiter.h
@@ -51,7 +51,7 @@
 #include <vector>
 
 #include "ProcessPlugin.h"
-#include "assert.h"
+#include <cassert>
 #include "limiterdsp.h"
 
 /** \brief The Limiter class confines the output dynamic range to a

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -47,8 +47,8 @@
 #endif  // endwhere
 
 //#include "JackTripWorker.h"
-#include <assert.h>
-#include <ctype.h>
+#include <cassert>
+#include <cctype>
 #include <getopt.h>  // for command line parsing
 
 #include <cstdlib>

--- a/src/compressordsp.h
+++ b/src/compressordsp.h
@@ -539,8 +539,8 @@ ZoneReader(zone, valueConverter) : a zone with a data converter
 
 ****************************************************************************************/
 
-#include <assert.h>
-#include <float.h>
+#include <cassert>
+#include <cfloat>
 
 #include <algorithm>  // std::max
 #include <cmath>
@@ -1572,7 +1572,7 @@ class APIUI
 #define FAUSTFLOAT float
 #endif
 
-#include <math.h>
+#include <cmath>
 
 #include <algorithm>
 #include <cmath>

--- a/src/freeverbdsp.h
+++ b/src/freeverbdsp.h
@@ -539,8 +539,8 @@ ZoneReader(zone, valueConverter) : a zone with a data converter
 
 ****************************************************************************************/
 
-#include <assert.h>
-#include <float.h>
+#include <cassert>
+#include <cfloat>
 
 #include <algorithm>  // std::max
 #include <cmath>
@@ -1572,7 +1572,7 @@ class APIUI
 #define FAUSTFLOAT float
 #endif
 
-#include <math.h>
+#include <cmath>
 
 #include <algorithm>
 #include <cmath>

--- a/src/freeverbmonodsp.h
+++ b/src/freeverbmonodsp.h
@@ -536,8 +536,8 @@ ZoneReader(zone, valueConverter) : a zone with a data converter
 
 ****************************************************************************************/
 
-#include <assert.h>
-#include <float.h>
+#include <cassert>
+#include <cfloat>
 
 #include <algorithm>  // std::max
 #include <cmath>
@@ -1569,7 +1569,7 @@ class APIUI
 #define FAUSTFLOAT float
 #endif
 
-#include <math.h>
+#include <cmath>
 
 #include <algorithm>
 #include <cmath>

--- a/src/limiterdsp.h
+++ b/src/limiterdsp.h
@@ -536,8 +536,8 @@ ZoneReader(zone, valueConverter) : a zone with a data converter
 
 ****************************************************************************************/
 
-#include <assert.h>
-#include <float.h>
+#include <cassert>
+#include <cfloat>
 
 #include <algorithm>  // std::max
 #include <cmath>
@@ -1569,7 +1569,7 @@ class APIUI
 #define FAUSTFLOAT float
 #endif
 
-#include <math.h>
+#include <cmath>
 
 #include <algorithm>
 #include <cmath>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,7 +43,7 @@
 #endif
 #include <QScopedPointer>
 #include <iostream>
-#include <signal.h>
+#include <csignal>
 #include "jacktrip_globals.h"
 #include "Settings.h"
 #include "UdpHubListener.h"

--- a/src/zitarevdsp.h
+++ b/src/zitarevdsp.h
@@ -536,8 +536,8 @@ ZoneReader(zone, valueConverter) : a zone with a data converter
 
 ****************************************************************************************/
 
-#include <assert.h>
-#include <float.h>
+#include <cassert>
+#include <cfloat>
 
 #include <algorithm>  // std::max
 #include <cmath>
@@ -1569,8 +1569,7 @@ class APIUI
 #define FAUSTFLOAT float
 #endif
 
-#include <math.h>
-
+#include <cmath>
 #include <algorithm>
 #include <cmath>
 

--- a/src/zitarevmonodsp.h
+++ b/src/zitarevmonodsp.h
@@ -536,8 +536,8 @@ ZoneReader(zone, valueConverter) : a zone with a data converter
 
 ****************************************************************************************/
 
-#include <assert.h>
-#include <float.h>
+#include <cassert>
+#include <cfloat>
 
 #include <algorithm>  // std::max
 #include <cmath>
@@ -1569,7 +1569,7 @@ class APIUI
 #define FAUSTFLOAT float
 #endif
 
-#include <math.h>
+#include <cmath>
 
 #include <algorithm>
 #include <cmath>


### PR DESCRIPTION
Let's start using clang-tidy with only two enabled checks. It's easier to review.