### PR TITLE
GHA: update static Qt version on Linux

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -39,8 +39,8 @@ jobs:
             weakjack: false
             # vcpkg-triplet: x64-mingw-static # used when installing rtaudio with vcpkg (Windows)
             # qt-arch: 'win64_msvc2019_64' # specify when using shared (official) qt libraries (Windows)
-            static-qt-version: 5.12.11 # if set, it will enable static Qt build
-            qt-static-cache-key: 'v25' # required for static qt; update this to force rebuilding static Qt
+            static-qt-version: 5.12.12 # if set, it will enable static Qt build
+            qt-static-cache-key: 'v26' # required for static qt; update this to force rebuilding static Qt
             jacktrip-path: jacktrip # needed for binary upload
             binary-path: binary # directory relative to build path; triggers artifact upload for jacktrip binary
             # bundle-path: bundle # directory relative to build path; triggers application bundle creation and upload (macOS)
@@ -66,8 +66,8 @@ jobs:
             bundled-rtaudio: false
             nogui: true
             weakjack: false
-            static-qt-version: 5.12.11
-            qt-static-cache-key: 'v24' # we use the same key as the main Linux build
+            static-qt-version: 5.12.12
+            qt-static-cache-key: 'v26' # we use the same key as the main Linux build
             jacktrip-path: jacktrip
             binary-path: binary
             build-system: qmake
@@ -90,8 +90,8 @@ jobs:
           #   bundled-rtaudio: false
           #   nogui: false
           #   weakjack: false
-          #   static-qt-version: 5.12.11
-          #   qt-static-cache-key: 'v22'
+          #   static-qt-version: 5.12.12
+          #   qt-static-cache-key: 'v26'
           #   jacktrip-path: jacktrip
           #   binary-path: binary
           #   build-system: meson


### PR DESCRIPTION
It seems that there is a a newer version of 5.12 available, let's use that on Linux.
~~This _might_ help with #615, but it's not only a guess.~~ EDIT: it does not fix that issue.

EDIT 1: Windows and Flatpak build failures are unrelated to this change
EDIT 2: Before merging, please download and run the Linux build. ~~For the record, please check if it by any chance changes the behavior observed in #615~~