### PR TITLE
QMake build script: exit when build fails

### DIFF
--- a/build
+++ b/build
@@ -148,6 +148,9 @@ fi
 mkdir -p builddir
 cd builddir
 
+# exit if build commands fail
+set -e
+
 # Build
 echo "qmake command:"
 echo "$QCMD -spec $QSPEC $CONFIG $PRO_FILE" $UNKNOWN_OPTIONS


### PR DESCRIPTION
QMake build script would not exit if the build command failed and thus the CI would not report failure. This PR fixes that behavior, making the build script exit with the appropriate code if one of the build command fails.

Fixes #494