### PR TITLE
Update install page to call out old versions on Debian and others

### DIFF
--- a/docs/Install.md
+++ b/docs/Install.md
@@ -1,6 +1,6 @@
 # Installation
 ## Linux
-On Linux the easiest way to install JackTrip is to use the distribution's package manager.
+On Linux the easiest way to install JackTrip is to use the distribution's package manager. However, this may not be the most up-to-date version. For the most recent version, go to the Github releases page below.
 
 === "Fedora"
 


### PR DESCRIPTION
the apt install and other package managers installation steps install older version. Making this clear to users.