### PR TITLE
AppStream - remove releases info

### DIFF
--- a/linux/org.jacktrip.JackTrip.metainfo.xml.in
+++ b/linux/org.jacktrip.JackTrip.metainfo.xml.in
@@ -34,45 +34,4 @@
     <content_attribute id="social-audio">intense</content_attribute>
   </content_rating>
 
-  <releases>
-    <release version="1.4.0-rc.2" type="development" date="2021-06-11">
-      <description>
-        <ul>
-          <li>(fixed) Windows installer build</li>
-          <li>(fixed) Appstream and Flatpak build</li>
-        </ul>
-      </description>
-    </release>
-    <release version="1.4.0-rc.1" type="development" date="2021-06-11">
-      <description>
-        <ul>
-          <li>(added) optional GUI from QJackTrip</li>
-          <li>(added) authentication in hub server mode</li>
-          <li>(added) different number of sending and receiving channels</li>
-          <li>(added) append thread IDs to jack client names</li>
-          <li>(added) new patcher mechanism that doesn't delete existing connections</li>
-          <li>(added) MkDocs based documentation</li>
-          <li>(added) weak jack linking</li>
-          <li>(added) manpage</li>
-          <li>(added) MSVC build</li>
-          <li>(added) RtAudio Meson subproject</li>
-          <li>(added) formatting with clang-format</li>
-          <li>(added) static snalysis with clang-tidy</li>
-          <li>(added) cross compilation for Windows</li>
-          <li>(added) flatpaks</li>
-          <li>(added) appstream</li>
-          <li>(added) automated builds and deployment for Linux, macOS and Windows</li>
-          <li>(added) macOS and Windows Installers</li>
-          <li>(fixed) regression in remote client name handling</li>
-          <li>(fixed) long jack client names (> 27 characters) in 1.9.11</li>
-          <li>(fixed) Hardcode Derived Class Names of ProcessPlugins to prevent undefined behavior</li>
-          <li>(update) Change helpscreen wording for --broadcast argument</li>
-          <li>(update) jitter buffer alternatives</li>
-          <li>(update) RtAudio revive (only default devices supported)</li>
-          <li>(update) build script moved to root directory</li>
-        </ul>
-      </description>
-    </release>
-  </releases>
-
 </component>


### PR DESCRIPTION
As discussed in #387, `<releases>` tag is not strictly required and it's additional burden to keep that file updated in addition to the changelog. 

@ntonnaett, would you be okay with removing that section for now? We might come up with an automated way to populate that in the future, if desired.

This potentially fixes #387