### PR TITLE
No dblsqd on Linux

### DIFF
--- a/jacktrip.pro
+++ b/jacktrip.pro
@@ -243,10 +243,12 @@ HEADERS += src/DataProtocol.h \
                src/gui/vsQuickView.h
   }
   !noupdater {
-    HEADERS += src/dblsqd/feed.h \
+    linux-g++ | linux-g++-64 {
+      HEADERS += src/dblsqd/feed.h \
                src/dblsqd/release.h \
                src/dblsqd/semver.h \
                src/dblsqd/update_dialog.h
+    }
   }
 }
 

--- a/jacktrip.pro
+++ b/jacktrip.pro
@@ -34,7 +34,7 @@ nogui {
     QT += quick
     QT += svg
   }
-  noupdater | linux-g++ | linux-g++-64 {
+  noupdater|linux-g++|linux-g++-64 {
     DEFINES += NO_UPDATER
   }
 }

--- a/jacktrip.pro
+++ b/jacktrip.pro
@@ -243,7 +243,7 @@ HEADERS += src/DataProtocol.h \
                src/gui/vsQuickView.h
   }
   !noupdater {
-    linux-g++ | linux-g++-64 {
+    !(linux-g++ | !linux-g++-64) {
       HEADERS += src/dblsqd/feed.h \
                src/dblsqd/release.h \
                src/dblsqd/semver.h \

--- a/jacktrip.pro
+++ b/jacktrip.pro
@@ -34,7 +34,7 @@ nogui {
     QT += quick
     QT += svg
   }
-  noupdater {
+  noupdater | linux-g++ | linux-g++-64 {
     DEFINES += NO_UPDATER
   }
 }
@@ -242,13 +242,11 @@ HEADERS += src/DataProtocol.h \
                src/gui/vsServerInfo.h \
                src/gui/vsQuickView.h
   }
-  !noupdater {
-    !(linux-g++ | !linux-g++-64) {
-      HEADERS += src/dblsqd/feed.h \
-               src/dblsqd/release.h \
-               src/dblsqd/semver.h \
-               src/dblsqd/update_dialog.h
-    }
+  !noupdater:!linux-g++:!linux-g++-64 {
+    HEADERS += src/dblsqd/feed.h \
+            src/dblsqd/release.h \
+            src/dblsqd/semver.h \
+            src/dblsqd/update_dialog.h
   }
 }
 
@@ -294,11 +292,11 @@ SOURCES += src/DataProtocol.cpp \
                src/gui/vsServerInfo.cpp \
                src/gui/vsQuickView.cpp
   }
-  !noupdater {
+  !noupdater:!linux-g++:!linux-g++-64 {
     SOURCES += src/dblsqd/feed.cpp \
-               src/dblsqd/release.cpp \
-               src/dblsqd/semver.cpp \
-               src/dblsqd/update_dialog.cpp
+              src/dblsqd/release.cpp \
+              src/dblsqd/semver.cpp \
+              src/dblsqd/update_dialog.cpp
   }
 }
 
@@ -313,7 +311,7 @@ SOURCES += src/DataProtocol.cpp \
   } else {
     RESOURCES += src/gui/qjacktrip.qrc
   }
-  !noupdater {
+  !noupdater:!linux-g++:!linux-g++-64 {
     FORMS += src/dblsqd/update_dialog.ui
   }
 }

--- a/meson.build
+++ b/meson.build
@@ -117,7 +117,7 @@ else
 		qres = ['src/gui/qjacktrip.qrc']
 	endif
 
-	if get_option('noupdater') == true
+	if get_option('noupdater') == true or host_machine.system() == 'linux'
 		defines += '-DNO_UPDATER'
 	else
 		src += [


### PR DESCRIPTION
We said we weren't going to include the dblsqd updater on Linux as the various package manager manage updates.