### PR TITLE
Verbose mode in GUI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(QJackTrip)
 set(nogui FALSE)
 set(rtaudio TRUE)
 set(weakjack TRUE)
+add_compile_definitions(NO_JTVS)
 add_compile_definitions(QT_OPENSOURCE)
 
 if (nogui)
@@ -111,6 +112,7 @@ if (NOT nogui)
     src/gui/qjacktrip.cpp
     src/gui/about.cpp
     src/gui/messageDialog.cpp
+    src/gui/textbuf.cpp
     src/gui/qjacktrip.qrc
   )
 

--- a/jacktrip.pro
+++ b/jacktrip.pro
@@ -232,7 +232,8 @@ HEADERS += src/JackAudioInterface.h \
 !nogui {
 HEADERS += src/gui/about.h \
            src/gui/messageDialog.h \
-           src/gui/qjacktrip.h
+           src/gui/qjacktrip.h \
+           src/gui/textbuf.h
 }
 
 rtaudio|bundled_rtaudio {
@@ -270,7 +271,8 @@ SOURCES += src/JackAudioInterface.cpp \
 !nogui {
 SOURCES += src/gui/messageDialog.cpp \
            src/gui/qjacktrip.cpp \
-           src/gui/about.cpp
+           src/gui/about.cpp \
+           src/gui/textbuf.cpp
 }
 
 !nogui {

--- a/meson.build
+++ b/meson.build
@@ -90,13 +90,15 @@ else
 	qt5_dep = dependency('qt5', modules: ['Core', 'Gui', 'Network', 'Widgets'], include_type: 'system')
 	src += ['src/gui/qjacktrip.cpp',
 		'src/gui/about.cpp',
-		'src/gui/messageDialog.cpp']
+		'src/gui/messageDialog.cpp',
+		'src/gui/textbuf.cpp']
 	ui_h += ['src/gui/qjacktrip.ui',
 		'src/gui/messageDialog.ui',
 		'src/gui/about.ui']
 	moc_h += ['src/gui/about.h',
 		'src/gui/qjacktrip.h',
-		'src/gui/messageDialog.h']
+		'src/gui/messageDialog.h',
+		'src/gui/textbuf.h']
 	qres = ['src/gui/qjacktrip.qrc']
 endif
 deps += qt5_dep

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -582,8 +582,7 @@ void JackTrip::completeConnection()
     if (mIOStatTimeout > 0) {
         cout << "STATS" << mIOStatTimeout << endl;
         if (!mIOStatStream.isNull()) {
-            mIOStatLogStream.rdbuf(
-                (reinterpret_cast<std::ostream*>(mIOStatStream.data()))->rdbuf());
+            mIOStatLogStream.rdbuf((mIOStatStream.data()->rdbuf()));
         }
         QTimer* timer = new QTimer(this);
         connect(timer, SIGNAL(timeout()), this, SLOT(onStatTimer()));

--- a/src/JackTrip.h
+++ b/src/JackTrip.h
@@ -271,7 +271,7 @@ class JackTrip : public QObject
     virtual void setNumOutputChannels(int num_chans) { mNumAudioChansOut = num_chans; }
 
     virtual void setIOStatTimeout(int timeout) { mIOStatTimeout = timeout; }
-    virtual void setIOStatStream(QSharedPointer<std::ofstream> statStream)
+    virtual void setIOStatStream(QSharedPointer<std::ostream> statStream)
     {
         mIOStatStream = statStream;
     }
@@ -678,7 +678,7 @@ class JackTrip : public QObject
     volatile bool mHasShutdown;
 
     bool mConnectDefaultAudioPorts;  ///< Connect or not default audio ports
-    QSharedPointer<std::ofstream> mIOStatStream;
+    QSharedPointer<std::ostream> mIOStatStream;
     int mIOStatTimeout;
     std::ostream mIOStatLogStream;
     double mSimulatedLossRate;

--- a/src/JackTripWorker.h
+++ b/src/JackTripWorker.h
@@ -113,7 +113,7 @@ class JackTripWorker : public QObject
     void setUseRtUdpPriority(bool use) { mUseRtUdpPriority = use; }
 
     void setIOStatTimeout(int timeout) { mIOStatTimeout = timeout; }
-    void setIOStatStream(QSharedPointer<std::ofstream> statStream)
+    void setIOStatStream(QSharedPointer<std::ostream> statStream)
     {
         mIOStatStream = statStream;
     }
@@ -181,7 +181,7 @@ class JackTripWorker : public QObject
     bool mUseRtUdpPriority      = false;
 
     int mIOStatTimeout = 0;
-    QSharedPointer<std::ofstream> mIOStatStream;
+    QSharedPointer<std::ostream> mIOStatStream;
 #ifdef WAIR                   // wair
     int mNumNetRevChans = 0;  ///< Number of Net Channels = net combs
     bool mWAIR          = false;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -461,12 +461,15 @@ void Settings::parseInput(int argc, char** argv)
             break;
         case 'G':  // IO Stat log file
             //-------------------------------------------------------
-            mIOStatStream.reset(new std::ofstream(optarg));
-            if (!mIOStatStream->is_open()) {
-                printUsage();
-                std::cerr << "--iostatlog FAILED to open " << optarg << " for writing."
-                          << endl;
-                std::exit(1);
+            {
+                std::ofstream *outStream = new std::ofstream(optarg);
+                if (!outStream->is_open()) {
+                    printUsage();
+                    std::cerr << "--iostatlog FAILED to open " << optarg << " for writing."
+                            << endl;
+                    std::exit(1);
+                }
+                mIOStatStream.reset(outStream);
             }
             break;
         case OPT_BUFSTRATEGY:  // Buf strategy

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -125,7 +125,7 @@ class Settings : public QObject
     unsigned int mHubConnectionMode = JackTrip::SERVERTOCLIENT;
     bool mConnectDefaultAudioPorts  = true;  ///< Connect or not jack audio ports
     int mIOStatTimeout              = 0;
-    QSharedPointer<std::ofstream> mIOStatStream;
+    QSharedPointer<std::ostream> mIOStatStream;
     Effects mEffects            = false;  // outgoing limiter OFF by default
     double mSimulatedLossRate   = 0.0;
     double mSimulatedJitterRate = 0.0;

--- a/src/UdpHubListener.h
+++ b/src/UdpHubListener.h
@@ -186,7 +186,7 @@ class UdpHubListener : public QObject
 #endif
 
     int mIOStatTimeout;
-    QSharedPointer<std::ofstream> mIOStatStream;
+    QSharedPointer<std::ostream> mIOStatStream;
 
     int mBufferStrategy;
     int mBroadcastQueue;
@@ -240,7 +240,7 @@ class UdpHubListener : public QObject
     }
 
     void setIOStatTimeout(int timeout) { mIOStatTimeout = timeout; }
-    void setIOStatStream(QSharedPointer<std::ofstream> statStream)
+    void setIOStatStream(QSharedPointer<std::ostream> statStream)
     {
         mIOStatStream = statStream;
     }

--- a/src/gui/messageDialog.cpp
+++ b/src/gui/messageDialog.cpp
@@ -47,6 +47,7 @@ MessageDialog::MessageDialog(QWidget* parent, QString windowFunction, quint32 st
     
     m_ui->messagesTextEdit->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(m_ui->messagesTextEdit, &QPlainTextEdit::customContextMenuRequested, this, &MessageDialog::provideContextMenu);
+    m_ui->messagesTextEdit->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
     
     if (!m_windowFunction.isEmpty()) {
         setWindowTitle(m_windowFunction);

--- a/src/gui/messageDialog.cpp
+++ b/src/gui/messageDialog.cpp
@@ -39,7 +39,7 @@ MessageDialog::MessageDialog(QWidget* parent, QString windowFunction, quint32 st
     , m_windowFunction(windowFunction)
 {
     m_ui->setupUi(this);
-    for (int i = 0; i < streamCount; i++) {
+    for (qint32 i = 0; i < streamCount; i++) {
         m_outBufs[i].reset(new textbuf);
         m_outStreams[i].reset(new std::ostream(m_outBufs.at(i).data()));
         connect(m_outBufs.at(i).data(), &textbuf::outputString, this, &MessageDialog::receiveOutput, Qt::QueuedConnection);
@@ -74,17 +74,17 @@ void MessageDialog::closeEvent(QCloseEvent* event)
     savePosition();
 }
 
-QSharedPointer<std::ostream> MessageDialog::getOutputStream(quint32 index)
+QSharedPointer<std::ostream> MessageDialog::getOutputStream(int index)
 {
-    if (index < m_outStreams.size()) {
+    if (index >=0 && index < m_outStreams.size()) {
         return m_outStreams.at(index);
     }
     return QSharedPointer<std::ostream>();
 }
 
-bool MessageDialog::setRelayStream(std::ostream *relay, quint32 index)
+bool MessageDialog::setRelayStream(std::ostream *relay, int index)
 {
-    if (index < m_outBufs.size()) {
+    if (index >=0 && index < m_outBufs.size()) {
         m_outBufs.at(index)->setOutStream(relay);
     }
     return false;

--- a/src/gui/messageDialog.cpp
+++ b/src/gui/messageDialog.cpp
@@ -39,7 +39,7 @@ MessageDialog::MessageDialog(QWidget* parent, QString windowFunction, quint32 st
     , m_windowFunction(windowFunction)
 {
     m_ui->setupUi(this);
-    for (qint32 i = 0; i < streamCount; i++) {
+    for (quint32 i = 0; i < streamCount; i++) {
         m_outBufs[i].reset(new textbuf);
         m_outStreams[i].reset(new std::ostream(m_outBufs.at(i).data()));
         connect(m_outBufs.at(i).data(), &textbuf::outputString, this, &MessageDialog::receiveOutput, Qt::QueuedConnection);

--- a/src/gui/messageDialog.cpp
+++ b/src/gui/messageDialog.cpp
@@ -48,6 +48,7 @@ MessageDialog::MessageDialog(QWidget* parent, QString windowFunction, quint32 st
     m_ui->messagesTextEdit->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(m_ui->messagesTextEdit, &QPlainTextEdit::customContextMenuRequested, this, &MessageDialog::provideContextMenu);
     m_ui->messagesTextEdit->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
+    connect(this, &QDialog::rejected, this, &MessageDialog::savePosition);
     
     if (!m_windowFunction.isEmpty()) {
         setWindowTitle(m_windowFunction);
@@ -70,12 +71,7 @@ void MessageDialog::showEvent(QShowEvent* event)
 void MessageDialog::closeEvent(QCloseEvent* event)
 {
     QDialog::closeEvent(event);
-    if (!m_windowFunction.isEmpty()) {
-        QSettings settings;
-        settings.beginGroup("Window");
-        settings.setValue(m_windowFunction + "Geometry", saveGeometry());
-        settings.endGroup();
-    }
+    savePosition();
 }
 
 QSharedPointer<std::ostream> MessageDialog::getOutputStream(quint32 index)
@@ -120,4 +116,18 @@ void MessageDialog::provideContextMenu()
     menu->exec(QCursor::pos());
 }
 
-MessageDialog::~MessageDialog() = default;
+void MessageDialog::savePosition()
+{
+    if (!m_windowFunction.isEmpty()) {
+        QSettings settings;
+        settings.beginGroup("Window");
+        settings.setValue(m_windowFunction + "Geometry", saveGeometry());
+        settings.endGroup();
+    }
+}
+
+MessageDialog::~MessageDialog() {
+    if (isVisible()) {
+        savePosition();
+    }
+}

--- a/src/gui/messageDialog.h
+++ b/src/gui/messageDialog.h
@@ -48,8 +48,8 @@ class MessageDialog : public QDialog
     void showEvent(QShowEvent* event) override;
     void closeEvent(QCloseEvent* event) override;
     
-    QSharedPointer<std::ostream> getOutputStream(quint32 index = 0);
-    bool setRelayStream(std::ostream *relay, quint32 index = 0);
+    QSharedPointer<std::ostream> getOutputStream(int index = 0);
+    bool setRelayStream(std::ostream *relay, int index = 0);
     
    public slots:
     void clearOutput();

--- a/src/gui/messageDialog.h
+++ b/src/gui/messageDialog.h
@@ -29,6 +29,7 @@
 #include <QDialog>
 #include <QScopedPointer>
 #include <QSharedPointer>
+#include <QVector>
 #include "textbuf.h"
 
 namespace Ui
@@ -41,14 +42,14 @@ class MessageDialog : public QDialog
     Q_OBJECT
 
    public:
-    explicit MessageDialog(QWidget* parent = nullptr, QString windowFunction = "");
+    explicit MessageDialog(QWidget* parent = nullptr, QString windowFunction = "", quint32 streamCount = 1);
     ~MessageDialog() override;
     
     void showEvent(QShowEvent* event) override;
     void closeEvent(QCloseEvent* event) override;
     
-    QSharedPointer<std::ostream> getOutputStream();
-    void setRelayStream(std::ostream *relay);
+    QSharedPointer<std::ostream> getOutputStream(quint32 index = 0);
+    bool setRelayStream(std::ostream *relay, quint32 index = 0);
     
    public slots:
     void clearOutput();
@@ -59,8 +60,8 @@ class MessageDialog : public QDialog
 
    private:
     QScopedPointer<Ui::MessageDialog> m_ui;
-    QSharedPointer<std::ostream> m_outStream;
-    QSharedPointer<textbuf> m_outBuf;
+    QVector<QSharedPointer<std::ostream>> m_outStreams;
+    QVector<QSharedPointer<textbuf>> m_outBufs;
     QString m_windowFunction;
 };
 

--- a/src/gui/messageDialog.h
+++ b/src/gui/messageDialog.h
@@ -57,8 +57,9 @@ class MessageDialog : public QDialog
    private slots:
     void receiveOutput(const QString& output);
     void provideContextMenu();
+    void savePosition();
 
-   private:
+   private:       
     QScopedPointer<Ui::MessageDialog> m_ui;
     QVector<QSharedPointer<std::ostream>> m_outStreams;
     QVector<QSharedPointer<textbuf>> m_outBufs;

--- a/src/gui/messageDialog.h
+++ b/src/gui/messageDialog.h
@@ -46,10 +46,13 @@ class MessageDialog : public QDialog
     
     QSharedPointer<std::ostream> getOutputStream();
     void setRelayStream(std::ostream *relay);
+    
+   public slots:
     void clearOutput();
     
-private slots:
+   private slots:
     void receiveOutput(const QString& output);
+    void provideContextMenu();
 
    private:
     QScopedPointer<Ui::MessageDialog> m_ui;

--- a/src/gui/messageDialog.h
+++ b/src/gui/messageDialog.h
@@ -59,7 +59,7 @@ class MessageDialog : public QDialog
     void provideContextMenu();
     void savePosition();
 
-   private:       
+   private:
     QScopedPointer<Ui::MessageDialog> m_ui;
     QVector<QSharedPointer<std::ostream>> m_outStreams;
     QVector<QSharedPointer<textbuf>> m_outBufs;

--- a/src/gui/messageDialog.h
+++ b/src/gui/messageDialog.h
@@ -41,8 +41,11 @@ class MessageDialog : public QDialog
     Q_OBJECT
 
    public:
-    explicit MessageDialog(QWidget* parent = nullptr);
+    explicit MessageDialog(QWidget* parent = nullptr, QString windowFunction = "");
     ~MessageDialog() override;
+    
+    void showEvent(QShowEvent* event) override;
+    void closeEvent(QCloseEvent* event) override;
     
     QSharedPointer<std::ostream> getOutputStream();
     void setRelayStream(std::ostream *relay);
@@ -58,6 +61,7 @@ class MessageDialog : public QDialog
     QScopedPointer<Ui::MessageDialog> m_ui;
     QSharedPointer<std::ostream> m_outStream;
     QSharedPointer<textbuf> m_outBuf;
+    QString m_windowFunction;
 };
 
 #endif  // MESSAGEDIALOG_H

--- a/src/gui/messageDialog.h
+++ b/src/gui/messageDialog.h
@@ -28,8 +28,8 @@
 
 #include <QDialog>
 #include <QScopedPointer>
-#include <QTemporaryFile>
-#include <QTimer>
+#include <QSharedPointer>
+#include "textbuf.h"
 
 namespace Ui
 {
@@ -43,19 +43,18 @@ class MessageDialog : public QDialog
    public:
     explicit MessageDialog(QWidget* parent = nullptr);
     ~MessageDialog() override;
-
-    void setStatsFile(QSharedPointer<QTemporaryFile> statsFile);
-    void startMonitoring();
-    void stopMonitoring();
-
-   private slots:
-    void writeOutput();
+    
+    QSharedPointer<std::ostream> getOutputStream();
+    void setRelayStream(std::ostream *relay);
+    void clearOutput();
+    
+private slots:
+    void receiveOutput(const QString& output);
 
    private:
     QScopedPointer<Ui::MessageDialog> m_ui;
-    QSharedPointer<QTemporaryFile> m_ioStatsFile;
-    // Using a QFileSystem watcher didn't work on OS X, so use a timer instead.
-    QTimer m_ioTimer;
+    QSharedPointer<std::ostream> m_outStream;
+    QSharedPointer<textbuf> m_outBuf;
 };
 
 #endif  // MESSAGEDIALOG_H

--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -61,8 +61,9 @@ QJackTrip::QJackTrip(QWidget* parent)
 #endif
     , m_netManager(new QNetworkAccessManager(this))
     , m_statsDialog(new MessageDialog(this, "Stats"))
-    , m_debugDialog(new MessageDialog(this, "Debug"))
+    , m_debugDialog(new MessageDialog(this, "Debug", 2))
     , m_realCout(std::cout.rdbuf())
+    , m_realCerr(std::cerr.rdbuf())
     , m_jackTripRunning(false)
     , m_isExiting(false)
     , m_hasIPv4Reply(false)
@@ -77,7 +78,9 @@ QJackTrip::QJackTrip(QWidget* parent)
     
     // Set up our debug window, and relay everything to our real cout.
     std::cout.rdbuf(m_debugDialog->getOutputStream()->rdbuf());
+    std::cerr.rdbuf(m_debugDialog->getOutputStream(1)->rdbuf());
     m_debugDialog->setRelayStream(&m_realCout);
+    m_debugDialog->setRelayStream(&m_realCerr, 1);
 
     // Create all our UI connections.
     connect(m_ui->typeComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
@@ -1470,4 +1473,5 @@ QJackTrip::~QJackTrip()
 {
     //Restore cout. (Stops a crash on exit.)
     std::cout.rdbuf(m_realCout.rdbuf());
+    std::cerr.rdbuf(m_realCerr.rdbuf());
 }

--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -60,8 +60,8 @@ QJackTrip::QJackTrip(QWidget* parent)
     , m_ui(new Ui::QJackTripVS)
 #endif
     , m_netManager(new QNetworkAccessManager(this))
-    , m_statsDialog(new MessageDialog(this))
-    , m_debugDialog(new MessageDialog(this))
+    , m_statsDialog(new MessageDialog(this, "Stats"))
+    , m_debugDialog(new MessageDialog(this, "Debug"))
     , m_realCout(std::cout.rdbuf())
     , m_jackTripRunning(false)
     , m_isExiting(false)
@@ -76,7 +76,6 @@ QJackTrip::QJackTrip(QWidget* parent)
     QCoreApplication::setApplicationName("JackTrip");
     
     // Set up our debug window, and relay everything to our real cout.
-    m_debugDialog->setWindowTitle("Debug");
     std::cout.rdbuf(m_debugDialog->getOutputStream()->rdbuf());
     m_debugDialog->setRelayStream(&m_realCout);
 
@@ -1082,7 +1081,7 @@ void QJackTrip::loadSettings()
     settings.beginGroup("Window");
     QByteArray geometry = settings.value("Geometry").toByteArray();
     if (geometry.size() > 0) {
-        restoreGeometry(settings.value("Geometry").toByteArray());
+        restoreGeometry(geometry);
     } else {
         // Because of hidden elements in our dialog window, it's vertical size in the
         // creator is getting rediculous. Set it to something sensible by default if this
@@ -1305,7 +1304,7 @@ QString QJackTrip::commandLineFromCurrentOptions()
     // Auth settings
     if (m_ui->typeComboBox->currentIndex() == HUB_SERVER) {
         if (m_ui->requireAuthCheckBox->isChecked()) {
-            commandLine.append(QString(" -A"));
+            commandLine.append(" -A");
             if (!m_ui->certEdit->text().isEmpty()) {
                 commandLine.append(" --certfile ").append(m_ui->certEdit->text());
             }
@@ -1318,7 +1317,7 @@ QString QJackTrip::commandLineFromCurrentOptions()
         }
     } else if (m_ui->typeComboBox->currentIndex() == HUB_CLIENT) {
         if (m_ui->authCheckBox->isChecked()) {
-            commandLine.append(QString(" -A"));
+            commandLine.append(" -A");
             if (!m_ui->usernameEdit->text().isEmpty()) {
                 commandLine.append(" --username ").append(m_ui->usernameEdit->text());
             }

--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -1401,6 +1401,8 @@ QString QJackTrip::commandLineFromCurrentOptions()
     if (m_ui->ioStatsCheckBox->isChecked()) {
         commandLine.append(QString(" -I %1").arg(m_ui->ioStatsSpinBox->value()));
     }
+    
+    if (m_ui->verboseCheckBox->isChecked()) { commandLine.append(" -V"); }
 
     if (m_ui->realTimeCheckBox->isChecked()) { commandLine.append(" --udprt"); }
 

--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -128,9 +128,16 @@ QJackTrip::QJackTrip(QWidget* parent)
     connect(m_ui->ioStatsCheckBox, &QCheckBox::stateChanged, this, [=]() {
         m_ui->ioStatsLabel->setEnabled(m_ui->ioStatsCheckBox->isChecked());
         m_ui->ioStatsSpinBox->setEnabled(m_ui->ioStatsCheckBox->isChecked());
+        if (!m_ui->ioStatsCheckBox->isChecked()) {
+            m_statsDialog->hide();
+        }
     });
     connect(m_ui->verboseCheckBox, &QCheckBox::stateChanged, this, [=]() {
         gVerboseFlag = m_ui->verboseCheckBox->isChecked();
+        if (!gVerboseFlag) {
+            m_debugDialog->hide();
+            m_debugDialog->clearOutput();
+        }
     });
     connect(m_ui->jitterCheckBox, &QCheckBox::stateChanged, this, [=]() {
         m_ui->broadcastCheckBox->setEnabled(m_ui->jitterCheckBox->isChecked());

--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -351,11 +351,11 @@ void QJackTrip::showEvent(QShowEvent* event)
 
     // One of our arguments will always be --gui, so if that's the only one
     // then we don't need to show the warning message.
-    if (m_argc > 2) {
+    if ((!gVerboseFlag && m_argc > 2) || m_argc > 3) {
         QMessageBox msgBox;
         msgBox.setText(
             "The GUI version of JackTrip currently\nignores any command line "
-            "options.\n\nThis may change in future.");
+            "options other\nthan the verbose option (-V).\n\nThis may change in future.");
         msgBox.setWindowTitle("Command line options");
         msgBox.exec();
     }

--- a/src/gui/qjacktrip.h
+++ b/src/gui/qjacktrip.h
@@ -51,7 +51,11 @@
 
 namespace Ui
 {
+#ifdef NO_JTVS
 class QJackTrip;
+#else
+class QJackTripVS;
+#endif
 }
 
 class QJackTrip : public QMainWindow
@@ -102,18 +106,22 @@ class QJackTrip : public QMainWindow
     void populateDeviceMenu(QComboBox* menu, bool isInput);
 #endif
 
-    void setupStatsWindow();
     void appendPlugins(JackTrip* jackTrip, int numSendChannels, int numRecvChannels);
 
     QString commandLineFromCurrentOptions();
     void showCommandLineMessageBox();
 
+#ifdef NO_JTVS
     QScopedPointer<Ui::QJackTrip> m_ui;
+#else
+    QScopedPointer<Ui::QJackTripVS> m_ui;
+#endif
     QScopedPointer<UdpHubListener> m_udpHub;
     QScopedPointer<JackTrip> m_jackTrip;
     QScopedPointer<QNetworkAccessManager> m_netManager;
-    QScopedPointer<MessageDialog> m_messageDialog;
-    QSharedPointer<QTemporaryFile> m_ioStatsOutput;
+    QScopedPointer<MessageDialog> m_statsDialog;
+    QScopedPointer<MessageDialog> m_debugDialog;
+    std::ostream m_realCout;
     bool m_jackTripRunning;
     bool m_isExiting;
 

--- a/src/gui/qjacktrip.h
+++ b/src/gui/qjacktrip.h
@@ -122,6 +122,7 @@ class QJackTrip : public QMainWindow
     QScopedPointer<MessageDialog> m_statsDialog;
     QScopedPointer<MessageDialog> m_debugDialog;
     std::ostream m_realCout;
+    std::ostream m_realCerr;
     bool m_jackTripRunning;
     bool m_isExiting;
 

--- a/src/gui/qjacktrip.ui
+++ b/src/gui/qjacktrip.ui
@@ -950,7 +950,7 @@ To connect to a hub server you need to run as a hub client.</string>
          </widget>
         </item>
         <item row="12" column="0" colspan="3">
-         <widget class="QCheckBox" name="checkBox">
+         <widget class="QCheckBox" name="verboseCheckBox">
           <property name="text">
            <string>Show &amp;Debug Information</string>
           </property>

--- a/src/gui/qjacktrip_novs.ui
+++ b/src/gui/qjacktrip_novs.ui
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>QJackTripVS</class>
- <widget class="QMainWindow" name="QJackTripVS">
+ <class>QJackTrip</class>
+ <widget class="QMainWindow" name="QJackTrip">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
     <width>409</width>
-    <height>845</height>
+    <height>817</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -239,6 +239,80 @@ To connect to a hub server you need to run as a hub client.</string>
              </property>
              <property name="buddy">
               <cstring>channelRecvSpinBox</cstring>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item row="8" column="0" colspan="3">
+         <widget class="QGroupBox" name="authGroupBox">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="title">
+           <string/>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_6">
+           <item row="0" column="0" colspan="2">
+            <widget class="QCheckBox" name="authCheckBox">
+             <property name="toolTip">
+              <string>Supply a username and password to connect to the server.</string>
+             </property>
+             <property name="text">
+              <string>&amp;Use Authentication</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QLineEdit" name="passwordEdit">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="toolTip">
+              <string>Enter your password. (This will not be shown or saved.)</string>
+             </property>
+             <property name="echoMode">
+              <enum>QLineEdit::Password</enum>
+             </property>
+             <property name="cursorPosition">
+              <number>0</number>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QLineEdit" name="usernameEdit">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="toolTip">
+              <string>Enter your username for the server.</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QLabel" name="passwordLabel">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="text">
+              <string>&amp;Password</string>
+             </property>
+             <property name="buddy">
+              <cstring>passwordEdit</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="usernameLabel">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="text">
+              <string>&amp;Username</string>
+             </property>
+             <property name="buddy">
+              <cstring>usernameEdit</cstring>
              </property>
             </widget>
            </item>
@@ -494,6 +568,48 @@ To connect to a hub server you need to run as a hub client.</string>
         <string>Advanced options</string>
        </attribute>
        <layout class="QGridLayout" name="gridLayout_4">
+        <item row="5" column="0">
+         <widget class="QLabel" name="queueLengthLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>&amp;Queue Buffer Length</string>
+          </property>
+          <property name="buddy">
+           <cstring>queueLengthSpinBox</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1" colspan="2">
+         <widget class="QLineEdit" name="clientNameEdit">
+          <property name="toolTip">
+           <string>Set the name of the Jack client.</string>
+          </property>
+          <property name="maxLength">
+           <number>64</number>
+          </property>
+          <property name="placeholderText">
+           <string>JackTrip</string>
+          </property>
+         </widget>
+        </item>
+        <item row="13" column="0">
+         <spacer name="advancedVerticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
         <item row="7" column="0">
          <widget class="QLabel" name="resolutionLabel">
           <property name="sizePolicy">
@@ -507,6 +623,16 @@ To connect to a hub server you need to run as a hub client.</string>
           </property>
           <property name="buddy">
            <cstring>resolutionComboBox</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1" colspan="2">
+         <widget class="QLineEdit" name="remoteNameEdit">
+          <property name="toolTip">
+           <string>Set the name of the Jack client as it will appear on the hub server.</string>
+          </property>
+          <property name="maxLength">
+           <number>64</number>
           </property>
          </widget>
         </item>
@@ -540,13 +666,99 @@ To connect to a hub server you need to run as a hub client.</string>
           </item>
          </widget>
         </item>
-        <item row="1" column="1" colspan="2">
-         <widget class="QLineEdit" name="remoteNameEdit">
+        <item row="9" column="0" colspan="3">
+         <widget class="QCheckBox" name="realTimeCheckBox">
           <property name="toolTip">
-           <string>Set the name of the Jack client as it will appear on the hub server.</string>
+           <string>Use real time priority for the networking threads.</string>
           </property>
-          <property name="maxLength">
-           <number>64</number>
+          <property name="text">
+           <string>Enable real&amp;time priority for networking threads</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="11" column="1">
+         <widget class="QSpinBox" name="ioStatsSpinBox">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="toolTip">
+           <string>Choose how often stats should be reported.</string>
+          </property>
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>120</number>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1" colspan="2">
+         <widget class="QSpinBox" name="basePortSpinBox">
+          <property name="toolTip">
+           <string>Set the base UDP port to be used by connecting hub clients. The default is 61002.
+(You should manually set this if running multiple hub servers on the same machine.)</string>
+          </property>
+          <property name="minimum">
+           <number>1024</number>
+          </property>
+          <property name="maximum">
+           <number>65535</number>
+          </property>
+          <property name="value">
+           <number>61002</number>
+          </property>
+         </widget>
+        </item>
+        <item row="14" column="0" colspan="3">
+         <layout class="QHBoxLayout" name="useDefaultsLayout">
+          <item>
+           <spacer name="useDefaultsSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QPushButton" name="commandLineButton">
+            <property name="toolTip">
+             <string>Show the equivalent command line for the current settings.</string>
+            </property>
+            <property name="text">
+             <string>Get Command &amp;Line</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="useDefaultsButton">
+            <property name="text">
+             <string>Use &amp;Defaults</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="remoteNameLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Remote Client &amp;Name</string>
+          </property>
+          <property name="buddy">
+           <cstring>remoteNameEdit</cstring>
           </property>
          </widget>
         </item>
@@ -566,22 +778,6 @@ To connect to a hub server you need to run as a hub client.</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="remoteNameLabel">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Remote Client &amp;Name</string>
-          </property>
-          <property name="buddy">
-           <cstring>remoteNameEdit</cstring>
-          </property>
-         </widget>
-        </item>
         <item row="3" column="0">
          <widget class="QLabel" name="remotePortLabel">
           <property name="sizePolicy">
@@ -595,6 +791,51 @@ To connect to a hub server you need to run as a hub client.</string>
           </property>
           <property name="buddy">
            <cstring>remotePortSpinBox</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="clientNameLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Custom Client &amp;Name</string>
+          </property>
+          <property name="buddy">
+           <cstring>clientNameEdit</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="0">
+         <widget class="QLabel" name="redundancyLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>&amp;Redundancy</string>
+          </property>
+          <property name="buddy">
+           <cstring>redundancySpinBox</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="0" colspan="3">
+         <widget class="QCheckBox" name="connectAudioCheckBox">
+          <property name="toolTip">
+           <string>Connect the Jack client to the default system audio ports.</string>
+          </property>
+          <property name="text">
+           <string>&amp;Connect default audio ports</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
@@ -615,78 +856,36 @@ To connect to a hub server you need to run as a hub client.</string>
           </property>
          </widget>
         </item>
-        <item row="13" column="0" colspan="3">
-         <widget class="QGroupBox" name="authGroupBox">
-          <property name="enabled">
-           <bool>true</bool>
+        <item row="3" column="1" colspan="2">
+         <widget class="QSpinBox" name="remotePortSpinBox">
+          <property name="toolTip">
+           <string>Set the remote port to use for the connection. The default is 4464.</string>
           </property>
-          <property name="title">
-           <string/>
+          <property name="minimum">
+           <number>1024</number>
           </property>
-          <layout class="QGridLayout" name="gridLayout_6">
-           <item row="0" column="0" colspan="2">
-            <widget class="QCheckBox" name="authCheckBox">
-             <property name="toolTip">
-              <string>Supply a username and password to connect to the server.</string>
-             </property>
-             <property name="text">
-              <string>&amp;Use Authentication</string>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="1">
-            <widget class="QLineEdit" name="passwordEdit">
-             <property name="enabled">
-              <bool>false</bool>
-             </property>
-             <property name="toolTip">
-              <string>Enter your password. (This will not be shown or saved.)</string>
-             </property>
-             <property name="echoMode">
-              <enum>QLineEdit::Password</enum>
-             </property>
-             <property name="cursorPosition">
-              <number>0</number>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <widget class="QLineEdit" name="usernameEdit">
-             <property name="enabled">
-              <bool>false</bool>
-             </property>
-             <property name="toolTip">
-              <string>Enter your username for the server.</string>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="0">
-            <widget class="QLabel" name="passwordLabel">
-             <property name="enabled">
-              <bool>false</bool>
-             </property>
-             <property name="text">
-              <string>&amp;Password</string>
-             </property>
-             <property name="buddy">
-              <cstring>passwordEdit</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="0">
-            <widget class="QLabel" name="usernameLabel">
-             <property name="enabled">
-              <bool>false</bool>
-             </property>
-             <property name="text">
-              <string>&amp;Username</string>
-             </property>
-             <property name="buddy">
-              <cstring>usernameEdit</cstring>
-             </property>
-            </widget>
-           </item>
-          </layout>
+          <property name="maximum">
+           <number>65535</number>
+          </property>
+          <property name="value">
+           <number>4464</number>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="basePortLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>&amp;UDP Base Port</string>
+          </property>
+          <property name="buddy">
+           <cstring>basePortSpinBox</cstring>
+          </property>
          </widget>
         </item>
         <item row="2" column="0">
@@ -705,64 +904,16 @@ To connect to a hub server you need to run as a hub client.</string>
           </property>
          </widget>
         </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="queueLengthLabel">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
+        <item row="6" column="1" colspan="2">
+         <widget class="QSpinBox" name="redundancySpinBox">
+          <property name="toolTip">
+           <string>Number of redundant packets to be sent to avoid glitches related to packet loss.</string>
           </property>
-          <property name="text">
-           <string>&amp;Queue Buffer Length</string>
+          <property name="minimum">
+           <number>1</number>
           </property>
-          <property name="buddy">
-           <cstring>queueLengthSpinBox</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="14" column="0">
-         <spacer name="advancedVerticalSpacer">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="basePortLabel">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>&amp;UDP Base Port</string>
-          </property>
-          <property name="buddy">
-           <cstring>basePortSpinBox</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="clientNameLabel">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Custom Client &amp;Name</string>
-          </property>
-          <property name="buddy">
-           <cstring>clientNameEdit</cstring>
+          <property name="value">
+           <number>1</number>
           </property>
          </widget>
         </item>
@@ -798,159 +949,8 @@ To connect to a hub server you need to run as a hub client.</string>
           </property>
          </widget>
         </item>
-        <item row="6" column="1" colspan="2">
-         <widget class="QSpinBox" name="redundancySpinBox">
-          <property name="toolTip">
-           <string>Number of redundant packets to be sent to avoid glitches related to packet loss.</string>
-          </property>
-          <property name="minimum">
-           <number>1</number>
-          </property>
-          <property name="value">
-           <number>1</number>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="redundancyLabel">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>&amp;Redundancy</string>
-          </property>
-          <property name="buddy">
-           <cstring>redundancySpinBox</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="11" column="1">
-         <widget class="QSpinBox" name="ioStatsSpinBox">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="toolTip">
-           <string>Choose how often stats should be reported.</string>
-          </property>
-          <property name="minimum">
-           <number>1</number>
-          </property>
-          <property name="maximum">
-           <number>120</number>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1" colspan="2">
-         <widget class="QSpinBox" name="remotePortSpinBox">
-          <property name="toolTip">
-           <string>Set the remote port to use for the connection. The default is 4464.</string>
-          </property>
-          <property name="minimum">
-           <number>1024</number>
-          </property>
-          <property name="maximum">
-           <number>65535</number>
-          </property>
-          <property name="value">
-           <number>4464</number>
-          </property>
-         </widget>
-        </item>
-        <item row="8" column="0" colspan="3">
-         <widget class="QCheckBox" name="connectAudioCheckBox">
-          <property name="toolTip">
-           <string>Connect the Jack client to the default system audio ports.</string>
-          </property>
-          <property name="text">
-           <string>&amp;Connect default audio ports</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1" colspan="2">
-         <widget class="QLineEdit" name="clientNameEdit">
-          <property name="toolTip">
-           <string>Set the name of the Jack client.</string>
-          </property>
-          <property name="maxLength">
-           <number>64</number>
-          </property>
-          <property name="placeholderText">
-           <string>JackTrip</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1" colspan="2">
-         <widget class="QSpinBox" name="basePortSpinBox">
-          <property name="toolTip">
-           <string>Set the base UDP port to be used by connecting hub clients. The default is 61002.
-(You should manually set this if running multiple hub servers on the same machine.)</string>
-          </property>
-          <property name="minimum">
-           <number>1024</number>
-          </property>
-          <property name="maximum">
-           <number>65535</number>
-          </property>
-          <property name="value">
-           <number>61002</number>
-          </property>
-         </widget>
-        </item>
-        <item row="15" column="0" colspan="3">
-         <layout class="QHBoxLayout" name="useDefaultsLayout">
-          <item>
-           <spacer name="useDefaultsSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <widget class="QPushButton" name="commandLineButton">
-            <property name="toolTip">
-             <string>Show the equivalent command line for the current settings.</string>
-            </property>
-            <property name="text">
-             <string>Get Command &amp;Line</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="useDefaultsButton">
-            <property name="text">
-             <string>Use &amp;Defaults</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="9" column="0" colspan="3">
-         <widget class="QCheckBox" name="realTimeCheckBox">
-          <property name="toolTip">
-           <string>Use real time priority for the networking threads.</string>
-          </property>
-          <property name="text">
-           <string>Enable real&amp;time priority for networking threads</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
         <item row="12" column="0" colspan="3">
-         <widget class="QCheckBox" name="checkBox">
+         <widget class="QCheckBox" name="verboseCheckBox">
           <property name="text">
            <string>Show &amp;Debug Information</string>
           </property>
@@ -1763,6 +1763,9 @@ and wetness is the essence of beauty.</string>
   <tabstop>keyBrowse</tabstop>
   <tabstop>credsEdit</tabstop>
   <tabstop>credsBrowse</tabstop>
+  <tabstop>authCheckBox</tabstop>
+  <tabstop>usernameEdit</tabstop>
+  <tabstop>passwordEdit</tabstop>
   <tabstop>aboutButton</tabstop>
   <tabstop>clientNameEdit</tabstop>
   <tabstop>remoteNameEdit</tabstop>
@@ -1776,9 +1779,7 @@ and wetness is the essence of beauty.</string>
   <tabstop>realTimeCheckBox</tabstop>
   <tabstop>ioStatsCheckBox</tabstop>
   <tabstop>ioStatsSpinBox</tabstop>
-  <tabstop>authCheckBox</tabstop>
-  <tabstop>usernameEdit</tabstop>
-  <tabstop>passwordEdit</tabstop>
+  <tabstop>verboseCheckBox</tabstop>
   <tabstop>commandLineButton</tabstop>
   <tabstop>useDefaultsButton</tabstop>
   <tabstop>backendComboBox</tabstop>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,6 +39,7 @@
 #include <QApplication>
 
 #include "gui/qjacktrip.h"
+#include <QCommandLineParser>
 #else
 #include <QCoreApplication>
 #endif
@@ -50,6 +51,13 @@
 #include "Settings.h"
 #include "UdpHubListener.h"
 #include "jacktrip_globals.h"
+
+#ifdef __WIN_32__
+#include <windows.h>
+#include <psapi.h>
+#include <tlhelp32.h>
+#include <winbase.h>
+#endif
 
 QCoreApplication* createApplication(int& argc, char* argv[])
 {
@@ -154,6 +162,49 @@ BOOL WINAPI windowsCtrlHandler(DWORD fdwCtrlType)
         return false;
     }
 }
+
+bool isRunFromCmd() {
+    //Get our parent process pid
+    HANDLE h = NULL;
+    PROCESSENTRY32 pe = {0};
+    DWORD pid = GetCurrentProcessId();
+    DWORD ppid = 0;
+    pe.dwSize = sizeof(PROCESSENTRY32);
+    h = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+    if (Process32First(h, &pe)) {
+        do {
+            //Loop through the list of processes until we find ours.
+            if (pe.th32ProcessID == pid) {
+                ppid = pe.th32ParentProcessID;
+                break;
+            }
+        } while (Process32Next(h, &pe));
+    }
+    CloseHandle(h);
+    
+    //Get the name of our parent process;
+    char pname[MAX_PATH] = {0};
+    DWORD size = MAX_PATH;
+    h = NULL;
+    h = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, ppid);
+    if (h) {
+        if (QueryFullProcessImageName(h, 0, pname, &size)) {
+            CloseHandle(h);
+            
+            //Check if our parent process is a command line.
+            if (size >= 14 && strncmp(pname + size - 14, "powershell.exe", 14) == 0) {
+                return true;
+            }
+            if (size >= 7 && strncmp(pname + size - 7, "cmd.exe", 7) == 0) {
+                return true;
+            }
+        } else {
+            CloseHandle(h);
+        }
+    }
+    
+    return false;
+}
 #endif
 
 int main(int argc, char* argv[])
@@ -166,14 +217,25 @@ int main(int argc, char* argv[])
     if (qobject_cast<QApplication*>(app.data())) {
         // Start the GUI if there are no command line options.
 #ifdef __WIN_32__
-        // Remove the console that appears if we're in windows.
-        FreeConsole();
+        // Remove the console that appears if we're on windows and not running from a command line.
+        if (!isRunFromCmd()) {
+            FreeConsole();
+        }
 #endif  // __WIN_32__
         app->setApplicationName("QJackTrip");
         window.reset(new QJackTrip);
         window->setArgc(argc);
         QObject::connect(window.data(), &QJackTrip::signalExit, app.data(),
                          &QCoreApplication::quit, Qt::QueuedConnection);
+        
+        QCommandLineParser parser;
+        QCommandLineOption verboseOption(QStringList() << "V" << "verbose");   
+        parser.addOption(verboseOption);
+        parser.parse(app->arguments());
+        if (parser.isSet(verboseOption)) {
+            gVerboseFlag = true;
+        }
+        
         window->show();
     } else {
 #endif  // NO_GUI

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,7 +56,6 @@
 #include <windows.h>
 #include <psapi.h>
 #include <tlhelp32.h>
-#include <winbase.h>
 #endif
 
 QCoreApplication* createApplication(int& argc, char* argv[])
@@ -188,7 +187,7 @@ bool isRunFromCmd() {
     h = NULL;
     h = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, ppid);
     if (h) {
-        if (QueryFullProcessImageName(h, 0, pname, &size)) {
+        if (QueryFullProcessImageNameA(h, 0, pname, &size)) {
             CloseHandle(h);
             
             //Check if our parent process is a command line.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -222,10 +222,6 @@ int main(int argc, char* argv[])
         }
 #endif  // __WIN_32__
         app->setApplicationName("QJackTrip");
-        window.reset(new QJackTrip);
-        window->setArgc(argc);
-        QObject::connect(window.data(), &QJackTrip::signalExit, app.data(),
-                         &QCoreApplication::quit, Qt::QueuedConnection);
         
         QCommandLineParser parser;
         QCommandLineOption verboseOption(QStringList() << "V" << "verbose");   
@@ -235,6 +231,10 @@ int main(int argc, char* argv[])
             gVerboseFlag = true;
         }
         
+        window.reset(new QJackTrip);
+        window->setArgc(argc);
+        QObject::connect(window.data(), &QJackTrip::signalExit, app.data(),
+                         &QCoreApplication::quit, Qt::QueuedConnection);
         window->show();
     } else {
 #endif  // NO_GUI


### PR DESCRIPTION
Enable the verbose flag to be set from the command line while using the GUI. (jacktrip --gui -V)

Also detect whether the program has been run from the command line on windows so that we don't detach ourselves from the console. (Otherwise we won't get any output on the terminal.)