### PR TITLE
Check if jack is available

### DIFF
--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -234,7 +234,7 @@ QJackTrip::QJackTrip(QWidget *parent) :
         if (!settings.value("HideJackWarning", false).toBool()) {
             QCheckBox *dontBugMe = new QCheckBox("Don't show this warning again");
             QMessageBox msgBox;
-            msgBox.setText("An instllation of JACK was not found. Only the RtAudio\nbackend will be available. (Hub Server mode is not\ncurrently supported in this configuration.");
+            msgBox.setText("An installation of JACK was not found. Only the RtAudio\nbackend will be available. (Hub Server mode is not\ncurrently supported in this configuration.");
             msgBox.setWindowTitle("JACK Not Available");
             msgBox.setCheckBox(dontBugMe);
             QObject::connect(dontBugMe, &QCheckBox::stateChanged, this, [=]() {
@@ -248,7 +248,7 @@ QJackTrip::QJackTrip(QWidget *parent) :
         settings.endGroup();
 #else
         QMessageBox msgBox;
-        msgBox.setText("An instllation of JACK was not found, and no other audio\nbackends are available. JackTrip will not be able to start.\n(Please install JACK to fix this.)");
+        msgBox.setText("An installation of JACK was not found, and no other audio\nbackends are available. JackTrip will not be able to start.\n(Please install JACK to fix this.)");
         msgBox.setWindowTitle("JACK Not Available");
         msgBox.exec();
 #endif // __RT_AUDIO__

--- a/src/gui/qjacktrip.h
+++ b/src/gui/qjacktrip.h
@@ -118,6 +118,7 @@ private:
     
     QLabel m_autoQueueIndicator;
     int m_argc;
+    bool m_hideWarning;
     
 #ifdef __MAC_OSX__
     NoNap m_noNap;

--- a/src/gui/qjacktrip.ui
+++ b/src/gui/qjacktrip.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>403</width>
-    <height>909</height>
+    <height>947</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -664,25 +664,6 @@ To connect to a hub server you need to run as a hub client.</string>
              </item>
             </widget>
            </item>
-           <item row="2" column="0">
-            <widget class="QLabel" name="bufferSizeLabel">
-             <property name="enabled">
-              <bool>false</bool>
-             </property>
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>&amp;Buffer Size:</string>
-             </property>
-             <property name="buddy">
-              <cstring>bufferSizeComboBox</cstring>
-             </property>
-            </widget>
-           </item>
            <item row="2" column="1">
             <widget class="QComboBox" name="bufferSizeComboBox">
              <property name="enabled">
@@ -690,9 +671,6 @@ To connect to a hub server you need to run as a hub client.</string>
              </property>
              <property name="toolTip">
               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the driver's buffer size to use with the RtAudio backend.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-             </property>
-             <property name="currentText">
-              <string>128</string>
              </property>
              <property name="currentIndex">
               <number>3</number>
@@ -732,6 +710,25 @@ To connect to a hub server you need to run as a hub client.</string>
                <string>1024</string>
               </property>
              </item>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="bufferSizeLabel">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>&amp;Buffer Size:</string>
+             </property>
+             <property name="buddy">
+              <cstring>bufferSizeComboBox</cstring>
+             </property>
             </widget>
            </item>
           </layout>


### PR DESCRIPTION
If built with weakjack, check if jack is available. If not and the rtaudio backend has been built in, fallback on this and show a warning dialog which the user can choose to hide in the future. If no other backend is available, show a warning that cannot be suppressed.

Also, remove redundant code to change UI based on audio backend choice in the loadSettings function. (This is taken care of when the backendComboBox value is set via the connected signal and slot.)