### PR TITLE
Apply workaround to enable dblsql to update from github releases

### DIFF
--- a/releases/edge/mac-manifests.json
+++ b/releases/edge/mac-manifests.json
@@ -2,6 +2,16 @@
     "app_name": "JackTrip",
 	"releases": [
 		{
+			"version": "1.6.0-rc.2",
+			"changelog": "Release candidate 2 for 1.6.0",
+			"download": {
+				"date": "2022-05-26T00:00:00Z",
+				"url": "https://files.jacktrip.org/app-builds/JackTrip-v1.6.0-rc.2-macOS-x64-signed-installer.pkg",
+				"downloadSize": 11460155,
+				"sha256": "ad508680115f73036da3a5328ddf0841b86620406406e0ffaa4b982e24a27771"
+			}
+		},
+		{
 			"version": "1.6.0-rc.1",
 			"changelog": "Release candidate 1 for 1.6.0",
 			"download": {

--- a/releases/edge/win-manifests.json
+++ b/releases/edge/win-manifests.json
@@ -2,6 +2,16 @@
     "app_name": "JackTrip",
 	"releases": [
 		{
+			"version": "1.6.0-rc.2",
+			"changelog": "Release candidate 2 for 1.6.0",
+			"download": {
+				"date": "2022-05-26T00:00:00Z",
+				"url": "https://files.jacktrip.org/app-builds/JackTrip-v1.6.0-rc.2-Windows-x64-signed-installer.msi",
+				"downloadSize": 43114496,
+				"sha256": "b1a7adc8dc0fb47f59515790e8531dd10838d799bacb4b5653192ed621bca208"
+			}
+		},
+		{
 			"version": "1.6.0-rc.1",
 			"changelog": "Release candidate 1 for 1.6.0",
 			"download": {

--- a/src/dblsqd/feed.cpp
+++ b/src/dblsqd/feed.cpp
@@ -271,6 +271,18 @@ void Feed::handleDownloadReadyRead()
 {
     if (downloadFile == NULL) {
         QString fileName = downloadReply->url().fileName();
+        // Workaround for dblsqd to extract filename via query params from a
+        // Github-formatted redirect URL
+        QUrl url     = downloadReply->url();
+        QString host = url.host();
+        if (host.contains("github", Qt::CaseInsensitive) && url.hasQuery()) {
+            QString query = url.query();
+            QRegExp rx("filename%3D(.*)&");
+            if (rx.indexIn(query) > -1) {
+                fileName = rx.cap(1);
+            }
+        }
+        // End workaround
         int extensionPos = fileName.indexOf(QRegExp("(?:\\.tar)?\\.[a-zA-Z0-9]+$"));
         if (extensionPos > -1) {
             fileName.insert(extensionPos, "-XXXXXX");

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -40,7 +40,7 @@
 
 #include "AudioInterface.h"
 
-constexpr const char* const gVersion = "1.6.0-rc.2";  ///< JackTrip version
+constexpr const char* const gVersion = "1.6.0-rc.3";  ///< JackTrip version
 
 //*******************************************************************************
 /// \name Default Values


### PR DESCRIPTION
This fixes a bug I encountered when trying to use the Github release download URL (ex: https://github.com/jacktrip/jacktrip/releases/download/v1.6.0-rc.2/JackTrip-v1.6.0-rc.2-macOS-x64-signed-installer.pkg) as the source of the package.

dblsqd expects the installer package filename to be the last segment of the URL. That works for the `https://files.jacktrip.org/app-builds/...` links because they point directly at builds, but the `https://github.com/jacktrip/jacktrip/releases/download/...` URLs are actually redirects to `https://objects.githubusercontent.com/...`. The redirect location doesn't include the filename in the URL anymore, but instead in the query parameters.

Also, bumping to rc3