### PR TITLE
Bugfix/win datagram available

### DIFF
--- a/src/DataProtocol.h
+++ b/src/DataProtocol.h
@@ -159,9 +159,6 @@ class DataProtocol : public QThread
      */
     virtual void setPeerPort(int port) = 0;
 
-    // virtual void getPeerAddressFromFirstPacket(QHostAddress& peerHostAddress,
-    //				     uint16_t& port) = 0;
-
 #if defined(_WIN32)
     virtual void setSocket(SOCKET& socket) = 0;
 #else

--- a/src/DataProtocol.h
+++ b/src/DataProtocol.h
@@ -159,6 +159,9 @@ class DataProtocol : public QThread
      */
     virtual void setPeerPort(int port) = 0;
 
+    // virtual void getPeerAddressFromFirstPacket(QHostAddress& peerHostAddress,
+    //				     uint16_t& port) = 0;
+
 #if defined(_WIN32)
     virtual void setSocket(SOCKET& socket) = 0;
 #else

--- a/src/UdpDataProtocol.cpp
+++ b/src/UdpDataProtocol.cpp
@@ -378,6 +378,27 @@ functions. DWORD n_bytes; WSABUF buffer; int error; buffer.len = n; buffer.buf =
 }
 
 //*******************************************************************************
+// void UdpDataProtocol::getPeerAddressFromFirstPacket(QHostAddress& peerHostAddress,
+//                                                     uint16_t& port)
+// {
+//     while (!datagramAvailable()) {
+//         msleep(100);
+//     }
+//     char buf[1];
+
+//     struct sockaddr_storage addr;
+//     std::memset(&addr, 0, sizeof(addr));
+//     socklen_t sa_len = sizeof(addr);
+//     ::recvfrom(mSocket, buf, 1, 0, (struct sockaddr*)&addr, &sa_len);
+//     peerHostAddress.setAddress((struct sockaddr*)&addr);
+//     if (mIPv6) {
+//         port = ((struct sockaddr_in6*)&addr)->sin6_port;
+//     } else {
+//         port = ((struct sockaddr_in*)&addr)->sin_port;
+//     }
+// }
+
+//*******************************************************************************
 void UdpDataProtocol::run()
 {
     if (gVerboseFlag)

--- a/src/UdpDataProtocol.cpp
+++ b/src/UdpDataProtocol.cpp
@@ -973,12 +973,14 @@ bool UdpDataProtocol::datagramAvailable()
     DWORD n     = 0;
     DWORD flags = MSG_PEEK;
     int ret     = WSARecv(mSocket, &buffer, 1, &n, &flags, NULL, NULL);
+    std::cout << "ret is " << ret << std::endl;
     if (ret == 0) {
         //True if no error,
         return true;
     } else {
         //or if our error is that our buffer is too small.
         int err = WSAGetLastError();
+        std::cout << "err is " << err << std::endl;
         return (err == WSAEMSGSIZE);
     }
 #else

--- a/src/UdpDataProtocol.cpp
+++ b/src/UdpDataProtocol.cpp
@@ -963,14 +963,12 @@ bool UdpDataProtocol::datagramAvailable()
     DWORD n     = 0;
     DWORD flags = MSG_PEEK;
     int ret     = WSARecv(mSocket, &buffer, 1, &n, &flags, NULL, NULL);
-    std::cout << "ret is " << ret << std::endl;
     if (ret == 0) {
         //True if no error,
         return true;
     } else {
         //or if our error is that our buffer is too small.
         int err = WSAGetLastError();
-        std::cout << "err is " << err << std::endl;
         return (err == WSAEMSGSIZE);
     }
 #else

--- a/src/UdpDataProtocol.h
+++ b/src/UdpDataProtocol.h
@@ -117,6 +117,14 @@ class UdpDataProtocol : public DataProtocol
      */
     virtual int sendPacket(const char* buf, const size_t n);
 
+    /** \brief Obtains the peer address from the first UDP packet received. This address
+     * is used by the SERVER mode to connect back to the client.
+     * \param peerHostAddress QHostAddress to store the peer address
+     * \param port Receiving port
+     */
+    // virtual void getPeerAddressFromFirstPacket(QHostAddress& peerHostAddress,
+    //                                            uint16_t& port);
+
     /** \brief Sets the bind port number
      */
     void setBindPort(int port) { mBindPort = port; }

--- a/src/UdpDataProtocol.h
+++ b/src/UdpDataProtocol.h
@@ -117,14 +117,6 @@ class UdpDataProtocol : public DataProtocol
      */
     virtual int sendPacket(const char* buf, const size_t n);
 
-    /** \brief Obtains the peer address from the first UDP packet received. This address
-     * is used by the SERVER mode to connect back to the client.
-     * \param peerHostAddress QHostAddress to store the peer address
-     * \param port Receiving port
-     */
-    virtual void getPeerAddressFromFirstPacket(QHostAddress& peerHostAddress,
-                                               uint16_t& port);
-
     /** \brief Sets the bind port number
      */
     void setBindPort(int port) { mBindPort = port; }


### PR DESCRIPTION
This seems to fix https://github.com/jacktrip/jacktrip/issues/648 and the user confirmed the fix. Apparently this is a windows socket bug, problem + fix described here: https://stackoverflow.com/a/42409198

While debugging where `datagramAvailable()` is used, I found that `getPeerAddressFromFirstPacket()` was an unused function so I took the liberty of removing it.