### PR TITLE
Replace cryptic error message on linux if no X or Wayland display

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(QJackTrip)
 set(nogui FALSE)
 
 if (nogui)
-  add_compile_definitions(__NO_GUI__)
+  add_compile_definitions(NO_GUI)
 endif ()
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ set(qjacktrip_SRC
   src/PacketHeader.cpp
   src/RingBuffer.cpp
   src/JitterBuffer.cpp
+  src/PoolBuffer.cpp
   src/Compressor.cpp
   src/Limiter.cpp
   src/Reverb.cpp

--- a/jacktrip.pro
+++ b/jacktrip.pro
@@ -13,7 +13,7 @@ CONFIG(debug, debug|release) {
   }
 
 nogui {
-  DEFINES += __NO_GUI__
+  DEFINES += NO_GUI
 } else {
   QT += gui
   QT += widgets

--- a/meson.build
+++ b/meson.build
@@ -65,7 +65,7 @@ endif
 deps = [threads_dep, jack_dep]
 
 if get_option('nogui') == true
-	defines += '-D__NO_GUI__'
+	defines += '-DNO_GUI'
 	qt5_dep = dependency('qt5', modules: ['Core', 'Network'])
 else
 	qt5_dep = dependency('qt5', modules: ['Core', 'Gui', 'Network', 'Widgets'])


### PR DESCRIPTION
If no x or wayland display is set, show the user a more informative error message than the qt plugin one that otherwise appears.

Also, replace \_\_NO_GUI\_\_ with NO_GUI (addresses part of #276)