### PR TITLE
GHA: include Linux nogui static build in the release

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -59,12 +59,17 @@ jobs:
             # binary-path: binary
             build-system: qmake
 
-          - name: Linux-x64-qmake-gcc-shared-nogui
+          - name: Linux-x64-qmake-gcc-static-nogui
+            release-name: Linux-x64-nogui
             runs-on: ubuntu-18.04
             system-rtaudio: false
             bundled-rtaudio: false
             nogui: true
             weakjack: false
+            static-qt-version: 5.12.11
+            qt-static-cache-key: 'v22' # we use the same key as the main Linux build
+            jacktrip-path: jacktrip
+            binary-path: binary
             build-system: qmake
 
           - name: Linux-x64-meson-gcc-shared-bundled_rtaudio

--- a/jacktrip.pro
+++ b/jacktrip.pro
@@ -22,6 +22,7 @@ equals(QT_EDITION, "OpenSource") {
 
 nogui {
   DEFINES += NO_GUI
+  QT -= gui
 } else {
   QT += gui
   QT += widgets


### PR DESCRIPTION
This also changes the nogui build to use static qt (I don't think we need both shared and static nogui build right?)

Fixes #509

(I haven't tested the actual release, but the build itself should be available in the artifacts of this PR once it's built)

EDIT: just to be clear, I don't expect there will be any issues with the release - the release artifact name is specified. I just haven't tested this so let's look out for this at the next release after this is merged.