### PR TITLE
Update CFBundleVersion with semantic version

### DIFF
--- a/macos/JackTrip.app_template/Contents/Info.plist
+++ b/macos/JackTrip.app_template/Contents/Info.plist
@@ -27,7 +27,7 @@
 		<string>MacOSX</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>16</string>
+	<string>%VERSION%</string>
 	<key>DTCompiler</key>
 	<string>com.apple.compilers.llvm.clang.1_0</string>
 	<key>DTPlatformBuild</key>


### PR DESCRIPTION
Per https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleversion - this also might be needed for various update-checking tools but that's not fully clear to me yet. 

I looked through a bunch of apps I have installed in `/Applications` and they all seem to use semantic versions for this key.