### PR TITLE
More user friendly confirmation of Virtual Studio login success

### DIFF
--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -808,7 +808,14 @@ void VirtualStudio::setupAuthenticator()
             }
         });
 
-        m_authenticator->setReplyHandler(new QOAuthHttpServerReplyHandler(port, this));
+        QOAuthHttpServerReplyHandler *replyHandler = new QOAuthHttpServerReplyHandler(port, this);
+        replyHandler->setCallbackText(QStringLiteral(
+            "<div id=\"container\" style=\"width:100%; max-width:1200px; height: auto; margin: 100px auto; text-align:center;\">\n"
+                "<img src=\"https://files.jacktrip.org/logos/jacktrip_icon.svg\" alt=\"JackTrip\">\n"
+                "<h1 style=\"font-size: 30px; font-weight: 600; padding-top:20px;\">Virtual Studio Login Successful</h1>\n"
+                "<p style=\"font-size: 21px; font-weight:300;\">You may close this window and return to the JackTrip application.</p>\n"
+            "</div>\n"));
+        m_authenticator->setReplyHandler(replyHandler);
         connect(m_authenticator.data(), &QOAuth2AuthorizationCodeFlow::granted, this,
                 &VirtualStudio::slotAuthSucceded);
         connect(m_authenticator.data(), &QOAuth2AuthorizationCodeFlow::requestFailed,

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -808,12 +808,17 @@ void VirtualStudio::setupAuthenticator()
             }
         });
 
-        QOAuthHttpServerReplyHandler *replyHandler = new QOAuthHttpServerReplyHandler(port, this);
+        QOAuthHttpServerReplyHandler* replyHandler =
+            new QOAuthHttpServerReplyHandler(port, this);
         replyHandler->setCallbackText(QStringLiteral(
-            "<div id=\"container\" style=\"width:100%; max-width:1200px; height: auto; margin: 100px auto; text-align:center;\">\n"
-                "<img src=\"https://files.jacktrip.org/logos/jacktrip_icon.svg\" alt=\"JackTrip\">\n"
-                "<h1 style=\"font-size: 30px; font-weight: 600; padding-top:20px;\">Virtual Studio Login Successful</h1>\n"
-                "<p style=\"font-size: 21px; font-weight:300;\">You may close this window and return to the JackTrip application.</p>\n"
+            "<div id=\"container\" style=\"width:100%; max-width:1200px; height: auto; "
+            "margin: 100px auto; text-align:center;\">\n"
+            "<img src=\"https://files.jacktrip.org/logos/jacktrip_icon.svg\" "
+            "alt=\"JackTrip\">\n"
+            "<h1 style=\"font-size: 30px; font-weight: 600; padding-top:20px;\">Virtual "
+            "Studio Login Successful</h1>\n"
+            "<p style=\"font-size: 21px; font-weight:300;\">You may close this window "
+            "and return to the JackTrip application.</p>\n"
             "</div>\n"));
         m_authenticator->setReplyHandler(replyHandler);
         connect(m_authenticator.data(), &QOAuth2AuthorizationCodeFlow::granted, this,


### PR DESCRIPTION
After logging into Virtual Studio, the default message displayed in your browser window is cryptic and looks bad. It's just raw text:

`Callback received. Feel free to close this page.`

This overrides the default with a more user friendly confirmation.

![Screenshot from 2022-05-16 11-47-14](https://user-images.githubusercontent.com/1159596/168662041-493587ee-2e9f-4aa5-9386-ea8f02d4be80.png)