### PR TITLE
Metainfo summary fix

### DIFF
--- a/linux/org.jacktrip.JackTrip.metainfo.xml.in
+++ b/linux/org.jacktrip.JackTrip.metainfo.xml.in
@@ -5,8 +5,7 @@
   <metadata_license>MIT</metadata_license>
   <project_license>GPL-3.0+</project_license>
   <name>JackTrip</name>
-  <summary>Connect and Play with other Musicians</summary>
-  <summary lang="de_DE">Verbinde dich und spiele mit anderen Musikern</summary>
+  <summary>Connect and play with other musicians</summary>
 
   <description>
     <p>


### PR DESCRIPTION
Removes the German translation that doesn't work as expected and Remove some capitalization (https://blogs.gnome.org/tbernard/2021/09/07/ready-for-software-41/). 