### PR TITLE
Set ToS IP header to use DSCP Expedited Forwarding for audio packets

### DIFF
--- a/src/UdpDataProtocol.cpp
+++ b/src/UdpDataProtocol.cpp
@@ -272,6 +272,17 @@ int UdpDataProtocol::bindSocket()
     ::setsockopt(sock_fd, SOL_SOCKET, SO_REUSEPORT, &one, sizeof(one));
 #endif
 
+    // Set ToS to DSCP Expedited Forwarding (EF), recommended for Audio
+    // See RFC2474 https://datatracker.ietf.org/doc/html/rfc2474
+    // See also
+    // https://www.slashroot.in/understanding-differentiated-services-tos-field-internet-protocol-header
+    const char tos = 0xB8;  // 10111000
+    if (mIPv6) {
+        ::setsockopt(sock_fd, IPPROTO_IPV6, IPV6_TCLASS, &tos, sizeof(tos));
+    } else {
+        ::setsockopt(sock_fd, IPPROTO_IP, IP_TOS, &tos, sizeof(tos));
+    }
+
     // Bind the Socket
     if (mIPv6) {
         if ((::bind(sock_fd, (struct sockaddr*)&local_addr6, sizeof(local_addr6))) < 0) {


### PR DESCRIPTION
I believe this is the latest standard for quality of service in routers. Expedited Forwarding (EF) is recommended for real time audio streams.