### PR TITLE
GHA: update cache actions

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -315,7 +315,7 @@ jobs:
       - name: cache Qt
         id: cache-qt
         if: matrix.qt-arch && !matrix.static-qt-version
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ../Qt
           key: $${{ runner.os }}-QtCache-${{ env.QT_VERSION }}-${{ matrix.build-system }}_${{matrix.qt-cache-key}}
@@ -330,7 +330,7 @@ jobs:
       - name: cache static Qt
         id: cache-static-qt
         if: matrix.static-qt-version
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ${{ env.QT_STATIC_BUILD_PATH }}
           key: ${{ runner.os }}-QtStaticCache-${{ matrix.static-qt-version }}_${{ matrix.qt-static-cache-key }}

--- a/.github/workflows/jacktriplabs.yml
+++ b/.github/workflows/jacktriplabs.yml
@@ -175,7 +175,7 @@ jobs:
       - name: cache Qt
         id: cache-qt
         if: matrix.qt-arch && !matrix.static-qt-version
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ../Qt
           key: $${{ runner.os }}-QtCache-${{ env.QT_VERSION }}-${{ matrix.build-system }}
@@ -189,7 +189,7 @@ jobs:
       - name: cache static Qt
         id: cache-static-qt
         if: matrix.static-qt-version
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ${{ env.QT_STATIC_BUILD_PATH }}
           key: ${{ runner.os }}-QtStaticCache-${{ matrix.static-qt-version }}_${{ matrix.qt-static-cache-key }}


### PR DESCRIPTION
I was puzzled to see that our scheduled builds [did not use](https://github.com/jacktrip/jacktrip/runs/7822792936?check_suite_focus=true#step:11:17), nor update, static Qt cache.

It seems that access to events that are triggered on schedule was [added to the newer version of the cache action](https://github.com/actions/cache/issues/63#issuecomment-629422053). I've updated our cache actions accordingly.

I've made the changes to both jacktrip and jacktrip labs workflows.

IMO this should make its way into `main` as soon as possible, as scheduled actions are based on the default branch. Thus, I'd like this to go in before releasing 1.6.2.