### PR TITLE
QMake: Linux installation improvements

### DIFF
--- a/build
+++ b/build
@@ -3,10 +3,11 @@
 
 # Parse command line options
 clean=1
+install=0
 CONFIG=
 UNKNOWN_OPTIONS=
 HELP_STR="usage:\n
-./build [noclean nojack rtaudio nogui static [-config static]]\n\n
+./build [noclean nojack rtaudio nogui static install [-config static]]\n\n
 options:\n
 noclean - do not run \"make clean\" first\n
 nojack - build without jack\n
@@ -14,6 +15,7 @@ rtaudio - build with rtaudio\n
 nogui - build without the gui\n
 static - build with static libraries\n
 weakjack - build with weak linking of jack libraries\n
+install - install jacktrip in system location (uses sudo)\n
 "
 while [[ "$#" -gt 0 ]]; do
   if [[ -z "$UNKNOWN_OPTIONS" ]]; then
@@ -38,6 +40,10 @@ while [[ "$#" -gt 0 ]]; do
       weakjack)
       echo "Building with static libraries"
       CONFIG="-config weakjack $CONFIG"
+      ;;
+      install)
+      echo "Will install JackTrip in system location"
+      install=1
       ;;
       -h|--help) 
       echo -e $HELP_STR; exit 
@@ -116,3 +122,8 @@ if [[ $clean == 1 ]]; then
 fi
 $QCMD -spec $QSPEC $CONFIG ../jacktrip.pro $UNKNOWN_OPTIONS
 $MCMD release
+if [[ $install == 1 ]]; then
+  echo "*** Installing JackTrip ***"
+  echo "We need elevated privileges to install JackTrip in the system location"
+  sudo $MCMD release-install
+fi

--- a/docs/Build/Linux.md
+++ b/docs/Build/Linux.md
@@ -23,68 +23,96 @@ dnf install "pkgconfig(jack)" alsa-lib-devel git help2man
 dnf install qjackctl
 ```
 
-Clone the git repo and run `./build` in the src directory or use QtCreator to compile
+Clone the git repo with submodules and run `./build install` in the project
+directory or use QtCreator to compile.
 
 ### Ubuntu and Debian/Raspbian
 ```sh
-apt install --no-install-recommends build-essential librtaudio-dev qt5-default autoconf automake libtool make libjack-jackd2-dev git help2man
+apt install --no-install-recommends build-essential qt5-default autoconf automake libtool make libjack-jackd2-dev git help2man
 apt install qjackctl
+apt install librtaudio-dev # if building with RtAudio
 ```
 
-Clone the git repo and run `./build` in the src directory or use QtCreator to compile
+Clone the git repo with submodules and run `./build install` in the project
+directory or use QtCreator to compile.
 
-### Other Linux distributions
+### Building and Installation instructions
 
-Install the dependencies listed above. Clone the git repo and run `./build` in the src directory or use QtCreator to compile.
-
-## Build
-You can compile using the build script or QtCreator.
+For other Linux distributions, install the dependencies listed above. Clone the
+git repo and run `./build install` (or `./build` to skip installation) in the
+project directory, or use QtCreator to compile.
 
 To clone the repo in the Terminal:
-$ git clone https://github.com/jacktrip/jacktrip.git
+```sh
+$ git clone --recurse-submodules https://github.com/jacktrip/jacktrip.git
+```
+Note that we need `--recurse-submodules` to also get the submodules!
 
-To compile using the build script:
+Next, navigate to the cloned repository:
 ```sh
 $ cd jacktrip
+```
+
+JackTrip provides a build script designed to simplify the build process and
+providing a number of options. To list them, run:
+```sh
+$ ./build -h
+```
+This should print:
+```sh
+usage:
+ ./build [noclean nojack rtaudio nogui static install [-config static]]
+
+ options:
+ noclean - do not run "make clean" first
+ nojack - build without jack
+ rtaudio - build with rtaudio
+ nogui - build without the gui
+ static - build with static libraries
+ weakjack - build with weak linking of jack libraries
+ install - install jacktrip in system location (uses sudo)
+```
+
+To just compile JackTrip using the build script, run:
+```sh
 $ ./build
 $ cd builddir
 $ ls
 ```
 
-You should see a `qjacktrip` executable and a `jacktrip` symlink in this folder.
+You should see a `jacktrip` in this folder.
 
-If the build script doesn't work on a different Linux flavor, try building
-the Makefiles yourself. You'd need qmake. Then you can build by:
-
+To compile **and install** using the build script, run:
 ```sh
-$ qmake jacktrip.pro
-$ make release
+$ ./build install
+# enter your password when prompted
 ```
 
+If the build script doesn't work, try running qmake directly. You'd need to have
+qmake in your `$PATH`. Then you can build with:
+
+```sh
+$ mkdir builddir
+$ cd builddir
+$ qmake ../jacktrip.pro
+$ make release
+$ sudo make release-install # to install JackTrip system-wide
+```
+
+You can pass configuration options to qmake with `-config <option>`, e.g. `qmake
+-config nogui ../jacktrip.pro`. Relevant options include:
+
+- `-config rtaudio` - build with rtaudio support
+- `-config nogui` - build without the GUI
+- `-config static` - build with static libraries
+- `-config weakjack` - build using weak linking of jack
+- `-config nojack` - build without jack support
+
 To build using QtCreator:
+
   * Open jacktrip.pro using QtCreator
   * Choose a correctly configured Kit
 
-## Installation
-
-You need to have a working Jack installation on your machine (see Dependencies above).
-
-To install using Terminal (skip the first three steps if you've already followed
-the Build instructions above):
-
-```sh
-$ git clone https://github.com/jacktrip/jacktrip.git
-$ cd jacktrip
-$ ./build
-$ cd builddir
-$ sudo cp qjacktrip /usr/local/bin/
-  (enter your password when prompted)
-$ sudo cp jacktrip /usr/local/bin/
-
-$ sudo chmod 755 /usr/local/bin/qjacktrip
-  (now you can run jacktrip from any directory using Terminal)
-```
-  
 ### Verification
 
 If you have installed jacktrip, from anywhere in the Terminal, type:
@@ -92,14 +120,17 @@ If you have installed jacktrip, from anywhere in the Terminal, type:
 $ jacktrip -v
 ```
 
-If you have compiled from source without installing, in the /builddir directory type:
+If you have compiled from source without installing, in the `/builddir`
+directory type:
 ```sh
 $ ./jacktrip -v
 ```
 
-If you see something like this, you have successfully installed Jacktrip:
+If you see something like this, you have successfully installed JackTrip:
 
->     JackTrip VERSION: 1.xx
->     Copyright (c) 2008-2020 Juan-Pablo Caceres, Chris Chafe.
->     SoundWIRE group at CCRMA, Stanford University
+```
+JackTrip VERSION: 1.x.x
+Copyright (c) 2008-2020 Juan-Pablo Caceres, Chris Chafe.
+SoundWIRE group at CCRMA, Stanford University
+```
 

--- a/docs/Build/Mac.md
+++ b/docs/Build/Mac.md
@@ -47,7 +47,7 @@ Clone the git repo and run `./build` in the src directory or use QtCreator to co
 You can compile using the build script or QtCreator.
 
 To clone the repo in the Terminal:
-$ git clone https://github.com/jacktrip/jacktrip.git
+$ git clone --recurse-submodules https://github.com/jacktrip/jacktrip.git
 
 To compile using the build script:
 ```sh
@@ -82,7 +82,7 @@ To install using Terminal (skip the first three steps if you've already followed
 the Build instructions above):
 
 ```sh
-$ git clone https://github.com/jacktrip/jacktrip.git
+$ git clone --recurse-submodules https://github.com/jacktrip/jacktrip.git
 $ cd jacktrip
 $ ./build
 $ cd builddir

--- a/docs/Build/Windows.md
+++ b/docs/Build/Windows.md
@@ -13,8 +13,8 @@ Open the command line by typing cmd.exe in the Windows search bar.
 Use the `cd` command to navigate to the directory where you would like to
 install jacktrip, e.g. `cd C:\Users\Your User Name\`.
 
-Use `git clone https://github.com/jacktrip/jacktrip.git` to download a fresh
-copy of the repo or `git pull` to update your repo.
+Use `git clone --recurse-submodules https://github.com/jacktrip/jacktrip.git` to
+download a fresh copy of the repo or `git pull` to update your repo.
 
 On Windows 10, the easiest way to build is in the command line:
 

--- a/jacktrip.pro
+++ b/jacktrip.pro
@@ -7,10 +7,14 @@ CONFIG -= app_bundle
 
 CONFIG += qt thread debug_and_release build_all
 CONFIG(debug, debug|release) {
-  TARGET = jacktrip_debug
+    TARGET = jacktrip_debug
+    application_id = 'org.jacktrip.JackTrip.Devel'
+    name_suffix = ' (Development Snapshot)'
   } else {
-  TARGET = jacktrip
-  }
+    TARGET = jacktrip
+    application_id = 'org.jacktrip.JackTrip'
+    name_suffix = ''
+}
 
 nogui {
   DEFINES += NO_GUI
@@ -163,7 +167,7 @@ win32 {
 }
 
 DESTDIR = .
-QMAKE_CLEAN += -r ./jacktrip ./jacktrip_debug ./release ./debug
+QMAKE_CLEAN += -r ./jacktrip ./jacktrip_debug ./release ./debug ./$${application_id}.xml ./$${application_id}.desktop ./$${application_id}.png ./$${application_id}.svg ./jacktrip.1
 
 # isEmpty(PREFIX) will allow path to be changed during the command line
 # call to qmake, e.g. qmake PREFIX=/usr
@@ -272,4 +276,51 @@ rtaudio {
 
 weakjack {
   SOURCES += externals/weakjack/weak_libjack.c
+}
+
+# install man page
+!win32 {
+    HELP2MAN_BIN = $$system(which help2man)
+
+    isEmpty(HELP2MAN_BIN) {
+        message("help2man not found")
+    } else {
+        message("Building man page with help2man")
+        man.extra = $${HELP2MAN_BIN} --no-info --section=1 --output $${OUT_PWD}/jacktrip.1 $${OUT_PWD}/jacktrip
+        man.CONFIG += no_check_exist
+        man.files = $${OUT_PWD}/jacktrip.1
+        man.path = $${PREFIX}/share/man/man1
+        INSTALLS += man
+    }
+}
+
+# install Linux desktop integration resources
+if(linux-g++ | linux-g++-64):!nogui {
+    appdata = $$cat($${PWD}/linux/org.jacktrip.JackTrip.metainfo.xml.in, blob)
+    appdata = $$replace(appdata, @appid@, $${application_id})
+    write_file($${OUT_PWD}/$${application_id}.metainfo.xml, appdata)
+
+    metainfo.files = $${OUT_PWD}/$${application_id}.metainfo.xml
+    metainfo.path = $${PREFIX}/share/metainfo
+
+    desktop_conf = $$cat($${PWD}/linux/org.jacktrip.JackTrip.desktop.in, blob)
+    desktop_conf = $$replace(desktop_conf, @icon@, $${application_id})
+    desktop_conf = $$replace(desktop_conf, @wmclass@, $$lower($${application_id}))
+    desktop_conf = $$replace(desktop_conf, @name_suffix@, $${name_suffix})
+    write_file($${OUT_PWD}/$${application_id}.desktop, desktop_conf)
+
+    desktop.files = $${OUT_PWD}/$${application_id}.desktop
+    desktop.path = $${PREFIX}/share/applications
+
+    icon48.extra = cp $${PWD}/linux/icons/jacktrip_48x48.png $${OUT_PWD}/$${application_id}.png
+    icon48.CONFIG += no_check_exist
+    icon48.files = $${OUT_PWD}/$${application_id}.png
+    icon48.path = $${PREFIX}/share/icons/hicolor/48x48/apps
+
+    icon_svg.extra = cp $${PWD}/linux/icons/jacktrip.svg $${OUT_PWD}/$${application_id}.svg
+    icon_svg.CONFIG += no_check_exist
+    icon_svg.files = $${OUT_PWD}/$${application_id}.svg
+    icon_svg.path = $${PREFIX}/share/icons/hicolor/scalable/apps
+
+    INSTALLS += metainfo desktop icon48 icon_svg
 }


### PR DESCRIPTION
This PR aims to add Linux desktop resource installation for feature parity with the `meson` build. Changes include:
- creation of `.desktop` and `.metainfo` files
- copying and renaming icons
- adding `install` option to the `build` script
- updating Linux build instructions
- ~~**possibly unrelated change**: on my Ubuntu 20.04 system jack was not found with pkg-config. I tried to fix it, but did not manage to do it (I've reinstalled `libjack-jackd2-dev` and `pkg-config` but that did not fix it); I've then added a flag in our `jacktrip.pro` to check if `jack` flags are available from `pkg-config`, and if not, use the previously hardcoded flags (`-ljack`), which works on my system. Let me know in case this change should be removed or put in a separate PR.~~ I reverted this change - it's probably better if we fail when jack is not found (*)

With these changes, qmake build gains most of the improvements from #361: Manpage, Icons, and Metainfo / Appstream data. If these changes look good, IMO we could release 1.4.0 without moving to meson (currently held up by an [issues with static build](https://github.com/jacktrip/jacktrip/issues/361#issuecomment-889516395)) and move to meson when ready. 

Previously Linux qmake instructions provided a rather manual installation instructions (`cp` and `chmod`...). We have however, as it turns out, installation feature in qmake (`(sudo) make release-install`). The updated instructions (and the build script) take advantage of that.

What do you all think?

EDIT:
(*) My problem with pkg-config was due to having a homebrew install of pkg-config (yes, on linux) which was listing only packages installed with homebrew. `brew unlink pkg-config` fixed it.