### PR TITLE
[Meson] Set RtAudio subproject to version 5.2.0

### DIFF
--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -44,7 +44,7 @@
 /// \todo Add this namespace
 // namespace JackTrip
 
-constexpr const char* const gVersion = "1.4.1";  ///< JackTrip version
+constexpr const char* const gVersion = "1.4.2";  ///< JackTrip version
 
 //*******************************************************************************
 /// \name Default Values

--- a/subprojects/rtaudio.wrap
+++ b/subprojects/rtaudio.wrap
@@ -1,6 +1,9 @@
-[wrap-git]
-url=https://github.com/thestk/rtaudio.git
-revision=head
+[wrap-file]
+directory = rtaudio-5.2.0
+source_url = https://github.com/thestk/rtaudio/archive/refs/tags/5.2.0.tar.gz
+source_filename = 5.2.0.tar.gz
+source_hash = a8d9c738addffd485c3f0bab14cbba72600267e3113f274398c67829bbb49332
 
 [provide]
 dependency_names = rtaudio
+


### PR DESCRIPTION
This fixes the failing CI meson builds. Sets the RtAudio version of meson's rtaudio subproject to 5.2.0.

Edit: I added rtaudio to Meson's wrapdb and updated our wrap file accordingly. So if the version in wrapdb gets updated it's only `meson wrap update rtaudio`.