### PR TITLE
Bug fix for erroroneous "device not found" when using virtual studio mode

### DIFF
--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -627,7 +627,7 @@ void VirtualStudio::completeConnection()
             if (m_outputDevice == QLatin1String("(default)")) {
                 m_jackTrip->setOutputDevice("");
             } else {
-                m_jackTrip->setOutputDevice(m_inputDevice.toStdString());
+                m_jackTrip->setOutputDevice(m_outputDevice.toStdString());
             }
         }
 #endif


### PR DESCRIPTION
It would only previously work if the input device name == output device name, due to a typo in the code.