### PR TITLE
Updating filename extraction regex to be position-independent

### DIFF
--- a/src/dblsqd/feed.cpp
+++ b/src/dblsqd/feed.cpp
@@ -277,7 +277,8 @@ void Feed::handleDownloadReadyRead()
         QString host = url.host();
         if (host.contains("github", Qt::CaseInsensitive) && url.hasQuery()) {
             QString query = url.query();
-            QRegExp rx("filename%3D(.*)&");
+            QRegExp rx("filename%3D(.*)(&|$)");
+            rx.setMinimal(true);
             if (rx.indexIn(query) > -1) {
                 fileName = rx.cap(1);
             }


### PR DESCRIPTION
Minor enhancement, but this should harden the regex a little bit in case the order in which the query parameters appear changes in the future