### PR TITLE
Don't crash on unsupported RtAudio sample rate

### DIFF
--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -1050,14 +1050,14 @@ void JackTrip::stop(const QString& errorMessage)
     mHasShutdown = true;
     std::cout << "Stopping JackTrip..." << std::endl;
 
-    if (mDataProtocolSender != nullptr){
+    if (mDataProtocolSender != nullptr) {
         // Stop The Sender
         mDataProtocolSender->stop();
         mDataProtocolSender->wait();
     }
 
-    if (mDataProtocolReceiver != nullptr){
-         // Stop The Receiver
+    if (mDataProtocolReceiver != nullptr) {
+        // Stop The Receiver
         mDataProtocolReceiver->stop();
         mDataProtocolReceiver->wait();
     }

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -1050,13 +1050,17 @@ void JackTrip::stop(const QString& errorMessage)
     mHasShutdown = true;
     std::cout << "Stopping JackTrip..." << std::endl;
 
-    // Stop The Sender
-    mDataProtocolSender->stop();
-    mDataProtocolSender->wait();
+    if (mDataProtocolSender != nullptr){
+        // Stop The Sender
+        mDataProtocolSender->stop();
+        mDataProtocolSender->wait();
+    }
 
-    // Stop The Receiver
-    mDataProtocolReceiver->stop();
-    mDataProtocolReceiver->wait();
+    if (mDataProtocolReceiver != nullptr){
+         // Stop The Receiver
+        mDataProtocolReceiver->stop();
+        mDataProtocolReceiver->wait();
+    }
 
     // Stop the audio processes
     // mAudioInterface->stopProcess();

--- a/src/RtAudioInterface.cpp
+++ b/src/RtAudioInterface.cpp
@@ -163,7 +163,7 @@ void RtAudioInterface::setup()
         setBufferSize(bufferFrames);
     } catch (RtAudioError& e) {
         std::cout << '\n' << e.getMessage() << '\n' << std::endl;
-        exit(0);
+        throw std::runtime_error(e.getMessage());
     }
 
     // Setup parent class

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -769,14 +769,7 @@ void VirtualStudio::completeConnection()
         m_connectionState = QStringLiteral("JackTrip Error");
         emit connectionStateChanged();
 
-        QMessageBox msgBox;
-        msgBox.setText(QStringLiteral("Error: ").append(e.what()));
-        msgBox.setWindowTitle(QStringLiteral("Doh!"));
-        msgBox.exec();
-
-        m_jackTripRunning = false;
-        emit disconnected();
-        m_onConnectedScreen = false;
+        processError(QString::fromUtf8(e.what()));
         return;
     }
 


### PR DESCRIPTION
What this change _actually_ does is pass RtAudio errors up to Qt for JackTrip to handle. If a GUI is present, the GUI handles it gracefully. 

In classic mode, it just pops up a message box and refuses to connect.

In Virtual Studio mode, it pops up a message box and goes back to the browse screen.