### PR TITLE
Fix GUI command line warning

### DIFF
--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -52,7 +52,7 @@
 #include "../Limiter.h"
 #include "../Reverb.h"
 
-QJackTrip::QJackTrip(QWidget* parent)
+QJackTrip::QJackTrip(int argc, QWidget* parent)
     : QMainWindow(parent)
 #ifdef NO_JTVS
     , m_ui(new Ui::QJackTrip)
@@ -67,7 +67,7 @@ QJackTrip::QJackTrip(QWidget* parent)
     , m_jackTripRunning(false)
     , m_isExiting(false)
     , m_hasIPv4Reply(false)
-    , m_argc(1)
+    , m_argc(argc)
     , m_hideWarning(false)
 {
     m_ui->setupUi(this);
@@ -272,6 +272,17 @@ QJackTrip::QJackTrip(QWidget* parent)
     }
 #endif
 
+    // One of our arguments will always be --gui, so if that's the only one
+    // then we don't need to show the warning message.
+    if ((!gVerboseFlag && m_argc > 2) || m_argc > 3) {
+        QMessageBox msgBox;
+        msgBox.setText(
+            "The GUI version of JackTrip currently ignores any command line "
+            "options other than the verbose option (-V).\n\nThis may change in future.");
+        msgBox.setWindowTitle(QStringLiteral("Command line options"));
+        msgBox.exec();
+    }
+    
     migrateSettings();
     loadSettings();
 
@@ -313,8 +324,8 @@ QJackTrip::QJackTrip(QWidget* parent)
                 new QCheckBox(QStringLiteral("Don't show this warning again"));
             QMessageBox msgBox;
             msgBox.setText(
-                "An installation of JACK was not found. Only the RtAudio\nbackend will "
-                "be available. (Hub Server mode is not\ncurrently supported in this "
+                "An installation of JACK was not found. Only the RtAudio backend will "
+                "be available. (Hub Server mode is not currently supported in this "
                 "configuration.");
             msgBox.setWindowTitle(QStringLiteral("JACK Not Available"));
             msgBox.setCheckBox(dontBugMe);
@@ -330,8 +341,8 @@ QJackTrip::QJackTrip(QWidget* parent)
 #else
         QMessageBox msgBox;
         msgBox.setText(
-            "An installation of JACK was not found, and no other audio\nbackends are "
-            "available. JackTrip will not be able to start.\n(Please install JACK to fix "
+            "An installation of JACK was not found, and no other audio backends are "
+            "available. JackTrip will not be able to start. (Please install JACK to fix "
             "this.)");
         msgBox.setWindowTitle("JACK Not Available");
         msgBox.exec();
@@ -379,27 +390,6 @@ void QJackTrip::resizeEvent(QResizeEvent* event)
     rect = metrics.boundingRect(0, 0, width, 0, Qt::TextWordWrap,
                                 m_ui->authDisclaimerLabel->text());
     m_ui->authDisclaimerLabel->setMinimumHeight(rect.height());
-}
-
-void QJackTrip::showEvent(QShowEvent* event)
-{
-    QMainWindow::showEvent(event);
-
-    // One of our arguments will always be --gui, so if that's the only one
-    // then we don't need to show the warning message.
-    if ((!gVerboseFlag && m_argc > 2) || m_argc > 3) {
-        QMessageBox msgBox;
-        msgBox.setText(
-            "The GUI version of JackTrip currently\nignores any command line "
-            "options other\nthan the verbose option (-V).\n\nThis may change in future.");
-        msgBox.setWindowTitle(QStringLiteral("Command line options"));
-        msgBox.exec();
-    }
-}
-
-void QJackTrip::setArgc(int argc)
-{
-    m_argc = argc;
 }
 
 void QJackTrip::processFinished()

--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -282,7 +282,7 @@ QJackTrip::QJackTrip(int argc, QWidget* parent)
         msgBox.setWindowTitle(QStringLiteral("Command line options"));
         msgBox.exec();
     }
-    
+
     migrateSettings();
     loadSettings();
 

--- a/src/gui/qjacktrip.h
+++ b/src/gui/qjacktrip.h
@@ -63,14 +63,11 @@ class QJackTrip : public QMainWindow
     Q_OBJECT
 
    public:
-    explicit QJackTrip(QWidget* parent = nullptr);
+    explicit QJackTrip(int argc = 0, QWidget* parent = nullptr);
     ~QJackTrip() override;
 
     void closeEvent(QCloseEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;
-    void showEvent(QShowEvent* event) override;
-
-    void setArgc(int argc);
 
    signals:
     void signalExit();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -235,8 +235,7 @@ int main(int argc, char* argv[])
             gVerboseFlag = true;
         }
 
-        window.reset(new QJackTrip);
-        window->setArgc(argc);
+        window.reset(new QJackTrip(argc));
         QObject::connect(window.data(), &QJackTrip::signalExit, app.data(),
                          &QCoreApplication::quit, Qt::QueuedConnection);
         window->show();


### PR DESCRIPTION
The dialog that warns that most command line options are ignored with the --gui switch was not being shown in some cases when verbose mode was already set in the GUI. Also, remove manual formatting of dialog box contents.