### PR TITLE
GHA: update name of the jacktrip labs workflow

### DIFF
--- a/.github/workflows/jacktriplabs.yml
+++ b/.github/workflows/jacktriplabs.yml
@@ -1,4 +1,4 @@
-name: build
+name: JackTrip Labs
 on:
   push:
     branches:


### PR DESCRIPTION
I proposed that we update the name of the JackTrip Labs workflow, so that it's easier to identify it (and identify regular builds) in the list of actions in PRs etc. 
I'm open to other names etc, I just would like it to be different from the regular `build`.