### PR TITLE
Update jacktrip_globals.h for 1.6.2-rc3

### DIFF
--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -40,7 +40,7 @@
 
 #include "AudioInterface.h"
 
-constexpr const char* const gVersion = "1.6.2-rc.2";  ///< JackTrip version
+constexpr const char* const gVersion = "1.6.2-rc.3";  ///< JackTrip version
 
 //*******************************************************************************
 /// \name Default Values


### PR DESCRIPTION
Bumps global `gVersion` value to `1.6.2-rc.3`