### PR TITLE
Adapt QML for 5.12 on Linux

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -40,7 +40,7 @@ jobs:
             # vcpkg-triplet: x64-mingw-static # used when installing rtaudio with vcpkg (Windows)
             # qt-arch: 'win64_msvc2019_64' # specify when using shared (official) qt libraries (Windows)
             static-qt-version: 5.12.11 # if set, it will enable static Qt build
-            qt-static-cache-key: 'v23' # required for static qt; update this to force rebuilding static Qt
+            qt-static-cache-key: 'v24' # required for static qt; update this to force rebuilding static Qt
             jacktrip-path: jacktrip # needed for binary upload
             binary-path: binary # directory relative to build path; triggers artifact upload for jacktrip binary
             # bundle-path: bundle # directory relative to build path; triggers application bundle creation and upload (macOS)
@@ -67,7 +67,7 @@ jobs:
             nogui: true
             weakjack: false
             static-qt-version: 5.12.11
-            qt-static-cache-key: 'v23' # we use the same key as the main Linux build
+            qt-static-cache-key: 'v24' # we use the same key as the main Linux build
             jacktrip-path: jacktrip
             binary-path: binary
             build-system: qmake
@@ -233,7 +233,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install --yes libjack-dev
           if [[ -n "${{ matrix.static-qt-version }}" ]]; then 
-            sudo apt-get install --yes libfreetype6-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libx11-xcb-dev libdrm-dev libglu1-mesa-dev libwayland-dev libwayland-egl1-mesa libgles2-mesa-dev libwayland-server0 libwayland-egl-backend-dev libxcb1-dev libxext-dev libfontconfig1-dev libxrender-dev libxcb-keysyms1-dev libxcb-image0-dev libxcb-shm0-dev libxcb-icccm4-dev libxcb-render-util0-dev libxcb-xinerama0-dev libxcomposite-dev libgtk-3-dev
+            sudo apt-get install --yes libfreetype6-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libx11-xcb-dev libdrm-dev libglu1-mesa-dev libwayland-dev libwayland-egl1-mesa libgles2-mesa-dev libwayland-server0 libwayland-egl-backend-dev libxcb1-dev libxext-dev libfontconfig1-dev libxrender-dev libxcb-keysyms1-dev libxcb-image0-dev libxcb-shm0-dev libxcb-icccm4-dev libxcb-render-util0-dev libxcomposite-dev libgtk-3-dev
           else
             sudo add-apt-repository universe
             sudo apt-get update

--- a/src/gui/Browse.qml
+++ b/src/gui/Browse.qml
@@ -40,7 +40,7 @@ Item {
         Rectangle {
             color: "transparent"
             height: 72 * virtualstudio.uiScale; x: 16 * virtualstudio.uiScale; width: ListView.view.width - (2 * x)
-            required property string section
+            property string section: "Studios"
             Text {
                 //anchors.bottom: parent.bottom
                 y: 12 * virtualstudio.uiScale

--- a/src/gui/Browse.qml
+++ b/src/gui/Browse.qml
@@ -40,18 +40,20 @@ Item {
         Rectangle {
             color: "transparent"
             height: 72 * virtualstudio.uiScale; x: 16 * virtualstudio.uiScale; width: ListView.view.width - (2 * x)
-            property string section: "Studios"
+            // required property string section: section (for 5.15)
             Text {
                 //anchors.bottom: parent.bottom
                 y: 12 * virtualstudio.uiScale
-                text: parent.section
+                // text: parent.section (for 5.15)
+                text: section
                 font { family: "Poppins"; pixelSize: 28 * virtualstudio.fontScale * virtualstudio.uiScale; weight: Font.Bold }
             }
             Image {
                 source: "logo.svg"
                 width: 32 * virtualstudio.uiScale; height: 59 * virtualstudio.uiScale
                 anchors.right: parent.right
-                visible: parent.section == virtualstudio.logoSection ? true : false
+                // visible: parent.section == virtualstudio.logoSection ? true : false (for 5.15)
+                visible: section == virtualstudio.logoSection ? true : false
             }
         }
     }


### PR DESCRIPTION
This seems to be the one issue in the code that is keeping things from running on 5.12. I have tried to move our builds to 5.15 unsuccessfully and am going to wait until we move to qt6 to continue down that path. 

For now, here is a fix. 

Going to test this before upgrade to a full PR.