### PR TITLE
Don't print every argument

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -90,7 +90,6 @@ QCoreApplication* createApplication(int& argc, char* argv[])
     // Check for some specific, GUI related command line options.
     bool forceGui = false;
     for (int i = 1; i < argc; i++) {
-        std::cout << argv[i] << std::endl;
         if (strcmp(argv[i], "--gui") == 0) {
             forceGui = true;
         } else if (strcmp(argv[i], "--test-gui") == 0) {


### PR DESCRIPTION
Not sure why this was added, but it definitely shouldn't be in a release version.