### PR TITLE
Fix cache for real

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -234,10 +234,18 @@ jobs:
           fi
           echo "::set-output name=version::$VERSION"
           echo "::set-output name=name::$NAME"
+          echo "::set-output name=stamp::$(date '+%Y-%m-%d')" # set timestamp for cache
       - name: setup python
         uses: actions/setup-python@v2
         with:
           python-version: '3.x'
+      - name: cache vcpkg on Windows
+        if: runner.os == 'Windows' && matrix.vcpkg-triplet
+        uses: actions/cache@v3
+        with:
+          path: ~/AppData/Local/vcpkg/archives
+          key: ${{ matrix.runs-on }}-${{ matrix.vcpkg-triplet }}-${{ matrix.system-rtaudio }}-${{ steps.set-version.outputs.stamp }}
+          restore-keys: ${{ matrix.runs-on }}-${{ matrix.vcpkg-triplet }}-${{ matrix.system-rtaudio }}
       - name: install dependencies for Linux
         if: runner.os == 'Linux'
         run: |

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -312,20 +312,14 @@ jobs:
       - name: setup MSVC
         uses: ilammy/msvc-dev-cmd@v1
         if: runner.os == 'Windows' && matrix.build-system == 'meson' # MSVC used only by meson
-      - name: cache Qt
-        id: cache-qt
-        if: matrix.qt-arch && !matrix.static-qt-version
-        uses: actions/cache@v3
-        with:
-          path: ../Qt
-          key: $${{ runner.os }}-QtCache-${{ env.QT_VERSION }}-${{ matrix.build-system }}_${{matrix.qt-cache-key}}
       - name: install Qt
-        uses: jurplel/install-qt-action@v2
+        uses: jurplel/install-qt-action@v3
         if: runner.os == 'Windows' && !matrix.static-qt-version
         with:
           version: ${{ env.QT_VERSION }}
           arch: ${{ matrix.qt-arch }}
-          cached: ${{ steps.cache-qt.outputs.cache-hit }}
+          cache: true
+          cache-key-prefix: $${{ runner.os }}-QtCache-${{ env.QT_VERSION }}-${{ matrix.build-system }}_${{matrix.qt-cache-key}}
           modules: 'qtnetworkauth'
       - name: cache static Qt
         id: cache-static-qt

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -208,7 +208,7 @@ jobs:
       QT_VERSION: '5.15.2' # for shared qt installer using install-qt-action
       DEVELOPER_DIR: '/Applications/Xcode_11.7.app/Contents/Developer' # specify XCode version on macOS
       QT_SRC_PATH: ${{ github.workspace }}/../qt-static-src
-      QT_STATIC_BUILD_PATH: ${{ github.workspace }}/../qt-static
+      QT_STATIC_BUILD_PATH: ${{ github.workspace }}/qt-static # note: don't use '..' here as this is used with the cache action, which doesn't support '.' and '..' in paths
       QT_STATIC_OPTIONS: '-static -release -optimize-size -no-pch -nomake tools -nomake tests -nomake examples -opensource -confirm-license -skip webengine -skip qt3d -skip qtactiveqt -skip qtandroidextras -skip qtcharts -skip qtdatavis3d -skip qtdoc -skip qtgamepad -skip qtimageformats -skip qtlocation -skip qtmultimedia -skip qtpurchasing -skip qtpurchasing -skip qtremoteobjects -skip qtscript -skip qtsensors -skip qtserialbus -skip qtserialport -skip qtspeech -skip qttools -skip qtvirtualkeyboard -skip qtwebchannel -skip qtwebengine -skip qtwebglplugin -skip qtwebview -skip qtxmlpatterns' # common for all platforms
       CLANG_TIDY_NAME: clang-tidy-result
       CLANG_TIDY_PATH: ${{ github.workspace }}/clang-tidy-result

--- a/.github/workflows/jacktriplabs.yml
+++ b/.github/workflows/jacktriplabs.yml
@@ -120,10 +120,18 @@ jobs:
           fi
           echo "::set-output name=version::$VERSION"
           echo "::set-output name=name::$NAME"
+          echo "::set-output name=stamp::$(date '+%Y-%m-%d')" # set timestamp for cache
       - name: setup python
         uses: actions/setup-python@v2
         with:
           python-version: '3.x'
+      - name: cache vcpkg on Windows
+        if: runner.os == 'Windows' && matrix.vcpkg-triplet
+        uses: actions/cache@v3
+        with:
+          path: ~/AppData/Local/vcpkg/archives
+          key: ${{ matrix.runs-on }}-${{ matrix.vcpkg-triplet }}-${{ matrix.system-rtaudio }}-${{ steps.set-version.outputs.stamp }}
+          restore-keys: ${{ matrix.runs-on }}-${{ matrix.vcpkg-triplet }}-${{ matrix.system-rtaudio }}
       - name: install dependencies for macOS
         if: runner.os == 'macOS'
         env:

--- a/.github/workflows/jacktriplabs.yml
+++ b/.github/workflows/jacktriplabs.yml
@@ -94,7 +94,7 @@ jobs:
       QT_VERSION: '5.15.2' # for shared qt installer using install-qt-action
       DEVELOPER_DIR: '/Applications/Xcode_11.7.app/Contents/Developer' # specify XCode version on macOS
       QT_SRC_PATH: ${{ github.workspace }}/../qt-static-src
-      QT_STATIC_BUILD_PATH: ${{ github.workspace }}/../qt-static
+      QT_STATIC_BUILD_PATH: ${{ github.workspace }}/qt-static # note: don't use '..' here as this is used with the cache action, which doesn't support '.' and '..' in paths
       QT_STATIC_OPTIONS: '-static -release -optimize-size -no-pch -nomake tools -nomake tests -nomake examples -opensource -confirm-license -skip webengine -skip qt3d -skip qtactiveqt -skip qtandroidextras -skip qtcharts -skip qtdatavis3d -skip qtdoc -skip qtgamepad -skip qtimageformats -skip qtlocation -skip qtmultimedia -skip qtpurchasing -skip qtpurchasing -skip qtremoteobjects -skip qtscript -skip qtsensors -skip qtserialbus -skip qtserialport -skip qtspeech -skip qttools -skip qtvirtualkeyboard -skip qtwebchannel -skip qtwebengine -skip qtwebglplugin -skip qtwebview -skip qtxmlpatterns' # common for all platforms
       CLANG_TIDY_NAME: clang-tidy-result
       CLANG_TIDY_PATH: ${{ github.workspace }}/clang-tidy-result

--- a/.github/workflows/jacktriplabs.yml
+++ b/.github/workflows/jacktriplabs.yml
@@ -172,20 +172,15 @@ jobs:
             pip install meson ninja
             mv /usr/bin/link.exe /usr/bin/link_disabled # disable gnu linker
           fi
-      - name: cache Qt
-        id: cache-qt
-        if: matrix.qt-arch && !matrix.static-qt-version
-        uses: actions/cache@v3
-        with:
-          path: ../Qt
-          key: $${{ runner.os }}-QtCache-${{ env.QT_VERSION }}-${{ matrix.build-system }}
       - name: install Qt
-        uses: jurplel/install-qt-action@v2
+        uses: jurplel/install-qt-action@v3
         if: runner.os == 'Windows' && !matrix.static-qt-version
         with:
           version: ${{ env.QT_VERSION }}
           arch: ${{ matrix.qt-arch }}
-          cached: ${{ steps.cache-qt.outputs.cache-hit }}
+          cache: true
+          cache-key-prefix: $${{ runner.os }}-QtCache-${{ env.QT_VERSION }}-${{ matrix.build-system }}_${{matrix.qt-cache-key}}
+          modules: 'qtnetworkauth'
       - name: cache static Qt
         id: cache-static-qt
         if: matrix.static-qt-version


### PR DESCRIPTION
Okay, this time for real... (?) 
It turns out, that my last fix for cache [did not fully work](https://github.com/jacktrip/jacktrip/runs/7887245774?check_suite_focus=true#step:50:2).

cache action@v1 [supports](https://github.com/jacktrip/jacktrip/runs/7866917357?check_suite_focus=true#step:50:3) relative paths (which we used for the static qt build), but does not work on scheduled jobs (that's why I updated it for 1.6.2).
cache action@v2/v3 works on scheduled jobs, but does not support relative paths... which this PR fixes.

This PR changes the location of the static qt build, which fixes caching with the new version of the action. IUUC, cache should also now work for the scheduled jobs (but we'll get the confirmation once the scheduled job gets triggered...)

The caching of the static build [did work](https://github.com/jacktrip/jacktrip/runs/7890961982?check_suite_focus=true#step:10:20) for the second build in this PR (i.e. at the very least caching is confirmed to work on the same branch).

Additionally, I've noticed that the "install qt" action (for shared qt library) now provides built-in caching, so I've switched to use that.

EDIT: I've also added caching for vcpkg on windows, which should save quite a bit of time. Compare vcpkg in builds [2603](https://github.com/jacktrip/jacktrip/runs/7891098371?check_suite_focus=true#step:8:276) and [2604](https://github.com/jacktrip/jacktrip/runs/7892034279?check_suite_focus=true#step:8:78).

Finally, I've made analogous changes to the JTLabs workflow, but I didn't (couldn't) test that.

---
Since we need this change on `main` in order to be applied to scheduled jobs, I think we should pull this into `main`, then pull `main` into `dev`. Is that okay?