### PR TITLE
Move #include <iostream> from .cpp to .h files to hopefully keep clan…

### DIFF
--- a/faust-src/zitarevdsp.dsp
+++ b/faust-src/zitarevdsp.dsp
@@ -2,7 +2,7 @@ import("stdfaust.lib");
 
 // Modified version from Faust Libraries demos.lib
 
-process = zita_rev1; //same as dm.zita_rev1 but for wetness control and some defaults
+process = zita_rev1; // same as dm.zita_rev1 but for wetness control and some defaults
 
 //process = zita_rev1 : _,attach(cout); // Not using this solution yet, but it works
 //cout = ffunction (int cout(), <iostream>, ""); // dummy function to force #include <iostream> in output

--- a/faust-src/zitarevdsp.dsp
+++ b/faust-src/zitarevdsp.dsp
@@ -2,7 +2,10 @@ import("stdfaust.lib");
 
 // Modified version from Faust Libraries demos.lib
 
-process = zita_rev1; // same as dm.zita_rev1 but for wetness control and some defaults
+process = zita_rev1; //same as dm.zita_rev1 but for wetness control and some defaults
+
+//process = zita_rev1 : _,attach(cout); // Not using this solution yet, but it works
+//cout = ffunction (int cout(), <iostream>, ""); // dummy function to force #include <iostream> in output
 
 //----------------------------------`(dm.)zita_rev1`------------------------------
 // Example GUI for `zita_rev1_stereo` (mostly following the Linux `zita-rev1` GUI).

--- a/src/Compressor.cpp
+++ b/src/Compressor.cpp
@@ -37,8 +37,6 @@
 
 #include "Compressor.h"
 
-#include <iostream>
-
 //*******************************************************************************
 void Compressor::compute(int nframes, float** inputs, float** outputs)
 {

--- a/src/Compressor.h
+++ b/src/Compressor.h
@@ -42,6 +42,7 @@
 #define __COMPRESSOR_H__
 
 #include <vector>
+#include <iostream>
 
 #include "CompressorPresets.h"
 #include "ProcessPlugin.h"

--- a/src/Compressor.h
+++ b/src/Compressor.h
@@ -41,8 +41,8 @@
 #ifndef __COMPRESSOR_H__
 #define __COMPRESSOR_H__
 
-#include <vector>
 #include <iostream>
+#include <vector>
 
 #include "CompressorPresets.h"
 #include "ProcessPlugin.h"

--- a/src/Limiter.cpp
+++ b/src/Limiter.cpp
@@ -38,8 +38,6 @@
 
 #include "Limiter.h"
 
-#include <iostream>
-
 #include "jacktrip_types.h"
 
 //*******************************************************************************

--- a/src/Limiter.h
+++ b/src/Limiter.h
@@ -49,8 +49,8 @@
 #endif
 
 #include <cassert>
-#include <vector>
 #include <iostream>
+#include <vector>
 
 #include "ProcessPlugin.h"
 #include "limiterdsp.h"

--- a/src/Limiter.h
+++ b/src/Limiter.h
@@ -50,6 +50,7 @@
 
 #include <cassert>
 #include <vector>
+#include <iostream>
 
 #include "ProcessPlugin.h"
 #include "limiterdsp.h"

--- a/src/Reverb.cpp
+++ b/src/Reverb.cpp
@@ -37,8 +37,6 @@
 
 #include "Reverb.h"
 
-#include <iostream>
-
 #include "jacktrip_types.h"
 
 //*******************************************************************************

--- a/src/Reverb.h
+++ b/src/Reverb.h
@@ -41,6 +41,8 @@
 #ifndef __REVERB_H__
 #define __REVERB_H__
 
+#include <iostream>
+
 //#define SINE_TEST
 
 #include "ProcessPlugin.h"


### PR DESCRIPTION
The theory is that clang-tidy insists Foo.cpp have #include "Foo.h" appear before all other includes.  If that's the rub, then this change should both work and be left alone by clang-tidy.
