### PR TITLE
Fix OpenSSL in build script (fixes #515)

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -275,7 +275,9 @@ jobs:
         shell: bash
         run: |
           choco install jack --version=1.9.17 --no-progress
-          vcpkg install openssl --triplet="${{ matrix.vcpkg-triplet }}"
+          if [[ "${{ matrix.build-system }}" == "qmake" && -n "${{ matrix.static-qt-version }}" && -n "${{ matrix.vcpkg-triplet }}" ]]; then 
+            vcpkg install openssl --triplet="${{ matrix.vcpkg-triplet }}"
+          fi
           if [[ "${{ matrix.system-rtaudio }}" == true && -n "${{ matrix.vcpkg-triplet }}" ]]; then 
             choco install pkgconfiglite --no-progress
             # check out an older version of rtaudio library, see issue #408

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -343,7 +343,7 @@ jobs:
           echo "installing Qt"
           make install
       - name: install openssl for Windows static builds
-        if: matrix.static-qt-version && steps.cache-static-qt.outputs.cache-hit != 'true' && runner.os == 'Windows'
+        if: matrix.static-qt-version && runner.os == 'Windows'
         shell: bash
         run: |
           if [[ -n "${{ matrix.vcpkg-triplet }}" ]]; then 

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -144,6 +144,7 @@ jobs:
             bundled-rtaudio: true
             nogui: false
             weakjack: true
+            vcpkg-triplet: x64-mingw-static
             static-qt-version: 5.15.2
             qt-static-cache-key: 'v05'
             jacktrip-path: release/jacktrip.exe

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -145,7 +145,7 @@ jobs:
             nogui: false
             weakjack: true
             static-qt-version: 5.15.2
-            qt-static-cache-key: 'v04'
+            qt-static-cache-key: 'v05'
             jacktrip-path: release/jacktrip.exe
             binary-path: binary
             installer-path: installer
@@ -275,7 +275,7 @@ jobs:
         shell: bash
         run: |
           choco install jack --version=1.9.17 --no-progress
-          choco install openssl --no-progress
+          vcpkg install openssl --triplet="${{ matrix.vcpkg-triplet }}"
           if [[ "${{ matrix.system-rtaudio }}" == true && -n "${{ matrix.vcpkg-triplet }}" ]]; then 
             choco install pkgconfiglite --no-progress
             # check out an older version of rtaudio library, see issue #408
@@ -347,7 +347,7 @@ jobs:
         shell: cmd
         run: |
           mkdir %QT_STATIC_BUILD_PATH%
-          call "%QT_SRC_PATH%/configure.bat" -static-runtime -opengl desktop -platform win32-g++ -prefix "%QT_STATIC_BUILD_PATH%" -openssl OPENSSL_PREFIX="C:\Program Files\OpenSSL-Win64" %QT_STATIC_OPTIONS%
+          call "%QT_SRC_PATH%/configure.bat" -static-runtime -opengl desktop -platform win32-g++ -prefix "%QT_STATIC_BUILD_PATH%" -openssl -openssl-linked -I "%VCPKG_INSTALLATION_ROOT%\installed\%VCPKG_TRIPLET%\include" -L "%VCPKG_INSTALLATION_ROOT%\installed\%VCPKG_TRIPLET%\lib"  OPENSSL_LIBS="-llibssl -llibcrypto -lcrypt32 -lws2_32" %QT_STATIC_OPTIONS%
           echo "building Qt"
           mingw32-make -j4
           echo "installing Qt"

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -343,7 +343,7 @@ jobs:
           echo "installing Qt"
           make install
       - name: install openssl for Windows static builds
-        if: matrix.static-qt-version && runner.os == 'Windows'
+        if: matrix.static-qt-version && steps.cache-static-qt.outputs.cache-hit != 'true' && runner.os == 'Windows'
         shell: bash
         run: |
           if [[ -n "${{ matrix.vcpkg-triplet }}" ]]; then 

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -276,6 +276,9 @@ jobs:
         shell: bash
         run: |
           choco install jack --version=1.9.17 --no-progress
+          if [[ "${{ matrix.build-system }}" == "qmake" && -n "${{ matrix.static-qt-version }}" && -n "${{ matrix.vcpkg-triplet }}" ]]; then 
+            vcpkg install openssl --triplet="${{ matrix.vcpkg-triplet }}"
+          fi
           if [[ "${{ matrix.system-rtaudio }}" == true && -n "${{ matrix.vcpkg-triplet }}" ]]; then 
             choco install pkgconfiglite --no-progress
             # check out an older version of rtaudio library, see issue #408
@@ -342,13 +345,6 @@ jobs:
           # install
           echo "installing Qt"
           make install
-      - name: install openssl for Windows static builds
-        if: matrix.static-qt-version && steps.cache-static-qt.outputs.cache-hit != 'true' && runner.os == 'Windows'
-        shell: bash
-        run: |
-          if [[ -n "${{ matrix.vcpkg-triplet }}" ]]; then 
-            vcpkg install openssl --triplet="${{ matrix.vcpkg-triplet }}"
-          fi
       - name: build static Qt on Windows
         if: matrix.static-qt-version && steps.cache-static-qt.outputs.cache-hit != 'true' && runner.os == 'Windows'
         shell: cmd

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -276,9 +276,6 @@ jobs:
         shell: bash
         run: |
           choco install jack --version=1.9.17 --no-progress
-          if [[ "${{ matrix.build-system }}" == "qmake" && -n "${{ matrix.static-qt-version }}" && -n "${{ matrix.vcpkg-triplet }}" ]]; then 
-            vcpkg install openssl --triplet="${{ matrix.vcpkg-triplet }}"
-          fi
           if [[ "${{ matrix.system-rtaudio }}" == true && -n "${{ matrix.vcpkg-triplet }}" ]]; then 
             choco install pkgconfiglite --no-progress
             # check out an older version of rtaudio library, see issue #408
@@ -345,6 +342,13 @@ jobs:
           # install
           echo "installing Qt"
           make install
+      - name: install openssl for Windows static builds
+        if: matrix.static-qt-version && steps.cache-static-qt.outputs.cache-hit != 'true' && runner.os == 'Windows'
+        shell: bash
+        run: |
+          if [[ -n "${{ matrix.vcpkg-triplet }}" ]]; then 
+            vcpkg install openssl --triplet="${{ matrix.vcpkg-triplet }}"
+          fi
       - name: build static Qt on Windows
         if: matrix.static-qt-version && steps.cache-static-qt.outputs.cache-hit != 'true' && runner.os == 'Windows'
         shell: cmd

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -355,6 +355,8 @@ jobs:
           mingw32-make -j4
           echo "installing Qt"
           mingw32-make install
+        env:
+          VCPKG_TRIPLET: ${{ matrix.vcpkg-triplet }}
       - name: set Qt environment variables # needed to find qmake depending on the way qt was installed
         shell: bash
         if: matrix.build-system == 'qmake'


### PR DESCRIPTION
Pulling from vcpkg instead of chocolatey gives us access to the static openssl libraries