### PR TITLE
QJackTrip: add basic backend selection

### DIFF
--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -793,15 +793,6 @@ void QJackTrip::loadSettings()
         m_ui->channelRecvSpinBox->setValue(settings.value("ChannelsRecv", gDefaultNumOutChannels).toInt());
     }
     
-#ifdef __RT_AUDIO__
-    m_ui->backendBox->setCurrentIndex(settings.value("Backend", 0).toInt());
-    m_ui->sampleRateBox->setValue(settings.value("SampleRate", 48000).toInt());
-    if (m_ui->backendBox->currentIndex() == 0) {
-        m_ui->sampleRateBox->setEnabled(false);
-    }
-    // TODO: load device
-#endif
-    
     m_ui->autoPatchComboBox->setCurrentIndex(settings.value("AutoPatchMode", 0).toInt());
     m_ui->zeroCheckBox->setChecked(settings.value("ZeroUnderrun", false).toBool());
     m_ui->timeoutCheckBox->setChecked(settings.value("Timeout", false).toBool());
@@ -816,6 +807,17 @@ void QJackTrip::loadSettings()
     m_ui->connectAudioCheckBox->setChecked(settings.value("ConnectAudio", true).toBool());
     m_ui->realTimeCheckBox->setChecked(settings.value("RTNetworking", true).toBool());
     m_lastPath = settings.value("LastPath", QDir::homePath()).toString();
+    
+#ifdef __RT_AUDIO__
+    settings.beginGroup("Audio");
+    m_ui->backendBox->setCurrentIndex(settings.value("Backend", 0).toInt());
+    m_ui->sampleRateBox->setValue(settings.value("SampleRate", 48000).toInt());
+    if (m_ui->backendBox->currentIndex() == 0) {
+        m_ui->sampleRateBox->setEnabled(false);
+    }
+    // TODO: load device
+    settings.endGroup();
+#endif
     
     settings.beginGroup("RecentServers");
     for (int i = 1; i <= 5; i++) {
@@ -891,11 +893,6 @@ void QJackTrip::saveSettings()
     settings.setValue("LastAddress", m_ui->addressComboBox->currentText());
     settings.setValue("ChannelsSend", m_ui->channelSendSpinBox->value());
     settings.setValue("ChannelsRecv", m_ui->channelRecvSpinBox->value());
-#ifdef __RT_AUDIO__
-    settings.setValue("Backend", m_ui->backendBox->currentIndex());
-    settings.setValue("SampleRate", m_ui->sampleRateBox->value());
-    // TODO: save device
-#endif
     settings.setValue("AutoPatchMode", m_ui->autoPatchComboBox->currentIndex());
     settings.setValue("ZeroUnderrun", m_ui->zeroCheckBox->isChecked());
     settings.setValue("Timeout", m_ui->timeoutCheckBox->isChecked());
@@ -910,6 +907,14 @@ void QJackTrip::saveSettings()
     settings.setValue("ConnectAudio", m_ui->connectAudioCheckBox->isChecked());
     settings.setValue("RTNetworking", m_ui->realTimeCheckBox->isChecked());
     settings.setValue("LastPath", m_lastPath);
+    
+#ifdef __RT_AUDIO__
+    settings.beginGroup("Audio");
+    settings.setValue("Backend", m_ui->backendBox->currentIndex());
+    settings.setValue("SampleRate", m_ui->sampleRateBox->value());
+    // TODO: save device
+    settings.endGroup();
+#endif
     
     settings.beginGroup("RecentServers");
     for (int i = 0; i < m_ui->addressComboBox->count(); i++) {

--- a/src/gui/qjacktrip.ui
+++ b/src/gui/qjacktrip.ui
@@ -552,6 +552,102 @@ To connect to a hub server you need to run as a hub client.</string>
           </layout>
          </widget>
         </item>
+        <item row="3" column="0" colspan="3">
+         <widget class="QGroupBox" name="backendGroupBox">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>80</height>
+           </size>
+          </property>
+          <property name="title">
+           <string/>
+          </property>
+          <widget class="QComboBox" name="backendBox">
+           <property name="geometry">
+            <rect>
+             <x>160</x>
+             <y>6</y>
+             <width>171</width>
+             <height>32</height>
+            </rect>
+           </property>
+           <property name="toolTip">
+            <string>set the backend</string>
+           </property>
+           <item>
+            <property name="text">
+             <string>Jack</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>RtAudio</string>
+            </property>
+           </item>
+          </widget>
+          <widget class="QSpinBox" name="sampleRateBox">
+           <property name="geometry">
+            <rect>
+             <x>170</x>
+             <y>46</y>
+             <width>151</width>
+             <height>21</height>
+            </rect>
+           </property>
+           <property name="toolTip">
+            <string>set sampling rate (RtAudio only)</string>
+           </property>
+           <property name="prefix">
+            <string/>
+           </property>
+           <property name="minimum">
+            <number>0</number>
+           </property>
+           <property name="maximum">
+            <number>384000</number>
+           </property>
+           <property name="stepType">
+            <enum>QAbstractSpinBox::DefaultStepType</enum>
+           </property>
+           <property name="value">
+            <number>48000</number>
+           </property>
+          </widget>
+          <widget class="QLabel" name="samplingRateLabel">
+           <property name="geometry">
+            <rect>
+             <x>17</x>
+             <y>46</y>
+             <width>120</width>
+             <height>21</height>
+            </rect>
+           </property>
+           <property name="text">
+            <string>Sampling rate:</string>
+           </property>
+          </widget>
+          <widget class="QLabel" name="backendLabel">
+           <property name="geometry">
+            <rect>
+             <x>17</x>
+             <y>6</y>
+             <width>80</width>
+             <height>30</height>
+            </rect>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Backend:</string>
+           </property>
+          </widget>
+         </widget>
+        </item>
        </layout>
       </widget>
       <widget class="QWidget" name="advancedTab">


### PR DESCRIPTION
Since we are now building JackTrip with rtaudio on macOS and Windows, I thought it would be nice to have a way to use it when running the GUI.

I've added a menu for choosing between Jack and RtAudio (or should that be called "native" or "direct"?) and added samplerate setting for RtAudio. I have not added audio device setting since this is not fully functional right now AFAIU.

I think I've added storing everything in settings, the dialog disappears when in hub server mode, and should be permanently hidden when built without rtaudio.

~~I've used Qt Creator to add new elements to the layout. The diff for `jacktrip.ui` looks bigger than the changes I've made, not sure if I've done this right.~~ I tried to clean this up and manually copied only the new section into the original `jacktrip.ui`. The diff looks much nicer, but when the UI is opened in Qt Creator, new elements overlap with the old ones. The previous version, that was done purely in and looks better in Qt Creator, can be found [here](https://github.com/dyfer/jacktrip/blob/gui-rtaudio-backup01/src/gui/qjacktrip.ui). Which one is better?

This is meant to be an addition to #218

Please review carefully, I'm not confident with my changes :)

![image](https://user-images.githubusercontent.com/1589177/121406481-09265200-c913-11eb-9ac5-6f26cb9f9ef4.png)

