### PR TITLE
Fix false error message (M1 builds)

### DIFF
--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -985,6 +985,8 @@ void JackTrip::tcpTimerTick()
 //*******************************************************************************
 void JackTrip::stop(const QString& errorMessage)
 {
+    // Take a snapshot of sJackStopped
+    bool serverStopped = sJackStopped;
     mStopped = true;
     // Make sure we're only run once
     if (mHasShutdown) {
@@ -1009,7 +1011,7 @@ void JackTrip::stop(const QString& errorMessage)
     cout << gPrintSeparator << endl;
 
     // Emit the jack stopped signal
-    if (sJackStopped) {
+    if (serverStopped) {
         emit signalError(QStringLiteral("The Jack Server was shut down!"));
     } else if (errorMessage.isEmpty()) {
         emit signalProcessesStopped();

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -987,7 +987,7 @@ void JackTrip::stop(const QString& errorMessage)
 {
     // Take a snapshot of sJackStopped
     bool serverStopped = sJackStopped;
-    mStopped = true;
+    mStopped           = true;
     // Make sure we're only run once
     if (mHasShutdown) {
         return;


### PR DESCRIPTION
The current JACK universal build (1.9.20) doesn't cleanly close the client on arm64 and triggers the jack_on_shutdown callback when it forcibly removes it. This workaround prevents the GUI from incorrectly reporting that the JACK server has shutdown.