### PR TITLE
fixes bug in computing stats on size 0 vector

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -99,7 +99,7 @@ jobs:
 
           - name: macOS-x64-qmake-clang-static
             release-name: macOS-x64
-            runs-on: macos-10.15
+            runs-on: macos-11
             system-rtaudio: true
             bundled-rtaudio: false
             nogui: false
@@ -113,7 +113,7 @@ jobs:
             build-system: qmake
 
           - name: macOS-x64-qmake-clang-shared-bundled_rtaudio
-            runs-on: macos-10.15
+            runs-on: macos-11
             system-rtaudio: false
             bundled-rtaudio: true
             nogui: false
@@ -125,7 +125,7 @@ jobs:
             build-system: qmake
 
           - name: macOS-x64-meson-clang-shared-bundled_rtaudio
-            runs-on: macos-10.15
+            runs-on: macos-11
             system-rtaudio: false
             bundled-rtaudio: true
             nogui: false

--- a/.github/workflows/jacktriplabs.yml
+++ b/.github/workflows/jacktriplabs.yml
@@ -59,7 +59,7 @@ jobs:
         include:
           - name: macOS-x64-qmake-clang-static
             release-name: macOS-x64
-            runs-on: macos-10.15
+            runs-on: macos-11
             system-rtaudio: true
             bundled-rtaudio: false
             nogui: false
@@ -362,7 +362,7 @@ jobs:
           - name: Sign macOS artifacts
             release-name: macOS-x64
             build-job-name: macOS-x64-qmake-clang-static
-            runs-on: macos-10.15
+            runs-on: macos-11
             binary-path: binary
             bundle-path: bundle
             installer-path: installer

--- a/src/vsPinger.cpp
+++ b/src/vsPinger.cpp
@@ -163,11 +163,34 @@ void VsPinger::updateStats()
         }
     }
 
+    // Deleted pings marked as expired by freeing the Ping object
+    // and clearing the map item
+    for (std::vector<uint32_t>::iterator it_expired = vec_expired.begin();
+         it_expired != vec_expired.end(); it_expired++) {
+        uint32_t expiredPingNum = *it_expired;
+        delete mPings.at(expiredPingNum);
+        mPings.erase(expiredPingNum);
+    }
+
     // Update RTT stats
     double min_rtt    = std::numeric_limits<qint64>::max();
     double max_rtt    = std::numeric_limits<qint64>::min();
     double avg_rtt    = 0;
     double stddev_rtt = 0;
+    
+    // avoid edge case due to min_rtt and max_rtt being at the numeric limits
+    // when vector size is 0
+    if (vec_rtt.size() == 0) {
+        stat.maxRtt    = 0;
+        stat.minRtt    = 0;
+        stat.avgRtt    = 0;
+        stat.stdDevRtt = 0;
+
+        // Update mStats
+        mStats = stat;
+        return;
+    }
+
     for (std::vector<qint64>::iterator it_rtt = vec_rtt.begin(); it_rtt != vec_rtt.end();
          it_rtt++) {
         double rtt = (double)*it_rtt;
@@ -193,15 +216,6 @@ void VsPinger::updateStats()
     stat.minRtt    = min_rtt;
     stat.avgRtt    = avg_rtt;
     stat.stdDevRtt = stddev_rtt;
-
-    // Deleted pings marked as expired by freeing the Ping object and clearing the map
-    // item
-    for (std::vector<uint32_t>::iterator it_expired = vec_expired.begin();
-         it_expired != vec_expired.end(); it_expired++) {
-        uint32_t expiredPingNum = *it_expired;
-        delete mPings.at(expiredPingNum);
-        mPings.erase(expiredPingNum);
-    }
 
     // Update mStats
     mStats = stat;

--- a/src/vsPinger.cpp
+++ b/src/vsPinger.cpp
@@ -177,7 +177,7 @@ void VsPinger::updateStats()
     double max_rtt    = std::numeric_limits<qint64>::min();
     double avg_rtt    = 0;
     double stddev_rtt = 0;
-    
+
     // avoid edge case due to min_rtt and max_rtt being at the numeric limits
     // when vector size is 0
     if (vec_rtt.size() == 0) {


### PR DESCRIPTION
Fixes an edge case bug when computing statistics for a size 0 vector. This PR resolves the bug by setting the min, max, average, and standard deviation to be 0 if the vector is size 0.