### PR TITLE
Options to include server in patching

### DIFF
--- a/src/JackTrip.h
+++ b/src/JackTrip.h
@@ -118,7 +118,9 @@ class JackTrip : public QObject
         RESERVEDMATRIX,  ///< Reserved for custom patch matrix (for TUB ensemble)
         FULLMIX,         ///< Client Fan Out to Clients and Fan In from Clients (including
                          ///< self-to-self)
-        NOAUTO           ///< No automatic patching
+        NOAUTO,          ///< No automatic patching
+        SERVFOFI,        ///< Like CLIENTFOFI, but include the server in the mix
+        SERVFULLMIX      ///< Like FULLMIX, but include the server in the mix
     };
     //---------------------------------------------------------
 

--- a/src/Patcher.cpp
+++ b/src/Patcher.cpp
@@ -36,28 +36,25 @@
  */
 
 #include "Patcher.h"
+
 #include <QVector>
 
 void Patcher::setPatchMode(JackTrip::hubConnectionModeT patchMode)
 {
-    m_patchMode = patchMode;
+    QMutexLocker locker(&m_connectionMutex);
+    m_fan = patchMode == JackTrip::CLIENTFOFI || patchMode == JackTrip::FULLMIX ||
+            patchMode == JackTrip::SERVFOFI || patchMode == JackTrip::SERVFULLMIX;
+    m_loop = patchMode == JackTrip::CLIENTECHO || patchMode == JackTrip::FULLMIX ||
+             patchMode == JackTrip::SERVFULLMIX;
+    m_includeServer = patchMode == JackTrip::SERVERTOCLIENT || patchMode == JackTrip::SERVFOFI ||
+                      patchMode == JackTrip::SERVFULLMIX;
 }
 
-void Patcher::setStereoUpmix(bool upmix)
-{
-    m_steroUpmix = upmix;
-}
+void Patcher::setStereoUpmix(bool upmix) { m_steroUpmix = upmix; }
 
 void Patcher::registerClient(const QString& clientName)
 {
     QMutexLocker locker(&m_connectionMutex);
-
-    if (!(m_patchMode == JackTrip::CLIENTECHO || m_patchMode == JackTrip::CLIENTFOFI
-          || m_patchMode == JackTrip::FULLMIX)) {
-        // Nothing to do here other than track our clients.
-        m_clients.append(clientName);
-        return;
-    }
 
     // If our jack client isn't running, start it.
     if (!m_jackClient) {
@@ -78,10 +75,10 @@ void Patcher::registerClient(const QString& clientName)
     // Find the ports belonging to our client.
     QVector<const char*> clientOutPorts;
     QVector<const char*> clientInPorts;
-    
+
     for (int i = 0; outPorts[i]; i++) {
         // Exclude broadcast ports.
-        if (QString(outPorts[i]).section(":", 0, 0) == clientName 
+        if (QString(outPorts[i]).section(":", 0, 0) == clientName
             && !QString(outPorts[i]).contains("broadcast")) {
             clientOutPorts.append(outPorts[i]);
         }
@@ -95,51 +92,66 @@ void Patcher::registerClient(const QString& clientName)
 
     bool clientIsMono = (clientOutPorts.count() == 1);
 
-    // Start with our receiving ports.
-    for (int i = 0; i < clientOutPorts.count(); i++) {
-        QString channel = QString(clientOutPorts.at(i)).section("_", -1, -1);
-        for (int j = 0; inPorts[j]; j++) {
-            QString otherClient = QString(inPorts[j]).section(":", 0, 0);
-            QString otherChannel = QString(inPorts[j]).section("_", -1, -1);
+    if (m_includeServer && clientIsMono && m_steroUpmix) {
+        // Most connections in server to client modes are created already by the code in
+        // JackAudioInterface. We only need to handle any upmixing of mono clients here.
+        const char** systemInPorts = jack_get_ports(m_jackClient, NULL, NULL,
+                                                    JackPortIsPhysical | JackPortIsInput);
+        if (systemInPorts[0] && systemInPorts[1]) {
+            jack_connect(m_jackClient, clientOutPorts.at(0), systemInPorts[1]);
+        }
+        jack_free(systemInPorts);
+    }
 
-            // First check if this is one of our other clients. (Fan out/in and full mix.)
-            if (m_patchMode == JackTrip::CLIENTFOFI || m_patchMode == JackTrip::FULLMIX) {
-                if (m_clients.contains(otherClient) && otherChannel == channel) {
-                    jack_connect(m_jackClient, clientOutPorts.at(i), inPorts[j]);
-                } else if (m_steroUpmix && clientIsMono) {
-                    // Deal with the special case of stereo upmix
-                    if (m_clients.contains(otherClient) && otherChannel == "2") {
+    if (m_fan || m_loop) {
+        // Start with our receiving ports.
+        for (int i = 0; i < clientOutPorts.count(); i++) {
+            QString channel = QString(clientOutPorts.at(i)).section("_", -1, -1);
+            for (int j = 0; inPorts[j]; j++) {
+                QString otherClient  = QString(inPorts[j]).section(":", 0, 0);
+                QString otherChannel = QString(inPorts[j]).section("_", -1, -1);
+
+                // First check if this is one of our other clients. (Fan out/in and full
+                // mix.)
+                if (m_fan) {
+                    if (m_clients.contains(otherClient) && otherChannel == channel) {
                         jack_connect(m_jackClient, clientOutPorts.at(i), inPorts[j]);
+                    } else if (m_steroUpmix && clientIsMono) {
+                        // Deal with the special case of stereo upmix
+                        if (m_clients.contains(otherClient) && otherChannel == "2") {
+                            jack_connect(m_jackClient, clientOutPorts.at(i), inPorts[j]);
+                        }
                     }
                 }
-            }
 
-            // Then check if it's our registering client. (Client Echo and full mix.)
-            if (m_patchMode == JackTrip::CLIENTECHO || m_patchMode == JackTrip::FULLMIX) {
-                if (otherClient == clientName && otherChannel == channel) {
-                    jack_connect(m_jackClient, clientOutPorts.at(i), inPorts[j]);
-                } else if (m_steroUpmix && clientIsMono) {
-                    if (otherClient == clientName && otherChannel == "2") {
+                // Then check if it's our registering client. (Client Echo and full mix.)
+                if (m_loop) {
+                    if (otherClient == clientName && otherChannel == channel) {
                         jack_connect(m_jackClient, clientOutPorts.at(i), inPorts[j]);
+                    } else if (m_steroUpmix && clientIsMono) {
+                        if (otherClient == clientName && otherChannel == "2") {
+                            jack_connect(m_jackClient, clientOutPorts.at(i), inPorts[j]);
+                        }
                     }
                 }
             }
         }
-    }
 
-    // Then our sending ports. We only need to check for other clients here.
-    // (Any loopback connections will have been made in the previous loop.)
-    if (m_patchMode == JackTrip::CLIENTFOFI || m_patchMode == JackTrip::FULLMIX) {
-        for (int i = 0; i < clientInPorts.count(); i++) {
-            QString channel = QString(clientInPorts.at(i)).section("_", -1, -1);
-            for (int j = 0; outPorts[j]; j++) {
-                QString otherClient = QString(outPorts[j]).section(":", 0, 0);
-                QString otherChannel = QString(outPorts[j]).section("_", -1, -1);
-                if (m_clients.contains(otherClient)
-                    && !QString(outPorts[j]).contains("broadcast")) {
-                    if (otherChannel == channel || 
-                        (m_steroUpmix && channel == "2" && m_monoClients.contains(otherClient))) {
-                        jack_connect(m_jackClient, outPorts[j], clientInPorts.at(i));
+        // Then our sending ports. We only need to check for other clients here.
+        // (Any loopback connections will have been made in the previous loop.)
+        if (m_fan) {
+            for (int i = 0; i < clientInPorts.count(); i++) {
+                QString channel = QString(clientInPorts.at(i)).section("_", -1, -1);
+                for (int j = 0; outPorts[j]; j++) {
+                    QString otherClient  = QString(outPorts[j]).section(":", 0, 0);
+                    QString otherChannel = QString(outPorts[j]).section("_", -1, -1);
+                    if (m_clients.contains(otherClient)
+                        && !QString(outPorts[j]).contains("broadcast")) {
+                        if (otherChannel == channel
+                            || (m_steroUpmix && channel == "2"
+                                && m_monoClients.contains(otherClient))) {
+                            jack_connect(m_jackClient, outPorts[j], clientInPorts.at(i));
+                        }
                     }
                 }
             }
@@ -147,9 +159,7 @@ void Patcher::registerClient(const QString& clientName)
     }
 
     m_clients.append(clientName);
-    if (clientIsMono) {
-        m_monoClients.append(clientName);
-    }
+    if (clientIsMono) { m_monoClients.append(clientName); }
     jack_free(outPorts);
     jack_free(inPorts);
 }

--- a/src/Patcher.h
+++ b/src/Patcher.h
@@ -67,7 +67,10 @@ class Patcher : public QObject
    private:
     QStringList m_clients;
     QStringList m_monoClients;
-    JackTrip::hubConnectionModeT m_patchMode = JackTrip::SERVERTOCLIENT;
+    
+    bool m_fan = false;
+    bool m_loop = false;
+    bool m_includeServer = true;
     bool m_steroUpmix = false;
 
     jack_client_t* m_jackClient = nullptr;

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -60,7 +60,7 @@ class Settings : public QObject
     Q_OBJECT;
 
    public:
-    Settings() : mAudioTester(new AudioTester) {}
+    Settings(QObject* parent = nullptr) : QObject(parent), mAudioTester(new AudioTester) {}
 
     /// \brief Parses command line input
     void parseInput(int argc, char** argv);
@@ -123,6 +123,7 @@ class Settings : public QObject
     std::string mInputDeviceName, mOutputDeviceName;
 #endif
     unsigned int mHubConnectionMode = JackTrip::SERVERTOCLIENT;
+    bool mPatchServerAudio          = false;
     bool mStereoUpmix               = false;
     bool mConnectDefaultAudioPorts  = true;  ///< Connect or not jack audio ports
     int mIOStatTimeout              = 0;

--- a/src/UdpHubListener.cpp
+++ b/src/UdpHubListener.cpp
@@ -75,7 +75,8 @@ UdpHubListener::UdpHubListener(int server_port, int server_udp_port)
     , mTotalRunningThreads(0)
     , mHubPatchDescriptions({"server-to-clients", "client loopback",
                              "client fan out/in but not loopback", "reserved for TUB",
-                             "full mix", "no auto patching"})
+                             "full mix", "no auto patching", "client fan out/in, including server",
+                             "full mix, including server"})
     , m_connectDefaultAudioPorts(false)
     , mIOStatTimeout(0)
 {

--- a/src/UdpHubListener.h
+++ b/src/UdpHubListener.h
@@ -223,7 +223,8 @@ class UdpHubListener : public QObject
         mPatcher.setPatchMode(static_cast<JackTrip::hubConnectionModeT>(p));
 #endif
         // Set the correct audio port connection setting for our chosen patch mode.
-        if (mHubPatch == JackTrip::SERVERTOCLIENT) {
+        if (mHubPatch == JackTrip::SERVERTOCLIENT || mHubPatch == JackTrip::SERVFOFI ||
+            mHubPatch == JackTrip::SERVFULLMIX) {
             m_connectDefaultAudioPorts = true;
         } else {
             m_connectDefaultAudioPorts = false;

--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -1271,6 +1271,10 @@ QString QJackTrip::commandLineFromCurrentOptions()
         if (hubConnectionMode > 0) {
             commandLine.append(QString(" -p %1").arg(hubConnectionMode));
         }
+        if (m_ui->patchServerCheckBox->isChecked() && (m_ui->typeComboBox->currentIndex() ==
+            CLIENTFOFI || m_ui->typeComboBox->currentIndex() == FULLMIX)) {
+            commandLine.append(" -i");
+        }
         if (m_ui->upmixCheckBox->isChecked()) {
             commandLine.append(" -u");
         }

--- a/src/gui/qjacktrip.h
+++ b/src/gui/qjacktrip.h
@@ -94,6 +94,7 @@ class QJackTrip : public QMainWindow
 
    private:
     enum runTypeT { P2P_CLIENT, P2P_SERVER, HUB_CLIENT, HUB_SERVER };
+    enum patchTypeT { SERVERTOCLIENT, CLIENTECHO, CLIENTFOFI, FULLMIX, NOAUTO };
 
     int findTab(const QString& tabName);
     void enableUi(bool enabled);

--- a/src/gui/qjacktrip.ui
+++ b/src/gui/qjacktrip.ui
@@ -165,146 +165,7 @@ To connect to a hub server you need to run as a hub client.</string>
         <string>Basic options</string>
        </attribute>
        <layout class="QGridLayout" name="gridLayout_3">
-        <item row="2" column="0" colspan="3">
-         <widget class="QGroupBox" name="channelGroupBox">
-          <layout class="QGridLayout" name="gridLayout_9">
-           <item row="3" column="0">
-            <widget class="QLabel" name="channelRecvLabel">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>&amp;Received from network:</string>
-             </property>
-             <property name="buddy">
-              <cstring>channelRecvSpinBox</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="1">
-            <widget class="QSpinBox" name="channelRecvSpinBox">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="toolTip">
-              <string>Number of audio channels toaccept from the network.</string>
-             </property>
-             <property name="minimum">
-              <number>1</number>
-             </property>
-             <property name="value">
-              <number>2</number>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="1">
-            <widget class="QSpinBox" name="channelSendSpinBox">
-             <property name="toolTip">
-              <string>Number of audio channels to send to the network.</string>
-             </property>
-             <property name="minimum">
-              <number>1</number>
-             </property>
-             <property name="value">
-              <number>2</number>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="0">
-            <widget class="QLabel" name="channelSendLabel">
-             <property name="text">
-              <string>&amp;Sent to network:</string>
-             </property>
-             <property name="buddy">
-              <cstring>channelSendSpinBox</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="0" colspan="2">
-            <widget class="QLabel" name="channelLabel">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>&amp;Number of channels</string>
-             </property>
-             <property name="buddy">
-              <cstring>channelRecvSpinBox</cstring>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item row="3" column="1" colspan="2">
-         <widget class="QComboBox" name="autoPatchComboBox">
-          <property name="toolTip">
-           <string>Select how you want audio to be routed by the hub server.</string>
-          </property>
-          <property name="currentIndex">
-           <number>0</number>
-          </property>
-          <item>
-           <property name="text">
-            <string>Server to clients</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Client loopback</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Client fan out/in but no loopback</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Full Mix</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>No auto patching</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-        <item row="11" column="0" colspan="3">
-         <layout class="QHBoxLayout" name="aboutLayout">
-          <item>
-           <spacer name="aboutSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <widget class="QPushButton" name="aboutButton">
-            <property name="text">
-             <string>About</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="7" column="0" colspan="3">
+        <item row="7" column="0" colspan="2">
          <widget class="QGroupBox" name="requireAuthGroupBox">
           <property name="title">
            <string/>
@@ -432,15 +293,29 @@ To connect to a hub server you need to run as a hub client.</string>
           </layout>
          </widget>
         </item>
-        <item row="6" column="0" colspan="3">
-         <widget class="QCheckBox" name="timeoutCheckBox">
-          <property name="toolTip">
-           <string>Stop JackTrip if no network traffic has been received for 10 seconds.</string>
-          </property>
-          <property name="text">
-           <string>&amp;Disconnect after 10 seconds of no network activity</string>
-          </property>
-         </widget>
+        <item row="11" column="0" colspan="2">
+         <layout class="QHBoxLayout" name="aboutLayout">
+          <item>
+           <spacer name="aboutSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QPushButton" name="aboutButton">
+            <property name="text">
+             <string>About</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
         <item row="9" column="0">
          <spacer name="basicVerticalSpacer">
@@ -458,7 +333,87 @@ To connect to a hub server you need to run as a hub client.</string>
           </property>
          </spacer>
         </item>
-        <item row="5" column="0" colspan="3">
+        <item row="2" column="0" colspan="2">
+         <widget class="QGroupBox" name="channelGroupBox">
+          <layout class="QGridLayout" name="gridLayout_9">
+           <item row="3" column="0">
+            <widget class="QLabel" name="channelRecvLabel">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>&amp;Received from network:</string>
+             </property>
+             <property name="buddy">
+              <cstring>channelRecvSpinBox</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QSpinBox" name="channelRecvSpinBox">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="toolTip">
+              <string>Number of audio channels toaccept from the network.</string>
+             </property>
+             <property name="minimum">
+              <number>1</number>
+             </property>
+             <property name="value">
+              <number>2</number>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="1">
+            <widget class="QSpinBox" name="channelSendSpinBox">
+             <property name="toolTip">
+              <string>Number of audio channels to send to the network.</string>
+             </property>
+             <property name="minimum">
+              <number>1</number>
+             </property>
+             <property name="value">
+              <number>2</number>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0">
+            <widget class="QLabel" name="channelSendLabel">
+             <property name="text">
+              <string>&amp;Sent to network:</string>
+             </property>
+             <property name="buddy">
+              <cstring>channelSendSpinBox</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0" colspan="2">
+            <widget class="QLabel" name="channelLabel">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>&amp;Number of channels</string>
+             </property>
+             <property name="buddy">
+              <cstring>channelRecvSpinBox</cstring>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item row="5" column="0" colspan="2">
          <widget class="QCheckBox" name="zeroCheckBox">
           <property name="toolTip">
            <string>Silence the audio when there's a buffer underrun.</string>
@@ -468,27 +423,98 @@ To connect to a hub server you need to run as a hub client.</string>
           </property>
          </widget>
         </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="autoPatchLabel">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
+        <item row="6" column="0" colspan="2">
+         <widget class="QCheckBox" name="timeoutCheckBox">
+          <property name="toolTip">
+           <string>Stop JackTrip if no network traffic has been received for 10 seconds.</string>
           </property>
           <property name="text">
-           <string>Hub auto&amp;patch mode</string>
-          </property>
-          <property name="buddy">
-           <cstring>autoPatchComboBox</cstring>
+           <string>&amp;Disconnect after 10 seconds of no network activity</string>
           </property>
          </widget>
         </item>
-        <item row="4" column="0" colspan="3">
-         <widget class="QCheckBox" name="upmixCheckBox">
-          <property name="text">
-           <string>&amp;Upmix mono clients to stereo</string>
+        <item row="3" column="0" colspan="2">
+         <widget class="QGroupBox" name="autoPatchGroupBox">
+          <property name="title">
+           <string/>
           </property>
+          <layout class="QGridLayout" name="gridLayout_10">
+           <item row="2" column="0" colspan="2">
+            <widget class="QCheckBox" name="upmixCheckBox">
+             <property name="toolTip">
+              <string>For clients that only send one channel of audio, relay their signal in stereo.</string>
+             </property>
+             <property name="text">
+              <string>&amp;Upmix mono clients to stereo</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QComboBox" name="autoPatchComboBox">
+             <property name="toolTip">
+              <string>Select how you want audio to be routed by the hub server.</string>
+             </property>
+             <property name="currentIndex">
+              <number>0</number>
+             </property>
+             <item>
+              <property name="text">
+               <string>Server to clients</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Client loopback</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Client fan out/in but no loopback</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Full Mix</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>No auto patching</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="autoPatchLabel">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Hub auto&amp;patch mode</string>
+             </property>
+             <property name="buddy">
+              <cstring>autoPatchComboBox</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0" colspan="2">
+            <widget class="QCheckBox" name="patchServerCheckBox">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="toolTip">
+              <string>Include the server in the audio patching. This allows an ensemble member to
+play from this machine. (Available in client fan out/in and full mix modes.)</string>
+             </property>
+             <property name="text">
+              <string>&amp;Include server in patching</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </widget>
         </item>
        </layout>
@@ -958,6 +984,9 @@ To connect to a hub server you need to run as a hub client.</string>
         </item>
         <item row="12" column="0" colspan="3">
          <widget class="QCheckBox" name="verboseCheckBox">
+          <property name="toolTip">
+           <string>Display debugging information that would normally appear on the console.</string>
+          </property>
           <property name="text">
            <string>Show &amp;Debug Information</string>
           </property>
@@ -1761,6 +1790,7 @@ and wetness is the essence of beauty.</string>
   <tabstop>channelRecvSpinBox</tabstop>
   <tabstop>channelSendSpinBox</tabstop>
   <tabstop>autoPatchComboBox</tabstop>
+  <tabstop>patchServerCheckBox</tabstop>
   <tabstop>upmixCheckBox</tabstop>
   <tabstop>zeroCheckBox</tabstop>
   <tabstop>timeoutCheckBox</tabstop>

--- a/src/gui/qjacktrip.ui
+++ b/src/gui/qjacktrip.ui
@@ -1814,6 +1814,7 @@ and wetness is the essence of beauty.</string>
   <tabstop>realTimeCheckBox</tabstop>
   <tabstop>ioStatsCheckBox</tabstop>
   <tabstop>ioStatsSpinBox</tabstop>
+  <tabstop>verboseCheckBox</tabstop>
   <tabstop>authCheckBox</tabstop>
   <tabstop>usernameEdit</tabstop>
   <tabstop>passwordEdit</tabstop>
@@ -1844,7 +1845,6 @@ and wetness is the essence of beauty.</string>
   <tabstop>outCompressorCheckBox</tabstop>
   <tabstop>outLimiterCheckBox</tabstop>
   <tabstop>outClientsSpinBox</tabstop>
-  <tabstop>verboseCheckBox</tabstop>
  </tabstops>
  <resources>
   <include location="qjacktrip.qrc"/>

--- a/src/gui/qjacktrip_novs.ui
+++ b/src/gui/qjacktrip_novs.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>409</width>
-    <height>817</height>
+    <height>889</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -165,7 +165,91 @@ To connect to a hub server you need to run as a hub client.</string>
         <string>Basic options</string>
        </attribute>
        <layout class="QGridLayout" name="gridLayout_3">
-        <item row="2" column="0" colspan="3">
+        <item row="3" column="0" colspan="2">
+         <widget class="QGroupBox" name="autoPatchGroupBox">
+          <property name="title">
+           <string/>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_10">
+           <item row="0" column="0" rowspan="2" colspan="2">
+            <widget class="QLabel" name="autoPatchLabel">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Hub auto&amp;patch mode</string>
+             </property>
+             <property name="buddy">
+              <cstring>autoPatchComboBox</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="2">
+            <widget class="QComboBox" name="autoPatchComboBox">
+             <property name="toolTip">
+              <string>Select how you want audio to be routed by the hub server.</string>
+             </property>
+             <property name="currentIndex">
+              <number>0</number>
+             </property>
+             <item>
+              <property name="text">
+               <string>Server to clients</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Client loopback</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Client fan out/in but no loopback</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Full Mix</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>No auto patching</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+           <item row="3" column="0" colspan="3">
+            <widget class="QCheckBox" name="upmixCheckBox">
+             <property name="toolTip">
+              <string>For clients that only send one channel of audio, relay their signal in stereo.</string>
+             </property>
+             <property name="text">
+              <string>&amp;Upmix mono clients to stereo</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0" colspan="3">
+            <widget class="QCheckBox" name="patchServerCheckBox">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="toolTip">
+              <string>Include the server in the audio patching. This allows an ensemble member to
+play from this machine. (Available in client fan out/in and full mix modes.)</string>
+             </property>
+             <property name="text">
+              <string>&amp;Include server in patching</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item row="2" column="0" colspan="2">
          <widget class="QGroupBox" name="channelGroupBox">
           <layout class="QGridLayout" name="gridLayout_9">
            <item row="3" column="0">
@@ -245,7 +329,17 @@ To connect to a hub server you need to run as a hub client.</string>
           </layout>
          </widget>
         </item>
-        <item row="8" column="0" colspan="3">
+        <item row="6" column="0" colspan="2">
+         <widget class="QCheckBox" name="timeoutCheckBox">
+          <property name="toolTip">
+           <string>Stop JackTrip if no network traffic has been received for 10 seconds.</string>
+          </property>
+          <property name="text">
+           <string>&amp;Disconnect after 10 seconds of no network activity</string>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="0" colspan="2">
          <widget class="QGroupBox" name="authGroupBox">
           <property name="enabled">
            <bool>true</bool>
@@ -319,66 +413,23 @@ To connect to a hub server you need to run as a hub client.</string>
           </layout>
          </widget>
         </item>
-        <item row="3" column="1" colspan="2">
-         <widget class="QComboBox" name="autoPatchComboBox">
-          <property name="toolTip">
-           <string>Select how you want audio to be routed by the hub server.</string>
+        <item row="9" column="0">
+         <spacer name="basicVerticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
           </property>
-          <property name="currentIndex">
-           <number>0</number>
+          <property name="sizeType">
+           <enum>QSizePolicy::Expanding</enum>
           </property>
-          <item>
-           <property name="text">
-            <string>Server to clients</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Client loopback</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Client fan out/in but no loopback</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Full Mix</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>No auto patching</string>
-           </property>
-          </item>
-         </widget>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
         </item>
-        <item row="11" column="0" colspan="3">
-         <layout class="QHBoxLayout" name="aboutLayout">
-          <item>
-           <spacer name="aboutSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <widget class="QPushButton" name="aboutButton">
-            <property name="text">
-             <string>About</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="7" column="0" colspan="3">
+        <item row="7" column="0" colspan="2">
          <widget class="QGroupBox" name="requireAuthGroupBox">
           <property name="title">
            <string/>
@@ -506,62 +557,37 @@ To connect to a hub server you need to run as a hub client.</string>
           </layout>
          </widget>
         </item>
-        <item row="6" column="0" colspan="3">
-         <widget class="QCheckBox" name="timeoutCheckBox">
-          <property name="toolTip">
-           <string>Stop JackTrip if no network traffic has been received for 10 seconds.</string>
-          </property>
-          <property name="text">
-           <string>&amp;Disconnect after 10 seconds of no network activity</string>
-          </property>
-         </widget>
+        <item row="11" column="0" colspan="2">
+         <layout class="QHBoxLayout" name="aboutLayout">
+          <item>
+           <spacer name="aboutSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QPushButton" name="aboutButton">
+            <property name="text">
+             <string>About</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
-        <item row="9" column="0">
-         <spacer name="basicVerticalSpacer">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Expanding</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="5" column="0" colspan="3">
+        <item row="5" column="0" colspan="2">
          <widget class="QCheckBox" name="zeroCheckBox">
           <property name="toolTip">
            <string>Silence the audio when there's a buffer underrun.</string>
           </property>
           <property name="text">
            <string>Set buffer to &amp;zero when underrun occurs</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="autoPatchLabel">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Hub auto&amp;patch mode</string>
-          </property>
-          <property name="buddy">
-           <cstring>autoPatchComboBox</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0" colspan="3">
-         <widget class="QCheckBox" name="upmixCheckBox">
-          <property name="text">
-           <string>&amp;Upmix mono clients to stereo</string>
           </property>
          </widget>
         </item>
@@ -958,6 +984,9 @@ To connect to a hub server you need to run as a hub client.</string>
         </item>
         <item row="12" column="0" colspan="3">
          <widget class="QCheckBox" name="verboseCheckBox">
+          <property name="toolTip">
+           <string>Display debugging information that would normally appear on the console.</string>
+          </property>
           <property name="text">
            <string>Show &amp;Debug Information</string>
           </property>
@@ -1761,6 +1790,7 @@ and wetness is the essence of beauty.</string>
   <tabstop>channelRecvSpinBox</tabstop>
   <tabstop>channelSendSpinBox</tabstop>
   <tabstop>autoPatchComboBox</tabstop>
+  <tabstop>patchServerCheckBox</tabstop>
   <tabstop>upmixCheckBox</tabstop>
   <tabstop>zeroCheckBox</tabstop>
   <tabstop>timeoutCheckBox</tabstop>


### PR DESCRIPTION
Add an option to include the server in the patching for client fan out/in and full mix modes. This allows an ensemble member to more easily run a server and their own audio on the same machine.

I've technically implemented these as patch modes 6 and 7, but am using a checkbox in the GUI as a modifier to the existing patch modes. Haven't implemented it on the command line yet and am open to suggestions on whether to add them to the -p list or to use a solution similar to the one in the GUI (ie, an additional switch).