### PR TITLE
RtAudio: handle names with commas in the command line

### DIFF
--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -1553,8 +1553,14 @@ QString QJackTrip::commandLineFromCurrentOptions()
         if (m_ui->outputDeviceComboBox->currentIndex() > 0) {
             outDevice = m_ui->outputDeviceComboBox->currentText();
         }
-        commandLine.append(
-            QStringLiteral(" --audiodevice \"%1\",\"%2\"").arg(inDevice, outDevice));
+        QString delim;  // note: this should match delimiters specified in
+                        // Settings::setDevicesByString
+        if (inDevice.contains(",") || outDevice.contains(","))
+            delim = "\\\\,";
+        else
+            delim = ",";
+        commandLine.append(QStringLiteral(" --audiodevice \"%1\"%2\"%3\"")
+                               .arg(inDevice, delim, outDevice));
     }
 #endif
 


### PR DESCRIPTION
Fixes #495 

We had no way of specifying RtAudio devices on the command line if their names included commas, which we use as a delimiter between input and output device.
The issue is about distinguishing comma separating the devices and the comma that's part of the device name. 

When investigating this, I noted that when `--audiodevice "name, with comma","name, with comma"` is passed to JT, we get `name, with comma,name, with comma` (without quotes) from the command line parser, so matching `","` is not an option, AFAICT.

I think the solution is to have an alternative separator. I've chosen `\\,` (well technically it's `\,` but we need double escape in the shell). I'm open to suggestions if we want it to be something different - it just needs to be reasonably unlikely to also come up in the device name itself. One alternative I was considering was two or three commas in a row, but I'm not sure if that's better.

Additionally, I've changed parsing so that comma + space is treated as part of a single device name, so that `Rogue Amoeba Software, Inc.: undley-closse` should be handled properly when used as a single (input/output) device. 

If there is a device name that uses a comma but no space after comma, it can still be used but it needs to be specified as both input and output device using the alternative delimiter, e.g. `--audiodevice "device name,no space after comma"\\,"device name,no space after comma"`. Not ideal, but workable I think?

I've updated command line parsing, help output and "get command line" function in the gui. 

Any and all feedback is welcome. :)