### PR TITLE
Use bundled RtAudio on macOS - fix compatibility with macOS 10.13

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -101,11 +101,11 @@ jobs:
           #   build-system: meson
           #   meson-library-type: static
 
-          - name: macOS-x64-qmake-clang-static
+          - name: macOS-x64-qmake-clang-static-bundled_rtaudio
             release-name: macOS-x64
             runs-on: macos-11
-            system-rtaudio: true
-            bundled-rtaudio: false
+            system-rtaudio: false
+            bundled-rtaudio: true
             nogui: false
             novs: false
             weakjack: true

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -117,10 +117,10 @@ jobs:
             installer-path: installer
             build-system: qmake
 
-          - name: macOS-x64-qmake-clang-shared-bundled_rtaudio
+          - name: macOS-x64-qmake-clang-shared
             runs-on: macos-11
-            system-rtaudio: false
-            bundled-rtaudio: true
+            system-rtaudio: true
+            bundled-rtaudio: false
             nogui: false
             novs: false
             weakjack: true

--- a/.github/workflows/jacktriplabs.yml
+++ b/.github/workflows/jacktriplabs.yml
@@ -57,11 +57,11 @@ jobs:
       fail-fast: false # don't abort if one of the build failse
       matrix:
         include:
-          - name: macOS-x64-qmake-clang-static
+          - name: macOS-x64-qmake-clang-static-bundled_rtaudio
             release-name: macOS-x64
             runs-on: macos-11
-            system-rtaudio: true
-            bundled-rtaudio: false
+            system-rtaudio: false
+            bundled-rtaudio: true
             nogui: false
             novs: false
             weakjack: true

--- a/rtaudio.pro
+++ b/rtaudio.pro
@@ -15,6 +15,7 @@ linux-g++ | linux-g++-64 {
 }
 macx {
   QMAKE_CXXFLAGS += -D__MACOSX_CORE__
+  QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.9 # the same deployment target as in jacktrip.pro
 }
 win32 {
   QMAKE_CXXFLAGS += -D__WINDOWS_ASIO__ -D__WINDOWS_WASAPI__


### PR DESCRIPTION
Fixes #671.

This ~~is an attempt to~~ fixes compatibility with macOS 10.13. RtAudio from homebrew is built for macOS 10.14 and later AFAIU so building RtAudio ourselves ~~might fix this~~ is necessary to support an earlier OS.

Changes in this PR:
- JT GHA: main macOS build uses bundled RtAudio
- JTLabs GHA: macOS build uses bundled RtAudio
- qmake file for RtAudio now specifies the same deployment target as JackTrip's qmake file
  - deployment target is set very low - 10.9 - but the current build practically supports only 10.13 and up. This is due to Qt's compatibility - Qt 5.15, which we use on macOS for the release builds, supports 10.13 at the earliest.
- JT GHA: shared macOS build (non-release) uses system RtAudio (for testing build configuration)
- affected actions are renamed to reflect the use of bundled/system RtAudio