### PR TITLE
VS: Replace "Manage" icon

### DIFF
--- a/src/gui/Browse.qml
+++ b/src/gui/Browse.qml
@@ -15,6 +15,7 @@ Item {
     
     property int buttonHeight: 25
     property int buttonWidth: 103
+    property int extraSettingsButtonWidth: 16
     property int fontMedium: 11
     
     property int scrollY: 0
@@ -320,7 +321,7 @@ Item {
             }
             onClicked: { virtualstudio.showAbout() }
             anchors.verticalCenter: parent.verticalCenter
-            x: parent.width - (230 * virtualstudio.uiScale)
+            x: parent.width - ((230 + extraSettingsButtonWidth) * virtualstudio.uiScale)
             width: buttonWidth * virtualstudio.uiScale; height: buttonHeight * virtualstudio.uiScale
             Text {
                 text: "About"
@@ -332,6 +333,11 @@ Item {
         
         Button {
             id: settingsButton
+            text: "Settings"
+            icon {
+                source: "cog.svg";
+                color: textColour;
+            }
             background: Rectangle {
                 radius: 6 * virtualstudio.uiScale
                 color: settingsButton.down ? buttonPressedColour : (settingsButton.hovered ? buttonHoverColour : buttonColour)
@@ -339,15 +345,17 @@ Item {
                 border.color: settingsButton.down ? buttonPressedStroke : (settingsButton.hovered ? buttonHoverStroke : buttonStroke)
             }
             onClicked: window.state = "settings"
-            anchors.verticalCenter: parent.verticalCenter
-            x: parent.width - (119 * virtualstudio.uiScale)
-            width: buttonWidth * virtualstudio.uiScale; height: buttonHeight * virtualstudio.uiScale
-            Text {
-                text: "Settings"
-                font { family: "Poppins"; pixelSize: fontMedium * virtualstudio.fontScale * virtualstudio.uiScale}
-                anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter }
-                color: textColour
+            display: AbstractButton.TextBesideIcon
+            font {
+                family: "Poppins"; 
+                pixelSize: fontMedium * virtualstudio.fontScale * virtualstudio.uiScale;
             }
+            leftPadding: 0
+            rightPadding: 4
+            spacing: 0
+            anchors.verticalCenter: parent.verticalCenter
+            x: parent.width - ((119 + extraSettingsButtonWidth) * virtualstudio.uiScale)
+            width: (buttonWidth + extraSettingsButtonWidth) * virtualstudio.uiScale; height: buttonHeight * virtualstudio.uiScale
         }
     }
     

--- a/src/gui/Browse.qml
+++ b/src/gui/Browse.qml
@@ -334,6 +334,7 @@ Item {
         Button {
             id: settingsButton
             text: "Settings"
+            palette.buttonText: textColour
             icon {
                 source: "cog.svg";
                 color: textColour;

--- a/src/gui/Studio.qml
+++ b/src/gui/Studio.qml
@@ -195,7 +195,7 @@ Rectangle {
         Image {
             width: 20 * virtualstudio.uiScale; height: width
             anchors { verticalCenter: parent.verticalCenter; horizontalCenter: parent.horizontalCenter }
-            source: "cog.svg"
+            source: "manage.svg"
         }
     }
     

--- a/src/gui/manage.svg
+++ b/src/gui/manage.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"/></svg>

--- a/src/gui/qjacktrip.qrc
+++ b/src/gui/qjacktrip.qrc
@@ -21,7 +21,7 @@
     <file>public.svg</file>
     <file>join.svg</file>
     <file>leave.svg</file>
-    <file>cog.svg</file>
+    <file>manage.svg</file>
     <file>mic.svg</file>
     <file>ethernet.png</file>
     <file>ohno.png</file>

--- a/src/gui/qjacktrip.qrc
+++ b/src/gui/qjacktrip.qrc
@@ -22,6 +22,7 @@
     <file>join.svg</file>
     <file>leave.svg</file>
     <file>manage.svg</file>
+    <file>cog.svg</file>
     <file>mic.svg</file>
     <file>ethernet.png</file>
     <file>ohno.png</file>


### PR DESCRIPTION
People have been confused thinking the "Manage" gear in an inactive Studio will take them to audio settings. So this replaces it with an "Open in new window" icon and adds a settings gear to the actual settings button in the bottom right.

<img width="808" alt="Screen Shot 2022-08-11 at 12 54 12 PM" src="https://user-images.githubusercontent.com/5567285/184208833-0f5ab324-084f-461b-92af-72fe46c9ebbf.png">
<img width="808" alt="Screen Shot 2022-08-11 at 1 04 13 PM" src="https://user-images.githubusercontent.com/5567285/184208847-c8da2b9a-9b8c-4b8d-999f-c9b72defd560.png">

