### PR TITLE
Fix windows executable icon (qmake build)

### DIFF
--- a/jacktrip.pro
+++ b/jacktrip.pro
@@ -174,6 +174,7 @@ win32 {
   LIBS += -lWs2_32
   DEFINES += _WIN32_WINNT=0x0600 #needed for inet_pton
   DEFINES += WIN32_LEAN_AND_MEAN
+  RC_FILE = win/qjacktrip.rc
 }
 
 DESTDIR = .


### PR DESCRIPTION
Adds the windows rc file to jacktrip.pro. Partial fix for #423. (Will still need to be done in the meson builds, but unfortunately I don't have a set up that I can test that with.)