### PR TITLE
Enabling join + connected view experience

### DIFF
--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -441,6 +441,24 @@ void VirtualStudio::setDebugText(QString text)
     emit debugTextChanged();
 }
 
+void VirtualStudio::joinStudio(const QUrl& url)
+{
+    if (url.scheme() != "jacktrip" || url.path().length() <= 1) {
+        return;
+    }
+    QString targetId = url.path().remove(0, 1);
+    // qDebug() << "target is" << targetId;
+
+    getServerList(true);
+    int i = 0;
+    for (i = 0; i < m_servers.count(); i++) {
+        if (static_cast<VsServerInfo*>(m_servers.at(i))->id() == targetId) {
+            // qDebug() << "found at index" << i;
+            connectToStudio(i);
+        }
+    }
+}
+
 void VirtualStudio::toStandard()
 {
     if (!m_standardWindow.isNull()) {
@@ -825,7 +843,8 @@ void VirtualStudio::exit()
 void VirtualStudio::testUrlScheme()
 {
     qDebug() << "testing url scheme";
-    QDesktopServices::openUrl(QUrl("jacktrip://join", QUrl::TolerantMode));
+    QDesktopServices::openUrl(
+        QUrl("jacktrip://join/745646a0-704b-4ba9-895d-e5f6752dad08", QUrl::TolerantMode));
 }
 
 void VirtualStudio::slotAuthSucceded()

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -135,6 +135,7 @@ class VirtualStudio : public QObject
     bool noUpdater();
     bool psiBuild();
     QString debugText();
+    void joinStudio(const QUrl& url);
     void setDebugText(QString text);
 
    public slots:

--- a/src/gui/vs.qml
+++ b/src/gui/vs.qml
@@ -114,7 +114,9 @@ Rectangle {
         onAuthFailed: {
             loginScreen.failTextVisible = true;
         }
-        // onConnected: { }
+        onConnected: {
+            window.state = "connected";
+        }
         onDisconnected: {
             window.state = "browse";
         }

--- a/src/gui/vsUrlHandler.cpp
+++ b/src/gui/vsUrlHandler.cpp
@@ -44,5 +44,5 @@ void VsUrlHandler::handleUrl(const QUrl& url)
 {
     qDebug() << "got URL in url handler";
     qDebug() << url.toString();
-    emit joinUrlClicked();
+    emit joinUrlClicked(url);
 }

--- a/src/gui/vsUrlHandler.h
+++ b/src/gui/vsUrlHandler.h
@@ -49,7 +49,7 @@ class VsUrlHandler : public QObject
     Q_OBJECT
 
    signals:
-    void joinUrlClicked();
+    void joinUrlClicked(const QUrl& url);
 
    public slots:
     void handleUrl(const QUrl& url);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -382,10 +382,12 @@ int main(int argc, char* argv[])
 
         VsUrlHandler* m_urlHandler = new VsUrlHandler();
         QDesktopServices::setUrlHandler("jacktrip", m_urlHandler, "handleUrl");
-        QObject::connect(m_urlHandler, &VsUrlHandler::joinUrlClicked, vs.data(), [&]() {
-            qDebug() << "In handler";
-            vs->setDebugText(QStringLiteral("It Worked!"));
-        });
+        QObject::connect(m_urlHandler, &VsUrlHandler::joinUrlClicked, vs.data(),
+                         [&](const QUrl& url) {
+                             qDebug() << "url found is " << url;
+                             vs->setDebugText(QStringLiteral("It Worked!"));
+                             vs->joinStudio(url);
+                         });
         // Open with any command line-passed url
         QDesktopServices::openUrl(QUrl(deeplink));
 


### PR DESCRIPTION
When clicking that semi-hidden testUrlScheme button, this joins the SF public studio and changes the view.

TODO: Error states (studio not found, bad path params and identifiers, etc.)