### PR TITLE
[RtAudio] Set mAudioBufferSize in jacktrip after RtAudio setup

### DIFF
--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -234,6 +234,8 @@ void JackTrip::setupAudio(
         // Setup might have reduced number of channels
         mNumAudioChansIn  = mAudioInterface->getNumInputChannels();
         mNumAudioChansOut = mAudioInterface->getNumOutputChannels();
+        // Setup might have changed buffer size
+        mAudioBufferSize = mAudioInterface->getBufferSizeInSamples();
 #endif
 #endif
     } else if (mAudiointerfaceMode == JackTrip::RTAUDIO) {
@@ -249,6 +251,8 @@ void JackTrip::setupAudio(
         // Setup might have reduced number of channels
         mNumAudioChansIn  = mAudioInterface->getNumInputChannels();
         mNumAudioChansOut = mAudioInterface->getNumOutputChannels();
+        // Setup might have changed buffer size
+        mAudioBufferSize = mAudioInterface->getBufferSizeInSamples();
 #endif
     }
 


### PR DESCRIPTION
#419 might not have been enough to fix the possible buffer size mismatch with RtAudio (and ASIO) because the jacktrip class has its own buffersize variable. This should fix it.