### PR TITLE
Update changelog.yml for 1.6.0

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -1,3 +1,12 @@
+- Version: "1.6.0"
+  Date: 2022-05-30
+  Description:
+  - (added) Virtual Studio integration; previous GUI is now called "Classic Mode"
+  - (added) dblsqd for auto-updates
+  - (updated) buffer strategy 3 - multiple updates and fixes, still experimental
+  - (added) JackTrip Labs signing scripts
+  - (fixed) OpenSSL in the build script
+  - (updated) code cleanup and maintenance
 - Version: "1.5.3"
   Date: 2022-03-28
   Description:


### PR DESCRIPTION
Here's an update to the changelog for 1.6.0. These changes are automatically propagated in the docs and also used in the Flatpak release I believe.

I've used an arbitrary future date, we might want to adjust this for the final 1.6.0 release.

I tried to synthesize the most important updates from the ones that are autogenerated in our [RCs](https://github.com/jacktrip/jacktrip/releases). Please let me know if anything is missing or should be phrased differently!

This fixes #587 