### PR TITLE
UI: fix fractional UI scaling on Windows

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -140,10 +140,20 @@ QCoreApplication* createApplication(int& argc, char* argv[])
 #if defined(Q_OS_MACOS) && !defined(NO_VS)
         // Turn on high DPI support.
         JTApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+        // Fix for display scaling like 125% or 150% on Windows
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+        QGuiApplication::setHighDpiScaleFactorRoundingPolicy(
+            Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
+#endif  // QT_VERSION
         return new JTApplication(argc, argv);
 #else
         // Turn on high DPI support.
         QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+        // Fix for display scaling like 125% or 150% on Windows
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+        QGuiApplication::setHighDpiScaleFactorRoundingPolicy(
+            Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
+#endif  // QT_VERSION
         return new QApplication(argc, argv);
 #endif  // Q_OS_MACOS
 #endif  // NO_GUI


### PR DESCRIPTION
Fixes #688

This applies primarily to Windows, when the display scaling is set to 150%, 125%, 175% etc. Previously, the interface was rendered at 100% or 200% (most noticeable for 150%, which was rendered at 200%). With this change, the interface is scaled accordingly to to the fractional scaling.

This might also apply to Linux, although not for our static build, which uses Qt 5.12 (the fix is only valid for Qt 5.14+).
macOS was already behaving correctly.

Reference: https://doc.qt.io/qt-5/highdpi.html#high-dpi-support-in-qt