### PR TITLE
Fix process plugin delete

### DIFF
--- a/src/AudioInterface.cpp
+++ b/src/AudioInterface.cpp
@@ -111,8 +111,8 @@ AudioInterface::~AudioInterface()
     for (int i = 0; i < aCnt; i++) { delete[] mAPInBuffer[i]; }
 #endif  // endwhere
 
-    for (auto& i : mProcessPluginsFromNetwork) { delete[] i; }
-    for (auto& i : mProcessPluginsToNetwork) { delete[] i; }
+    for (auto* i : mProcessPluginsFromNetwork) { delete i; }
+    for (auto* i : mProcessPluginsToNetwork) { delete i; }
     for (int i = 0; i < mNumInChans; i++) { delete[] mInBufCopy[i]; }
 }
 


### PR DESCRIPTION
This fixes:

```
==16328== Invalid read of size 8
==16328==    at 0x46DC40: AudioInterface::~AudioInterface() (AudioInterface.cpp:115)
==16328==    by 0x4768B5: JackAudioInterface::~JackAudioInterface() (JackAudioInterface.cpp:92)
==16328==    by 0x4768D1: JackAudioInterface::~JackAudioInterface() (JackAudioInterface.cpp:92)
==16328==    by 0x418CF9: JackTrip::closeAudio() (JackTrip.cpp:283)
==16328==    by 0x41C45A: JackTrip::stop(QString) (JackTrip.cpp:953)
==16328==    by 0x414D59: JackTrip::slotStopProcessesDueToError(QString const&) (JackTrip.h:526)
==16328==    by 0x41FC0E: QtPrivate::FunctorCall<QtPrivate::IndexesList<0>, QtPrivate::List<QString const&>, void, void (JackTrip::*)(QString const&)>::call(void (JackTrip::*)(QString const&), JackTrip*, void**) (qobjectdefs_impl.h:152)
==16328==    by 0x41FAE0: void QtPrivate::FunctionPointer<void (JackTrip::*)(QString const&)>::call<QtPrivate::List<QString const&>, void>(void (JackTrip::*)(QString const&), JackTrip*, void**) (qobjectdefs_impl.h:185)
==16328==    by 0x41F7DB: QtPrivate::QSlotObject<void (JackTrip::*)(QString const&), QtPrivate::List<QString const&>, void>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*) (qobjectdefs_impl.h:418)
==16328==    by 0x4B42256: QObject::event(QEvent*) (in /usr/lib64/libQt5Core.so.5.15.2)
==16328==    by 0x4B1AF2A: QCoreApplication::notifyInternal2(QObject*, QEvent*) (in /usr/lib64/libQt5Core.so.5.15.2)
==16328==    by 0x4B1DC75: QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) (in /usr/lib64/libQt5Core.so.5.15.2)
==16328==  Address 0x175264a8 is 8 bytes before a block of size 120 alloc'd
==16328==    at 0x4840FF5: operator new(unsigned long) (vg_replace_malloc.c:417)
==16328==    by 0x454B81: Effects::allocateOutgoingEffects(int) (Effects.h:243)
==16328==    by 0x438B03: Settings::getConfiguredJackTrip() (Settings.cpp:971)
==16328==    by 0x471ADC: main (main.cpp:206)
==16328== 
==16328== Invalid free() / delete / delete[] / realloc()
==16328==    at 0x484465B: operator delete[](void*) (vg_replace_malloc.c:938)
==16328==    by 0x46DC87: AudioInterface::~AudioInterface() (AudioInterface.cpp:115)
==16328==    by 0x4768B5: JackAudioInterface::~JackAudioInterface() (JackAudioInterface.cpp:92)
==16328==    by 0x4768D1: JackAudioInterface::~JackAudioInterface() (JackAudioInterface.cpp:92)
==16328==    by 0x418CF9: JackTrip::closeAudio() (JackTrip.cpp:283)
==16328==    by 0x41C45A: JackTrip::stop(QString) (JackTrip.cpp:953)
==16328==    by 0x414D59: JackTrip::slotStopProcessesDueToError(QString const&) (JackTrip.h:526)
==16328==    by 0x41FC0E: QtPrivate::FunctorCall<QtPrivate::IndexesList<0>, QtPrivate::List<QString const&>, void, void (JackTrip::*)(QString const&)>::call(void (JackTrip::*)(QString const&), JackTrip*, void**) (qobjectdefs_impl.h:152)
==16328==    by 0x41FAE0: void QtPrivate::FunctionPointer<void (JackTrip::*)(QString const&)>::call<QtPrivate::List<QString const&>, void>(void (JackTrip::*)(QString const&), JackTrip*, void**) (qobjectdefs_impl.h:185)
==16328==    by 0x41F7DB: QtPrivate::QSlotObject<void (JackTrip::*)(QString const&), QtPrivate::List<QString const&>, void>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*) (qobjectdefs_impl.h:418)
==16328==    by 0x4B42256: QObject::event(QEvent*) (in /usr/lib64/libQt5Core.so.5.15.2)
==16328==    by 0x4B1AF2A: QCoreApplication::notifyInternal2(QObject*, QEvent*) (in /usr/lib64/libQt5Core.so.5.15.2)
==16328==  Address 0x175264a8 is 8 bytes before a block of size 120 alloc'd
==16328==    at 0x4840FF5: operator new(unsigned long) (vg_replace_malloc.c:417)
==16328==    by 0x454B81: Effects::allocateOutgoingEffects(int) (Effects.h:243)
==16328==    by 0x438B03: Settings::getConfiguredJackTrip() (Settings.cpp:971)
==16328==    by 0x471ADC: main (main.cpp:206)
```

@josmithiii Could you check please!