### PR TITLE
update homebrew rtaudio name

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -267,8 +267,8 @@ jobs:
             brew link qt5 --force
           fi
           if [[ "${{ matrix.system-rtaudio }}" == true ]]; then 
-            brew install rt-audio
-            rm -f `brew --prefix rt-audio`/lib/*.dylib # remove the shared library, we want static only
+            brew install rtaudio
+            rm -f `brew --prefix rtaudio`/lib/*.dylib # remove the shared library, we want static only
           fi
           if [[ -n "${{ matrix.installer-path }}" ]]; then
             brew install packages

--- a/.github/workflows/jacktriplabs.yml
+++ b/.github/workflows/jacktriplabs.yml
@@ -141,8 +141,8 @@ jobs:
             brew link qt5 --force
           fi
           if [[ "${{ matrix.system-rtaudio }}" == true ]]; then 
-            brew install rt-audio
-            rm -f `brew --prefix rt-audio`/lib/*.dylib # remove the shared library, we want static only
+            brew install rtaudio
+            rm -f `brew --prefix rtaudio`/lib/*.dylib # remove the shared library, we want static only
           fi
           if [[ -n "${{ matrix.installer-path }}" ]]; then
             brew install packages

--- a/docs/Build/Meson_build.md
+++ b/docs/Build/Meson_build.md
@@ -20,7 +20,7 @@ find its documentation at [mesonbuild.com](https://mesonbuild.com/).
 === "MacOS"
 
     ```bash
-    brew install meson qt5 rt-audio help2man
+    brew install meson qt5 rtaudio help2man
     ```
     
     You also need to install Jack, unless you want to disable jack support


### PR DESCRIPTION
In homebrew apparently package name is `rtaudio` now, and not `rt-audio`, per [documentation](https://formulae.brew.sh/formula/rtaudio).
See https://github.com/jacktrip/jacktrip/runs/6540304068?check_suite_focus=true#step:6:47 for a warning in the CI.

This PR changes occurences of the old name project-wide.
