### PR TITLE
Plc asym auto fix

### DIFF
--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -681,6 +681,9 @@ void JackTrip::onStatTimer()
             //                     << pkt_stat.outOfOrder << "/" << pkt_stat.revived
             << " \n tot: "
             << pkt_stat.tot
+            << " \t autoq: "
+            << setw(5)
+            << INVFLOATFACTOR * recv_io_stat.autoq_corr
             //                     << " sync: " << recv_io_stat.level << "/"
             //                     << recv_io_stat.buf_inc_underrun << "/"
             //                     << recv_io_stat.buf_inc_compensate << "/"

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -679,7 +679,7 @@ void JackTrip::onStatTimer()
             //                     << "/" << recv_io_stat.overflows << " prot: " <<
             //                     pkt_stat.lost << "/"
             //                     << pkt_stat.outOfOrder << "/" << pkt_stat.revived
-            << " \n tot: " << pkt_stat.tot << " \t autoq: " << setw(5)
+            << " \n tot: " << pkt_stat.tot << " \t tol: " << setw(5)
             << INVFLOATFACTOR * recv_io_stat.autoq_corr
             //                     << " sync: " << recv_io_stat.level << "/"
             //                     << recv_io_stat.buf_inc_underrun << "/"

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -380,9 +380,8 @@ void JackTrip::setupRingBuffers()
             qDebug() << "experimental buffer strategy 3 -- regulator with PLC";
             mSendRingBuffer =
                 new RingBuffer(audio_input_slot_size, gDefaultOutputQueueLength);
-            mReceiveRingBuffer =
-                new Regulator(mSampleRate, mNumAudioChansOut, mAudioBitResolution,
-                              mAudioBufferSize, mBufferQueueLength);
+            mReceiveRingBuffer = new Regulator(mNumAudioChansOut, mAudioBitResolution,
+                                               mAudioBufferSize, mBufferQueueLength);
             // bufStrategy 3, mBufferQueueLength is in integer msec not packets
 
             mPacketHeader->setBufferRequiresSameSettings(false);  // = asym is default

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -679,10 +679,7 @@ void JackTrip::onStatTimer()
             //                     << "/" << recv_io_stat.overflows << " prot: " <<
             //                     pkt_stat.lost << "/"
             //                     << pkt_stat.outOfOrder << "/" << pkt_stat.revived
-            << " \n tot: "
-            << pkt_stat.tot
-            << " \t autoq: "
-            << setw(5)
+            << " \n tot: " << pkt_stat.tot << " \t autoq: " << setw(5)
             << INVFLOATFACTOR * recv_io_stat.autoq_corr
             //                     << " sync: " << recv_io_stat.level << "/"
             //                     << recv_io_stat.buf_inc_underrun << "/"

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -257,10 +257,9 @@ void Regulator::shimFPP(const int8_t* buf, int len, int seq_num)
             if (mFPPratioNumerator > 1) {  // 2/1, 4/1 peer FPP is lower
                 int tmp = (seq_num % mFPPratioNumerator) * mBytesPeerPacket;
                 memcpy(&mAssembledPacket[tmp], buf, mBytesPeerPacket);
-                seq_num /= mFPPratioNumerator;
                 if ((seq_num % mFPPratioNumerator) == mModCycle) {
                     if (mAssemblyCnt == mModCycle)
-                        pushPacket(mAssembledPacket, seq_num);
+                        pushPacket(mAssembledPacket, seq_num / mFPPratioNumerator);
                     //                else qDebug() << "incomplete due to lost packet";
                     mAssemblyCnt = 0;
                 } else

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -224,8 +224,8 @@ void Regulator::setFPPratio()
             mFPPratioDenominator = mPeerFPP / mFPP;
         else
             mFPPratioNumerator = mFPP / mPeerFPP;
-        qDebug() << "peerBuffers / localBuffers" << mFPPratioNumerator << " / "
-                 << mFPPratioDenominator;
+        //        qDebug() << "peerBuffers / localBuffers" << mFPPratioNumerator << " / "
+        //                 << mFPPratioDenominator;
     }
     if (mFPPratioNumerator > 1) {
         mBytesPeerPacket = mBytes / mFPPratioNumerator;
@@ -239,7 +239,6 @@ void Regulator::setFPPratio()
 //*******************************************************************************
 void Regulator::shimFPP(const int8_t* buf, int len, int seq_num)
 {
-    //    qDebug() << "rcv packet" << seq_num;
     if (seq_num != -1) {
         if (!mFPPratioIsSet) {  // first peer packet
             mPeerFPP = len / (mNumChannels * mBitResolutionMode);
@@ -299,9 +298,8 @@ void Regulator::shimFPP(const int8_t* buf, int len, int seq_num)
 void Regulator::pushPacket(const int8_t* buf, int seq_num)
 {
     QMutexLocker locker(&mMutex);
-    //    qDebug() << "\t" << seq_num;
     seq_num %= mModSeqNum;
-    // if (seq_num==0) return;   // if (seq_num==1) return; // impose regular loss
+    // if (seq_num==0) return;   // impose regular loss
     mIncomingTiming[seq_num] =
         mMsecTolerance + (double)mIncomingTimer.nsecsElapsed() / 1000000.0;
     mLastSeqNumIn = seq_num;
@@ -474,7 +472,7 @@ bool BurgAlgorithm::classify(double d)
         tmp = true;
         break;
     case FP_ZERO:
-        //      qDebug() <<  ("zero");
+        qDebug() << ("zero");
         tmp = true;
         break;
     case FP_SUBNORMAL:

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -338,14 +338,14 @@ PACKETOK : {
         processPacket(true);
     else
         processPacket(false);
-    pullStat->tick();  // sets up first 2 secs
+    pullStat->tick();
     goto OUTPUT;
 }
 
 UNDERRUN : {
     processPacket(true);
     pullStat->plcUnderruns++;  // count late
-    pullStat->tick();          // sets up first 2 secs
+    pullStat->tick();
     goto OUTPUT;
 }
 
@@ -622,6 +622,8 @@ void StdDev::reset()
 
 double StdDev::calcAuto()
 {
+    if ((longTermStdDev == 0.0) || (longTermMax == 0.0))
+        return AutoHeadroom;
     return AutoHeadroom + longTermStdDev
            + ((longTermMax > AutoMax) ? AutoMax : longTermMax);
 };

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -249,17 +249,17 @@ void Regulator::shimFPP(const int8_t* buf, int len, int seq_num)
             seq_num %= modSeqNumPeer;
             //        qDebug() << seq_num << seq_num / mFPPratioNumerator <<
             //        mPartialPacketCnt;
-            seq_num /= mFPPratioNumerator;
-            int tmp = (mPartialPacketCnt % mFPPratioNumerator) * mBytesPeerPacket;
+            int assemblySeq_num = seq_num / mFPPratioNumerator;
+            int tmp = (seq_num % mFPPratioNumerator) * mBytesPeerPacket;
             memcpy(&mAssembledPacket[tmp], buf, mBytesPeerPacket);
-            if ((mPartialPacketCnt % mFPPratioNumerator) == (mFPPratioNumerator - 1)) {
-                if (mAssembly == (mFPPratioNumerator - 1)) pushPacket(mAssembledPacket, seq_num);
+            if ((seq_num % mFPPratioNumerator) == (mFPPratioNumerator - 1)) {
+                if (mAssembly == (mFPPratioNumerator - 1)) pushPacket(mAssembledPacket, assemblySeq_num);
                 else qDebug() << "incomplete due to lost packet";
                 mAssembly = 0;
             } else mAssembly++;
 
             // lost packets will not work, parts are missing or the count doesn't correspond
-            mPartialPacketCnt++;
+//            mPartialPacketCnt++;
         } else if (mFPPratioDenominator > 1) {  // 1/2, 1/4 peer FPP is higher
             int modSeqNumPeer = mModSeqNum / mFPPratioDenominator;
             seq_num %= modSeqNumPeer;

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -81,7 +81,8 @@ constexpr int ModSeqNumInit   = 256;  // bounds on seqnums, 65536 is max in pack
 constexpr int NumSlotsMax     = 128;  // mNumSlots looped for recent arrivals
 constexpr int LostWindowMax   = 32;   // mLostWindow looped for recent arrivals
 constexpr double AutoHeadroom = 1.0;  // msec padding for auto adjusting mMsecTolerance
-constexpr double AutoInitDur  = 6000.0;  // msec init phase
+constexpr double AutoMax = 250.0;  // msec bounds on insane IPI, like ethernet unplugged
+constexpr double AutoInitDur = 6000.0;  // msec init phase
 constexpr double AutoInitVal =
     100.0;  // msec for initial mMsecTolerance during init phase if unspecified
 //*******************************************************************************
@@ -625,8 +626,8 @@ void StdDev::reset()
 
 double StdDev::calcAuto()
 {
-    //    qDebug() << "yes";
-    return longTermStdDev + longTermMax + AutoHeadroom;
+    return AutoHeadroom + longTermStdDev
+           + ((longTermMax > AutoMax) ? AutoMax : longTermMax);
 };
 
 void StdDev::tick()

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -80,7 +80,7 @@ constexpr int NumSlotsMax     = 128;  // mNumSlots looped for recent arrivals
 constexpr int LostWindowMax   = 32;   // mLostWindow looped for recent arrivals
 constexpr double AutoHeadroom = 1.0;  // msec padding for auto adjusting mMsecTolerance
 constexpr double AutoMax = 250.0;  // msec bounds on insane IPI, like ethernet unplugged
-constexpr double AutoInitDur = 8000.0;  // msec init phase
+constexpr double AutoInitDur = 6000.0;  // msec init phase
 constexpr double AutoInitVal =
     100.0;  // msec for initial mMsecTolerance during init phase if unspecified
 //*******************************************************************************

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -253,7 +253,7 @@ void Regulator::shimFPP(const int8_t* buf, int len, int seq_num)
             setFPPratio();
             // number of stats tick calls per sec depends on FPP
             pushStat =
-                new StdDev(1, &mIncomingTimer, (int)(floor(48000.0 / (double)mPeerFPP)));
+                new StdDev(1, &mIncomingTimer, (int)(floor(48000.0 / (double)mFPP)));
             pullStat =
                 new StdDev(2, &mIncomingTimer, (int)(floor(48000.0 / (double)mFPP)));
             mFPPratioIsSet = true;

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -200,8 +200,8 @@ void Regulator::changeGlobal_3(int x)
 
 void Regulator::printParams()
 {
-//    qDebug() << "mMsecTolerance" << mMsecTolerance << "mNumSlots" << mNumSlots
-//             << "mModSeqNum" << mModSeqNum << "mLostWindow" << mLostWindow;
+    qDebug() << "mMsecTolerance" << mMsecTolerance << "mNumSlots" << mNumSlots
+             << "mModSeqNum" << mModSeqNum << "mLostWindow" << mLostWindow;
 #ifdef GUIBS3
     updateGUI((int)mMsecTolerance, mNumSlots);
 #endif

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -269,8 +269,8 @@ void Regulator::shimFPP(const int8_t* buf, int len, int seq_num)
                 if ((seq_num % mFPPratioNumerator) == mModCycle) {
                     if (mAssemblyCnt == mModCycle)
                         pushPacket(mAssembledPacket, seq_num / mFPPratioNumerator);
-                    else
-                        qDebug() << "incomplete due to lost packet";
+                    //                    else
+                    //                        qDebug() << "incomplete due to lost packet";
                     mAssemblyCnt = 0;
                 } else
                     mAssemblyCnt++;
@@ -623,7 +623,7 @@ void StdDev::reset()
 
 double StdDev::calcAuto()
 {
-    qDebug() << longTermStdDev << longTermMax << AutoMax << window << longTermCnt;
+    //    qDebug() << longTermStdDev << longTermMax << AutoMax << window << longTermCnt;
     if ((longTermStdDev == 0.0) || (longTermMax == 0.0))
         return AutoMax;
     return AutoHeadroom + longTermStdDev

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -260,8 +260,8 @@ void Regulator::shimFPP(const int8_t* buf, int len, int seq_num)
                 if ((seq_num % mFPPratioNumerator) == mModCycle) {
                     if (mAssemblyCnt == mModCycle)
                         pushPacket(mAssembledPacket, seq_num / mFPPratioNumerator);
-                    else
-                        qDebug() << "incomplete due to lost packet";
+                    //                    else
+                    //                        qDebug() << "incomplete due to lost packet";
                     mAssemblyCnt = 0;
                 } else
                     mAssemblyCnt++;

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -242,14 +242,15 @@ void Regulator::shimFPP(const int8_t* buf, int len, int seq_num)
 {
     QMutexLocker locker(&mMutex);
     if (seq_num != -1) {
-        if (!mFPPratioIsSet) { // first peer packet
+        if (!mFPPratioIsSet) {  // first peer packet
             mPeerFPP                 = len / (mNumChannels * mBitResolutionMode);
             double peerPacketDurMsec = 1000.0 * (double)mPeerFPP / (double)mSampleRate;
             // Anton's autoq mode overloads qLen with negative
             if (mMsecTolerance < 0) {  // handle -q auto or, for example, -q auto10
                 mAuto = true;
                 // default is -500 from
-                mMsecTolerance = (mMsecTolerance == -500.0) ? peerPacketDurMsec : -mMsecTolerance;
+                mMsecTolerance =
+                    (mMsecTolerance == -500.0) ? peerPacketDurMsec : -mMsecTolerance;
             };
             setFPPratio(len);
             // number of stats tick calls per sec depends on FPP

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -682,6 +682,10 @@ bool Regulator::getStats(RingBuffer::IOStat* stat, bool reset)
     stat->level             = FLOATFACTOR * pushStat->longTermMax;  // was lastMax
     stat->buf_dec_overflows = FLOATFACTOR * pushStat->lastStdDev;
 
+    double tmp = pushStat->longTermStdDev + pushStat->longTermMax;
+
+    stat->autoq_corr = FLOATFACTOR * tmp;
+
     stat->buf_dec_pktloss    = FLOATFACTOR * pullStat->longTermStdDev;
     stat->buf_inc_underrun   = FLOATFACTOR * pullStat->lastMean;
     stat->buf_inc_compensate = FLOATFACTOR * pullStat->lastMin;

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -36,30 +36,56 @@
  */
 
 // EXPERIMENTAL for testing in JackTrip v1.5.<n>
-// server and client can have different FPP (tested from FPP 32 to 512)
+// server and client can have different FPP (tested from FPP 16 to 1024)
+// stress tested by repeatedly starting & stopping across range of FPP's
 // server and client can have different in / out channel count
+// auto mode -- use -q auto
+// or for manual setting of initial mMsecTolerance -- use -q auto<msec>
+// gathers data for 6 sec and then goes full auto
 
-// ./jacktrip -S --udprt -p1 --bufstrategy 3  -I 1 -q10
-// PIPEWIRE_LATENCY=32/48000 ./jacktrip -C <SERV> --udprt --bufstrategy 3 -I 1 -q4
+// example WAN test
+// ./jacktrip -S --udprt -p1 --bufstrategy 3 -q auto
+// PIPEWIRE_LATENCY=32/48000 ./jacktrip -C <SERV> --udprt --bufstrategy 3 -q auto
 
+// example WAN test
 // at 48000 / 32 = 2.667 ms total roundtrip latency
-// local loopback test with 4 terminals running and the following jmess file
+// local loopback test with 4 terminals running and a jmess file
 // jacktrip -S --udprt --nojackportsconnect -q1 --bufstrategy 3
 // jacktrip -C localhost --udprt --nojackportsconnect -q1  --bufstrategy 3
 // use jack_iodelay
-// use jmess -s delay.xml and jmess -c delay.xml
+// use jmess -c delay.xml
+/* delay.xml
+<jmess>
+  <connection>
+    <output>localhost:receive_1</output>
+    <input>jack_delay:in</input>
+  </connection>
+  <connection>
+    <output>jack_delay:out</output>
+    <input>localhost:send_1</input>
+  </connection>
+  <connection>
+    <output>__1:receive_1</output>
+    <input>__1:send_2</input>
+  </connection>
+  <connection>
+    <output>__1:receive_1</output>
+    <input>__1:send_1</input>
+  </connection>
+</jmess>
+*/
 
 // tested outgoing loss impairments with (replace lo with relevant network interface)
-// sudo tc qdisc add dev lo root netem loss 2%
-// sudo tc qdisc del dev lo root netem loss 2%
-// or more revealing
+// sudo tc qdisc add dev lo root netem loss 5%
+// sudo tc qdisc del dev lo root netem loss 5%
+// or very revealing
 // sudo tc qdisc add dev lo root netem loss 20%
 // sudo tc qdisc del dev lo root netem loss 20%
 // tested jitter impairments with
-// for wifi
+// wifi simulation
 // sudo tc qdisc add dev lo root netem slot distribution pareto 0.1ms 3.0ms
 // sudo tc qdisc del dev lo root netem slot distribution pareto 0.1ms 3.0ms
-// for wired cmn9
+// ugly wired simulation
 // sudo tc qdisc add dev lo root netem slot distribution pareto 0.2ms 0.3ms
 // sudo tc qdisc del dev lo root netem slot distribution pareto 0.2ms 0.3ms
 
@@ -73,7 +99,7 @@ using std::cout;
 using std::endl;
 using std::setw;
 
-// constants... tested for now
+// constants...
 constexpr int HIST            = 6;    // at FPP32
 constexpr int ModSeqNumInit   = 256;  // bounds on seqnums, 65536 is max in packet header
 constexpr int NumSlotsMax     = 128;  // mNumSlots looped for recent arrivals

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -627,7 +627,7 @@ double StdDev::calcAuto()
 
 double StdDev::tick()
 {
-    qDebug() << mId;  // << lastTime;
+//    qDebug() << mId;  // << lastTime;
     double returnVal = -1.0;
     double now       = (double)mTimer->nsecsElapsed() / 1000000.0;
     double msElapsed = now - lastTime;

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -54,6 +54,9 @@
 // tested outgoing loss impairments with (replace lo with relevant network interface)
 // sudo tc qdisc add dev lo root netem loss 2%
 // sudo tc qdisc del dev lo root netem loss 2%
+// or more revealing
+// sudo tc qdisc add dev lo root netem loss 20%
+// sudo tc qdisc del dev lo root netem loss 20%
 // tested jitter impairments with
 // for wifi
 // sudo tc qdisc add dev lo root netem slot distribution pareto 0.1ms 3.0ms

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -247,8 +247,7 @@ void Regulator::shimFPP(const int8_t* buf, int len, int seq_num)
             if (mMsecTolerance < 0) {  // handle -q auto or, for example, -q auto10
                 mAuto = true;
                 // default is -500 from
-                mMsecTolerance = (mMsecTolerance == -500.0) ? (2.0 * mPeerPacketDurMsec)
-                                                            : -mMsecTolerance;
+                mMsecTolerance = (mMsecTolerance == -500.0) ? 100.0 : -mMsecTolerance;
             };
             setFPPratio();
             // number of stats tick calls per sec depends on FPP

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -252,8 +252,9 @@ void Regulator::shimFPP(const int8_t* buf, int len, int seq_num)
             };
             setFPPratio();
             // number of stats tick calls per sec depends on FPP
+            int maxFPP = (mPeerFPP > mFPP) ? mPeerFPP : mFPP;
             pushStat =
-                new StdDev(1, &mIncomingTimer, (int)(floor(48000.0 / (double)mFPP)));
+                new StdDev(1, &mIncomingTimer, (int)(floor(48000.0 / (double)maxFPP)));
             pullStat =
                 new StdDev(2, &mIncomingTimer, (int)(floor(48000.0 / (double)mFPP)));
             mFPPratioIsSet = true;

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -253,10 +253,10 @@ void Regulator::shimFPP(const int8_t* buf, int len, int seq_num)
             int tmp = (mPartialPacketCnt % mFPPratioNumerator) * mBytesPeerPacket;
             memcpy(&mAssembledPacket[tmp], buf, mBytesPeerPacket);
             if ((mPartialPacketCnt % mFPPratioNumerator) == (mFPPratioNumerator - 1)) {
-                if (mAssembly == mFPPratioNumerator) pushPacket(mAssembledPacket, seq_num);
+                if (mAssembly == (mFPPratioNumerator - 1)) pushPacket(mAssembledPacket, seq_num);
                 else qDebug() << "incomplete due to lost packet";
                 mAssembly = 0;
-            }
+            } else mAssembly++;
 
             // lost packets will not work, parts are missing or the count doesn't correspond
             mPartialPacketCnt++;

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -218,7 +218,7 @@ Regulator::~Regulator()
         delete mChanData[i];
 }
 
-void Regulator::setFPPratio(int len)
+void Regulator::setFPPratio()
 {
     if (mPeerFPP != mFPP) {
         if (mPeerFPP > mFPP)

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -248,10 +248,9 @@ void Regulator::setFPPratio(int len)
 void Regulator::shimFPP(const int8_t* buf, int len, int seq_num)
 {
     if (seq_num != -1) {
-        //        if (!mFPPratioIsSet)
-        //            setFPPratio(len);
-        if (true) {
-            //            if (mFPPratioNumerator == mFPPratioDenominator) {
+        if (!mFPPratioIsSet)
+            setFPPratio(len);
+        if (mFPPratioNumerator == mFPPratioDenominator) {
             pushPacket(buf, seq_num);
         } else {
             seq_num %= mModSeqNumPeer;

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -627,7 +627,7 @@ double StdDev::calcAuto()
 
 double StdDev::tick()
 {
-//    qDebug() << mId;  // << lastTime;
+    //    qDebug() << mId;  // << lastTime;
     double returnVal = -1.0;
     double now       = (double)mTimer->nsecsElapsed() / 1000000.0;
     double msElapsed = now - lastTime;

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -159,7 +159,6 @@ Regulator::Regulator(int sample_rate, int channels, int bit_res, int FPP, int qL
     mModSeqNum           = mNumSlots * 2;
     mFPPratioNumerator   = 1;
     mFPPratioDenominator = 1;
-    mPartialPacketCnt    = 0;
     mFPPratioIsSet       = false;
     mBytesPeerPacket     = mBytes;
     mAssemblyCnt = 0;

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -148,8 +148,8 @@ Regulator::Regulator(int sample_rate, int channels, int bit_res, int FPP, int qL
     memcpy(mZeros, mXfrBuffer, mBytes);
     mAssembledPacket = new int8_t[mBytes];  // for asym
     memcpy(mAssembledPacket, mXfrBuffer, mBytes);
-    pushStat = new StdDev(&mIncomingTimer, (int)(floor(4 * 48000.0 / (double)mFPP)), 1);
-    pullStat = new StdDev(&mIncomingTimer, (int)(floor(4 * 48000.0 / (double)mFPP)), 2);
+    pushStat = new StdDev(&mIncomingTimer, (int)(floor(48000.0 / (double)mFPP)), 1);
+    pullStat = new StdDev(&mIncomingTimer, (int)(floor(48000.0 / (double)mFPP)), 2);
     //    pushStat       = new StdDev(&mIncomingTimer, (int)(floor(48000.0 /
     //    (double)mFPP)), 1); pullStat       = new StdDev(&mIncomingTimer,
     //    (int)(floor(48000.0 / (double)mFPP)), 2);
@@ -230,6 +230,7 @@ Regulator::~Regulator()
 void Regulator::setFPPratio(int len)
 {
     int peerFPP = len / (mNumChannels * mBitResolutionMode);
+    pushStat->setWindow((int)(floor(48000.0 / (double)peerFPP)));
     if (peerFPP != mFPP) {
         if (peerFPP > mFPP)
             mFPPratioDenominator = peerFPP / mFPP;

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -622,8 +622,9 @@ void StdDev::reset()
 
 double StdDev::calcAuto()
 {
+    //    qDebug() << longTermStdDev << longTermMax << AutoMax;
     if ((longTermStdDev == 0.0) || (longTermMax == 0.0))
-        return AutoHeadroom;
+        return AutoMax;
     return AutoHeadroom + longTermStdDev
            + ((longTermMax > AutoMax) ? AutoMax : longTermMax);
 };

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -201,8 +201,8 @@ void Regulator::changeGlobal_3(int x)
 
 void Regulator::printParams()
 {
-    qDebug() << "mMsecTolerance" << mMsecTolerance << "mNumSlots" << mNumSlots
-             << "mModSeqNum" << mModSeqNum << "mLostWindow" << mLostWindow;
+//    qDebug() << "mMsecTolerance" << mMsecTolerance << "mNumSlots" << mNumSlots
+//             << "mModSeqNum" << mModSeqNum << "mLostWindow" << mLostWindow;
 #ifdef GUIBS3
     updateGUI((int)mMsecTolerance, mNumSlots);
 #endif

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -622,7 +622,7 @@ void StdDev::reset()
 
 double StdDev::calcAuto()
 {
-    //    qDebug() << longTermStdDev << longTermMax << AutoMax;
+    qDebug() << longTermStdDev << longTermMax << AutoMax;
     if ((longTermStdDev == 0.0) || (longTermMax == 0.0))
         return AutoMax;
     return AutoHeadroom + longTermStdDev

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -35,11 +35,9 @@
  * \date May-Sep 2021
  */
 
-// EXPERIMENTAL for testing in JackTrip v1.5.0
-// requires server and client have same FPP
-// runs ok from FPP 16 up to 1024
-// number of in / out channels should be the same
-// mono, stereo and -n3 tested fine
+// EXPERIMENTAL for testing in JackTrip v1.5.<n>
+// server and client can have different FPP (tested from FPP 32 to 512)
+// server and client can have different in / out channel count
 
 // ./jacktrip -S --udprt -p1 --bufstrategy 3  -I 1 -q10
 // PIPEWIRE_LATENCY=32/48000 ./jacktrip -C <SERV> --udprt --bufstrategy 3 -I 1 -q4
@@ -285,10 +283,8 @@ void Regulator::shimFPP(const int8_t* buf, int len, int seq_num)
                 }
             }
         }
-        // first packet has arrived use theoretical length while measuring for 2 secs
-
-        double adjustAuto = pushStat->calcAuto();
         pushStat->tick();
+        double adjustAuto = pushStat->calcAuto();
         if (mAuto && (pushStat->lastTime > AutoInitDur))
             mMsecTolerance = adjustAuto;
     }

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -252,7 +252,7 @@ void Regulator::shimFPP(const int8_t* buf, int len, int seq_num)
                 mMsecTolerance =
                     (mMsecTolerance == -500.0) ? peerPacketDurMsec : -mMsecTolerance;
             };
-            setFPPratio(len);
+            setFPPratio();
             // number of stats tick calls per sec depends on FPP
             pushStat =
                 new StdDev(&mIncomingTimer, (int)(floor(48000.0 / (double)mPeerFPP)), 1);

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -260,7 +260,8 @@ void Regulator::shimFPP(const int8_t* buf, int len, int seq_num)
                 if ((seq_num % mFPPratioNumerator) == mModCycle) {
                     if (mAssemblyCnt == mModCycle)
                         pushPacket(mAssembledPacket, seq_num / mFPPratioNumerator);
-                    //                else qDebug() << "incomplete due to lost packet";
+                    else
+                        qDebug() << "incomplete due to lost packet";
                     mAssemblyCnt = 0;
                 } else
                     mAssemblyCnt++;

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -89,12 +89,12 @@ Regulator::Regulator(int sample_rate, int channels, int bit_res, int FPP, int qL
     , mSampleRate(sample_rate)
     , mMsecTolerance((double)qLen)
     , mAuto(false)
-    , mAutoHeadroom((double)qLen)
 {
-    if (qLen < 0) {  // handle, for example, CLI -q auto15 or -q auto
+    if (qLen < 0) {  // handle -q auto
         mAuto = true;
-        mMsecTolerance *= -1.0;
-        mAutoHeadroom *= -1.0;
+        // no adjstments necessary, so make it not possible
+        mMsecTolerance = 1.0;
+        mAutoHeadroom  = 1.0;
     };
     switch (mAudioBitRes) {  // int from JitterBuffer to AudioInterface enum
     case 1:
@@ -181,7 +181,7 @@ Regulator::Regulator(int sample_rate, int channels, int bit_res, int FPP, int qL
 }
 
 void Regulator::changeGlobal(double x)
-{  // mMsecTolerance
+{
     mMsecTolerance = x;
     printParams();
 }

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -184,13 +184,6 @@ Regulator::Regulator(int channels, int bit_res, int FPP, int qLen)
     mModCycle            = 1;
     mModSeqNumPeer       = 1;
     mPeerFPP             = mFPP;  // use local until first packet arrives
-#ifdef GUIBS3
-    // hg for GUI
-    hg = new HerlperGUI(qApp->activeWindow());
-    connect(hg, SIGNAL(moved(double)), this, SLOT(changeGlobal(double)));
-    connect(hg, SIGNAL(moved_2(int)), this, SLOT(changeGlobal_2(int)));
-    connect(hg, SIGNAL(moved_3(int)), this, SLOT(changeGlobal_3(int)));
-#endif
     changeGlobal_3(LostWindowMax);
     changeGlobal_2(NumSlotsMax);  // need hg if running GUI
 }
@@ -218,21 +211,10 @@ void Regulator::changeGlobal_3(int x)
     printParams();
 }
 
-void Regulator::printParams()
-{
-//    qDebug() << "mMsecTolerance" << mMsecTolerance << "mNumSlots" << mNumSlots
-//             << "mModSeqNum" << mModSeqNum << "mLostWindow" << mLostWindow;
-#ifdef GUIBS3
-    updateGUI((int)mMsecTolerance, mNumSlots);
-#endif
+void Regulator::printParams(){
+    //    qDebug() << "mMsecTolerance" << mMsecTolerance << "mNumSlots" << mNumSlots
+    //             << "mModSeqNum" << mModSeqNum << "mLostWindow" << mLostWindow;
 };
-
-#ifdef GUIBS3
-void Regulator::updateGUI(double msTol, int nSlots)
-{
-    hg->updateDisplay(msTol, nSlots, 0);  // need to remove last param
-}
-#endif
 
 Regulator::~Regulator()
 {

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -80,7 +80,7 @@ constexpr int NumSlotsMax     = 128;  // mNumSlots looped for recent arrivals
 constexpr int LostWindowMax   = 32;   // mLostWindow looped for recent arrivals
 constexpr double AutoHeadroom = 1.0;  // msec padding for auto adjusting mMsecTolerance
 constexpr double AutoMax = 250.0;  // msec bounds on insane IPI, like ethernet unplugged
-constexpr double AutoInitDur = 6000.0;  // msec init phase
+constexpr double AutoInitDur = 8000.0;  // msec init phase
 constexpr double AutoInitVal =
     100.0;  // msec for initial mMsecTolerance during init phase if unspecified
 //*******************************************************************************

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -288,7 +288,7 @@ void Regulator::pushPacket(const int8_t* buf, int seq_num)
     double nowMS = pushStat->tick();
     if (mAuto && (nowMS > 2000.0)) {
         double tmp = pushStat->longTermStdDev + pushStat->longTermMax;
-        tmp += 2.0;  // 2 ms -- kind of a guess
+        tmp += 4.0;  // 2 ms -- kind of a guess
         changeGlobal(tmp);
     }
 };

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -285,8 +285,10 @@ void Regulator::shimFPP(const int8_t* buf, int len, int seq_num)
             }
         }
         // first packet has arrived use theoretical length while measuring for 2 secs
-        double adjustAuto = pushStat->tick(mPeerPacketDurMsec);
-        mMsecTolerance    = (mAuto) ? adjustAuto : mMsecTolerance;
+
+        double adjustAuto = pushStat->calcAuto();
+        pushStat->tick(mPeerPacketDurMsec);
+        if (pushStat->lastTime > 12000.0) mMsecTolerance = (mAuto) ? adjustAuto : mMsecTolerance;
     }
 };
 
@@ -622,6 +624,7 @@ void StdDev::reset()
 
 double StdDev::calcAuto()
 {
+//    qDebug() << "yes";
     return longTermStdDev + longTermMax + AutoHeadroom;
 };
 
@@ -669,8 +672,6 @@ double StdDev::tick(double defaultToPeerDur)
         lastMax    = max;
         lastStdDev = stdDev;
         reset();
-        if (lastTime > 2000.0)
-            returnVal = calcAuto();
     }
     return returnVal;
 }

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -110,12 +110,11 @@ constexpr double AutoInitDur = 6000.0;  // msec init phase
 constexpr double AutoInitValFactor =
     0.5;  // scale for initial mMsecTolerance during init phase if unspecified
 //*******************************************************************************
-Regulator::Regulator(int sample_rate, int channels, int bit_res, int FPP, int qLen)
+Regulator::Regulator(int channels, int bit_res, int FPP, int qLen)
     : RingBuffer(0, 0)
     , mNumChannels(channels)
     , mAudioBitRes(bit_res)
     , mFPP(FPP)
-    , mSampleRate(sample_rate)
     , mMsecTolerance((double)qLen)  // handle non-auto mode, expects positive qLen
     , mAuto(false)
 {
@@ -640,8 +639,7 @@ StdDev::StdDev(int id, QElapsedTimer* timer, int w) : mId(id), mTimer(timer), wi
 
 void StdDev::reset()
 {
-    mean = 0.0;
-    //        varRunning = 0.0;
+    mean         = 0.0;
     acc          = 0.0;
     min          = 999999.0;
     max          = 0.0;

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -250,7 +250,8 @@ void Regulator::shimFPP(const int8_t* buf, int len, int seq_num)
     if (seq_num != -1) {
         if (!mFPPratioIsSet)
             setFPPratio(len);
-        if (mFPPratioNumerator == mFPPratioDenominator) {
+        if (true) {
+            //            if (mFPPratioNumerator == mFPPratioDenominator) {
             pushPacket(buf, seq_num);
         } else {
             seq_num %= mModSeqNumPeer;

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -286,7 +286,7 @@ void Regulator::shimFPP(const int8_t* buf, int len, int seq_num)
             }
         }
         double adjustAuto = pushStat->tick();
-        mMsecTolerance    = (adjustAuto > 0.0) ? adjustAuto : mMsecTolerance;
+        mMsecTolerance    = (mAuto) ? adjustAuto : mMsecTolerance;
     }
 };
 

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -148,8 +148,11 @@ Regulator::Regulator(int sample_rate, int channels, int bit_res, int FPP, int qL
     memcpy(mZeros, mXfrBuffer, mBytes);
     mAssembledPacket = new int8_t[mBytes];  // for asym
     memcpy(mAssembledPacket, mXfrBuffer, mBytes);
-    pushStat       = new StdDev(&mIncomingTimer, (int)(floor(48000.0 / (double)mFPP)), 1);
-    pullStat       = new StdDev(&mIncomingTimer, (int)(floor(48000.0 / (double)mFPP)), 2);
+    pushStat = new StdDev(&mIncomingTimer, (int)(floor(4 * 48000.0 / (double)mFPP)), 1);
+    pullStat = new StdDev(&mIncomingTimer, (int)(floor(4 * 48000.0 / (double)mFPP)), 2);
+    //    pushStat       = new StdDev(&mIncomingTimer, (int)(floor(48000.0 /
+    //    (double)mFPP)), 1); pullStat       = new StdDev(&mIncomingTimer,
+    //    (int)(floor(48000.0 / (double)mFPP)), 2);
     mLastLostCount = 0;  // for stats
     mIncomingTimer.start();
     mLastSeqNumIn  = -1;

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -622,7 +622,7 @@ void StdDev::reset()
 
 double StdDev::calcAuto()
 {
-    qDebug() << longTermStdDev << longTermMax << AutoMax;
+    qDebug() << longTermStdDev << longTermMax << AutoMax << window << longTermCnt;
     if ((longTermStdDev == 0.0) || (longTermMax == 0.0))
         return AutoMax;
     return AutoHeadroom + longTermStdDev

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -288,7 +288,8 @@ void Regulator::shimFPP(const int8_t* buf, int len, int seq_num)
 
         double adjustAuto = pushStat->calcAuto();
         pushStat->tick(mPeerPacketDurMsec);
-        if (pushStat->lastTime > 12000.0) mMsecTolerance = (mAuto) ? adjustAuto : mMsecTolerance;
+        if (pushStat->lastTime > 12000.0)
+            mMsecTolerance = (mAuto) ? adjustAuto : mMsecTolerance;
     }
 };
 
@@ -624,7 +625,7 @@ void StdDev::reset()
 
 double StdDev::calcAuto()
 {
-//    qDebug() << "yes";
+    //    qDebug() << "yes";
     return longTermStdDev + longTermMax + AutoHeadroom;
 };
 

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -89,10 +89,12 @@ Regulator::Regulator(int sample_rate, int channels, int bit_res, int FPP, int qL
     , mSampleRate(sample_rate)
     , mMsecTolerance((double)qLen)
     , mAuto(false)
+    , mAutoHeadroom((double)qLen)
 {
-    if (mMsecTolerance < 0.0) {  // handle, for example, CLI -q auto15 or -q auto
+    if (qLen < 0) {  // handle, for example, CLI -q auto15 or -q auto
         mAuto = true;
         mMsecTolerance *= -1.0;
+        mAutoHeadroom *= -1.0;
     };
     switch (mAudioBitRes) {  // int from JitterBuffer to AudioInterface enum
     case 1:
@@ -173,7 +175,6 @@ Regulator::Regulator(int sample_rate, int channels, int bit_res, int FPP, int qL
 #endif
     changeGlobal_3(LostWindowMax);
     changeGlobal_2(NumSlotsMax);  // need hg if running GUI
-    changeGlobal(0.0);
 }
 
 void Regulator::changeGlobal(double x)
@@ -247,7 +248,7 @@ void Regulator::setFPPratio(int len)
 //*******************************************************************************
 double Regulator::calcAuto()
 {
-    return pushStat->longTermStdDev + pushStat->longTermMax;
+    return pushStat->longTermStdDev + pushStat->longTermMax + mAutoHeadroom;
 };
 
 //*******************************************************************************

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -248,8 +248,8 @@ void Regulator::setFPPratio(int len)
 void Regulator::shimFPP(const int8_t* buf, int len, int seq_num)
 {
     if (seq_num != -1) {
-        if (!mFPPratioIsSet)
-            setFPPratio(len);
+        //        if (!mFPPratioIsSet)
+        //            setFPPratio(len);
         if (true) {
             //            if (mFPPratioNumerator == mFPPratioDenominator) {
             pushPacket(buf, seq_num);

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -293,7 +293,7 @@ void Regulator::pushPacket(const int8_t* buf, int seq_num)
     double nowMS = pushStat->tick();
     if (mAuto && (nowMS > 2000.0)) {
         double tmp = pushStat->longTermStdDev + pushStat->longTermMax;
-        tmp += 4.0;  // 2 ms -- kind of a guess
+        tmp += 2.0;  // 2 ms -- kind of a guess
         changeGlobal(tmp);
     }
 };
@@ -679,7 +679,7 @@ bool Regulator::getStats(RingBuffer::IOStat* stat, bool reset)
     stat->overflows         = FLOATFACTOR * pushStat->longTermStdDev;
     stat->skew              = FLOATFACTOR * pushStat->lastMean;
     stat->skew_raw          = FLOATFACTOR * pushStat->lastMin;
-    stat->level             = FLOATFACTOR * pushStat->lastMax;
+    stat->level             = FLOATFACTOR * pushStat->longTermMax;  // was lastMax
     stat->buf_dec_overflows = FLOATFACTOR * pushStat->lastStdDev;
 
     stat->buf_dec_pktloss    = FLOATFACTOR * pullStat->longTermStdDev;

--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -200,6 +200,7 @@ class Regulator : public RingBuffer
     int mFPPratioNumerator;
     int mFPPratioDenominator;
     int mPartialPacketCnt;
+    int mAssembly;
     bool mAuto;
 #ifdef GUIBS3
     HerlperGUI* hg;

--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -163,13 +163,14 @@ class Regulator : public RingBuffer
     virtual bool getStats(IOStat* stat, bool reset);
 
    private:
-    int setFPPratio(int len);
+    void setFPPratio(int len);
     bool mFPPratioIsSet;
     void processPacket(bool glitch);
     void processChannel(int ch, bool glitch, int packetCnt, bool lastWasGlitch);
     int mNumChannels;
     int mAudioBitRes;
     int mFPP;
+    int mPeerFPP;
     int mSampleRate;
     uint32_t mLastLostCount;
     int mNumSlots;

--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -97,6 +97,7 @@ class StdDev
    public:
     StdDev(QElapsedTimer* timer, int w, int id);
     double tick(double autoHeadroom);
+    void setWindow(int w) { window = w; };
     int plcUnderruns;
     double lastMean;
     double lastMin;

--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -115,8 +115,6 @@ class StdDev
     QElapsedTimer* mTimer;
     std::vector<double> data;
     double mean;
-    double var;
-    //    double varRunning;
     int window;
     double acc;
     double min;
@@ -136,7 +134,7 @@ class Regulator : public RingBuffer
 {
 #endif
    public:
-    Regulator(int sample_rate, int channels, int bit_res, int FPP, int qLen);
+    Regulator(int channels, int bit_res, int FPP, int qLen);
     virtual ~Regulator();
 
     void shimFPP(const int8_t* buf, int len, int seq_num);
@@ -169,7 +167,6 @@ class Regulator : public RingBuffer
     int mAudioBitRes;
     int mFPP;
     int mPeerFPP;
-    int mSampleRate;
     uint32_t mLastLostCount;
     int mNumSlots;
     int mHist;

--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -200,8 +200,9 @@ class Regulator : public RingBuffer
     int mFPPratioNumerator;
     int mFPPratioDenominator;
     int mPartialPacketCnt;
-    int mAssembly;
-    bool mAuto;
+    int mAssemblyCnt;
+int mModCycle;
+bool mAuto;
 #ifdef GUIBS3
     HerlperGUI* hg;
     void updateGUI(double msTol, int nSlots, int lostWin);

--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -96,7 +96,7 @@ class StdDev
 {
    public:
     StdDev(int id, QElapsedTimer* timer, int w);
-    double tick(double defaultToPeerDur);
+    void tick();
     double calcAuto();
     double lastTime;
     int mId;

--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -95,9 +95,8 @@ class ChanData
 class StdDev
 {
    public:
-    StdDev(QElapsedTimer* timer, int w, int id);
+    StdDev(int id, QElapsedTimer* timer, int w);
     double tick();
-    void setWindow(int w) { window = w; };
     int mId;
     int plcUnderruns;
     double lastMean;

--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -96,8 +96,9 @@ class StdDev
 {
    public:
     StdDev(QElapsedTimer* timer, int w, int id);
-    double tick(double autoHeadroom);
+    double tick();
     void setWindow(int w) { window = w; };
+    int mId;
     int plcUnderruns;
     double lastMean;
     double lastMin;
@@ -117,14 +118,13 @@ class StdDev
     double var;
     //    double varRunning;
     int window;
-    int mId;
     double acc;
     double min;
     double max;
     int ctr;
     double lastTime;
     int longTermCnt;
-    double calcAuto(double autoHeadroom);
+    double calcAuto();
 };
 
 #ifdef GUIBS3
@@ -163,7 +163,7 @@ class Regulator : public RingBuffer
     virtual bool getStats(IOStat* stat, bool reset);
 
    private:
-    void setFPPratio(int len);
+    int setFPPratio(int len);
     bool mFPPratioIsSet;
     void processPacket(bool glitch);
     void processChannel(int ch, bool glitch, int packetCnt, bool lastWasGlitch);
@@ -207,7 +207,6 @@ class Regulator : public RingBuffer
     int mModCycle;
     bool mAuto;
     int mModSeqNumPeer;
-    double mAutoHeadroom;
 #ifdef GUIBS3
     HerlperGUI* hg;
     void updateGUI(double msTol, int nSlots, int lostWin);

--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -163,7 +163,7 @@ class Regulator : public RingBuffer
     virtual bool getStats(IOStat* stat, bool reset);
 
    private:
-    void setFPPratio(int len);
+    void setFPPratio();
     bool mFPPratioIsSet;
     void processPacket(bool glitch);
     void processChannel(int ch, bool glitch, int packetCnt, bool lastWasGlitch);

--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -200,8 +200,9 @@ class Regulator : public RingBuffer
     int mFPPratioNumerator;
     int mFPPratioDenominator;
     int mAssemblyCnt;
-int mModCycle;
-bool mAuto;
+    int mModCycle;
+    bool mAuto;
+    int mModSeqNumPeer;
 #ifdef GUIBS3
     HerlperGUI* hg;
     void updateGUI(double msTol, int nSlots, int lostWin);

--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -203,6 +203,7 @@ class Regulator : public RingBuffer
     int mModCycle;
     bool mAuto;
     int mModSeqNumPeer;
+    double calcAuto();
 #ifdef GUIBS3
     HerlperGUI* hg;
     void updateGUI(double msTol, int nSlots, int lostWin);

--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -204,6 +204,7 @@ class Regulator : public RingBuffer
     bool mAuto;
     int mModSeqNumPeer;
     double calcAuto();
+    double mAutoHeadroom;
 #ifdef GUIBS3
     HerlperGUI* hg;
     void updateGUI(double msTol, int nSlots, int lostWin);

--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -96,8 +96,20 @@ class StdDev
 {
    public:
     StdDev(QElapsedTimer* timer, int w, int id);
+    double tick(double autoHeadroom);
+    int plcUnderruns;
+    double lastMean;
+    double lastMin;
+    double lastMax;
+    int lastPlcUnderruns;
+    double lastStdDev;
+    double longTermStdDev;
+    double longTermStdDevAcc;
+    double longTermMax;
+    double longTermMaxAcc;
+
+   private:
     void reset();
-    double tick();
     QElapsedTimer* mTimer;
     std::vector<double> data;
     double mean;
@@ -109,18 +121,9 @@ class StdDev
     double min;
     double max;
     int ctr;
-    double lastMean;
-    double lastMin;
-    double lastMax;
-    int plcUnderruns;
-    int lastPlcUnderruns;
-    double lastStdDev;
-    double longTermStdDev;
-    double longTermStdDevAcc;
-    double longTermMax;
-    double longTermMaxAcc;
     double lastTime;
     int longTermCnt;
+    double calcAuto(double autoHeadroom);
 };
 
 #ifdef GUIBS3
@@ -203,7 +206,6 @@ class Regulator : public RingBuffer
     int mModCycle;
     bool mAuto;
     int mModSeqNumPeer;
-    double calcAuto();
     double mAutoHeadroom;
 #ifdef GUIBS3
     HerlperGUI* hg;

--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -97,6 +97,8 @@ class StdDev
    public:
     StdDev(int id, QElapsedTimer* timer, int w);
     double tick(double defaultToPeerDur);
+    double calcAuto();
+    double lastTime;
     int mId;
     int plcUnderruns;
     double lastMean;
@@ -121,9 +123,7 @@ class StdDev
     double min;
     double max;
     int ctr;
-    double lastTime;
     int longTermCnt;
-    double calcAuto();
 };
 
 #ifdef GUIBS3

--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -35,8 +35,7 @@
  * \date May 2021
  */
 
-// EXPERIMENTAL for testing in JackTrip v1.4.0
-// Initial references and starter code
+// Initial references and starter code to bring up Burg's recursion
 // http://www.emptyloop.com/technotes/A%20tutorial%20on%20Burg's%20method,%20algorithm%20and%20recursion.pdf
 // https://metacpan.org/source/SYP/Algorithm-Burg-0.001/README
 

--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -199,7 +199,6 @@ class Regulator : public RingBuffer
     int mSkip;
     int mFPPratioNumerator;
     int mFPPratioDenominator;
-    int mPartialPacketCnt;
     int mAssemblyCnt;
 int mModCycle;
 bool mAuto;

--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -50,14 +50,6 @@
 #include "AudioInterface.h"
 #include "RingBuffer.h"
 
-//#define GUIBS3
-#ifdef GUIBS3
-#include <QWidget>
-
-#include "herlpergui.h"
-#include "ui_herlpergui.h"
-#endif
-
 class BurgAlgorithm
 {
    public:
@@ -123,16 +115,8 @@ class StdDev
     int longTermCnt;
 };
 
-#ifdef GUIBS3
-class Regulator
-    : public QObject
-    , public RingBuffer
-{
-    Q_OBJECT;
-#else
 class Regulator : public RingBuffer
 {
-#endif
    public:
     Regulator(int channels, int bit_res, int FPP, int qLen);
     virtual ~Regulator();
@@ -202,11 +186,6 @@ class Regulator : public RingBuffer
     int mModCycle;
     bool mAuto;
     int mModSeqNumPeer;
-#ifdef GUIBS3
-    HerlperGUI* hg;
-    void updateGUI(double msTol, int nSlots, int lostWin);
-   public slots:
-#endif
     void changeGlobal(double);
     void changeGlobal_2(int);
     void changeGlobal_3(int);

--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -96,7 +96,7 @@ class StdDev
 {
    public:
     StdDev(int id, QElapsedTimer* timer, int w);
-    double tick();
+    double tick(double defaultToPeerDur);
     int mId;
     int plcUnderruns;
     double lastMean;
@@ -170,6 +170,7 @@ class Regulator : public RingBuffer
     int mAudioBitRes;
     int mFPP;
     int mPeerFPP;
+    double mPeerPacketDurMsec;
     int mSampleRate;
     uint32_t mLastLostCount;
     int mNumSlots;
@@ -195,7 +196,6 @@ class Regulator : public RingBuffer
     QElapsedTimer mIncomingTimer;
     int mLastSeqNumIn;
     int mLastSeqNumOut;
-    double mPacketDurMsec;
     std::vector<double> mPhasor;
     std::vector<double> mIncomingTiming;
     int mModSeqNum;

--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -170,7 +170,6 @@ class Regulator : public RingBuffer
     int mAudioBitRes;
     int mFPP;
     int mPeerFPP;
-    double mPeerPacketDurMsec;
     int mSampleRate;
     uint32_t mLastLostCount;
     int mNumSlots;


### PR DESCRIPTION
for eventual 1.5.4 release
server and client can have different FPP (tested from FPP 16 to 1024)
stress tested by repeatedly starting & stopping across full range of FPP's
server and client can have different in / out channel count
auto mode -- use -q auto
or for manual setting of initial mMsecTolerance -- use -q auto<msec>
gathers data for 6 sec and then goes full auto
