### PR TITLE
Fix static Linux build in GitHub Actions

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -30,7 +30,7 @@ jobs:
         include:
           - name: Linux-x64
             runs-on: ubuntu-18.04
-            static: true
+            static-qt-version: 5.12.11 # older Qt version so that we can compile in xcb platform plugin
             jacktrip-path: jacktrip
             binary-path: binary
 
@@ -48,7 +48,7 @@ jobs:
           - name: macOS-x64
             runs-on: macos-10.15
             rtaudio: true
-            static: true
+            static-qt-version: 5.12.11 # if set, it will enable static Qt build
             weakjack: true
             jacktrip-path: jacktrip # relative to build path
             binary-path: binary # directory relative to build path; triggers artifact upload for jacktrip binary
@@ -64,7 +64,7 @@ jobs:
             # suffix: installer
             runs-on: windows-2019
             rtaudio: true
-            static: true
+            static-qt-version: 5.15.2
             weakjack: true
             jacktrip-path: release/jacktrip.exe
             binary-path: binary # directory relative to build path; triggers artifact upload for jacktrip binary
@@ -72,13 +72,12 @@ jobs:
 
     env:
       BUILD_PATH: ${{ github.workspace }}/builddir
-      QT_VERSION: '5.15.2'
+      QT_VERSION: '5.15.2' # for dynamic qt installer using install-qt-action
       DEVELOPER_DIR: '/Applications/Xcode_11.7.app/Contents/Developer' # specify XCode version on macOS
-      QT_SRC_URL: 'https://download.qt.io/official_releases/qt/5.15/5.15.2/single/qt-everywhere-src-5.15.2.tar.xz'
       QT_SRC_PATH: ${{ github.workspace }}/../qt-static-src
       QT_STATIC_BUILD_PATH: ${{ github.workspace }}/../qt-static
-      QT_STATIC_CACHE_KEY: '5.15.2_v02' # update this to force rebuilding static Qt
-      QT_STATIC_OPTIONS: '-static -release -optimize-size -no-pch -nomake tools -nomake tests -nomake examples -opensource -confirm-license -skip webengine -skip qt3d -skip qtactiveqt -skip qtandroidextras -skip qtcharts -skip qtdatavis3d -skip qtdeclarative -skip qtdoc -skip qtgamepad -skip qtgraphicaleffects -skip qtimageformats -skip qtlocation -skip qtlottie -skip qtmultimedia -skip qtpurchasing -skip qtquick3d -skip qtpurchasing -skip qtquickcontrols -skip qtquickcontrols2 -skip qtquicktimeline -skip qtremoteobjects -skip qtscript -skip qtsensors -skip qtserialbus -skip qtserialport -skip qtspeech -skip qtsvg -skip qttools -skip qtvirtualkeyboard -skip qtwayland -skip qtwebchannel -skip qtwebengine -skip qtwebglplugin -skip qtwebsockets -skip qtwebview -skip qtxmlpatterns' # common for all platforms
+      QT_STATIC_VERSION: 'v02' # update this to force rebuilding static Qt
+      QT_STATIC_OPTIONS: '-static -release -optimize-size -no-pch -nomake tools -nomake tests -nomake examples -opensource -confirm-license -skip webengine -skip qt3d -skip qtactiveqt -skip qtandroidextras -skip qtcharts -skip qtdatavis3d -skip qtdeclarative -skip qtdoc -skip qtgamepad -skip qtgraphicaleffects -skip qtimageformats -skip qtlocation -skip qtmultimedia -skip qtpurchasing -skip qtpurchasing -skip qtquickcontrols -skip qtquickcontrols2 -skip qtremoteobjects -skip qtscript -skip qtsensors -skip qtserialbus -skip qtserialport -skip qtspeech -skip qtsvg -skip qttools -skip qtvirtualkeyboard -skip qtwayland -skip qtwebchannel -skip qtwebengine -skip qtwebglplugin -skip qtwebsockets -skip qtwebview -skip qtxmlpatterns' # common for all platforms
       
     steps:
       - uses: actions/checkout@v2
@@ -111,7 +110,7 @@ jobs:
           curl -L https://github.com/jackaudio/jack2-releases/releases/download/v1.9.16/jack2-macOS-v1.9.16.tar.gz -o jack2.tar.gz
           tar -xf jack2.tar.gz
           sudo installer -pkg jack2-osx-1.9.16.pkg -target /
-          if [[ "${{ matrix.static }}" != true ]]; then 
+          if [[ -z "${{ matrix.static-qt-version }}" ]]; then 
             brew install qt5
             brew link qt5 --force
           fi
@@ -135,37 +134,40 @@ jobs:
           fi
       - name: cache Qt
         id: cache-qt
-        if: runner.os == 'Windows' && matrix.static != true
+        if: runner.os == 'Windows' && '!matrix.static-qt-version'
         uses: actions/cache@v1
         with:
           path: ../Qt
           key: ${{ runner.os }}-QtCache-${{ env.QT_VERSION }}
       - name: install Qt
         uses: jurplel/install-qt-action@v2
-        if: runner.os == 'Windows' && matrix.static != true
+        if: runner.os == 'Windows' && '!matrix.static-qt-version'
         with:
           version: ${{ env.QT_VERSION }}
           arch: 'win64_mingw81'
           cached: ${{ steps.cache-qt.outputs.cache-hit }}
       - name: cache static Qt
         id: cache-static-qt
-        if: matrix.static == true
+        if: matrix.static-qt-version
         uses: actions/cache@v1
         with:
           path: ${{ env.QT_STATIC_BUILD_PATH }}
-          key: ${{ runner.os }}-QtStaticCache-${{ env.QT_STATIC_CACHE_KEY }}
+          key: ${{ runner.os }}-QtStaticCache-${{ matrix.static-qt-version }}_${{ env.QT_STATIC_VERSION }}
       - name: download Qt sources
-        if: matrix.static == true && steps.cache-static-qt.outputs.cache-hit != 'true'
+        if: matrix.static-qt-version && steps.cache-static-qt.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          echo "Downloading Qt source"
+          QT_FULL_VERSION=${{ matrix.static-qt-version }}
+          QT_MAJOR_MINOR_VERSION=`echo $QT_FULL_VERSION | cut -d '.' -f1-2`
+          QT_SRC_URL="https://download.qt.io/official_releases/qt/$QT_MAJOR_MINOR_VERSION/$QT_FULL_VERSION/single/qt-everywhere-src-$QT_FULL_VERSION.tar.xz"
+          echo "Downloading Qt source from $QT_SRC_URL"
           curl -L $QT_SRC_URL -o qt.tar.xz
           echo "Unpacking Qt source"
           tar -xf qt.tar.xz
           # move qt to a known location
           mv qt-everywhere* $QT_SRC_PATH
       - name: build static Qt on Linux / macOS
-        if: matrix.static == true && steps.cache-static-qt.outputs.cache-hit != 'true' && runner.os != 'Windows'
+        if: matrix.static-qt-version && steps.cache-static-qt.outputs.cache-hit != 'true' && runner.os != 'Windows'
         run: |
           mkdir $QT_STATIC_BUILD_PATH
           # configure
@@ -177,7 +179,7 @@ jobs:
           echo "installing Qt"
           make install
       - name: build static Qt on Windows
-        if: matrix.static == true && steps.cache-static-qt.outputs.cache-hit != 'true' && runner.os == 'Windows'
+        if: matrix.static-qt-version && steps.cache-static-qt.outputs.cache-hit != 'true' && runner.os == 'Windows'
         shell: cmd
         run: |
           mkdir %QT_STATIC_BUILD_PATH%
@@ -189,7 +191,7 @@ jobs:
       - name: set Qt environment variables
         shell: bash
         run: |
-          if [[ "${{ matrix.static }}" == true ]]; then 
+          if [[ -n "${{ matrix.static-qt-version }}" ]]; then 
             echo "$QT_STATIC_BUILD_PATH/bin" >> $GITHUB_PATH
           elif [[ "${{ runner.os }}" == "macOS" ]]; then
             echo "`brew --prefix qt5`/bin" >> $GITHUB_PATH
@@ -200,7 +202,7 @@ jobs:
         shell: bash
         run: |
           CONFIG_STRING="noclean"
-          if [[ "${{ matrix.static }}" == true ]]; then 
+          if [[ -n "${{ matrix.static-qt-version }}" ]]; then 
             CONFIG_STRING="static $CONFIG_STRING"
           fi
           if [[ "${{ matrix.rtaudio }}" == true ]]; then 

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -76,8 +76,8 @@ jobs:
       DEVELOPER_DIR: '/Applications/Xcode_11.7.app/Contents/Developer' # specify XCode version on macOS
       QT_SRC_PATH: ${{ github.workspace }}/../qt-static-src
       QT_STATIC_BUILD_PATH: ${{ github.workspace }}/../qt-static
-      QT_STATIC_CACHE_KEY: 'v04' # update this to force rebuilding static Qt
-      QT_STATIC_OPTIONS: '-static -release -optimize-size -no-pch -nomake tools -nomake tests -nomake examples -opensource -confirm-license -skip webengine -skip qt3d -skip qtactiveqt -skip qtandroidextras -skip qtcharts -skip qtdatavis3d -skip qtdeclarative -skip qtdoc -skip qtgamepad -skip qtgraphicaleffects -skip qtimageformats -skip qtlocation -skip qtmultimedia -skip qtpurchasing -skip qtpurchasing -skip qtquickcontrols -skip qtquickcontrols2 -skip qtremoteobjects -skip qtscript -skip qtsensors -skip qtserialbus -skip qtserialport -skip qtspeech -skip qtsvg -skip qttools -skip qtvirtualkeyboard -skip qtwayland -skip qtwebchannel -skip qtwebengine -skip qtwebglplugin -skip qtwebsockets -skip qtwebview -skip qtxmlpatterns' # common for all platforms
+      QT_STATIC_CACHE_KEY: 'v06' # update this to force rebuilding static Qt
+      QT_STATIC_OPTIONS: '-static -release -optimize-size -no-pch -nomake tools -nomake tests -nomake examples -opensource -confirm-license -skip webengine -skip qt3d -skip qtactiveqt -skip qtandroidextras -skip qtcharts -skip qtdatavis3d -skip qtdeclarative -skip qtdoc -skip qtgamepad -skip qtgraphicaleffects -skip qtimageformats -skip qtlocation -skip qtmultimedia -skip qtpurchasing -skip qtpurchasing -skip qtquickcontrols -skip qtquickcontrols2 -skip qtremoteobjects -skip qtscript -skip qtsensors -skip qtserialbus -skip qtserialport -skip qtspeech -skip qtsvg -skip qttools -skip qtvirtualkeyboard -skip qtwebchannel -skip qtwebengine -skip qtwebglplugin -skip qtwebsockets -skip qtwebview -skip qtxmlpatterns' # common for all platforms
       
     steps:
       - uses: actions/checkout@v2
@@ -99,7 +99,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install --yes libjack-dev
           if [[ -n "${{ matrix.static-qt-version }}" ]]; then 
-            sudo apt-get install --yes libfreetype6-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libx11-xcb-dev libdrm-dev libglu1-mesa-dev
+            sudo apt-get install --yes libfreetype6-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libx11-xcb-dev libdrm-dev libglu1-mesa-dev libwayland-dev libwayland-egl1-mesa libgles2-mesa-dev libwayland-server0
           else
             sudo apt-get install --yes qt5-default qt5-qmake qttools5-dev
           fi

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -31,6 +31,7 @@ jobs:
           - name: Linux-x64
             runs-on: ubuntu-18.04
             static-qt-version: 5.12.11 # older Qt version so that we can compile in xcb platform plugin
+            qt-static-cache-key: 'v07' # required for static qt; update this to force rebuilding static Qt
             jacktrip-path: jacktrip
             binary-path: binary
 
@@ -49,6 +50,7 @@ jobs:
             runs-on: macos-10.15
             rtaudio: true
             static-qt-version: 5.12.11 # if set, it will enable static Qt build
+            qt-static-cache-key: 'v04' # required for static qt; update this to force rebuilding static Qt
             weakjack: true
             jacktrip-path: jacktrip # relative to build path
             binary-path: binary # directory relative to build path; triggers artifact upload for jacktrip binary
@@ -65,6 +67,7 @@ jobs:
             runs-on: windows-2019
             rtaudio: true
             static-qt-version: 5.15.2
+            qt-static-cache-key: 'v04' # required for static qt; update this to force rebuilding static Qt
             weakjack: true
             jacktrip-path: release/jacktrip.exe
             binary-path: binary # directory relative to build path; triggers artifact upload for jacktrip binary
@@ -76,7 +79,6 @@ jobs:
       DEVELOPER_DIR: '/Applications/Xcode_11.7.app/Contents/Developer' # specify XCode version on macOS
       QT_SRC_PATH: ${{ github.workspace }}/../qt-static-src
       QT_STATIC_BUILD_PATH: ${{ github.workspace }}/../qt-static
-      QT_STATIC_CACHE_KEY: 'v07' # update this to force rebuilding static Qt
       QT_STATIC_OPTIONS: '-static -release -optimize-size -no-pch -nomake tools -nomake tests -nomake examples -opensource -confirm-license -skip webengine -skip qt3d -skip qtactiveqt -skip qtandroidextras -skip qtcharts -skip qtdatavis3d -skip qtdeclarative -skip qtdoc -skip qtgamepad -skip qtgraphicaleffects -skip qtimageformats -skip qtlocation -skip qtmultimedia -skip qtpurchasing -skip qtpurchasing -skip qtquickcontrols -skip qtquickcontrols2 -skip qtremoteobjects -skip qtscript -skip qtsensors -skip qtserialbus -skip qtserialport -skip qtspeech -skip qtsvg -skip qttools -skip qtvirtualkeyboard -skip qtwebchannel -skip qtwebengine -skip qtwebglplugin -skip qtwebsockets -skip qtwebview -skip qtxmlpatterns' # common for all platforms
       
     steps:
@@ -157,7 +159,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ${{ env.QT_STATIC_BUILD_PATH }}
-          key: ${{ runner.os }}-QtStaticCache-${{ matrix.static-qt-version }}_${{ env.QT_STATIC_CACHE_KEY }}
+          key: ${{ runner.os }}-QtStaticCache-${{ matrix.static-qt-version }}_${{ matrix.qt-static-cache-key }}
       - name: download Qt sources
         if: matrix.static-qt-version && steps.cache-static-qt.outputs.cache-hit != 'true'
         shell: bash

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -30,8 +30,8 @@ jobs:
         include:
           - name: Linux-x64
             runs-on: ubuntu-18.04
-            static-qt-version: 5.12.11 # older Qt version so that we can compile in xcb platform plugin
-            qt-static-cache-key: 'v07' # required for static qt; update this to force rebuilding static Qt
+            static-qt-version: 5.15.2 # older Qt version so that we can compile in xcb platform plugin
+            qt-static-cache-key: 'v08' # required for static qt; update this to force rebuilding static Qt
             jacktrip-path: jacktrip
             binary-path: binary
 
@@ -179,7 +179,7 @@ jobs:
           mkdir $QT_STATIC_BUILD_PATH
           # configure
           if [[ "${{ runner.os }}" == "Linux" ]]; then
-            QT_STATIC_OPTIONS="-qt-zlib -qt-libpng -qt-libjpeg -system-freetype -fontconfig -qt-pcre -qt-harfbuzz -qt-xcb -no-icu -opengl desktop $QT_STATIC_OPTIONS"
+            QT_STATIC_OPTIONS="-qt-zlib -qt-libpng -qt-libjpeg -system-freetype -fontconfig -qt-pcre -qt-harfbuzz -no-icu -opengl desktop $QT_STATIC_OPTIONS"
           fi
           "$QT_SRC_PATH/configure" -ltcg -prefix "$QT_STATIC_BUILD_PATH" $QT_STATIC_OPTIONS
           # build

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -76,7 +76,7 @@ jobs:
       DEVELOPER_DIR: '/Applications/Xcode_11.7.app/Contents/Developer' # specify XCode version on macOS
       QT_SRC_PATH: ${{ github.workspace }}/../qt-static-src
       QT_STATIC_BUILD_PATH: ${{ github.workspace }}/../qt-static
-      QT_STATIC_VERSION: 'v02' # update this to force rebuilding static Qt
+      QT_STATIC_VERSION: 'v04' # update this to force rebuilding static Qt
       QT_STATIC_OPTIONS: '-static -release -optimize-size -no-pch -nomake tools -nomake tests -nomake examples -opensource -confirm-license -skip webengine -skip qt3d -skip qtactiveqt -skip qtandroidextras -skip qtcharts -skip qtdatavis3d -skip qtdeclarative -skip qtdoc -skip qtgamepad -skip qtgraphicaleffects -skip qtimageformats -skip qtlocation -skip qtmultimedia -skip qtpurchasing -skip qtpurchasing -skip qtquickcontrols -skip qtquickcontrols2 -skip qtremoteobjects -skip qtscript -skip qtsensors -skip qtserialbus -skip qtserialport -skip qtspeech -skip qtsvg -skip qttools -skip qtvirtualkeyboard -skip qtwayland -skip qtwebchannel -skip qtwebengine -skip qtwebglplugin -skip qtwebsockets -skip qtwebview -skip qtxmlpatterns' # common for all platforms
       
     steps:
@@ -97,7 +97,12 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install --yes libjack-dev qt5-default qt5-qmake qttools5-dev
+          sudo apt-get install --yes libjack-dev
+          if [[ -n "${{ matrix.static-qt-version }}" ]]; then 
+            sudo apt-get install --yes libfreetype6-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libx11-xcb-dev libdrm-dev libglu1-mesa-dev
+          else
+            sudo apt-get install --yes qt5-default qt5-qmake qttools5-dev
+          fi
       - name: install dependencies for macOS
         if: runner.os == 'macOS'
         env:
@@ -171,6 +176,9 @@ jobs:
         run: |
           mkdir $QT_STATIC_BUILD_PATH
           # configure
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            QT_STATIC_OPTIONS="-qt-zlib -qt-libpng -qt-libjpeg -system-freetype -fontconfig -qt-pcre -qt-harfbuzz -qt-xcb -no-icu -opengl desktop $QT_STATIC_OPTIONS"
+          fi
           "$QT_SRC_PATH/configure" -ltcg -prefix "$QT_STATIC_BUILD_PATH" $QT_STATIC_OPTIONS
           # build
           echo "building Qt"

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -76,7 +76,7 @@ jobs:
       DEVELOPER_DIR: '/Applications/Xcode_11.7.app/Contents/Developer' # specify XCode version on macOS
       QT_SRC_PATH: ${{ github.workspace }}/../qt-static-src
       QT_STATIC_BUILD_PATH: ${{ github.workspace }}/../qt-static
-      QT_STATIC_VERSION: 'v04' # update this to force rebuilding static Qt
+      QT_STATIC_CACHE_KEY: 'v04' # update this to force rebuilding static Qt
       QT_STATIC_OPTIONS: '-static -release -optimize-size -no-pch -nomake tools -nomake tests -nomake examples -opensource -confirm-license -skip webengine -skip qt3d -skip qtactiveqt -skip qtandroidextras -skip qtcharts -skip qtdatavis3d -skip qtdeclarative -skip qtdoc -skip qtgamepad -skip qtgraphicaleffects -skip qtimageformats -skip qtlocation -skip qtmultimedia -skip qtpurchasing -skip qtpurchasing -skip qtquickcontrols -skip qtquickcontrols2 -skip qtremoteobjects -skip qtscript -skip qtsensors -skip qtserialbus -skip qtserialport -skip qtspeech -skip qtsvg -skip qttools -skip qtvirtualkeyboard -skip qtwayland -skip qtwebchannel -skip qtwebengine -skip qtwebglplugin -skip qtwebsockets -skip qtwebview -skip qtxmlpatterns' # common for all platforms
       
     steps:
@@ -157,7 +157,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ${{ env.QT_STATIC_BUILD_PATH }}
-          key: ${{ runner.os }}-QtStaticCache-${{ matrix.static-qt-version }}_${{ env.QT_STATIC_VERSION }}
+          key: ${{ runner.os }}-QtStaticCache-${{ matrix.static-qt-version }}_${{ env.QT_STATIC_CACHE_KEY }}
       - name: download Qt sources
         if: matrix.static-qt-version && steps.cache-static-qt.outputs.cache-hit != 'true'
         shell: bash

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -76,7 +76,7 @@ jobs:
       DEVELOPER_DIR: '/Applications/Xcode_11.7.app/Contents/Developer' # specify XCode version on macOS
       QT_SRC_PATH: ${{ github.workspace }}/../qt-static-src
       QT_STATIC_BUILD_PATH: ${{ github.workspace }}/../qt-static
-      QT_STATIC_CACHE_KEY: 'v06' # update this to force rebuilding static Qt
+      QT_STATIC_CACHE_KEY: 'v07' # update this to force rebuilding static Qt
       QT_STATIC_OPTIONS: '-static -release -optimize-size -no-pch -nomake tools -nomake tests -nomake examples -opensource -confirm-license -skip webengine -skip qt3d -skip qtactiveqt -skip qtandroidextras -skip qtcharts -skip qtdatavis3d -skip qtdeclarative -skip qtdoc -skip qtgamepad -skip qtgraphicaleffects -skip qtimageformats -skip qtlocation -skip qtmultimedia -skip qtpurchasing -skip qtpurchasing -skip qtquickcontrols -skip qtquickcontrols2 -skip qtremoteobjects -skip qtscript -skip qtsensors -skip qtserialbus -skip qtserialport -skip qtspeech -skip qtsvg -skip qttools -skip qtvirtualkeyboard -skip qtwebchannel -skip qtwebengine -skip qtwebglplugin -skip qtwebsockets -skip qtwebview -skip qtxmlpatterns' # common for all platforms
       
     steps:
@@ -99,7 +99,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install --yes libjack-dev
           if [[ -n "${{ matrix.static-qt-version }}" ]]; then 
-            sudo apt-get install --yes libfreetype6-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libx11-xcb-dev libdrm-dev libglu1-mesa-dev libwayland-dev libwayland-egl1-mesa libgles2-mesa-dev libwayland-server0
+            sudo apt-get install --yes libfreetype6-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libx11-xcb-dev libdrm-dev libglu1-mesa-dev libwayland-dev libwayland-egl1-mesa libgles2-mesa-dev libwayland-server0 libwayland-egl-backend-dev
           else
             sudo apt-get install --yes qt5-default qt5-qmake qttools5-dev
           fi

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -30,8 +30,8 @@ jobs:
         include:
           - name: Linux-x64
             runs-on: ubuntu-18.04
-            static-qt-version: 5.15.2 # older Qt version so that we can compile in xcb platform plugin
-            qt-static-cache-key: 'v08' # required for static qt; update this to force rebuilding static Qt
+            static-qt-version: 5.12.11 # if set, it will enable static Qt build
+            qt-static-cache-key: 'v21' # required for static qt; update this to force rebuilding static Qt
             jacktrip-path: jacktrip
             binary-path: binary
 
@@ -101,7 +101,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install --yes libjack-dev
           if [[ -n "${{ matrix.static-qt-version }}" ]]; then 
-            sudo apt-get install --yes libfreetype6-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libx11-xcb-dev libdrm-dev libglu1-mesa-dev libwayland-dev libwayland-egl1-mesa libgles2-mesa-dev libwayland-server0 libwayland-egl-backend-dev
+            sudo apt-get install --yes libfreetype6-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libx11-xcb-dev libdrm-dev libglu1-mesa-dev libwayland-dev libwayland-egl1-mesa libgles2-mesa-dev libwayland-server0 libwayland-egl-backend-dev libxcb1-dev libxext-dev libfontconfig1-dev libxrender-dev libxcb-keysyms1-dev libxcb-image0-dev libxcb-shm0-dev libxcb-icccm4-dev libxcb-render-util0-dev libxcb-xinerama0-dev libxcomposite-dev libgtk-3-dev
           else
             sudo apt-get install --yes qt5-default qt5-qmake qttools5-dev
           fi


### PR DESCRIPTION
This should fix the Linux static build... tested on Ubuntu only.

~~It turned out, that in order to build static Qt that runs in X11, one needs to bundle the qt `xcb` platform plugin. This has been [disabled in Qt 5.15](https://doc.qt.io/qt-5/linux-requirements.html), but is still [possible in Qt 5.12](https://doc.qt.io/qt-5.12/linux-requirements.html).~~

It turned out that bundling xcb platform plugin was not necessary. Qt 5.15 seems to be incompatible with the distribution I was testing with (Ubuntu 20.04, running X11). 

Compatibility with Wayland is still TBD.

In this PR
- I made the qt version configurable in the build matrix
- I set Linux and macOS to use Qt 5.12
  - ~~on Linux, I've used build flags specifically for 5.12, namely `-qt-xcb`, which bundles the xcb plugin with the library; this is the main qt "fix" in this PR~~ (aside from bundling `libjpeg` and the like)
- on all platforms I removed `-skip qtquick3d -skip qtlottie -skip qtquicktimeline` when building static qt since they are not present in 5.12 and caused errors; the increased build time should be negligible
- on macOS I used the earlier Qt version so we support slightly older operating systems (macOS 10.12 I believe) - why not? I can revert that if desired
- Linux build now installs only the needed libraries when building qt, instead of installing qt from apt
- I kept Windows at Qt 5.15 since AFAIR only that version (or 5.14 maybe) fixes the issue with fractional display scaling

**EDIT: here's the link to the [Linux static build](https://github.com/jacktrip/jacktrip/suites/2934741456/artifacts/65930498)**