### PR TITLE
macOS: disable upload of the jacktrip binary

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -102,7 +102,7 @@ jobs:
             static-qt-version: 5.12.11
             qt-static-cache-key: 'v05'
             jacktrip-path: jacktrip
-            binary-path: binary
+            # binary-path: binary # don't upload the binary itself since we upload the bundle
             bundle-path: bundle
             installer-path: installer
             build-system: qmake


### PR DESCRIPTION
I think that it is confusing to users to have to choose between application bundle, single binary, and an installer for macOS.
I propose that for the release (and generally build artifacts) we do not upload a single binary for macOS - we offer the application bundle already and the binary can be accessed inside it if needed.

See discussion in #512 