### PR TITLE
UI: add buffer size setting for RtAudio

### DIFF
--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -178,9 +178,13 @@ QJackTrip::QJackTrip(QWidget *parent) :
             if (index == 1) {
                 m_ui->sampleRateComboBox->setEnabled(true);
                 m_ui->sampleRateLabel->setEnabled(true);
+                m_ui->bufferSizeComboBox->setEnabled(true);
+                m_ui->bufferSizeLabel->setEnabled(true);
             } else {
                 m_ui->sampleRateComboBox->setEnabled(false);
                 m_ui->sampleRateLabel->setEnabled(false);
+                m_ui->bufferSizeComboBox->setEnabled(false);
+                m_ui->bufferSizeLabel->setEnabled(false);
             }
         } );
 #else
@@ -602,6 +606,7 @@ void QJackTrip::start()
             if (m_ui->backendComboBox->currentIndex() == 1) { 
                 m_jackTrip->setAudiointerfaceMode(JackTrip::RTAUDIO); 
                 m_jackTrip->setSampleRate(m_ui->sampleRateComboBox->currentText().toInt());
+                m_jackTrip->setAudioBufferSizeInSamples(m_ui->bufferSizeComboBox->currentText().toInt());
                 // TODO: set device
             }
 #endif
@@ -826,8 +831,10 @@ void QJackTrip::loadSettings()
     settings.beginGroup("Audio");
     m_ui->backendComboBox->setCurrentIndex(settings.value("Backend", 0).toInt());
     m_ui->sampleRateComboBox->setCurrentText(settings.value("SampleRate", "48000").toString());
+    m_ui->bufferSizeComboBox->setCurrentText(settings.value("BufferSize", "128").toString());
     if (m_ui->backendComboBox->currentIndex() == 0) {
         m_ui->sampleRateComboBox->setEnabled(false);
+        m_ui->bufferSizeComboBox->setEnabled(false);
     }
     // TODO: load device
     settings.endGroup();
@@ -928,6 +935,7 @@ void QJackTrip::saveSettings()
     settings.beginGroup("Audio");
     settings.setValue("Backend", m_ui->backendComboBox->currentIndex());
     settings.setValue("SampleRate", m_ui->sampleRateComboBox->currentText());
+    settings.setValue("BufferSize", m_ui->bufferSizeComboBox->currentText());
     // TODO: save device
     settings.endGroup();
 #endif
@@ -1211,6 +1219,7 @@ QString QJackTrip::commandLineFromCurrentOptions()
     if (m_ui->typeComboBox->currentIndex() != HUB_SERVER && m_ui->backendComboBox->currentIndex() == 1) {
         commandLine.append(" --rtaudio");
         commandLine.append(QString(" --srate %1").arg(m_ui->sampleRateComboBox->currentText()));
+        commandLine.append(QString(" --bufsize %1").arg(m_ui->bufferSizeComboBox->currentText()));
         // TODO: set device
     }
 #endif

--- a/src/gui/qjacktrip.ui
+++ b/src/gui/qjacktrip.ui
@@ -664,6 +664,76 @@ To connect to a hub server you need to run as a hub client.</string>
              </item>
             </widget>
            </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="bufferSizeLabel">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>&amp;Buffer Size:</string>
+             </property>
+             <property name="buddy">
+              <cstring>bufferSizeComboBox</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QComboBox" name="bufferSizeComboBox">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the driver's buffer size to use with the RtAudio backend.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="currentText">
+              <string>128</string>
+             </property>
+             <property name="currentIndex">
+              <number>3</number>
+             </property>
+             <item>
+              <property name="text">
+               <string>16</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>32</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>64</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>128</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>256</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>512</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>1024</string>
+              </property>
+             </item>
+            </widget>
+           </item>
           </layout>
          </widget>
         </item>
@@ -1583,6 +1653,7 @@ and wetness is the essence of beauty.</string>
   <tabstop>channelSendSpinBox</tabstop>
   <tabstop>backendComboBox</tabstop>
   <tabstop>sampleRateComboBox</tabstop>
+  <tabstop>bufferSizeComboBox</tabstop>
   <tabstop>autoPatchComboBox</tabstop>
   <tabstop>zeroCheckBox</tabstop>
   <tabstop>timeoutCheckBox</tabstop>


### PR DESCRIPTION
Add buffer size setting to RtAudio settings in the GUI. Fixes #331.

I've edited `qjacktrip.ui` by hand - feel free to correct as needed.