### PR TITLE
Don't connect our UDP socket

### DIFF
--- a/src/UdpDataProtocol.cpp
+++ b/src/UdpDataProtocol.cpp
@@ -337,7 +337,7 @@ functions. DWORD n_bytes; WSABUF buffer; int error; buffer.len = n; buffer.buf =
         n_bytes = ::sendto(mSocket, buf, n, 0, (struct sockaddr*)&mPeerAddr6,
                            sizeof(mPeerAddr6));
     } else {
-        n_bytes = 
+        n_bytes =
             ::sendto(mSocket, buf, n, 0, (struct sockaddr*)&mPeerAddr, sizeof(mPeerAddr));
     }
     return n_bytes;

--- a/src/UdpDataProtocol.cpp
+++ b/src/UdpDataProtocol.cpp
@@ -337,8 +337,8 @@ functions. DWORD n_bytes; WSABUF buffer; int error; buffer.len = n; buffer.buf =
         n_bytes = ::sendto(mSocket, buf, n, 0, (struct sockaddr*)&mPeerAddr6,
                            sizeof(mPeerAddr6));
     } else {
-        n_bytes = ::sendto(mSocket, buf, n, 0, (struct sockaddr*)&mPeerAddr,
-                           sizeof(mPeerAddr));
+        n_bytes = 
+            ::sendto(mSocket, buf, n, 0, (struct sockaddr*)&mPeerAddr, sizeof(mPeerAddr));
     }
     return n_bytes;
     //#endif


### PR DESCRIPTION
One of the quirks of the pre-IPv6 networking code was that we called connect on our UDP socket. The benefit was that we could just call send rather than sendto and it would only accept packets arriving from the specified destination.

I abandoned it for IPv6 because adapters commonly have multiple addresses and there was no guarantee that packets would be arriving back from the same address. I kept it for IPv4 because if it ain't broke... But it is broken. It seems to cause issues with both epoll and kqueue causing them to report that the socket is ready for reading when there's no data on it. Fixes #474.

(Also, clean out some of the very old and very broken 'two sockets on a single port' code.)