### PR TITLE
Unregister jack ports before closing client to prevent indirect memory leaks (with pipewire)

### DIFF
--- a/src/JackAudioInterface.cpp
+++ b/src/JackAudioInterface.cpp
@@ -254,6 +254,9 @@ int JackAudioInterface::startProcess() const
 int JackAudioInterface::stopProcess() const
 {
     QMutexLocker locker(&sJackMutex);
+    for(auto* inPort: qAsConst(mInPorts)) jack_port_unregister(mClient, inPort);
+    for(auto* outPort: qAsConst(mOutPorts)) jack_port_unregister(mClient, outPort);
+    for(auto* port: qAsConst(mBroadcastPorts)) jack_port_unregister(mClient, port);
     int code = (jack_client_close(mClient));
     if (code != 0) {
         std::cerr << "Cannot disconnect client" << std::endl;


### PR DESCRIPTION
This prevents indirect memory leaks (at least in pipewire). Jack's
simple_client looks like this shouldn't happen and is probably a
bug in pipewire. But unregistering ports doesn't hurt.