### PR TITLE
Clang format ignore dsp

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,3 +1,4 @@
 externals/*
 faust-src/faust2header.cpp
+src/*dsp.h
 

--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,1 +1,3 @@
 externals/*
+faust-src/faust2header.cpp
+

--- a/faust-src/faust2header.cpp
+++ b/faust-src/faust2header.cpp
@@ -14,9 +14,8 @@
 //----------------------------------------------------------------------------
 //  FAUST Generated Code
 //----------------------------------------------------------------------------
-// clang-format off
+
 <<includeIntrinsic>>
 
-    <<includeclass>>
+<<includeclass>>
 
-    // clang-format on


### PR DESCRIPTION
Let's ignore faust's formatting.