### PR TITLE
Bugfix/win debug

### DIFF
--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1107,7 +1107,7 @@ void VirtualStudio::setupAuthenticator()
 
 void VirtualStudio::sendHeartbeat()
 {
-    if (m_device != nullptr) {
+    if (m_device != nullptr && m_connectionState != "Connecting...") {
         m_device->sendHeartbeat();
     }
 }

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -236,7 +236,7 @@ class VirtualStudio : public QObject
     bool m_selectableBackend  = true;
     bool m_useRtAudio         = false;
     int m_currentStudio       = -1;
-    QString m_connectionState = QStringLiteral("Connecting...");
+    QString m_connectionState = QStringLiteral("Waiting");
     QScopedPointer<JackTrip> m_jackTrip;
     QTimer m_startTimer;
     QTimer m_retryPeriodTimer;


### PR DESCRIPTION
This fixes an issue where some clients require multiple attempts to establish a connection on Windows.

Because of how we're reacting to heartbeat responses in order to disconnect the app, it's possible that a response is interpreted while the connection is still in progress. This is more noticeable on windows because of how long it takes to establish the client-server connection.