### PR TITLE
Clean up weakjack include

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -1,3 +1,7 @@
+- Version: "1.5.1"
+  Date: 2022-01-03
+  Description:
+  - (fixed) [Meson] Only add weakjack include directory when enabled
 - Version: "1.5.0"
   Date: 2022-01-03
   Description:

--- a/meson.build
+++ b/meson.build
@@ -27,7 +27,7 @@ elif host_machine.system() == 'windows'
 	defines += '-DNOMINMAX'
 endif
 
-incdir = include_directories('externals/weakjack')
+incdirs = []
 
 src = [	'src/DataProtocol.cpp',
 	'src/JackTrip.cpp',
@@ -73,6 +73,7 @@ else
 		'src/Patcher.cpp']
 	moc_h += ['src/Patcher.h']
 	if get_option('weakjack') == true
+		incdirs += include_directories('externals/weakjack')
 		src += 'externals/weakjack/weak_libjack.c'
 		defines += '-DUSE_WEAK_JACK'
 		c_defines += '-DUSE_WEAK_JACK'
@@ -144,7 +145,7 @@ endif
 
 subdir('linux')
 
-jacktrip = executable('jacktrip', src, prepro_files, include_directories: incdir, dependencies: deps, c_args: c_defines, cpp_args: defines, install: true )
+jacktrip = executable('jacktrip', src, prepro_files, include_directories: incdirs, dependencies: deps, c_args: c_defines, cpp_args: defines, install: true )
 
 help2man = find_program('help2man', required: false)
 if not (host_machine.system() == 'windows')

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -40,7 +40,7 @@
 
 #include "AudioInterface.h"
 
-constexpr const char* const gVersion = "1.5.0";  ///< JackTrip version
+constexpr const char* const gVersion = "1.5.1";  ///< JackTrip version
 
 //*******************************************************************************
 /// \name Default Values


### PR DESCRIPTION
Just saw that in meson the weakjack include directory is unnecessarily added when it's actually disabled.

Bumps version to 1.5.1. But we might want to wait for more changes.