### PR TITLE
Update installer scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,9 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET 10.13)
 project(QJackTrip)
 
 set(nogui FALSE)
-set (rtaudio TRUE)
-set (weakjack TRUE)
+set(rtaudio TRUE)
+set(weakjack TRUE)
+add_compile_definitions(QT_OPENSOURCE)
 
 if (nogui)
   add_compile_definitions(NO_GUI)

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -139,7 +139,6 @@ JackTrip::JackTrip(jacktripModeT JacktripMode, dataProtocolT DataProtocolType,
     , mSimulatedJitterRate(0.0)
     , mSimulatedDelayRel(0.0)
     , mUseRtUdpPriority(false)
-    , mAudioTesterP(nullptr)
 {
     createHeader(mPacketHeaderType);
     sJackStopped = false;
@@ -254,11 +253,11 @@ void JackTrip::setupAudio(
     }
 
     mAudioInterface->setLoopBack(mLoopBack);
-    if (mAudioTesterP) {  // if we're a hub server, this will be a nullptr - MAJOR
+    if (!mAudioTesterP.isNull()) {  // if we're a hub server, this will be a nullptr - MAJOR
                           // REFACTOR NEEDED, in my opinion
         mAudioTesterP->setSampleRate(mSampleRate);
     }
-    mAudioInterface->setAudioTesterP(mAudioTesterP);
+    mAudioInterface->setAudioTesterP(mAudioTesterP.data());
 
     std::cout << "The Sampling Rate is: " << mSampleRate << std::endl;
     std::cout << gPrintSeparator << std::endl;
@@ -601,7 +600,7 @@ void JackTrip::onStatTimer()
 
     static QMutex mutex;
     QMutexLocker locker(&mutex);
-    if (mAudioTesterP && mAudioTesterP->getEnabled()) { mIOStatLogStream << "\n"; }
+    if (!mAudioTesterP.isNull() && mAudioTesterP->getEnabled()) { mIOStatLogStream << "\n"; }
     mIOStatLogStream << now.toLocal8Bit().constData() << " "
                      << getPeerAddress().toLocal8Bit().constData()
                      << " send: " << send_io_stat.underruns << "/"

--- a/src/JackTrip.h
+++ b/src/JackTrip.h
@@ -335,7 +335,7 @@ class JackTrip : public QObject
         mAudioInterface = AudioInterface;
     }
     virtual void setLoopBack(bool b) { mLoopBack = b; }
-    virtual void setAudioTesterP(AudioTester* atp) { mAudioTesterP = atp; }
+    virtual void setAudioTesterP(QSharedPointer<AudioTester> atp) { mAudioTesterP = atp; }
 
     void setSampleRate(uint32_t sample_rate) { mSampleRate = sample_rate; }
     void setDeviceID(uint32_t device_id) { mDeviceID = device_id; }
@@ -686,7 +686,7 @@ class JackTrip : public QObject
     double mSimulatedDelayRel;
     bool mUseRtUdpPriority;
 
-    AudioTester* mAudioTesterP;
+    QSharedPointer<AudioTester> mAudioTesterP;
 };
 
 #endif

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -561,10 +561,10 @@ void Settings::parseInput(int argc, char** argv)
             //-------------------------------------------------------
             char cmd[]{"--examine-audio-delay (-x)"};
             if (tolower(optarg[0]) == 'h') {
-                mAudioTester.printHelp(cmd, ch);
+                mAudioTester->printHelp(cmd, ch);
                 std::exit(0);
             }
-            mAudioTester.setEnabled(true);
+            mAudioTester->setEnabled(true);
             if (optarg == 0 || optarg[0] == '-'
                 || optarg[0] == 0) {  // happens when no -f argument specified
                 printUsage();
@@ -573,7 +573,7 @@ void Settings::parseInput(int argc, char** argv)
                              "see every delay)\n";
                 std::exit(1);
             }
-            mAudioTester.setPrintIntervalSec(atof(optarg));
+            mAudioTester->setPrintIntervalSec(atof(optarg));
             break;
         }
         case ':': {
@@ -611,9 +611,9 @@ void Settings::parseInput(int argc, char** argv)
         std::exit(1);
     }
 
-    if (true == mAudioTester.getEnabled()) {
+    if (true == mAudioTester->getEnabled()) {
         assert(mNumAudioInputChans > 0);
-        mAudioTester.setSendChannel(mNumAudioInputChans
+        mAudioTester->setSendChannel(mNumAudioInputChans
                                     - 1);  // use last channel for latency testing
         // Originally, testing only in the last channel was adopted
         // because channel 0 ("left") was a clap track on CCRMA loopback
@@ -640,12 +640,12 @@ void Settings::parseInput(int argc, char** argv)
         // don't exit since an outgoing limiter should be the default (could exit for
         // incoming case): std::exit(1);
     }
-    if (mAudioTester.getEnabled() && haveSomeServerMode) {
+    if (mAudioTester->getEnabled() && haveSomeServerMode) {
         std::cerr << "*** --examine-audio-delay (-x) ERROR: Audio latency measurement "
                      "not supported in server modes (-S and -s)\n\n";
         std::exit(1);
     }
-    if (mAudioTester.getEnabled() && (mAudioBitResolution != AudioInterface::BIT16)
+    if (mAudioTester->getEnabled() && (mAudioBitResolution != AudioInterface::BIT16)
         && (mAudioBitResolution
             != AudioInterface::BIT32)) {  // BIT32 not tested but should be ok
         // BIT24 should work also, but there's a comment saying it's broken right now, so
@@ -1027,11 +1027,11 @@ JackTrip* Settings::getConfiguredJackTrip()
         jackTrip->setIOStatStream(mIOStatStream);
     }
 
-    jackTrip->setAudioTesterP(&mAudioTester);
+    jackTrip->setAudioTesterP(mAudioTester);
 
     // Allocate audio effects in client, if any:
     int nReservedChans =
-        mAudioTester.getEnabled() ? 1 : 0;  // no fx allowed on tester channel
+        mAudioTester->getEnabled() ? 1 : 0;  // no fx allowed on tester channel
 
     std::vector<ProcessPlugin*> outgoingEffects =
         mEffects.allocateOutgoingEffects(mNumAudioInputChans - nReservedChans);

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -60,6 +60,8 @@ class Settings : public QObject
     Q_OBJECT;
 
    public:
+    Settings() : mAudioTester(new AudioTester) {}
+
     /// \brief Parses command line input
     void parseInput(int argc, char** argv);
 
@@ -138,7 +140,7 @@ class Settings : public QObject
     QString mUsername;
     QString mPassword;
 
-    AudioTester mAudioTester;
+    QSharedPointer<AudioTester> mAudioTester;
 };
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -161,10 +161,6 @@ int main(int argc, char* argv[])
     QScopedPointer<QCoreApplication> app(createApplication(argc, argv));
     QScopedPointer<JackTrip> jackTrip;
     QScopedPointer<UdpHubListener> udpHub;
-    // settings has to stay in scope until app->exec() is reached because
-    // AudioTester lives in settings but is used with a pointer
-    // from jacktrip. TODO Let Settings be just a struct with settings
-    Settings settings;
 #ifndef NO_GUI
     QScopedPointer<QJackTrip> window;
     if (qobject_cast<QApplication*>(app.data())) {
@@ -185,6 +181,7 @@ int main(int argc, char* argv[])
         QLoggingCategory::setFilterRules(QStringLiteral("*.debug=true"));
         qInstallMessageHandler(qtMessageHandler);
         try {
+            Settings settings;
             settings.parseInput(argc, argv);
 
             // Either start our hub server or our jacktrip process as appropriate.

--- a/win/jacktrip.wxs
+++ b/win/jacktrip.wxs
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='windows-1252'?>
 <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
     <Product Name='JackTrip' Manufacturer='JackTrip'
-        Id='d5a8cca9-264c-41fd-8efc-1cef0850091f'
+        Id='*'
         UpgradeCode='70450e42-8a91-4c28-8f00-52c6b8e86e37'
         Language='1033' Codepage='1252' Version='$(var.Version)'>
 
@@ -10,6 +10,8 @@
             InstallerVersion='100' Languages='1033' Compressed='yes' SummaryCodepage='1252' />
         <Media Id='1' Cabinet='JackTrip.cab' EmbedCab='yes' DiskPrompt='Disk 1' />
         <Property Id='DiskPrompt' Value='JackTrip Installer File' />
+        <MajorUpgrade AllowDowngrades="no" DowngradeErrorMessage="A newer version is already installed."
+            AllowSameVersionUpgrades="no" />
 
         <Directory Id='TARGETDIR' Name='SourceDir'>
             <Directory Id='ProgramFilesFolder' Name='PFiles'>


### PR DESCRIPTION
Add an option to specify the binary location in the MacOS packaging script to allow easier signing of downloaded github artifacts.

Allow upgrades with Windows installer.

Use a smart pointer for the AudioTester so that we don't need to keep the Settings object around.