### PR TITLE
macOS arm64

### DIFF
--- a/build
+++ b/build
@@ -94,6 +94,10 @@ MCMD=make
 elif [[ $platform == 'macosx' ]]; then
   QCMD=qmake
   QSPEC=macx-clang
+  arch=`arch`
+  if [[ "$arch" == 'arm64' ]]; then
+    QSPEC=macx-clang-arm64
+  fi  
   # if qmake is not in path, try homebrew qt5
   if ! command -v $QCMD &> /dev/null; then
     # echo "qmake not found in \$PATH, searching for homebrew qt5"


### PR DESCRIPTION
I've tried to build JackTrip on macOS 11.6 under Xcode 13.2 on m1 hardware (arm64)

TL;DR:
JackTrip builds and runs fine on arm64 mac (aka Apple Silicon / M1).

The good:
- with this change JackTrip builds
- works fine with Jack and RtAudio

~~The bad~~
- ~~doesn't work with RtAudio~~

**There is no issue with RtAudio**, something was wrong with my system. RtAudio backend works fine after restarting.

~~I'm not sure if we want to merge this PR in the current form. While it provides the minimum to detect the architecture and build in qmake, we might also consider being able to set architecture (e.g. to cross-compile or compile universal binary)~~ EDIT: I think it's fine as it is. I think cross-compiling is a topic to be considered at a later stage.

Also: 
- meson build worked fine on arm64 with no changes
- I haven't tested CMake

All in all, I'm somewhat hopeful about being able to provide a native arm64 build at some point. Whether we can make it a universal binary before moving to Qt 6, that I'm not sure. But we could offer two binaries on macOS for the time being.