### PR TITLE
Bundle RtAudio in QMake

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -172,10 +172,10 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: |
-          choco install jack --version=1.9.17
-          choco install openssl
+          choco install jack --version=1.9.17 --no-progress
+          choco install openssl --no-progress
           if [[ "${{ matrix.rtaudio }}" == true ]] && [[ "${{ matrix.build-rtaudio }}" != true ]]; then 
-            choco install pkgconfiglite
+            choco install pkgconfiglite --no-progress
             vcpkg install rtaudio[asio] --triplet=x64-mingw-static
             echo "PKG_CONFIG_PATH=$VCPKG_INSTALLATION_ROOT\installed\x64-mingw-static\lib\pkgconfig" >> $GITHUB_ENV
           fi

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -36,6 +36,15 @@ jobs:
             qt-static-cache-key: 'v22' # required for static qt; update this to force rebuilding static Qt
             jacktrip-path: jacktrip
             binary-path: binary
+            
+          - name: Linux-x64-bundled-rtaudio
+            runs-on: ubuntu-18.04
+            rtaudio: true
+            build-rtaudio: true
+            static-qt-version: 5.12.11 # if set, it will enable static Qt build
+            qt-static-cache-key: 'v22' # required for static qt; update this to force rebuilding static Qt
+            jacktrip-path: jacktrip
+            binary-path: binary
 
           - name: Linux-x64-dynamic-nogui
             runs-on: ubuntu-18.04
@@ -51,6 +60,7 @@ jobs:
           - name: macOS-x64
             runs-on: macos-10.15
             rtaudio: true
+            build-rtaudio: false
             static-qt-version: 5.12.11 # if set, it will enable static Qt build
             qt-static-cache-key: 'v05' # required for static qt; update this to force rebuilding static Qt
             weakjack: true
@@ -58,6 +68,16 @@ jobs:
             binary-path: binary # directory relative to build path; triggers artifact upload for jacktrip binary
             bundle-path: bundle # directory relative to build path; triggers application bundle creation and upload (macOS)
             installer-path: installer # directory relative to build path; triggers installer creation and upload
+
+          - name: macOS-x64-bundled-rtaudio
+            runs-on: macos-10.15
+            rtaudio: true
+            build-rtaudio: true
+            static-qt-version: 5.12.11 # if set, it will enable static Qt build
+            qt-static-cache-key: 'v05' # required for static qt; update this to force rebuilding static Qt
+            weakjack: true
+            jacktrip-path: jacktrip # relative to build path
+            binary-path: binary # directory relative to build path; triggers artifact upload for jacktrip binary
 
           # - name: Windows-dynamic
           #   runs-on: windows-2019
@@ -68,12 +88,24 @@ jobs:
             # suffix: installer
             runs-on: windows-2019
             rtaudio: true
+            build-rtaudio: false
             static-qt-version: 5.15.2
             qt-static-cache-key: 'v04' # required for static qt; update this to force rebuilding static Qt
             weakjack: true
             jacktrip-path: release/jacktrip.exe
             binary-path: binary # directory relative to build path; triggers artifact upload for jacktrip binary
             installer-path: installer # directory relative to build path; triggers installer creation and upload
+            
+          - name: Windows-x64-bundled-rtaudio
+            # suffix: installer
+            runs-on: windows-2019
+            rtaudio: true
+            build-rtaudio: true
+            static-qt-version: 5.15.2
+            qt-static-cache-key: 'v04' # required for static qt; update this to force rebuilding static Qt
+            weakjack: true
+            jacktrip-path: release/jacktrip.exe
+            binary-path: binary # directory relative to build path; triggers artifact upload for jacktrip binary
 
     env:
       BUILD_PATH: ${{ github.workspace }}/builddir
@@ -107,6 +139,12 @@ jobs:
           else
             sudo apt-get install --yes qt5-default qt5-qmake qttools5-dev
           fi
+          if [[ "${{ matrix.rtaudio }}" == true ]] && [[ "${{ matrix.build-rtaudio }}" != true ]]; then 
+            sudo apt-get install --yes rtaudio
+          fi
+          if [[ "${{ matrix.build-rtaudio }}" == true ]]; then 
+            sudo apt-get install --yes libasound2-dev libpulse-dev
+          fi
       - name: install dependencies for macOS
         if: runner.os == 'macOS'
         env:
@@ -123,7 +161,7 @@ jobs:
             brew install qt5
             brew link qt5 --force
           fi
-          if [[ "${{ matrix.rtaudio }}" == true ]]; then 
+          if [[ "${{ matrix.rtaudio }}" == true ]] && [[ "${{ matrix.build-rtaudio }}" != true ]]; then 
             brew install rt-audio
             rm -f `brew --prefix rt-audio`/lib/*.dylib # remove the dynamic library, we want static only
           fi
@@ -136,7 +174,7 @@ jobs:
         run: |
           choco install jack --version=1.9.17
           choco install openssl
-          if [[ "${{ matrix.rtaudio }}" == true ]]; then 
+          if [[ "${{ matrix.rtaudio }}" == true ]] && [[ "${{ matrix.build-rtaudio }}" != true ]]; then 
             choco install pkgconfiglite
             vcpkg install rtaudio[asio] --triplet=x64-mingw-static
             echo "PKG_CONFIG_PATH=$VCPKG_INSTALLATION_ROOT\installed\x64-mingw-static\lib\pkgconfig" >> $GITHUB_ENV
@@ -228,6 +266,9 @@ jobs:
           fi
           if [[ "${{ matrix.weakjack }}" == true ]]; then 
             CONFIG_STRING="weakjack $CONFIG_STRING"
+          fi
+          if [[ "${{ matrix.build-rtaudio }}" == true ]]; then 
+            CONFIG_STRING="build_rtaudio $CONFIG_STRING"
           fi
           ./build $CONFIG_STRING
       - name: compress the binary

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -181,14 +181,14 @@ jobs:
           fi
       - name: cache Qt
         id: cache-qt
-        if: runner.os == 'Windows' && '!matrix.static-qt-version'
+        if: runner.os == 'Windows' && !matrix.static-qt-version
         uses: actions/cache@v1
         with:
           path: ../Qt
           key: ${{ runner.os }}-QtCache-${{ env.QT_VERSION }}
       - name: install Qt
         uses: jurplel/install-qt-action@v2
-        if: runner.os == 'Windows' && '!matrix.static-qt-version'
+        if: runner.os == 'Windows' && !matrix.static-qt-version
         with:
           version: ${{ env.QT_VERSION }}
           arch: 'win64_mingw81'

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -165,7 +165,7 @@ jobs:
             brew install rt-audio
             rm -f `brew --prefix rt-audio`/lib/*.dylib # remove the dynamic library, we want static only
           fi
-          if [[ -n ${{ matrix.installer-path }} ]]; then
+          if [[ -n "${{ matrix.installer-path }}" ]]; then
             brew install packages
           fi
       - name: install dependencies for Windows

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "documentation/doxygen-awesome-css"]
 	path = externals/doxygen-awesome-css
 	url = https://github.com/jothepro/doxygen-awesome-css.git
+[submodule "externals/rtaudio"]
+	path = externals/rtaudio
+	url = https://github.com/thestk/rtaudio.git

--- a/build
+++ b/build
@@ -16,6 +16,7 @@ nogui - build without the gui\n
 static - build with static libraries\n
 weakjack - build with weak linking of jack libraries\n
 install - install jacktrip in system location (uses sudo)\n
+build_rtaudio - build rtaudio instead of using system library\n
 "
 while [[ "$#" -gt 0 ]]; do
   if [[ -z "$UNKNOWN_OPTIONS" ]]; then
@@ -40,6 +41,10 @@ while [[ "$#" -gt 0 ]]; do
       weakjack)
       echo "Building with static libraries"
       CONFIG="-config weakjack $CONFIG"
+      ;;
+      build_rtaudio)
+      echo "Building rtaudio library"
+      CONFIG="-config build_rtaudio $CONFIG"
       ;;
       install)
       echo "Will install JackTrip in system location"

--- a/build
+++ b/build
@@ -39,7 +39,7 @@ while [[ "$#" -gt 0 ]]; do
       CONFIG="-config static $CONFIG" 
       ;;
       weakjack)
-      echo "Building with static libraries"
+      echo "Building with weak linking of jack"
       CONFIG="-config weakjack $CONFIG"
       ;;
       build_rtaudio)

--- a/jacktrip.pro
+++ b/jacktrip.pro
@@ -88,43 +88,43 @@ macx {
 }
 
 linux-g++ | linux-g++-64 {
-#   LIBS += -lasound -lrtaudio
+  #   LIBS += -lasound -lrtaudio
   QMAKE_CXXFLAGS += -D__LINUX_ALSA__ #-D__LINUX_OSS__ #RtAudio Flags
-
-FEDORA = $$system(cat /proc/version | grep -o fc)
-
-contains( FEDORA, fc): {
-  message(building on fedora)
-}
-
-UBUNTU = $$system(cat /proc/version | grep -o Ubuntu)
-
-contains( UBUNTU, Ubuntu): {
-  message(building on  Ubuntu)
-
-# workaround for Qt bug under ubuntu 18.04
-# gcc version 7.3.0 (Ubuntu 7.3.0-16ubuntu3)
-# QMake version 3.1
-# Using Qt version 5.9.5 in /usr/lib/x86_64-linux-gnu
-  INCLUDEPATH += /usr/include/x86_64-linux-gnu/c++/7
-
-# sets differences from original fedora version
-  DEFINES += __UBUNTU__
-}
-
+  
+  FEDORA = $$system(cat /proc/version | grep -o fc)
+  
+  contains( FEDORA, fc): {
+    message(building on fedora)
+  }
+  
+  UBUNTU = $$system(cat /proc/version | grep -o Ubuntu)
+  
+  contains( UBUNTU, Ubuntu): {
+    message(building on  Ubuntu)
+    
+    # workaround for Qt bug under ubuntu 18.04
+    # gcc version 7.3.0 (Ubuntu 7.3.0-16ubuntu3)
+    # QMake version 3.1
+    # Using Qt version 5.9.5 in /usr/lib/x86_64-linux-gnu
+    INCLUDEPATH += /usr/include/x86_64-linux-gnu/c++/7
+    
+    # sets differences from original fedora version
+    DEFINES += __UBUNTU__
+  }
+  
   QMAKE_CXXFLAGS += -g -O2
   DEFINES += __LINUX__
-  }
+}
 
 linux-g++ {
   message(Linux)
   QMAKE_CXXFLAGS += -D__LINUX_ALSA__ #-D__LINUX_OSS__ #RtAudio Flags
-  }
+}
 
 linux-g++-64 {
   message(Linux 64bit)
   QMAKE_CXXFLAGS += -fPIC -D__LINUX_ALSA__ #-D__LINUX_OSS__ #RtAudio Flags
-  }
+}
 
 
 win32 {

--- a/jacktrip.pro
+++ b/jacktrip.pro
@@ -73,7 +73,6 @@ rtaudio {
 
 macx {
   message(Building on MAC OS X)
-  QMAKE_CXXFLAGS += -D__MACOSX_CORE__ #-D__UNIX_JACK__ #RtAudio Flags
   QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.9
   #QMAKE_MAC_SDK = macosx10.9
   CONFIG -= app_bundle
@@ -88,8 +87,6 @@ macx {
 }
 
 linux-g++ | linux-g++-64 {
-  #   LIBS += -lasound -lrtaudio
-  QMAKE_CXXFLAGS += -D__LINUX_ALSA__ #-D__LINUX_OSS__ #RtAudio Flags
   
   FEDORA = $$system(cat /proc/version | grep -o fc)
   
@@ -118,12 +115,10 @@ linux-g++ | linux-g++-64 {
 
 linux-g++ {
   message(Linux)
-  QMAKE_CXXFLAGS += -D__LINUX_ALSA__ #-D__LINUX_OSS__ #RtAudio Flags
 }
 
 linux-g++-64 {
   message(Linux 64bit)
-  QMAKE_CXXFLAGS += -fPIC -D__LINUX_ALSA__ #-D__LINUX_OSS__ #RtAudio Flags
 }
 
 


### PR DESCRIPTION
I would like us to consider to re-bundle RtAudio with JackTrip, like we had around v.1.1. The main goal is to build RtAudio on Windows (to avoid cumbersome library installation), however it seems it does build on all 3 platforms. Of course it is still possible to use system library. Also, I know meson downloads RtAudio, but getting meson environment is also not that straightforward on Windows - QMake/MinGW is still the easiest to install.

This PR attempts to bring back building RtAudio into qmake, with following changes:
- RtAudio is updated to the current version
- RtAudio is a proper submodule now
- I'm not 100% sure about my qmake implementation (I'm not using a build script that comes with RtAudio)
  - RtAudio is still built somewhat separately from the rest of the project, using QMake's ["add compiler" functionality](https://stackoverflow.com/questions/27683777/how-to-specify-compiler-flag-to-a-single-source-file-with-qmake)
  - on Linux and macOS RtAudio uses the same compiler flags as the rest of the project, which is probably fine
  - on Windows it uses different flags, since RtAudio doesn't build if `..._WINNT=` and `WIN32...MEAN` are set
- RtAudio builds on Linux, but I haven't tested if this runs. I think this is something to investigate after releasing 1.4
  - My idea is that for the static binary that we release we could add RtAudio (if it performs adequately with PulseAudio or Alsa). In that case RtAudio could be built without Jack, so that we can keep using weakjack and have jack as an optional requirement also on Linux. I'm fine if we don't want to do this, it's just an option. And again, this should wait after 1.4, as it should be well tested before releasing it into the wild.

For now I've added qmake builds to GitHub Actions next to our regular builds; eventually I think we should replace Windows GHA build from using VCPKG's RtAudio to use bundled RtAudio. We don't have to change macOS build, but we could (?)

macOS build runs, but I haven't tested it beyond that. I haven't tried running Linux build. ~~Windows build seems to not run (I thought it had, but now I can't run it anymore)~~ It seems that it's an issue with RtAudio. Using an older commit of RtAudio fixes the Windows build.

The PR has also some housekeeping commits, if desired I can take them out and put them in a separate PR.

TODO:
- [ ] test Windows build
  - ~~figure out why it doesn't run...~~
- [ ] test macOS build 
- [ ] test Linux build
- [ ] review if my implementation of qmake build of RtAudio is clean/proper enough
- [ ] clean up GitHub Actions
  - [ ] decide if we leave both bundled and system rtaudio builds for all platforms (for testing, no artifact upload)
  - [ ] change the default Windows build to use bundled RtAudio
- [ ] optionally update qmake build docs (these don't document the build script well anyway, so maybe that should be a separate task/PR)
- [ ] have meson use the rtaudio submodule instead of downloading it, if that's OK with @ntonnaett (?)

