### PR TITLE
Add .clang-tidy-ignore file

### DIFF
--- a/.clang-tidy-ignore
+++ b/.clang-tidy-ignore
@@ -1,0 +1,4 @@
+subprojects
+externals
+documentation
+src/*dsp.h


### PR DESCRIPTION
Adds .clang-tidy-ignore file. This should silence clang-tidy GHA for all dsp headers.