### PR TITLE
RtAudio warning changes

### DIFF
--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -233,6 +233,7 @@ QJackTrip::QJackTrip(int argc, QWidget* parent)
     m_ui->basePortSpinBox->setVisible(false);
     m_ui->autoPatchGroupBox->setVisible(false);
     m_ui->requireAuthGroupBox->setVisible(false);
+    m_ui->backendWarningLabel->setVisible(false);
 
 #ifdef RT_AUDIO
     connect(m_ui->backendComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged),
@@ -247,6 +248,7 @@ QJackTrip::QJackTrip(int argc, QWidget* parent)
                     m_ui->outputDeviceComboBox->setEnabled(true);
                     m_ui->outputDeviceLabel->setEnabled(true);
                     m_ui->refreshDevicesButton->setEnabled(true);
+                    m_ui->backendWarningLabel->setVisible(true);
                     populateDeviceMenu(m_ui->inputDeviceComboBox, true);
                     populateDeviceMenu(m_ui->outputDeviceComboBox, false);
                 } else {
@@ -259,6 +261,7 @@ QJackTrip::QJackTrip(int argc, QWidget* parent)
                     m_ui->outputDeviceComboBox->setEnabled(false);
                     m_ui->outputDeviceLabel->setEnabled(false);
                     m_ui->refreshDevicesButton->setEnabled(false);
+                    m_ui->backendWarningLabel->setVisible(false);
                 }
             });
     connect(m_ui->refreshDevicesButton, &QPushButton::clicked, this, [=]() {
@@ -317,6 +320,9 @@ QJackTrip::QJackTrip(int argc, QWidget* parent)
             m_ui->typeComboBox->setCurrentIndex(P2P_SERVER);
         }
         m_ui->typeComboBox->removeItem(HUB_SERVER);
+        m_ui->backendWarningLabel->setText(
+            "JACK was not found. This means that only the RtAudio backend is available "
+            "and that JackTrip cannot be run in hub server mode.");
 
 #ifdef NO_JTVS
         QSettings settings;

--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -354,8 +354,8 @@ QJackTrip::QJackTrip(int argc, QWidget* parent)
             settings.setValue(QStringLiteral("UsingFallback"), false);
         }
         settings.endGroup();
-#endif
-#else
+#endif  // NO_JTVS
+#else  // RT_AUDIO
         QMessageBox msgBox;
         msgBox.setText(
             "An installation of JACK was not found, and no other audio backends are "

--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -355,7 +355,7 @@ QJackTrip::QJackTrip(int argc, QWidget* parent)
         }
         settings.endGroup();
 #endif  // NO_JTVS
-#else  // RT_AUDIO
+#else   // RT_AUDIO
         QMessageBox msgBox;
         msgBox.setText(
             "An installation of JACK was not found, and no other audio backends are "

--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -341,7 +341,7 @@ QJackTrip::QJackTrip(int argc, QWidget* parent)
                 settings.setValue(QStringLiteral("HideJackWarning"), true);
             }
             if (!usingRtAudioAlready) {
-                settings.setValue(QStringLiteral("UsingFallback"), true); 
+                settings.setValue(QStringLiteral("UsingFallback"), true);
             }
         }
         settings.endGroup();

--- a/src/gui/qjacktrip.ui
+++ b/src/gui/qjacktrip.ui
@@ -999,6 +999,13 @@ play from this machine. (Available in client fan out/in and full mix modes.)</st
         <string>Audio Backend</string>
        </attribute>
        <layout class="QGridLayout" name="gridLayout_11">
+        <item row="3" column="1">
+         <widget class="QComboBox" name="inputDeviceComboBox">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
         <item row="0" column="0">
          <widget class="QLabel" name="backendLabel">
           <property name="sizePolicy">
@@ -1015,40 +1022,52 @@ play from this machine. (Available in client fan out/in and full mix modes.)</st
           </property>
          </widget>
         </item>
-        <item row="0" column="1">
-         <widget class="QComboBox" name="backendComboBox">
-          <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Choose the audio backend to use. JACK is the default and is well tested, but requires the JACK audio server to be installed.&lt;/p&gt;&lt;p&gt;RtAudio is still a work in progress, but it works with your operating system's native audio drivers and requires no additional software.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <item>
-           <property name="text">
-            <string>JACK</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>RtAudio</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="sampleRateLabel">
+        <item row="2" column="1">
+         <widget class="QComboBox" name="bufferSizeComboBox">
           <property name="enabled">
            <bool>false</bool>
           </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the driver's buffer size to use with the RtAudio backend.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
-          <property name="text">
-           <string>&amp;Sampling Rate:</string>
+          <property name="currentIndex">
+           <number>3</number>
           </property>
-          <property name="buddy">
-           <cstring>sampleRateComboBox</cstring>
-          </property>
+          <item>
+           <property name="text">
+            <string>16</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>32</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>64</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>128</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>256</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>512</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>1024</string>
+           </property>
+          </item>
          </widget>
         </item>
         <item row="1" column="1">
@@ -1102,73 +1121,6 @@ play from this machine. (Available in client fan out/in and full mix modes.)</st
           </item>
          </widget>
         </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="bufferSizeLabel">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>&amp;Buffer Size:</string>
-          </property>
-          <property name="buddy">
-           <cstring>bufferSizeComboBox</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QComboBox" name="bufferSizeComboBox">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the driver's buffer size to use with the RtAudio backend.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="currentIndex">
-           <number>3</number>
-          </property>
-          <item>
-           <property name="text">
-            <string>16</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>32</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>64</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>128</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>256</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>512</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>1024</string>
-           </property>
-          </item>
-         </widget>
-        </item>
         <item row="3" column="0">
          <widget class="QLabel" name="inputDeviceLabel">
           <property name="enabled">
@@ -1188,40 +1140,7 @@ play from this machine. (Available in client fan out/in and full mix modes.)</st
           </property>
          </widget>
         </item>
-        <item row="3" column="1">
-         <widget class="QComboBox" name="inputDeviceComboBox">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="outputDeviceLabel">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>&amp;Output Device:</string>
-          </property>
-          <property name="buddy">
-           <cstring>outputDeviceComboBox</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="QComboBox" name="outputDeviceComboBox">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
+        <item row="6" column="1">
          <spacer name="backendSpacer">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
@@ -1234,7 +1153,7 @@ play from this machine. (Available in client fan out/in and full mix modes.)</st
           </property>
          </spacer>
         </item>
-        <item row="8" column="0" colspan="2">
+        <item row="9" column="0" colspan="2">
          <layout class="QHBoxLayout" name="deviceManagementLayout">
           <item>
            <spacer name="backendTabSpacer">
@@ -1257,6 +1176,97 @@ play from this machine. (Available in client fan out/in and full mix modes.)</st
            </widget>
           </item>
          </layout>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="outputDeviceLabel">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>&amp;Output Device:</string>
+          </property>
+          <property name="buddy">
+           <cstring>outputDeviceComboBox</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="bufferSizeLabel">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>&amp;Buffer Size:</string>
+          </property>
+          <property name="buddy">
+           <cstring>bufferSizeComboBox</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QComboBox" name="backendComboBox">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Choose the audio backend to use. JACK is the default and is well tested, but requires the JACK audio server to be installed.&lt;/p&gt;&lt;p&gt;RtAudio is still a work in progress, but it works with your operating system's native audio drivers and requires no additional software.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <item>
+           <property name="text">
+            <string>JACK</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>RtAudio</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="sampleRateLabel">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>&amp;Sampling Rate:</string>
+          </property>
+          <property name="buddy">
+           <cstring>sampleRateComboBox</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="QComboBox" name="outputDeviceComboBox">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="0" colspan="2">
+         <widget class="QLabel" name="backendWarningLabel">
+          <property name="text">
+           <string>These settings are ignored in Hub Server mode which requires JACK to operate.</string>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
         </item>
        </layout>
       </widget>

--- a/src/gui/qjacktrip_novs.ui
+++ b/src/gui/qjacktrip_novs.ui
@@ -999,21 +999,29 @@ play from this machine. (Available in client fan out/in and full mix modes.)</st
         <string>Audio Backend</string>
        </attribute>
        <layout class="QGridLayout" name="gridLayout_11">
-        <item row="0" column="0">
-         <widget class="QLabel" name="backendLabel">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Audio &amp;Backend:</string>
-          </property>
-          <property name="buddy">
-           <cstring>backendComboBox</cstring>
-          </property>
-         </widget>
+        <item row="9" column="0" colspan="2">
+         <layout class="QHBoxLayout" name="deviceManagementLayout">
+          <item>
+           <spacer name="backendTabSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QPushButton" name="refreshDevicesButton">
+            <property name="text">
+             <string>&amp;Refresh Device List</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
         <item row="0" column="1">
          <widget class="QComboBox" name="backendComboBox">
@@ -1032,8 +1040,28 @@ play from this machine. (Available in client fan out/in and full mix modes.)</st
           </item>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="sampleRateLabel">
+        <item row="3" column="1">
+         <widget class="QComboBox" name="inputDeviceComboBox">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="1">
+         <spacer name="backendSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>444</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="inputDeviceLabel">
           <property name="enabled">
            <bool>false</bool>
           </property>
@@ -1044,10 +1072,93 @@ play from this machine. (Available in client fan out/in and full mix modes.)</st
            </sizepolicy>
           </property>
           <property name="text">
-           <string>&amp;Sampling Rate:</string>
+           <string>&amp;Input Device:</string>
           </property>
           <property name="buddy">
-           <cstring>sampleRateComboBox</cstring>
+           <cstring>inputDeviceComboBox</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QComboBox" name="bufferSizeComboBox">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the driver's buffer size to use with the RtAudio backend.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="currentIndex">
+           <number>3</number>
+          </property>
+          <item>
+           <property name="text">
+            <string>16</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>32</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>64</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>128</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>256</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>512</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>1024</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="backendLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Audio &amp;Backend:</string>
+          </property>
+          <property name="buddy">
+           <cstring>backendComboBox</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="bufferSizeLabel">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>&amp;Buffer Size:</string>
+          </property>
+          <property name="buddy">
+           <cstring>bufferSizeComboBox</cstring>
           </property>
          </widget>
         </item>
@@ -1102,8 +1213,8 @@ play from this machine. (Available in client fan out/in and full mix modes.)</st
           </item>
          </widget>
         </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="bufferSizeLabel">
+        <item row="1" column="0">
+         <widget class="QLabel" name="sampleRateLabel">
           <property name="enabled">
            <bool>false</bool>
           </property>
@@ -1114,84 +1225,10 @@ play from this machine. (Available in client fan out/in and full mix modes.)</st
            </sizepolicy>
           </property>
           <property name="text">
-           <string>&amp;Buffer Size:</string>
+           <string>&amp;Sampling Rate:</string>
           </property>
           <property name="buddy">
-           <cstring>bufferSizeComboBox</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QComboBox" name="bufferSizeComboBox">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the driver's buffer size to use with the RtAudio backend.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="currentIndex">
-           <number>3</number>
-          </property>
-          <item>
-           <property name="text">
-            <string>16</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>32</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>64</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>128</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>256</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>512</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>1024</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="inputDeviceLabel">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>&amp;Input Device:</string>
-          </property>
-          <property name="buddy">
-           <cstring>inputDeviceComboBox</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="QComboBox" name="inputDeviceComboBox">
-          <property name="enabled">
-           <bool>false</bool>
+           <cstring>sampleRateComboBox</cstring>
           </property>
          </widget>
         </item>
@@ -1221,42 +1258,15 @@ play from this machine. (Available in client fan out/in and full mix modes.)</st
           </property>
          </widget>
         </item>
-        <item row="5" column="1">
-         <spacer name="backendSpacer">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
+        <item row="5" column="0" colspan="2">
+         <widget class="QLabel" name="backendWarningLabel">
+          <property name="text">
+           <string>These settings are ignored in hub server mode which requires JACK to operate.</string>
           </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>444</height>
-           </size>
+          <property name="wordWrap">
+           <bool>true</bool>
           </property>
-         </spacer>
-        </item>
-        <item row="8" column="0" colspan="2">
-         <layout class="QHBoxLayout" name="deviceManagementLayout">
-          <item>
-           <spacer name="backendTabSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <widget class="QPushButton" name="refreshDevicesButton">
-            <property name="text">
-             <string>&amp;Refresh Device List</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
+         </widget>
         </item>
        </layout>
       </widget>


### PR DESCRIPTION
Remove the RtAudio warning for official builds and tweak it for NO_JTVS builds (the binaries maintained by @psiborg112).

Additionally, save if RtAudio has been used as a fallback option rather than selected as a deliberate choice by the user. That way, if JACK is installed later, it can be reinstated as the default backend. (NO_JTVS builds)