### PR TITLE
Add warning that cmake build is not officially supported

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET 10.13)
 set(CMAKE_OSX_ARCHITECTURES arm64;x86_64)
 project(QJackTrip)
 
+message(WARNING "The CMake build of JackTrip is currently NOT officially supported. Meson or QMake are recommended for a full featured build. "
+	"https://jacktrip.github.io/jacktrip/Build/Meson_build/")
+
 set(nogui FALSE)
 set(rtaudio TRUE)
 set(weakjack TRUE)


### PR DESCRIPTION
There were several occasions that people tried to build jacktrip with cmake and complained about missing features (e.g. #637). This change adds a warning to the cmake build that the cmake build is not supported and that Meson and QMake are recommended.