### PR TITLE
Fix perpetual "Logging In" screen

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -39,8 +39,8 @@ jobs:
             weakjack: false
             # vcpkg-triplet: x64-mingw-static # used when installing rtaudio with vcpkg (Windows)
             # qt-arch: 'win64_msvc2019_64' # specify when using shared (official) qt libraries (Windows)
-            static-qt-version: 5.15.2 # if set, it will enable static Qt build
-            qt-static-cache-key: 'v26' # required for static qt; update this to force rebuilding static Qt
+            static-qt-version: 5.12.11 # if set, it will enable static Qt build
+            qt-static-cache-key: 'v25' # required for static qt; update this to force rebuilding static Qt
             jacktrip-path: jacktrip # needed for binary upload
             binary-path: binary # directory relative to build path; triggers artifact upload for jacktrip binary
             # bundle-path: bundle # directory relative to build path; triggers application bundle creation and upload (macOS)
@@ -66,8 +66,8 @@ jobs:
             bundled-rtaudio: false
             nogui: true
             weakjack: false
-            static-qt-version: 5.15.2
-            qt-static-cache-key: 'v26' # we use the same key as the main Linux build
+            static-qt-version: 5.12.11
+            qt-static-cache-key: 'v24' # we use the same key as the main Linux build
             jacktrip-path: jacktrip
             binary-path: binary
             build-system: qmake

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -39,8 +39,8 @@ jobs:
             weakjack: false
             # vcpkg-triplet: x64-mingw-static # used when installing rtaudio with vcpkg (Windows)
             # qt-arch: 'win64_msvc2019_64' # specify when using shared (official) qt libraries (Windows)
-            static-qt-version: 5.12.11 # if set, it will enable static Qt build
-            qt-static-cache-key: 'v25' # required for static qt; update this to force rebuilding static Qt
+            static-qt-version: 5.15.2 # if set, it will enable static Qt build
+            qt-static-cache-key: 'v26' # required for static qt; update this to force rebuilding static Qt
             jacktrip-path: jacktrip # needed for binary upload
             binary-path: binary # directory relative to build path; triggers artifact upload for jacktrip binary
             # bundle-path: bundle # directory relative to build path; triggers application bundle creation and upload (macOS)
@@ -66,8 +66,8 @@ jobs:
             bundled-rtaudio: false
             nogui: true
             weakjack: false
-            static-qt-version: 5.12.11
-            qt-static-cache-key: 'v24' # we use the same key as the main Linux build
+            static-qt-version: 5.15.2
+            qt-static-cache-key: 'v26' # we use the same key as the main Linux build
             jacktrip-path: jacktrip
             binary-path: binary
             build-system: qmake

--- a/src/gui/Login.qml
+++ b/src/gui/Login.qml
@@ -136,6 +136,6 @@ Item {
             anchors.verticalCenter: parent.verticalCenter
             color: backButton.down ? buttonTextPressed : (backButton.hovered ? buttonTextHover : buttonTextColour)
         }
-        visible: !virtualstudio.hasRefreshToken
+        visible: true
     }
 }

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -882,6 +882,17 @@ void VirtualStudio::endRetryPeriod()
     m_retryPeriodTimer.stop();
 }
 
+void VirtualStudio::launchBrowser(const QUrl& url)
+{
+    std::cout << "Launching Browser" << std::endl;
+    bool success = QDesktopServices::openUrl(url);
+    if (success) {
+        std::cout << "Success" << std::endl;
+    } else {
+        std::cout << "Unable to open URL" << std::endl;
+    }
+}
+
 void VirtualStudio::setupAuthenticator()
 {
     if (m_authenticator.isNull()) {
@@ -890,8 +901,8 @@ void VirtualStudio::setupAuthenticator()
         m_authenticator->setScope(
             QStringLiteral("openid profile email offline_access read:servers"));
         connect(m_authenticator.data(),
-                &QOAuth2AuthorizationCodeFlow::authorizeWithBrowser,
-                &QDesktopServices::openUrl);
+                &QOAuth2AuthorizationCodeFlow::authorizeWithBrowser, this,
+                &VirtualStudio::launchBrowser);
 
         const QUrl authUri(QStringLiteral("https://auth.jacktrip.org/authorize"));
         const QString clientId = QStringLiteral("cROUJag0UVKDaJ6jRAKRzlVjKVFNU39I");

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -764,6 +764,7 @@ void VirtualStudio::exit()
 
 void VirtualStudio::slotAuthSucceded()
 {
+    qDebug() << "In slotAuthSucceded";
     m_refreshToken = m_authenticator->refreshToken();
     emit hasRefreshTokenChanged();
     QSettings settings;
@@ -782,6 +783,7 @@ void VirtualStudio::slotAuthSucceded()
 
 void VirtualStudio::slotAuthFailed()
 {
+    qDebug() << "In slotAuthFailed";
     emit authFailed();
 }
 
@@ -946,6 +948,7 @@ void VirtualStudio::setupAuthenticator()
 
 void VirtualStudio::getServerList(bool firstLoad, int index)
 {
+    qDebug() << "in get server list";
     {
         QMutexLocker locker(&m_refreshMutex);
         if (!m_allowRefresh || m_refreshInProgress) {
@@ -982,7 +985,7 @@ void VirtualStudio::getServerList(bool firstLoad, int index)
             return;
         }
         QJsonArray servers = serverList.array();
-
+        qDebug() << "got servers";
         // Divide our servers by category initially so that they're easier to sort
         QList<QObject*> yourServers;
         QList<QObject*> subServers;
@@ -1089,6 +1092,7 @@ void VirtualStudio::getServerList(bool firstLoad, int index)
             }
         }
         if (firstLoad) {
+            qDebug() << "emitting auth succeeded";
             emit authSucceeded();
             m_refreshTimer.setInterval(10000);
             m_refreshTimer.start();
@@ -1122,7 +1126,7 @@ void VirtualStudio::getUserId()
         settings.setValue(QStringLiteral("UserId"), m_userId);
         settings.endGroup();
         getSubscriptions();
-
+        qDebug() << "got userID";
         reply->deleteLater();
     });
 }
@@ -1154,7 +1158,7 @@ void VirtualStudio::getSubscriptions()
                 subscriptions.at(i)[QStringLiteral("serverId")].toString());
         }
         getServerList(true);
-
+        qDebug() << "got subscriptions";
         reply->deleteLater();
     });
 }

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -180,6 +180,7 @@ class VirtualStudio : public QObject
     void receivedConnectionFromPeer();
     void checkForHostname();
     void endRetryPeriod();
+    void launchBrowser(const QUrl &url);
 
    private:
     void setupAuthenticator();

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -180,7 +180,7 @@ class VirtualStudio : public QObject
     void receivedConnectionFromPeer();
     void checkForHostname();
     void endRetryPeriod();
-    void launchBrowser(const QUrl &url);
+    void launchBrowser(const QUrl& url);
 
    private:
     void setupAuthenticator();

--- a/src/gui/vs.qml
+++ b/src/gui/vs.qml
@@ -105,6 +105,7 @@ Rectangle {
     Connections {
         target: virtualstudio
         function onAuthSucceeded() { 
+            console.log("in auth succeeded");
             if (virtualstudio.showDeviceSetup) {
                 window.state = "setup";
             } else {

--- a/src/gui/vs.qml
+++ b/src/gui/vs.qml
@@ -104,16 +104,19 @@ Rectangle {
 
     Connections {
         target: virtualstudio
-        function onAuthSucceeded() { 
-            console.log("in auth succeeded");
+        onAuthSucceeded: { 
             if (virtualstudio.showDeviceSetup) {
                 window.state = "setup";
             } else {
                 window.state = "browse";
             }
         }
-        function onAuthFailed() { loginScreen.failTextVisible = true }
-        //function onConnected() { }
-        function onDisconnected() { window.state = "browse" }
+        onAuthFailed: {
+            loginScreen.failTextVisible = true;
+        }
+        // onConnected: { }
+        onDisconnected: {
+            window.state = "browse";
+        }
     }
 }


### PR DESCRIPTION
Deep Google searches led me to these two issues which seem to fix the auth flow behavior on Ubuntu 20.04:
* https://bugreports.qt.io/browse/QTBUG-84866
* https://stackoverflow.com/questions/69585272/c-signal-is-not-received-in-qml-slot

I've also enabled the "Back" button on the "Logging in" screen so you can return to the original start state if it ever does hang again.

The more appropriate fix would be to use QT 5.15.x for Linux (which we're already using for Mac + Windows) but that's currently not an option for reasons beyond my knowledge.