### PR TITLE
VS: Add device setup screen after login

### DIFF
--- a/src/gui/Setup.qml
+++ b/src/gui/Setup.qml
@@ -33,7 +33,7 @@ Item {
         model: backendComboModel
         currentIndex: virtualstudio.audioBackend == "JACK" ? 0 : 1
         onActivated: { virtualstudio.audioBackend = currentText }
-        x: 234 * virtualstudio.uiScale; y: 200 * virtualstudio.uiScale
+        x: 234 * virtualstudio.uiScale; y: 150 * virtualstudio.uiScale
         width: parent.width - x - (16 * virtualstudio.uiScale); height: 36 * virtualstudio.uiScale
         visible: virtualstudio.selectableBackend
     }
@@ -49,7 +49,7 @@ Item {
     
     Text {
         id: jackLabel
-        x: leftMargin * virtualstudio.uiScale; y: 200 * virtualstudio.uiScale
+        x: leftMargin * virtualstudio.uiScale; y: 150 * virtualstudio.uiScale
         width: parent.width - x - (16 * virtualstudio.uiScale)
         text: "Using JACK for audio input and output. Use QjackCtl to adjust your sample rate, buffer, and device settings."
         font { family: "Poppins"; pixelSize: fontMedium * virtualstudio.fontScale * virtualstudio.uiScale }
@@ -62,7 +62,7 @@ Item {
         model: inputComboModel
         currentIndex: virtualstudio.inputDevice
         onActivated: { virtualstudio.inputDevice = currentIndex }
-        x: 234 * virtualstudio.uiScale; y: virtualstudio.uiScale * (virtualstudio.selectableBackend ? 248 : 200)
+        x: 234 * virtualstudio.uiScale; y: virtualstudio.uiScale * (virtualstudio.selectableBackend ? 198 : 150)
         width: parent.width - x - (16 * virtualstudio.uiScale); height: 36 * virtualstudio.uiScale
         visible: virtualstudio.audioBackend != "JACK"
     }
@@ -78,6 +78,7 @@ Item {
     }
     
     Text {
+        id: inputLabel
         anchors.verticalCenter: inputCombo.verticalCenter
         x: leftMargin * virtualstudio.uiScale
         text: "Input Device"
@@ -86,6 +87,7 @@ Item {
     }
     
     Text {
+        id: outputLabel
         anchors.verticalCenter: outputCombo.verticalCenter
         x: leftMargin * virtualstudio.uiScale
         text: "Output Device"
@@ -112,6 +114,20 @@ Item {
         }
     }
 
+    Text {
+        anchors.left: outputLabel.left
+        anchors.right: outputCombo.right
+        anchors.leftMargin: 16 * virtualstudio.uiScale
+        anchors.rightMargin: 16 * virtualstudio.uiScale
+        y: inputCombo.y + (160 * virtualstudio.uiScale)
+        text: "JackTrip on Windows requires use of an audio device with ASIO drivers. If you do not see your device, you may need to install drivers from your manufacturer."
+        horizontalAlignment: Text.AlignHCenter
+        wrapMode: Text.WordWrap
+        color: "#DB0A0A"
+        font { family: "Poppins"; pixelSize: 11 * virtualstudio.fontScale * virtualstudio.uiScale }
+        visible: Qt.platform.os == "windows" && virtualstudio.audioBackend != "JACK"
+    }
+
     Button {
         id: saveButton
         background: Rectangle {
@@ -135,7 +151,7 @@ Item {
         anchors.bottom: parent.bottom
         width: 150 * virtualstudio.uiScale; height: 30 * virtualstudio.uiScale
         Text {
-            text: "Save Changes"
+            text: "Save Settings"
             font.family: "Poppins"
             font.pixelSize: 11 * virtualstudio.fontScale * virtualstudio.uiScale
             font.weight: Font.Bold

--- a/src/gui/Setup.qml
+++ b/src/gui/Setup.qml
@@ -1,0 +1,162 @@
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtGraphicalEffects 1.12
+
+Item {
+    width: parent.width; height: parent.height
+    clip: true
+    
+    Rectangle {
+        width: parent.width; height: parent.height
+        color: "#FAFBFB"
+    }
+
+    property int fontBig: 28
+    property int fontMedium: 13
+    property int fontSmall: 11
+    
+    property int leftMargin: 48
+    property int buttonWidth: 103
+    property int buttonHeight: 25
+    property bool showContents: true
+
+    visible: showContents
+    
+    Text {
+        x: 16 * virtualstudio.uiScale; y: 32 * virtualstudio.uiScale
+        text: "Choose your audio devices"
+        font { family: "Poppins"; weight: Font.Bold; pixelSize: fontBig * virtualstudio.fontScale * virtualstudio.uiScale }
+    }
+    
+    ComboBox {
+        id: backendCombo
+        model: backendComboModel
+        currentIndex: virtualstudio.audioBackend == "JACK" ? 0 : 1
+        onActivated: { virtualstudio.audioBackend = currentText }
+        x: 234 * virtualstudio.uiScale; y: 200 * virtualstudio.uiScale
+        width: parent.width - x - (16 * virtualstudio.uiScale); height: 36 * virtualstudio.uiScale
+        visible: virtualstudio.selectableBackend
+    }
+    
+    Text {
+        id: backendLabel
+         anchors.verticalCenter: backendCombo.verticalCenter
+        x: leftMargin * virtualstudio.uiScale
+        text: "Audio Backend"
+        font { family: "Poppins"; pixelSize: fontMedium * virtualstudio.fontScale * virtualstudio.uiScale }
+        visible: virtualstudio.selectableBackend
+    }
+    
+    Text {
+        id: jackLabel
+        x: leftMargin * virtualstudio.uiScale; y: 200 * virtualstudio.uiScale
+        width: parent.width - x - (16 * virtualstudio.uiScale)
+        text: "Using JACK for audio input and output. Use QjackCtl to adjust your sample rate, buffer, and device settings."
+        font { family: "Poppins"; pixelSize: fontMedium * virtualstudio.fontScale * virtualstudio.uiScale }
+        wrapMode: Text.WordWrap
+        visible: virtualstudio.audioBackend == "JACK" && !virtualstudio.selectableBackend
+    }
+    
+    ComboBox {
+        id: inputCombo
+        model: inputComboModel
+        currentIndex: virtualstudio.inputDevice
+        onActivated: { virtualstudio.inputDevice = currentIndex }
+        x: 234 * virtualstudio.uiScale; y: virtualstudio.uiScale * (virtualstudio.selectableBackend ? 248 : 200)
+        width: parent.width - x - (16 * virtualstudio.uiScale); height: 36 * virtualstudio.uiScale
+        visible: virtualstudio.audioBackend != "JACK"
+    }
+    
+    ComboBox {
+        id: outputCombo
+        model: outputComboModel
+        currentIndex: virtualstudio.outputDevice
+        onActivated: { virtualstudio.outputDevice = currentIndex }
+        x: backendCombo.x; y: inputCombo.y + (48 * virtualstudio.uiScale)
+        width: backendCombo.width; height: backendCombo.height
+        visible: virtualstudio.audioBackend != "JACK"
+    }
+    
+    Text {
+        anchors.verticalCenter: inputCombo.verticalCenter
+        x: leftMargin * virtualstudio.uiScale
+        text: "Input Device"
+        font { family: "Poppins"; pixelSize: fontMedium * virtualstudio.fontScale * virtualstudio.uiScale }
+        visible: virtualstudio.audioBackend != "JACK"
+    }
+    
+    Text {
+        anchors.verticalCenter: outputCombo.verticalCenter
+        x: leftMargin * virtualstudio.uiScale
+        text: "Output Device"
+        font { family: "Poppins"; pixelSize: 13 * virtualstudio.fontScale * virtualstudio.uiScale }
+        visible: virtualstudio.audioBackend != "JACK"
+    }
+
+    Button {
+        id: refreshButton
+        background: Rectangle {
+            radius: 6 * virtualstudio.uiScale
+            color: refreshButton.down ? "#DEE0E0" : (refreshButton.hovered ? "#D3D4D4" : "#EAECEC")
+            border.width: 1
+            border.color: refreshButton.down || refreshButton.hovered ? "#BABCBC" : "#34979797"
+        }
+        onClicked: { virtualstudio.refreshDevices() }
+        x: parent.width - (232 * virtualstudio.uiScale); y: inputCombo.y + (100 * virtualstudio.uiScale)
+        width: 216 * virtualstudio.uiScale; height: 30 * virtualstudio.uiScale
+        visible: virtualstudio.audioBackend != "JACK"
+        Text {
+            text: "Refresh Device List"
+            font { family: "Poppins"; pixelSize: 11 * virtualstudio.fontScale * virtualstudio.uiScale }
+            anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter }
+        }
+    }
+    
+    // Image {
+    //     id: mic
+    //     source: "mic.svg"
+    //     x: 80 * virtualstudio.uiScale; y: 250 * virtualstudio.uiScale
+    //     width: 18 * virtualstudio.uiScale; height: 28 * virtualstudio.uiScale
+    // }
+    
+    // Image {
+    //     id: headphones
+    //     source: "headphones.svg"
+    //     anchors.horizontalCenter: mic.horizontalCenter
+    //     y: 329 * virtualstudio.uiScale
+    //     width: 24 * virtualstudio.uiScale; height: 26 * virtualstudio.uiScale
+    // }
+
+    Button {
+        id: saveButton
+        background: Rectangle {
+            radius: 6 * virtualstudio.uiScale
+            color: saveButton.down ? "#E7E8E8" : "#F2F3F3"
+            border.width: 1
+            border.color: saveButton.down ? "#B0B5B5" : "#EAEBEB"
+            layer.enabled: saveButton.hovered && !saveButton.down
+            layer.effect: DropShadow {
+                horizontalOffset: 1 * virtualstudio.uiScale
+                verticalOffset: 1 * virtualstudio.uiScale
+                radius: 8.0 * virtualstudio.uiScale
+                samples: 17
+                color: "#80A1A1A1"
+            }
+        }
+        onClicked: { window.state = "browse"; virtualstudio.applySettings() }
+        anchors.right: parent.right
+        anchors.rightMargin: 16
+        anchors.bottomMargin: 16
+        anchors.bottom: parent.bottom
+        width: 150 * virtualstudio.uiScale; height: 30 * virtualstudio.uiScale
+        Text {
+            text: "Save Changes"
+            font.family: "Poppins"
+            font.pixelSize: 11 * virtualstudio.fontScale * virtualstudio.uiScale
+            font.weight: Font.Bold
+            color: "#DB0A0A"
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.verticalCenter: parent.verticalCenter
+        }
+    }
+}

--- a/src/gui/Setup.qml
+++ b/src/gui/Setup.qml
@@ -21,6 +21,24 @@ Item {
     property bool showContents: true
 
     visible: showContents
+
+    property string backgroundColour: virtualstudio.darkMode ? "#272525" : "#FAFBFB"
+    property string textColour: virtualstudio.darkMode ? "#FAFBFB" : "#0F0D0D"
+    property string buttonColour: virtualstudio.darkMode ? "#494646" : "#EAECEC"
+    property string buttonHoverColour: virtualstudio.darkMode ? "#5B5858" : "#D3D4D4"
+    property string buttonPressedColour: virtualstudio.darkMode ? "#524F4F" : "#DEE0E0"
+    property string buttonStroke: virtualstudio.darkMode ? "#80827D7D" : "#34979797"
+    property string buttonHoverStroke: virtualstudio.darkMode ? "#7B7777" : "#BABCBC"
+    property string buttonPressedStroke: virtualstudio.darkMode ? "#827D7D" : "#BABCBC"
+    property string saveButtonShadow: "#80A1A1A1"
+    property string saveButtonBackgroundColour: "#F2F3F3"
+    property string saveButtonPressedColour: "#E7E8E8"
+    property string saveButtonStroke: "#EAEBEB"
+    property string saveButtonPressedStroke: "#B0B5B5"
+    property string warningText: "#DB0A0A"
+    property string saveButtonText: "#DB0A0A"
+    property string checkboxStroke: "#0062cc"
+    property string checkboxPressedStroke: "#007AFF"
     
     Text {
         x: 16 * virtualstudio.uiScale; y: 32 * virtualstudio.uiScale
@@ -99,9 +117,9 @@ Item {
         id: refreshButton
         background: Rectangle {
             radius: 6 * virtualstudio.uiScale
-            color: refreshButton.down ? "#DEE0E0" : (refreshButton.hovered ? "#D3D4D4" : "#EAECEC")
+            color: refreshButton.down ? buttonPressedColour : (refreshButton.hovered ? buttonHoverColour : buttonColour)
             border.width: 1
-            border.color: refreshButton.down || refreshButton.hovered ? "#BABCBC" : "#34979797"
+            border.color: refreshButton.down ? buttonPressedStroke : (refreshButton.hovered ? buttonHoverStroke : buttonStroke)
         }
         onClicked: { virtualstudio.refreshDevices() }
         x: parent.width - (232 * virtualstudio.uiScale); y: inputCombo.y + (100 * virtualstudio.uiScale)
@@ -123,7 +141,7 @@ Item {
         text: "JackTrip on Windows requires use of an audio device with ASIO drivers. If you do not see your device, you may need to install drivers from your manufacturer."
         horizontalAlignment: Text.AlignHCenter
         wrapMode: Text.WordWrap
-        color: "#DB0A0A"
+        color: warningText
         font { family: "Poppins"; pixelSize: 11 * virtualstudio.fontScale * virtualstudio.uiScale }
         visible: Qt.platform.os == "windows" && virtualstudio.audioBackend != "JACK"
     }
@@ -132,16 +150,16 @@ Item {
         id: saveButton
         background: Rectangle {
             radius: 6 * virtualstudio.uiScale
-            color: saveButton.down ? "#E7E8E8" : "#F2F3F3"
+            color: saveButton.down ? saveButtonPressedColour : saveButtonBackgroundColour
             border.width: 1
-            border.color: saveButton.down ? "#B0B5B5" : "#EAEBEB"
+            border.color: saveButton.down ? saveButtonPressedStroke : saveButtonStroke
             layer.enabled: saveButton.hovered && !saveButton.down
             layer.effect: DropShadow {
                 horizontalOffset: 1 * virtualstudio.uiScale
                 verticalOffset: 1 * virtualstudio.uiScale
                 radius: 8.0 * virtualstudio.uiScale
                 samples: 17
-                color: "#80A1A1A1"
+                color: saveButtonShadow
             }
         }
         onClicked: { window.state = "browse"; virtualstudio.applySettings() }
@@ -155,7 +173,7 @@ Item {
             font.family: "Poppins"
             font.pixelSize: 11 * virtualstudio.fontScale * virtualstudio.uiScale
             font.weight: Font.Bold
-            color: "#DB0A0A"
+            color: saveButtonText
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.verticalCenter: parent.verticalCenter
         }
@@ -175,7 +193,7 @@ Item {
             x: showAgainCheckbox.leftPadding
             y: parent.height / 2 - height / 2
             radius: 3 * virtualstudio.uiScale
-            border.color: showAgainCheckbox.down ? "#007AFF" : "#0062cc"
+            border.color: showAgainCheckbox.down ? checkboxPressedStroke : checkboxStroke
 
             Rectangle {
                 width: 10 * virtualstudio.uiScale
@@ -183,7 +201,7 @@ Item {
                 x: 3 * virtualstudio.uiScale
                 y: 3 * virtualstudio.uiScale
                 radius: 2 * virtualstudio.uiScale
-                color: showAgainCheckbox.down ? "#007AFF" : "#0062cc"
+                color: showAgainCheckbox.down ? checkboxPressedStroke : checkboxStroke
                 visible: showAgainCheckbox.checked
             }
         }

--- a/src/gui/Setup.qml
+++ b/src/gui/Setup.qml
@@ -130,8 +130,8 @@ Item {
         }
         onClicked: { window.state = "browse"; virtualstudio.applySettings() }
         anchors.right: parent.right
-        anchors.rightMargin: 16
-        anchors.bottomMargin: 16
+        anchors.rightMargin: 16 * virtualstudio.uiScale
+        anchors.bottomMargin: 16 * virtualstudio.uiScale
         anchors.bottom: parent.bottom
         width: 150 * virtualstudio.uiScale; height: 30 * virtualstudio.uiScale
         Text {
@@ -142,6 +142,42 @@ Item {
             color: "#DB0A0A"
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.verticalCenter: parent.verticalCenter
+        }
+    }
+
+    CheckBox {
+        id: showAgainCheckbox
+        checked: virtualstudio.showDeviceSetup
+        text: qsTr("Ask again next time")
+        anchors.right: saveButton.left
+        anchors.rightMargin: 16 * virtualstudio.uiScale
+        anchors.verticalCenter: saveButton.verticalCenter
+        onClicked: { virtualstudio.toggleShowDeviceSetup() }
+        indicator: Rectangle {
+            implicitWidth: 16 * virtualstudio.uiScale
+            implicitHeight: 16 * virtualstudio.uiScale
+            x: showAgainCheckbox.leftPadding
+            y: parent.height / 2 - height / 2
+            radius: 3 * virtualstudio.uiScale
+            border.color: showAgainCheckbox.down ? "#007AFF" : "#0062cc"
+
+            Rectangle {
+                width: 10 * virtualstudio.uiScale
+                height: 10 * virtualstudio.uiScale
+                x: 3 * virtualstudio.uiScale
+                y: 3 * virtualstudio.uiScale
+                radius: 2 * virtualstudio.uiScale
+                color: showAgainCheckbox.down ? "#007AFF" : "#0062cc"
+                visible: showAgainCheckbox.checked
+            }
+        }
+        contentItem: Text {
+            text: showAgainCheckbox.text
+            font.family: "Poppins"
+            font.pixelSize: 10 * virtualstudio.fontScale * virtualstudio.uiScale
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.verticalCenter: parent.verticalCenter
+            leftPadding: showAgainCheckbox.indicator.width + showAgainCheckbox.spacing
         }
     }
 }

--- a/src/gui/Setup.qml
+++ b/src/gui/Setup.qml
@@ -111,21 +111,6 @@ Item {
             anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter }
         }
     }
-    
-    // Image {
-    //     id: mic
-    //     source: "mic.svg"
-    //     x: 80 * virtualstudio.uiScale; y: 250 * virtualstudio.uiScale
-    //     width: 18 * virtualstudio.uiScale; height: 28 * virtualstudio.uiScale
-    // }
-    
-    // Image {
-    //     id: headphones
-    //     source: "headphones.svg"
-    //     anchors.horizontalCenter: mic.horizontalCenter
-    //     y: 329 * virtualstudio.uiScale
-    //     width: 24 * virtualstudio.uiScale; height: 26 * virtualstudio.uiScale
-    // }
 
     Button {
         id: saveButton

--- a/src/gui/qjacktrip.qrc
+++ b/src/gui/qjacktrip.qrc
@@ -12,6 +12,7 @@
     <file>Browse.qml</file>
     <file>Settings.qml</file>
     <file>Connected.qml</file>
+    <file>Setup.qml</file>
     <file>logo.svg</file>
     <file>wedge.svg</file>
     <file>wedge_inactive.svg</file>

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -65,9 +65,10 @@ VirtualStudio::VirtualStudio(bool firstRun, QObject* parent)
 {
     QSettings settings;
     settings.beginGroup(QStringLiteral("VirtualStudio"));
-    m_refreshToken = settings.value(QStringLiteral("RefreshToken"), "").toString();
-    m_userId       = settings.value(QStringLiteral("UserId"), "").toString();
-    m_uiScale      = settings.value(QStringLiteral("UiScale"), 1).toFloat();
+    m_refreshToken      = settings.value(QStringLiteral("RefreshToken"), "").toString();
+    m_userId            = settings.value(QStringLiteral("UserId"), "").toString();
+    m_uiScale           = settings.value(QStringLiteral("UiScale"), 1).toFloat();
+    m_showDeviceSetup   = settings.value(QStringLiteral("ShowDeviceSetup"), true).toBool();
     settings.endGroup();
     m_previousUiScale = m_uiScale;
 
@@ -290,6 +291,16 @@ QString VirtualStudio::connectionState()
     return m_connectionState;
 }
 
+bool VirtualStudio::showDeviceSetup()
+{
+    return m_showDeviceSetup;
+}
+
+void VirtualStudio::setShowDeviceSetup(bool show)
+{
+    m_showDeviceSetup = show;
+}
+
 float VirtualStudio::fontScale()
 {
     return m_fontScale;
@@ -418,6 +429,7 @@ void VirtualStudio::applySettings()
     QSettings settings;
     settings.beginGroup(QStringLiteral("VirtualStudio"));
     settings.setValue(QStringLiteral("UiScale"), m_uiScale);
+    settings.setValue(QStringLiteral("ShowDeviceSetup"), m_showDeviceSetup);
     settings.endGroup();
 #ifdef RT_AUDIO
     settings.beginGroup(QStringLiteral("Audio"));
@@ -432,7 +444,6 @@ void VirtualStudio::applySettings()
     m_previousInput      = m_inputDevice;
     m_previousOutput     = m_outputDevice;
 
-    // make sure device change signals are emitting
     emit inputDeviceChanged();
     emit outputDeviceChanged();
 #endif
@@ -637,6 +648,11 @@ void VirtualStudio::manageStudio(int studioIndex)
         QUrl(QStringLiteral("https://app.jacktrip.org/studios/%1")
                  .arg(static_cast<VsServerInfo*>(m_servers.at(studioIndex))->id()));
     QDesktopServices::openUrl(url);
+}
+
+void VirtualStudio::toggleShowDeviceSetup()
+{
+    setShowDeviceSetup(!m_showDeviceSetup);
 }
 
 void VirtualStudio::createStudio()

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -431,6 +431,10 @@ void VirtualStudio::applySettings()
     m_previousBuffer     = m_bufferSize;
     m_previousInput      = m_inputDevice;
     m_previousOutput     = m_outputDevice;
+
+    // make sure device change signals are emitting
+    emit inputDeviceChanged();
+    emit outputDeviceChanged();
 #endif
 }
 

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -65,10 +65,10 @@ VirtualStudio::VirtualStudio(bool firstRun, QObject* parent)
 {
     QSettings settings;
     settings.beginGroup(QStringLiteral("VirtualStudio"));
-    m_refreshToken      = settings.value(QStringLiteral("RefreshToken"), "").toString();
-    m_userId            = settings.value(QStringLiteral("UserId"), "").toString();
-    m_uiScale           = settings.value(QStringLiteral("UiScale"), 1).toFloat();
-    m_showDeviceSetup   = settings.value(QStringLiteral("ShowDeviceSetup"), true).toBool();
+    m_refreshToken    = settings.value(QStringLiteral("RefreshToken"), "").toString();
+    m_userId          = settings.value(QStringLiteral("UserId"), "").toString();
+    m_uiScale         = settings.value(QStringLiteral("UiScale"), 1).toFloat();
+    m_showDeviceSetup = settings.value(QStringLiteral("ShowDeviceSetup"), true).toBool();
     settings.endGroup();
     m_previousUiScale = m_uiScale;
 

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -74,6 +74,7 @@ class VirtualStudio : public QObject
     Q_PROPERTY(int currentStudio READ currentStudio NOTIFY currentStudioChanged)
     Q_PROPERTY(QString connectionState READ connectionState NOTIFY connectionStateChanged)
     Q_PROPERTY(float fontScale READ fontScale CONSTANT)
+    Q_PROPERTY(bool showDeviceSetup READ showDeviceSetup NOTIFY showDeviceSetupChanged)
     Q_PROPERTY(float uiScale READ uiScale WRITE setUiScale NOTIFY uiScaleChanged)
 
     Q_PROPERTY(bool psiBuild READ psiBuild CONSTANT)
@@ -103,6 +104,8 @@ class VirtualStudio : public QObject
     float fontScale();
     float uiScale();
     void setUiScale(float scale);
+    bool showDeviceSetup();
+    void setShowDeviceSetup(bool show);
     bool psiBuild();
 
    public slots:
@@ -118,6 +121,7 @@ class VirtualStudio : public QObject
     void completeConnection();
     void disconnect();
     void manageStudio(int studioIndex);
+    void toggleShowDeviceSetup();
     void createStudio();
     void showAbout();
     void exit();
@@ -137,6 +141,7 @@ class VirtualStudio : public QObject
     void bufferSizeChanged();
     void currentStudioChanged();
     void connectionStateChanged();
+    void showDeviceSetupChanged();
     void uiScaleChanged();
     void newScale();
     void signalExit();
@@ -190,6 +195,7 @@ class VirtualStudio : public QObject
 
     bool m_onConnectedScreen = false;
     bool m_isExiting         = false;
+    bool m_showDeviceSetup = true;
     float m_fontScale        = 1;
     float m_uiScale;
     float m_previousUiScale;

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -195,7 +195,7 @@ class VirtualStudio : public QObject
 
     bool m_onConnectedScreen = false;
     bool m_isExiting         = false;
-    bool m_showDeviceSetup = true;
+    bool m_showDeviceSetup   = true;
     float m_fontScale        = 1;
     float m_uiScale;
     float m_previousUiScale;

--- a/src/gui/vs.qml
+++ b/src/gui/vs.qml
@@ -101,7 +101,7 @@ Rectangle {
 
     Connections {
         target: virtualstudio
-        function onAuthSucceeded() { window.state = "setup" }
+        function onAuthSucceeded() { if (virtualstudio.showDeviceSetup) { window.state = "setup" } else { window.state = "browse"; setupScreen.showContents = false }}
         function onAuthFailed() { loginScreen.failTextVisible = true }
         //function onConnected() { }
         function onDisconnected() { window.state = "browse" }

--- a/src/gui/vs.qml
+++ b/src/gui/vs.qml
@@ -14,6 +14,7 @@ Rectangle {
             name: "start"
             PropertyChanges { target: startScreen; x: 0 }
             PropertyChanges { target: loginScreen; x: window.width; failTextVisible: loginScreen.failTextVisible }
+            PropertyChanges { target: setupScreen; x: window.width }
             PropertyChanges { target: browseScreen; x: window.width }
             PropertyChanges { target: settingsScreen; x: window.width }
             PropertyChanges { target: connectedScreen; x: window.width }
@@ -23,6 +24,17 @@ Rectangle {
             name: "login"
             PropertyChanges { target: startScreen; x: -startScreen.width }
             PropertyChanges { target: loginScreen; x: 0; failTextVisible: false }
+            PropertyChanges { target: setupScreen; x: window.width; showContents: false }
+            PropertyChanges { target: browseScreen; x: window.width }
+            PropertyChanges { target: settingsScreen; x: window.width }
+            PropertyChanges { target: connectedScreen; x: window.width }
+        },
+
+        State {
+            name: "setup"
+            PropertyChanges { target: loginScreen; x: -loginScreen.width }
+            PropertyChanges { target: startScreen; x: -startScreen.width }
+            PropertyChanges { target: setupScreen; x: 0 }
             PropertyChanges { target: browseScreen; x: window.width }
             PropertyChanges { target: settingsScreen; x: window.width }
             PropertyChanges { target: connectedScreen; x: window.width }
@@ -32,6 +44,7 @@ Rectangle {
             name: "browse"
             PropertyChanges { target: loginScreen; x: -loginScreen.width }
             PropertyChanges { target: startScreen; x: -startScreen.width }
+            PropertyChanges { target: setupScreen; x: -setupScreen.width }
             PropertyChanges { target: browseScreen; x: 0 }
             PropertyChanges { target: settingsScreen; x: window.width }
             PropertyChanges { target: connectedScreen; x: window.width }
@@ -41,6 +54,7 @@ Rectangle {
             name: "settings"
             PropertyChanges { target: loginScreen; x: -loginScreen.width }
             PropertyChanges { target: startScreen; x: -startScreen.width }
+            PropertyChanges { target: setupScreen; x: -2*setupScreen.width }
             PropertyChanges { target: browseScreen; x: -browseScreen.width }
             PropertyChanges { target: settingsScreen; x: 0 }
             PropertyChanges { target: connectedScreen; x: window.width }
@@ -50,6 +64,7 @@ Rectangle {
             name: "connected"
             PropertyChanges { target: loginScreen; x: -loginScreen.width }
             PropertyChanges { target: startScreen; x: -startScreen.width }
+            PropertyChanges { target: setupScreen; x: -setupScreen.width }
             PropertyChanges { target: browseScreen; x: -browseScreen.width }
             PropertyChanges { target: settingsScreen; x: window.width }
             PropertyChanges { target: connectedScreen; x: 0 }
@@ -80,9 +95,13 @@ Rectangle {
         id: connectedScreen
     }
 
+    Setup {
+        id: setupScreen
+    }
+
     Connections {
         target: virtualstudio
-        function onAuthSucceeded() { window.state = "browse" }
+        function onAuthSucceeded() { window.state = "setup" }
         function onAuthFailed() { loginScreen.failTextVisible = true }
         //function onConnected() { }
         function onDisconnected() { window.state = "browse" }


### PR DESCRIPTION
<img width="808" alt="Screen Shot 2022-05-16 at 5 38 36 PM" src="https://user-images.githubusercontent.com/5567285/168694795-56fac5f7-6f22-411d-b87c-848ccfd7830b.png">

This comes up after login. That means it loads every launch if you're using Virtual Studio mode. It's basically the top portion of the settings menu. 

I wanted to do device selection in the Connected screen but found managing the necessary disconnect/reconnect work to be too cumbersome for the time I have at the moment.