### PR TITLE
Add warning for command line arguments in GUI mode

### DIFF
--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -46,7 +46,8 @@ QJackTrip::QJackTrip(QWidget *parent) :
     m_messageDialog(new MessageDialog(this)),
     m_jackTripRunning(false),
     m_isExiting(false),
-    m_hasIPv4Reply(false)
+    m_hasIPv4Reply(false),
+    m_argc(1)
 {
     m_ui->setupUi(this);
     
@@ -221,6 +222,25 @@ void QJackTrip::resizeEvent(QResizeEvent* event)
             m_ui->requireAuthGroupBox->contentsMargins().right();
     rect = metrics.boundingRect(0, 0, width, 0, Qt::TextWordWrap, m_ui->authDisclaimerLabel->text());
     m_ui->authDisclaimerLabel->setMinimumHeight(rect.height());
+}
+
+void QJackTrip::showEvent(QShowEvent* event)
+{
+    QMainWindow::showEvent(event);
+    
+    //One of our arguments will always be --gui, so if that's the only one
+    //then we don't need to show the warning message.
+    if (m_argc > 2) {
+        QMessageBox msgBox;
+        msgBox.setText("The GUI version of JackTrip currently\nignores any command line options.\n\nThis may change in future.");
+        msgBox.setWindowTitle("Command line options");
+        msgBox.exec();
+    }
+}
+
+void QJackTrip::setArgc(int argc)
+{
+    m_argc = argc;
 }
 
 void QJackTrip::processFinished()

--- a/src/gui/qjacktrip.h
+++ b/src/gui/qjacktrip.h
@@ -58,7 +58,10 @@ public:
     
     void closeEvent(QCloseEvent *event) override;
     void resizeEvent(QResizeEvent *event) override;
-
+    void showEvent(QShowEvent* event) override;
+    
+    void setArgc(int argc);
+    
 signals:
     void signalExit();
     
@@ -114,6 +117,7 @@ private:
     QString m_lastPath;
     
     QLabel m_autoQueueIndicator;
+    int m_argc;
     
 #ifdef __MAC_OSX__
     NoNap m_noNap;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,8 +60,12 @@ QCoreApplication *createApplication(int &argc, char *argv[])
             //Command line option to test if the binary has been built with GUI support.
             //Exits immediately. Exits with an error if GUI support has not been built in.
 #ifdef NO_GUI
+            std::cout << "This version of JackTrip has been built without GUI support." << std::endl;
+            std::cout << "(To run JackTrip normally, please omit the --test-gui option.)" << std::endl;
             std::exit(1);
 #else
+            std::cout << "This version of JackTrip has been built with GUI support." << std::endl;
+            std::cout << "(To run JackTrip normally, please omit the --test-gui option.)" << std::endl;
             std::exit(0);
 #endif
         }
@@ -152,6 +156,7 @@ int main(int argc, char *argv[])
 #endif // __WIN_32__
         app->setApplicationName("QJackTrip");
         window.reset(new QJackTrip);
+        window->setArgc(argc);
         QObject::connect(window.data(), &QJackTrip::signalExit, app.data(), &QCoreApplication::quit, Qt::QueuedConnection);
         window->show();
     } else {


### PR DESCRIPTION
Alert the user that command line options are currently ignored in GUI mode. And if they manage to stumble upon --test-gui, let them know they need to remove it for jacktrip to run normally.