### PR TITLE
Port change to avoid collisions

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -40,7 +40,7 @@ jobs:
             # vcpkg-triplet: x64-mingw-static # used when installing rtaudio with vcpkg (Windows)
             # qt-arch: 'win64_msvc2019_64' # specify when using shared (official) qt libraries (Windows)
             static-qt-version: 5.12.11 # if set, it will enable static Qt build
-            qt-static-cache-key: 'v24' # required for static qt; update this to force rebuilding static Qt
+            qt-static-cache-key: 'v25' # required for static qt; update this to force rebuilding static Qt
             jacktrip-path: jacktrip # needed for binary upload
             binary-path: binary # directory relative to build path; triggers artifact upload for jacktrip binary
             # bundle-path: bundle # directory relative to build path; triggers application bundle creation and upload (macOS)

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -785,7 +785,7 @@ void VirtualStudio::setupAuthenticator()
         const QUrl authUri(QStringLiteral("https://auth.jacktrip.org/authorize"));
         const QString clientId = QStringLiteral("cROUJag0UVKDaJ6jRAKRzlVjKVFNU39I");
         const QUrl tokenUri(QStringLiteral("https://auth.jacktrip.org/oauth/token"));
-        const quint16 port = 42424;
+        const quint16 port = 52424;
 
         m_authenticator->setAuthorizationUrl(authUri);
         m_authenticator->setClientIdentifier(clientId);


### PR DESCRIPTION
Swapping the callback port from 42424 to 52424 to avoid a collision experienced in testing. This is in a range that is less likely to have collisions overall.