### PR TITLE
Update edge manifests with 1.6.2 release

### DIFF
--- a/releases/edge/mac-manifests.json
+++ b/releases/edge/mac-manifests.json
@@ -2,6 +2,16 @@
     "app_name": "JackTrip",
     "releases": [
         {
+            "version": "1.6.2",
+            "changelog": "Ability to open app via URL schemes, displaying latency stats, and Virtual Studio device support. Learn more here: https://github.com/jacktrip/jacktrip/releases/tag/v1.6.2",
+            "download": {
+                "date": "2022-08-17T00:00:00Z",
+                "url": "https://github.com/jacktrip/jacktrip/releases/download/v1.6.2/JackTrip-v1.6.2-macOS-x64-installer.pkg",
+                "downloadSize": 11536442,
+                "sha256": "450222f4db1922275e07286d0be6ea2df2873a8a39c3b23096bcfbce342b7b3c"
+            }
+        },
+        {
             "version": "1.6.2-rc.3",
             "changelog": "Ability to open app via URL schemes, displaying latency stats, and Virtual Studio device support. Learn more here: https://github.com/jacktrip/jacktrip/releases/tag/v1.6.2-rc3",
             "download": {

--- a/releases/edge/win-manifests.json
+++ b/releases/edge/win-manifests.json
@@ -2,6 +2,16 @@
     "app_name": "JackTrip",
     "releases": [
         {
+            "version": "1.6.2",
+            "changelog": "Ability to open app via URL schemes, displaying latency stats, and Virtual Studio device support. Learn more here: https://github.com/jacktrip/jacktrip/releases/tag/v1.6.2",
+            "download": {
+                "date": "2022-08-17T00:00:00Z",
+                "url": "https://github.com/jacktrip/jacktrip/releases/download/v1.6.2/JackTrip-v1.6.2-Windows-x64-installer.msi",
+                "downloadSize": 43606016,
+                "sha256": "2bb06fe3624df447d56da0d72fef1f4328346fd92c6dffccf66ba37253ec5e62"
+            }
+        },
+        {
             "version": "1.6.2-rc.3",
             "changelog": "Ability to open app via URL schemes, displaying latency stats, and Virtual Studio device support. Learn more here: https://github.com/jacktrip/jacktrip/releases/tag/v1.6.2-rc3",
             "download": {


### PR DESCRIPTION
Forgot to include this in the last PR