### PR TITLE
Fix/active studios

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -40,7 +40,7 @@ jobs:
             # vcpkg-triplet: x64-mingw-static # used when installing rtaudio with vcpkg (Windows)
             # qt-arch: 'win64_msvc2019_64' # specify when using shared (official) qt libraries (Windows)
             static-qt-version: 5.12.11 # if set, it will enable static Qt build
-            qt-static-cache-key: 'v24' # required for static qt; update this to force rebuilding static Qt
+            qt-static-cache-key: 'v25' # required for static qt; update this to force rebuilding static Qt
             jacktrip-path: jacktrip # needed for binary upload
             binary-path: binary # directory relative to build path; triggers artifact upload for jacktrip binary
             # bundle-path: bundle # directory relative to build path; triggers application bundle creation and upload (macOS)

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -866,6 +866,8 @@ void VirtualStudio::getServerList(bool firstLoad, int index)
                     serverInfo->setName(servers.at(i)[QStringLiteral("name")].toString());
                     serverInfo->setHost(
                         servers.at(i)[QStringLiteral("serverHost")].toString());
+                    serverInfo->setStatus(
+                        servers.at(i)[QStringLiteral("status")].toString());
                     serverInfo->setPort(
                         servers.at(i)[QStringLiteral("serverPort")].toInt());
                     serverInfo->setIsPublic(

--- a/src/gui/vsServerInfo.cpp
+++ b/src/gui/vsServerInfo.cpp
@@ -75,9 +75,14 @@ QString VsServerInfo::host()
     return m_host;
 }
 
+QString VsServerInfo::status()
+{
+    return m_status;
+}
+
 bool VsServerInfo::canConnect()
 {
-    return !m_host.isEmpty();
+    return !m_host.isEmpty() && m_status == "Ready";
 }
 
 bool VsServerInfo::canStart()
@@ -92,6 +97,12 @@ bool VsServerInfo::canStart()
 void VsServerInfo::setHost(const QString& host)
 {
     m_host = host;
+    emit canConnectChanged();
+}
+
+void VsServerInfo::setStatus(const QString& status)
+{
+    m_status = status;
     emit canConnectChanged();
 }
 

--- a/src/gui/vsServerInfo.h
+++ b/src/gui/vsServerInfo.h
@@ -57,6 +57,7 @@ class VsServerInfo : public QObject
     Q_PROPERTY(quint16 period READ period CONSTANT)
     Q_PROPERTY(quint32 sampleRate READ sampleRate CONSTANT)
     Q_PROPERTY(quint16 queueBuffer READ queueBuffer CONSTANT)
+    Q_PROPERTY(QString status READ status CONSTANT)
 
    public:
     enum serverSectionT { YOUR_STUDIOS, SUBSCRIBED_STUDIOS, PUBLIC_STUDIOS };
@@ -91,6 +92,8 @@ class VsServerInfo : public QObject
     void setQueueBuffer(quint16 queueBuffer);
     QString id();
     void setId(const QString& id);
+    QString status();
+    void setStatus(const QString& status);
 
    signals:
     void canConnectChanged();
@@ -107,6 +110,7 @@ class VsServerInfo : public QObject
     quint32 m_sampleRate;
     quint16 m_queueBuffer;
     QString m_id;
+    QString m_status;
 
     /* Remaining JSON fields
     "loopback": true,


### PR DESCRIPTION
Previously, studios you were admin of would show as active even if the Status wasn't ready because of the `isManageable` check.

This just adds an extra check to `canConnect` that checks the `status` field from the API and looks for "Ready".