### PR TITLE
[GHA] Fix weekly cron job entry

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -21,7 +21,7 @@ on:
       - 'README**'
   workflow_dispatch:
   schedule:
-    - cron:  '* * * * 0' # run weekly to refresh static Qt cache
+    - cron:  '0 0 * * 0' # run weekly to refresh static Qt cache
 jobs:
   build:
     runs-on: ${{ matrix.runs-on }}


### PR DESCRIPTION
I just recognized that we have gha builds every minute right now. So I thought there might be someone who's tampering with our stuff. But our cron job entry is just wrong. Right now every minute on sundays a jacktrip build is started. I think one time a week instead of 1440 times is sufficient.

https://crontab.guru/#0_0_*_*_0