### PR TITLE
Move static Linux builds to 5.15

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -40,7 +40,7 @@ jobs:
             # vcpkg-triplet: x64-mingw-static # used when installing rtaudio with vcpkg (Windows)
             # qt-arch: 'win64_msvc2019_64' # specify when using shared (official) qt libraries (Windows)
             static-qt-version: 5.15.2 # if set, it will enable static Qt build
-            qt-static-cache-key: 'v26' # required for static qt; update this to force rebuilding static Qt
+            qt-static-cache-key: 'v27' # required for static qt; update this to force rebuilding static Qt
             jacktrip-path: jacktrip # needed for binary upload
             binary-path: binary # directory relative to build path; triggers artifact upload for jacktrip binary
             # bundle-path: bundle # directory relative to build path; triggers application bundle creation and upload (macOS)
@@ -67,7 +67,7 @@ jobs:
             nogui: true
             weakjack: false
             static-qt-version: 5.15.2
-            qt-static-cache-key: 'v26' # we use the same key as the main Linux build
+            qt-static-cache-key: 'v27' # we use the same key as the main Linux build
             jacktrip-path: jacktrip
             binary-path: binary
             build-system: qmake

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -382,7 +382,6 @@ jobs:
             CONFIG_STRING="static $CONFIG_STRING"
             export QML_IMPORT_PATH=$QT_STATIC_BUILD_PATH/qml
             export QML2_IMPORT_PATH=$QT_STATIC_BUILD_PATH/qml
-            # export QT_QPA_PLATFORM_PLUGIN_PATH=$QT_SRC_PATH/qtbase/src/plugins/platforms
           fi
           if [[ "${{ matrix.system-rtaudio }}" == true ]] || [[ "${{ matrix.bundled-rtaudio }}" == true ]]; then 
             CONFIG_STRING="rtaudio $CONFIG_STRING"

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -40,7 +40,7 @@ jobs:
             # vcpkg-triplet: x64-mingw-static # used when installing rtaudio with vcpkg (Windows)
             # qt-arch: 'win64_msvc2019_64' # specify when using shared (official) qt libraries (Windows)
             static-qt-version: 5.15.2 # if set, it will enable static Qt build
-            qt-static-cache-key: 'v24' # required for static qt; update this to force rebuilding static Qt
+            qt-static-cache-key: 'v25' # required for static qt; update this to force rebuilding static Qt
             jacktrip-path: jacktrip # needed for binary upload
             binary-path: binary # directory relative to build path; triggers artifact upload for jacktrip binary
             # bundle-path: bundle # directory relative to build path; triggers application bundle creation and upload (macOS)
@@ -67,7 +67,7 @@ jobs:
             nogui: true
             weakjack: false
             static-qt-version: 5.15.2
-            qt-static-cache-key: 'v24' # we use the same key as the main Linux build
+            qt-static-cache-key: 'v25' # we use the same key as the main Linux build
             jacktrip-path: jacktrip
             binary-path: binary
             build-system: qmake

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -40,7 +40,7 @@ jobs:
             # vcpkg-triplet: x64-mingw-static # used when installing rtaudio with vcpkg (Windows)
             # qt-arch: 'win64_msvc2019_64' # specify when using shared (official) qt libraries (Windows)
             static-qt-version: 5.15.2 # if set, it will enable static Qt build
-            qt-static-cache-key: 'v23' # required for static qt; update this to force rebuilding static Qt
+            qt-static-cache-key: 'v24' # required for static qt; update this to force rebuilding static Qt
             jacktrip-path: jacktrip # needed for binary upload
             binary-path: binary # directory relative to build path; triggers artifact upload for jacktrip binary
             # bundle-path: bundle # directory relative to build path; triggers application bundle creation and upload (macOS)
@@ -67,7 +67,7 @@ jobs:
             nogui: true
             weakjack: false
             static-qt-version: 5.15.2
-            qt-static-cache-key: 'v23' # we use the same key as the main Linux build
+            qt-static-cache-key: 'v24' # we use the same key as the main Linux build
             jacktrip-path: jacktrip
             binary-path: binary
             build-system: qmake

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -39,7 +39,7 @@ jobs:
             weakjack: false
             # vcpkg-triplet: x64-mingw-static # used when installing rtaudio with vcpkg (Windows)
             # qt-arch: 'win64_msvc2019_64' # specify when using shared (official) qt libraries (Windows)
-            static-qt-version: 5.12.11 # if set, it will enable static Qt build
+            static-qt-version: 5.15.2 # if set, it will enable static Qt build
             qt-static-cache-key: 'v23' # required for static qt; update this to force rebuilding static Qt
             jacktrip-path: jacktrip # needed for binary upload
             binary-path: binary # directory relative to build path; triggers artifact upload for jacktrip binary

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -233,7 +233,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install --yes libjack-dev
           if [[ -n "${{ matrix.static-qt-version }}" ]]; then 
-            sudo apt-get install --yes libfreetype6-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libx11-xcb-dev libdrm-dev libglu1-mesa-dev libwayland-dev libwayland-egl1-mesa libgles2-mesa-dev libwayland-server0 libwayland-egl-backend-dev libxcb1-dev libxext-dev libfontconfig1-dev libxrender-dev libxcb-keysyms1-dev libxcb-image0-dev libxcb-shm0-dev libxcb-icccm4-dev libxcb-render-util0-dev libxcb-xinerama0-dev libxcomposite-dev libgtk-3-dev
+            sudo apt-get install --yes libfreetype6-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libx11-xcb-dev libdrm-dev libglu1-mesa-dev libwayland-dev libwayland-egl1-mesa libgles2-mesa-dev libwayland-server0 libwayland-egl-backend-dev libxcb1-dev libxext-dev libfontconfig1-dev libxrender-dev libxcb-keysyms1-dev libxcb-image0-dev libxcb-shm0-dev libxcb-icccm4-dev libxcb-render-util0-dev libxcb-xinerama0-dev libxcomposite-dev libgtk-3-dev libxcb-util-dev libx11-dev libxfixes-dev libxcb-glx0-dev libxcb-sync0-dev libxcb-xfixes0-dev libxcb-shape0-dev libxcb-randr0-dev
           else
             sudo add-apt-repository universe
             sudo apt-get update

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -343,7 +343,7 @@ jobs:
           # configure
           if [[ "${{ runner.os }}" == "Linux" ]]; then
             QT_STATIC_OPTIONS="-qt-zlib -qt-libpng -qt-libjpeg -system-freetype -fontconfig -qt-pcre -qt-harfbuzz -no-icu -opengl desktop $QT_STATIC_OPTIONS"
-            if [[ "${{ matrix.nogui }}" == true ]]; then 
+            if [[ "${{ matrix.nogui }}" != true ]]; then 
               QT_STATIC_OPTIONS="-xcb -xcb-xlib -bundled-xcb-xinput -L/usr/lib/x86_64-linux-gnu $QT_STATIC_OPTIONS"
             fi
           fi

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -347,6 +347,10 @@ jobs:
           "$QT_SRC_PATH/configure" -prefix "$QT_STATIC_BUILD_PATH" $QT_STATIC_OPTIONS
           echo "QT Configure command"
           echo ""$QT_SRC_PATH/configure" -prefix "$QT_STATIC_BUILD_PATH" $QT_STATIC_OPTIONS"
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            ls /usr/lib/x86_64-linux-gnu
+            exit 2
+          fi
           # build
           echo "building Qt"
           make -j4

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -40,7 +40,7 @@ jobs:
             # vcpkg-triplet: x64-mingw-static # used when installing rtaudio with vcpkg (Windows)
             # qt-arch: 'win64_msvc2019_64' # specify when using shared (official) qt libraries (Windows)
             static-qt-version: 5.15.2 # if set, it will enable static Qt build
-            qt-static-cache-key: 'v25' # required for static qt; update this to force rebuilding static Qt
+            qt-static-cache-key: 'v26' # required for static qt; update this to force rebuilding static Qt
             jacktrip-path: jacktrip # needed for binary upload
             binary-path: binary # directory relative to build path; triggers artifact upload for jacktrip binary
             # bundle-path: bundle # directory relative to build path; triggers application bundle creation and upload (macOS)
@@ -67,7 +67,7 @@ jobs:
             nogui: true
             weakjack: false
             static-qt-version: 5.15.2
-            qt-static-cache-key: 'v25' # we use the same key as the main Linux build
+            qt-static-cache-key: 'v26' # we use the same key as the main Linux build
             jacktrip-path: jacktrip
             binary-path: binary
             build-system: qmake

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -385,6 +385,7 @@ jobs:
             CONFIG_STRING="static $CONFIG_STRING"
             export QML_IMPORT_PATH=$QT_STATIC_BUILD_PATH/qml
             export QML2_IMPORT_PATH=$QT_STATIC_BUILD_PATH/qml
+            export QT_QPA_PLATFORM_PLUGIN_PATH=$QT_SRC_PATH/qtbase/src/plugins/platforms
           fi
           if [[ "${{ matrix.system-rtaudio }}" == true ]] || [[ "${{ matrix.bundled-rtaudio }}" == true ]]; then 
             CONFIG_STRING="rtaudio $CONFIG_STRING"

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -342,7 +342,7 @@ jobs:
           mkdir $QT_STATIC_BUILD_PATH
           # configure
           if [[ "${{ runner.os }}" == "Linux" ]]; then
-            QT_STATIC_OPTIONS="-qt-zlib -qt-libpng -qt-libjpeg -system-freetype -fontconfig -qt-pcre -qt-harfbuzz -no-icu -opengl desktop $QT_STATIC_OPTIONS"
+            QT_STATIC_OPTIONS="-qt-zlib -qt-libpng -qt-libjpeg -system-freetype -fontconfig -qt-pcre -qt-harfbuzz -no-icu -opengl desktop -xcb -xcb-xlib -bundled-xcb-input $QT_STATIC_OPTIONS"
           fi
           "$QT_SRC_PATH/configure" -prefix "$QT_STATIC_BUILD_PATH" $QT_STATIC_OPTIONS
           echo "QT Configure command"

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -344,7 +344,7 @@ jobs:
           if [[ "${{ runner.os }}" == "Linux" ]]; then
             QT_STATIC_OPTIONS="-qt-zlib -qt-libpng -qt-libjpeg -system-freetype -fontconfig -qt-pcre -qt-harfbuzz -no-icu -opengl desktop $QT_STATIC_OPTIONS"
             if [[ "${{ matrix.nogui }}" == true ]]; then 
-              QT_STATIC_OPTIONS="-xcb -xcb-xlib -bundled-xcb-xinput -L/usr/lib/x86_64-linux-gnu $QT_STATIC_OPTIONS""
+              QT_STATIC_OPTIONS="-xcb -xcb-xlib -bundled-xcb-xinput -L/usr/lib/x86_64-linux-gnu $QT_STATIC_OPTIONS"
             fi
           fi
           "$QT_SRC_PATH/configure" -prefix "$QT_STATIC_BUILD_PATH" $QT_STATIC_OPTIONS

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -350,10 +350,6 @@ jobs:
           "$QT_SRC_PATH/configure" -prefix "$QT_STATIC_BUILD_PATH" $QT_STATIC_OPTIONS
           echo "QT Configure command"
           echo ""$QT_SRC_PATH/configure" -prefix "$QT_STATIC_BUILD_PATH" $QT_STATIC_OPTIONS"
-          if [[ "${{ runner.os }}" == "Linux" ]]; then
-            ls /usr/lib/x86_64-linux-gnu
-            exit 2
-          fi
           # build
           echo "building Qt"
           make -j4

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -233,7 +233,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install --yes libjack-dev
           if [[ -n "${{ matrix.static-qt-version }}" ]]; then 
-            sudo apt-get install --yes libfreetype6-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libx11-xcb-dev libdrm-dev libglu1-mesa-dev libwayland-dev libwayland-egl1-mesa libgles2-mesa-dev libwayland-server0 libwayland-egl-backend-dev libxcb1-dev libxext-dev libfontconfig1-dev libxrender-dev libxcb-keysyms1-dev libxcb-image0-dev libxcb-shm0-dev libxcb-icccm4-dev libxcb-render-util0-dev libxcb-xinerama0-dev libxcomposite-dev libgtk-3-dev libxcb-util-dev libx11-dev libxfixes-dev libxcb-glx0-dev libxcb-sync0-dev libxcb-xfixes0-dev libxcb-shape0-dev libxcb-randr0-dev
+            sudo apt-get install --yes libfreetype6-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libx11-xcb-dev libdrm-dev libglu1-mesa-dev libwayland-dev libwayland-egl1-mesa libgles2-mesa-dev libwayland-server0 libwayland-egl-backend-dev libxcb1-dev libxext-dev libfontconfig1-dev libxrender-dev libxcb-keysyms1-dev libxcb-image0-dev libxcb-shm0-dev libxcb-icccm4-dev libxcb-render-util0-dev libxcomposite-dev libgtk-3-dev libxcb-util-dev libx11-dev libxfixes-dev libxcb-glx0-dev libxcb-sync0-dev libxcb-xfixes0-dev libxcb-shape0-dev libxcb-randr0-dev
           else
             sudo add-apt-repository universe
             sudo apt-get update
@@ -344,7 +344,7 @@ jobs:
           if [[ "${{ runner.os }}" == "Linux" ]]; then
             QT_STATIC_OPTIONS="-qt-zlib -qt-libpng -qt-libjpeg -system-freetype -fontconfig -qt-pcre -qt-harfbuzz -no-icu -opengl desktop $QT_STATIC_OPTIONS"
             if [[ "${{ matrix.nogui }}" != true ]]; then 
-              QT_STATIC_OPTIONS="-xcb -xcb-xlib -bundled-xcb-xinput -L/usr/lib/x86_64-linux-gnu $QT_STATIC_OPTIONS"
+              QT_STATIC_OPTIONS="-no-xinerama $QT_STATIC_OPTIONS"
             fi
           fi
           "$QT_SRC_PATH/configure" -prefix "$QT_STATIC_BUILD_PATH" $QT_STATIC_OPTIONS
@@ -388,7 +388,7 @@ jobs:
             CONFIG_STRING="static $CONFIG_STRING"
             export QML_IMPORT_PATH=$QT_STATIC_BUILD_PATH/qml
             export QML2_IMPORT_PATH=$QT_STATIC_BUILD_PATH/qml
-            export QT_QPA_PLATFORM_PLUGIN_PATH=$QT_SRC_PATH/qtbase/src/plugins/platforms
+            # export QT_QPA_PLATFORM_PLUGIN_PATH=$QT_SRC_PATH/qtbase/src/plugins/platforms
           fi
           if [[ "${{ matrix.system-rtaudio }}" == true ]] || [[ "${{ matrix.bundled-rtaudio }}" == true ]]; then 
             CONFIG_STRING="rtaudio $CONFIG_STRING"

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -342,7 +342,7 @@ jobs:
           mkdir $QT_STATIC_BUILD_PATH
           # configure
           if [[ "${{ runner.os }}" == "Linux" ]]; then
-            QT_STATIC_OPTIONS="-qt-zlib -qt-libpng -qt-libjpeg -system-freetype -fontconfig -qt-pcre -qt-harfbuzz -no-icu -opengl desktop -xcb -xcb-xlib -bundled-xcb-input $QT_STATIC_OPTIONS"
+            QT_STATIC_OPTIONS="-qt-zlib -qt-libpng -qt-libjpeg -system-freetype -fontconfig -qt-pcre -qt-harfbuzz -no-icu -opengl desktop -xcb -xcb-xlib -bundled-xcb-xinput $QT_STATIC_OPTIONS"
           fi
           "$QT_SRC_PATH/configure" -prefix "$QT_STATIC_BUILD_PATH" $QT_STATIC_OPTIONS
           echo "QT Configure command"

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -341,12 +341,6 @@ jobs:
         run: |
           mkdir $QT_STATIC_BUILD_PATH
           # configure
-          if [[ "${{ runner.os }}" == "Linux" ]]; then
-            QT_STATIC_OPTIONS="-qt-zlib -qt-libpng -qt-libjpeg -system-freetype -fontconfig -qt-pcre -qt-harfbuzz -no-icu -opengl desktop $QT_STATIC_OPTIONS"
-            if [[ "${{ matrix.nogui }}" != true ]]; then 
-              QT_STATIC_OPTIONS="-no-xinerama $QT_STATIC_OPTIONS"
-            fi
-          fi
           "$QT_SRC_PATH/configure" -prefix "$QT_STATIC_BUILD_PATH" $QT_STATIC_OPTIONS
           echo "QT Configure command"
           echo ""$QT_SRC_PATH/configure" -prefix "$QT_STATIC_BUILD_PATH" $QT_STATIC_OPTIONS"

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -342,7 +342,7 @@ jobs:
           mkdir $QT_STATIC_BUILD_PATH
           # configure
           if [[ "${{ runner.os }}" == "Linux" ]]; then
-            QT_STATIC_OPTIONS="-qt-zlib -qt-libpng -qt-libjpeg -system-freetype -fontconfig -qt-pcre -qt-harfbuzz -no-icu -opengl desktop -xcb -xcb-xlib -bundled-xcb-xinput $QT_STATIC_OPTIONS"
+            QT_STATIC_OPTIONS="-qt-zlib -qt-libpng -qt-libjpeg -system-freetype -fontconfig -qt-pcre -qt-harfbuzz -no-icu -opengl desktop -xcb -xcb-xlib -bundled-xcb-xinput -L/usr/lib/x86_64-linux-gnu $QT_STATIC_OPTIONS"
           fi
           "$QT_SRC_PATH/configure" -prefix "$QT_STATIC_BUILD_PATH" $QT_STATIC_OPTIONS
           echo "QT Configure command"

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -342,7 +342,10 @@ jobs:
           mkdir $QT_STATIC_BUILD_PATH
           # configure
           if [[ "${{ runner.os }}" == "Linux" ]]; then
-            QT_STATIC_OPTIONS="-qt-zlib -qt-libpng -qt-libjpeg -system-freetype -fontconfig -qt-pcre -qt-harfbuzz -no-icu -opengl desktop -xcb -xcb-xlib -bundled-xcb-xinput -L/usr/lib/x86_64-linux-gnu $QT_STATIC_OPTIONS"
+            QT_STATIC_OPTIONS="-qt-zlib -qt-libpng -qt-libjpeg -system-freetype -fontconfig -qt-pcre -qt-harfbuzz -no-icu -opengl desktop $QT_STATIC_OPTIONS"
+            if [[ "${{ matrix.nogui }}" == true ]]; then 
+              QT_STATIC_OPTIONS="-xcb -xcb-xlib -bundled-xcb-xinput -L/usr/lib/x86_64-linux-gnu $QT_STATIC_OPTIONS""
+            fi
           fi
           "$QT_SRC_PATH/configure" -prefix "$QT_STATIC_BUILD_PATH" $QT_STATIC_OPTIONS
           echo "QT Configure command"

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -66,7 +66,7 @@ jobs:
             bundled-rtaudio: false
             nogui: true
             weakjack: false
-            static-qt-version: 5.12.11
+            static-qt-version: 5.15.2
             qt-static-cache-key: 'v23' # we use the same key as the main Linux build
             jacktrip-path: jacktrip
             binary-path: binary

--- a/jacktrip.pro
+++ b/jacktrip.pro
@@ -61,8 +61,10 @@ INCLUDEPATH += faust-src-lair/stk
 
 # link static plugins
 !nogui {
-  linux-g++ | linux-g++-64 {
-    QTPLUGIN.platforms += qxcb
+  static {
+    linux-g++ | linux-g++-64 {
+      QTPLUGIN.platforms += qxcb
+    }
   }
 }
 
@@ -143,6 +145,13 @@ linux-g++ | linux-g++-64 {
     # QMake version 3.1
     # Using Qt version 5.9.5 in /usr/lib/x86_64-linux-gnu
     INCLUDEPATH += /usr/include/x86_64-linux-gnu/c++/7
+
+    # Attempt to fix libxcb-xinerama not being statically linked
+    !nogui {
+      static {
+        LIBS += -L/usr/lib/x86_64-linux-gnu/libxcb-xinerama.a
+      }
+    }
     
     # sets differences from original fedora version
     DEFINES += __UBUNTU__
@@ -158,7 +167,6 @@ linux-g++ {
 linux-g++-64 {
   message(Linux 64bit)
 }
-
 
 win32 {
   message(Building on win32)

--- a/jacktrip.pro
+++ b/jacktrip.pro
@@ -16,9 +16,9 @@ CONFIG(debug, debug|release) {
     name_suffix = ''
 }
 
-static {
-  CONFIG += static
-}
+# static {
+#  CONFIG += static
+# }
 
 equals(QT_EDITION, "OpenSource") {
     DEFINES += QT_OPENSOURCE
@@ -60,13 +60,13 @@ nojack {
 INCLUDEPATH += faust-src-lair/stk
 
 # link static plugins
-!nogui {
-  static {
-    linux-g++ | linux-g++-64 {
-      QTPLUGIN.platforms += qxcb qwayland
-    }
-  }
-}
+# !nogui {
+#  static {
+#    linux-g++ | linux-g++-64 {
+#      QTPLUGIN.platforms += qxcb
+#    }
+#  }
+# }
 
 !win32 {
   INCLUDEPATH+=/usr/local/include
@@ -145,13 +145,6 @@ linux-g++ | linux-g++-64 {
     # QMake version 3.1
     # Using Qt version 5.9.5 in /usr/lib/x86_64-linux-gnu
     INCLUDEPATH += /usr/include/x86_64-linux-gnu/c++/7
-
-    # Attempt to fix libxcb-xinerama not being statically linked
-    !nogui {
-      static {
-        LIBS += -L/usr/lib/x86_64-linux-gnu/libxcb-xinerama.a
-      }
-    }
     
     # sets differences from original fedora version
     DEFINES += __UBUNTU__

--- a/jacktrip.pro
+++ b/jacktrip.pro
@@ -63,7 +63,7 @@ INCLUDEPATH += faust-src-lair/stk
 !nogui {
   static {
     linux-g++ | linux-g++-64 {
-      QTPLUGIN.platforms += qxcb
+      QTPLUGIN.platforms += qxcb qwayland
     }
   }
 }

--- a/jacktrip.pro
+++ b/jacktrip.pro
@@ -16,6 +16,10 @@ CONFIG(debug, debug|release) {
     name_suffix = ''
 }
 
+static {
+  CONFIG += static
+}
+
 equals(QT_EDITION, "OpenSource") {
     DEFINES += QT_OPENSOURCE
 }
@@ -54,6 +58,13 @@ nojack {
 
 # for plugins
 INCLUDEPATH += faust-src-lair/stk
+
+# link static plugins
+!nogui {
+  linux-g++ | linux-g++-64 {
+    QTPLUGIN.platforms += qxcb
+  }
+}
 
 !win32 {
   INCLUDEPATH+=/usr/local/include

--- a/jacktrip.pro
+++ b/jacktrip.pro
@@ -16,9 +16,9 @@ CONFIG(debug, debug|release) {
     name_suffix = ''
 }
 
-# static {
-#  CONFIG += static
-# }
+static {
+  CONFIG += static
+}
 
 equals(QT_EDITION, "OpenSource") {
     DEFINES += QT_OPENSOURCE
@@ -58,15 +58,6 @@ nojack {
 
 # for plugins
 INCLUDEPATH += faust-src-lair/stk
-
-# link static plugins
-# !nogui {
-#  static {
-#    linux-g++ | linux-g++-64 {
-#      QTPLUGIN.platforms += qxcb
-#    }
-#  }
-# }
 
 !win32 {
   INCLUDEPATH+=/usr/local/include


### PR DESCRIPTION
Added missing dependencies and updated flags for the 5.15 world. Creating the PR before testing so we can rely on Windows and Mac static qt caches for build times.

I can tell you from early testing that 5.15 worked with minimal installs necessary on 20.04. If these flags truly do bundle those libraries with the binary, then this should work for us.