### PR TITLE
QMake macOS: add "visibility=hidden" to linker flags for static builds

### DIFF
--- a/jacktrip.pro
+++ b/jacktrip.pro
@@ -85,6 +85,11 @@ macx {
     LIBS += -framework Foundation
     CONFIG += objective_c
   }
+  static {
+    # fix ld warning "direct access in function (...) to global weak symbol (...) means the weak symbol cannot be overridden at runtime
+    # see issue #393
+    QMAKE_LFLAGS += -fvisibility=hidden -fvisibility-inlines-hidden
+  }
 }
 
 linux-g++ | linux-g++-64 {

--- a/jacktrip.pro
+++ b/jacktrip.pro
@@ -88,6 +88,7 @@ macx {
   static {
     # fix ld warning "direct access in function (...) to global weak symbol (...) means the weak symbol cannot be overridden at runtime
     # see issue #393
+    message(adding visibility hidden flags)
     QMAKE_LFLAGS += -fvisibility=hidden -fvisibility-inlines-hidden
   }
 }

--- a/jacktrip.pro
+++ b/jacktrip.pro
@@ -89,7 +89,7 @@ macx {
     # fix ld warning "direct access in function (...) to global weak symbol (...) means the weak symbol cannot be overridden at runtime
     # see issue #393
     message(adding visibility hidden flags)
-    QMAKE_LFLAGS += -fvisibility=hidden -fvisibility-inlines-hidden
+    QMAKE_LFLAGS += -fvisibility=hidden
   }
 }
 


### PR DESCRIPTION
Should fix #393, but it doesn't seem to.