### PR TITLE
Prepare 1.4.0 rc.2

### DIFF
--- a/.github/workflows/flatpak-release.yml
+++ b/.github/workflows/flatpak-release.yml
@@ -6,6 +6,7 @@ jobs:
   flatpak:
     name: "Flatpak"
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/head/main')
     container:
       image: bilelmoussaoui/flatpak-github-actions:kde-5.15
       options: --privileged

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -44,7 +44,7 @@
 /// \todo Add this namespace
 //namespace JackTrip
 
-const char* const gVersion = "1.4.0-rc.1";  ///< JackTrip version
+const char* const gVersion = "1.4.0-rc.2";  ///< JackTrip version
 
 //*******************************************************************************
 /// \name Default Values


### PR DESCRIPTION
- ~~fix XML file, as suggested by @ntonnaett~~
- update version to 1.4.0-rc.2
- flatpak stable deployment only runs on the main branch (as requested by @ntonnaett)

~~EDIT: I removed changes to the flatpak XML file from this PR as they did not work. I don't know what's wrong there - [here's what I've tried](https://github.com/dyfer/jacktrip/blob/xml-change-copy/linux/org.jacktrip.JackTrip.metainfo.xml.in).~~

~~Flatpak GitHub Action failure should not interfere with the release candidate, so IMO we can go ahead with rc.2. I think @ntonnaett is on board with that :) ~~ Flatpak issue is now resolved