### PR TITLE
Fix include path to fcntl.h

### DIFF
--- a/src/UdpDataProtocol.cpp
+++ b/src/UdpDataProtocol.cpp
@@ -52,7 +52,7 @@
 //#include <winsock.h>
 #include <winsock2.h>  //cc need SD_SEND
 #else
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <sys/socket.h>  // for POSIX Sockets
 #include <unistd.h>
 #ifndef MANUAL_POLL


### PR DESCRIPTION
When trying to build jacktrip on Alpine Linux for my Docker container I've got some warnings. One commit fixes the include path for fcntl.h.

The second commit doesn't fix the warning about non initialized struct members but changes the setRealtimeProcessPriority() function to be C on POSIX systems. Designated initializers are part of C since C99 but were introduced in C++ only with C++20. As this change doesn't fix anything I'm open to remove this. Happy to hear your opinion.