### PR TITLE
[Docs] Make edit symbol work

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: JackTrip
 repo_url: https://github.com/jacktrip/jacktrip
+edit_uri: edit/dev/docs/
 nav:
   - Home: index.md
   - User Guide:


### PR DESCRIPTION
Sets edit_uri to dev branch. If you click on the edit symbol in a docs page you should be directed to the correct edit page on github.

Please rebase merge as it is only one commit!