### PR TITLE
Use bundled rtaudio for Windows release builds

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -132,22 +132,8 @@ jobs:
             build-system: meson
             meson-library-type: both
             
-          - name: Windows-x64-qmake-gcc-static
-            release-name: Windows-x64
-            runs-on: windows-2019
-            system-rtaudio: true
-            bundled-rtaudio: false
-            nogui: false
-            weakjack: true
-            vcpkg-triplet: x64-mingw-static
-            static-qt-version: 5.15.2
-            qt-static-cache-key: 'v04'
-            jacktrip-path: release/jacktrip.exe
-            binary-path: binary
-            installer-path: installer
-            build-system: qmake
-            
           - name: Windows-x64-qmake-gcc-static-bundled_rtaudio
+            release-name: Windows-x64
             runs-on: windows-2019
             system-rtaudio: false
             bundled-rtaudio: true
@@ -155,8 +141,9 @@ jobs:
             weakjack: true
             static-qt-version: 5.15.2
             qt-static-cache-key: 'v04'
-            # jacktrip-path: release/jacktrip.exe
-            # binary-path: binary
+            jacktrip-path: release/jacktrip.exe
+            binary-path: binary
+            installer-path: installer
             build-system: qmake
 
           - name: Windows-x64-qmake-gcc-shared

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -49,14 +49,12 @@ jobs:
             # meson-library-type: shared # shared, static, both
             # static-analysis: true # run clang-tidy static analysis (meson/Linux only)
             
-          - name: Linux-x64-qmake-gcc-static-bundled_rtaudio
+          - name: Linux-x64-qmake-gcc-shared-bundled_rtaudio
             runs-on: ubuntu-18.04
             system-rtaudio: false
             bundled-rtaudio: true
             nogui: false
             weakjack: false
-            static-qt-version: 5.12.11
-            qt-static-cache-key: 'v22'
             # jacktrip-path: jacktrip
             # binary-path: binary
             build-system: qmake
@@ -109,14 +107,12 @@ jobs:
             installer-path: installer
             build-system: qmake
 
-          - name: macOS-x64-qmake-clang-static-bundled_rtaudio
+          - name: macOS-x64-qmake-clang-shared-bundled_rtaudio
             runs-on: macos-10.15
             system-rtaudio: false
             bundled-rtaudio: true
             nogui: false
             weakjack: true
-            static-qt-version: 5.12.11
-            qt-static-cache-key: 'v05'
             # jacktrip-path: jacktrip
             # binary-path: binary
             # bundle-path: bundle


### PR DESCRIPTION
This is mostly a housekeeping PR aiming to optimize our GHA builds.

The main change I'm suggesting is to use bundled rtaudio in static Windows release builds (currently we use the build from vcpkg, which does get built every time anyway). I'll test this build before marking the PR ready for review to make sure there are no regressions.

Reasoning: 
Using bundled rtaudio is much easier on Windows than installing the library using vcpkg (at least until a better solution is implemented, like moving to MSYS2). Thus I'd like to **use bundled rtaudio as the default approach for building the release artifacts** on Windows. Using rtaudio from vcpkg is still supported and tested for (in the shared library Windows build). 

This PR also removes one build from our already considerable build matrix, while - I believe - still testing for most practical built configurations.

Other changes in this PR include changing macOS and Linux `bundled_rtaudio` builds to use shared qt library to avoid unnecessary builds of Qt when cache is not available, e.g. on releases. 

Once rtaudio is more tested on Linux and we decide it's a viable option for that platform, we could add bundled rtaudio to the Linux static build (if we keep providing it), but that's to be considered in the future.