### PR TITLE
GitHub Actions: use short SHA in artifact names

### DIFF
--- a/.github/workflows/flatpak-devel.yml
+++ b/.github/workflows/flatpak-devel.yml
@@ -23,8 +23,10 @@ jobs:
       env:
         REPO: https://github.com/${{ github.repository }}
         REF: ${{ github.ref }}
+    - name: Add SHORT_SHA environment variable
+      run: echo "SHORT_SHA=`echo ${GITHUB_SHA::7}`" >> $GITHUB_ENV
     - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v3
       with:
-        bundle: jacktrip-dev-${{ github.sha }}.flatpak
+        bundle: JackTrip-Devel-${{ env.SHORT_SHA }}.flatpak
         manifest-path: linux/flatpak/org.jacktrip.JackTrip.Devel.yml
         cache-key: flatpak-builder-${{ github.sha }}

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -94,7 +94,7 @@ jobs:
           if [[ "$GITHUB_REF" == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
           else
-            VERSION=$GITHUB_SHA
+            VERSION=${GITHUB_SHA::7}
           fi
           echo "::set-output name=version::$VERSION"
       - name: install dependencies for Linux


### PR DESCRIPTION
This changes artifact names to use short SHA (first 7 digits)
I've also attempted to change the name for Flatpak dev build. @ntonnaett is the capitalization OK? I wanted to make it consistent with other artifacts.