### PR TITLE
Weakjack part2

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -93,16 +93,16 @@ jobs:
         env:
           DEVELOPER_DIR: '/Applications/Xcode_11.7.app/Contents/Developer' # specify XCode version on macOS
         run: |
-          meson --buildtype release $BUILD_PATH
+          meson --buildtype release -Drtaudio=enabled $BUILD_PATH
           cd $BUILD_PATH
-          meson configure -Ddefault_library=static -Drtaudio=enabled -Dweakjack=true
+          meson configure -Ddefault_library=static -Drtaudio:jack=disabled -Dweakjack=true
           meson compile
       - name: build on Windows
         if: runner.os == 'Windows'
         run: |
           meson --buildtype release -Drtaudio=enabled builddir
           cd builddir
-          meson configure -Ddefault_library=both -Drtaudio:default_library=static -Drtaudio:wasapi=true -Dwingetopt:default_library=static -Dweakjack=true
+          meson configure -Ddefault_library=both -Drtaudio:default_library=static -Drtaudio:wasapi=true -Drtaudio:jack=disabled -Dwingetopt:default_library=static -Dweakjack=true
           meson compile
       - name: upload artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -36,6 +36,8 @@ jobs:
       QT_VERSION: '5.15.2'
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: true
       - name: Set up Python
         uses: actions/setup-python@v2
       - name: install dependencies for Linux

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -79,14 +79,21 @@ jobs:
           target: 'desktop'
           arch: 'win64_msvc2019_64'
           cached: ${{ steps.cache-qt.outputs.cache-hit }}
-      - name: build on Linux / macOS
-        if: runner.os != 'Windows'
+      - name: build on Linux
+        if: runner.os == 'Linux'
+        run: |
+          meson --buildtype release $BUILD_PATH
+          cd $BUILD_PATH
+          meson configure -Ddefault_library=static -Drtaudio=enabled
+          meson compile
+      - name: build on macOS
+        if: runner.os == 'macOS'
         env:
           DEVELOPER_DIR: '/Applications/Xcode_11.7.app/Contents/Developer' # specify XCode version on macOS
         run: |
           meson --buildtype release $BUILD_PATH
           cd $BUILD_PATH
-          meson configure -Ddefault_library=static -Drtaudio=enabled
+          meson configure -Ddefault_library=static -Drtaudio=enabled -Dweakjack=true
           meson compile
       - name: build on Windows
         if: runner.os == 'Windows'

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           meson --buildtype release -Drtaudio=enabled builddir
           cd builddir
-          meson configure -Ddefault_library=both -Drtaudio:default_library=static -Drtaudio:wasapi=true -Dwingetopt:default_library=static
+          meson configure -Ddefault_library=both -Drtaudio:default_library=static -Drtaudio:wasapi=true -Dwingetopt:default_library=static -Dweakjack=true
           meson compile
       - name: upload artifacts
         uses: actions/upload-artifact@v2

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "subprojects/weakjack"]
-	path = subprojects/weakjack
+	path = externals/weakjack
 	url = https://github.com/x42/weakjack.git
 [submodule "linux/flatpak/shared-modules"]
 	path = linux/flatpak/shared-modules

--- a/jacktrip.pro
+++ b/jacktrip.pro
@@ -45,7 +45,7 @@ INCLUDEPATH += faust-src-lair/stk
   LIBS += -L/usr/local/lib -lm
   weakjack {
     message(Building with weak linking of JACK)
-    INCLUDEPATH += subprojects/weakjack
+    INCLUDEPATH += externals/weakjack
     DEFINES += USE_WEAK_JACK
   } else {
     nojack {
@@ -128,7 +128,7 @@ win32 {
     INCLUDEPATH += "C:\Program Files\JACK2\include"
     weakjack {
       message(Building with weak linking of JACK)
-      INCLUDEPATH += subprojects/weakjack
+      INCLUDEPATH += externals/weakjack
       DEFINES += USE_WEAK_JACK
     } else {
       LIBS += "C:\Program Files\JACK2\lib\libjack64.lib"
@@ -140,7 +140,7 @@ win32 {
       INCLUDEPATH += "C:\Program Files (x86)\Jack\includes"
       weakjack {
         message(Building with weak linking of JACK)
-        INCLUDEPATH += subprojects/weakjack
+        INCLUDEPATH += externals/weakjack
         DEFINES += USE_WEAK_JACK
       } else {
         LIBS += "C:\Program Files (x86)\Jack\lib\libjack64.lib"
@@ -271,5 +271,5 @@ rtaudio {
 }
 
 weakjack {
-  SOURCES += subprojects/weakjack/weak_libjack.c
+  SOURCES += externals/weakjack/weak_libjack.c
 }

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('jacktrip', 'cpp',
+project('jacktrip', ['cpp','c'],
 		default_options: ['cpp_std=c++17','warning_level=2'])
 qt5 = import('qt5')
 cmake = import('cmake')
@@ -6,6 +6,7 @@ cmake = import('cmake')
 compiler = meson.get_compiler('cpp')
 
 defines = ['-DWAIRTOHUB']
+c_defines = []
 if host_machine.system() == 'linux'
 	defines += '-D__LINUX__'
 elif host_machine.system() == 'darwin'
@@ -16,6 +17,8 @@ elif host_machine.system() == 'windows'
 	defines += '-DWIN32_LEAN_AND_MEAN'
 	defines += '-DNOMINMAX'
 endif
+
+incdir = include_directories('externals/weakjack')
 
 src = [	'src/DataProtocol.cpp',
 	'src/JackTrip.cpp',
@@ -51,7 +54,7 @@ moc_h = ['src/DataProtocol.h',
 ui_h = []
 qres = []
 
-threads_dep = dependency('threads')
+deps = [dependency('threads')]
 jack_dep = dependency('jack', required: get_option('jack'))
 if not jack_dep.found()
 	defines += '-D__NO_JACK__'
@@ -60,9 +63,16 @@ else
 		'src/JMess.cpp',
 		'src/Patcher.cpp']
 	moc_h += ['src/Patcher.h']
+	if get_option('weakjack') == true
+		src += 'externals/weakjack/weak_libjack.c'
+		defines += '-DUSE_WEAK_JACK'
+		c_defines += '-DUSE_WEAK_JACK'
+		deps += jack_dep.partial_dependency(includes: true)
+		deps += compiler.find_library('dl', required : false)
+	else
+		deps += jack_dep
+	endif
 endif
-
-deps = [threads_dep, jack_dep]
 
 if get_option('nogui') == true
 	defines += '-DNO_GUI'
@@ -115,7 +125,7 @@ endif
 
 subdir('linux')
 
-jacktrip = executable('jacktrip', src, prepro_files, dependencies: deps, cpp_args: defines, install: true )
+jacktrip = executable('jacktrip', src, prepro_files, include_directories: incdir, dependencies: deps, c_args: c_defines, cpp_args: defines, install: true )
 
 if not (host_machine.system() == 'windows')
 	help2man = find_program('help2man', required: false)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,5 @@
 option('wair', type : 'feature', value : 'disabled', description: 'WAIR')
 option('rtaudio', type : 'feature', value : 'auto', description: 'Build with RtAudio Backend')
-option('jack', type : 'feature', value : 'auto', description: 'Build with Jack Backend')
+option('jack', type : 'feature', value : 'auto', description: 'Build with JACK Backend')
+option('weakjack', type : 'boolean', value : 'false', description: 'Weak link JACK library')
 option('nogui', type : 'boolean', value : 'false', description: 'Build without graphical user interface')


### PR DESCRIPTION
This moves weakjack from the subprojects directory into JackTrip's own src directory because weakjack is not a subproject. The subprojects directory is a special meson directory that is protected to only contain subprojects. Weakjack is supposed to be part of your projects source code (copied or as a git submodule).

Additionally this PR adds a weakjack option for meson. Tested on Linux. This seems to be broken with QMake because of the dl dependency.

PS: QMake is slow… and links jacknet because of some reason.