### PR TITLE
Fix qDebug segfault

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,8 @@ if (NOT nogui)
       src/gui/vsUrlHandler.cpp
       src/gui/vsWebSocket.cpp
       src/gui/qjacktrip.qrc
+      # Need to include this for AUTOMOC to do its thing
+      src/JTApplication.h
     )
   else ()
     set (qjacktrip_SRC ${qjacktrip_SRC} src/gui/qjacktrip_novs.qrc)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -506,7 +506,6 @@ int main(int argc, char* argv[])
 #endif  // NO_GUI
         // Otherwise use the non-GUI version, and parse our command line.
         QLoggingCategory::setFilterRules(QStringLiteral("*.debug=true"));
-        qInstallMessageHandler(qtMessageHandler);
         try {
             Settings settings;
             settings.parseInput(argc, argv);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -90,7 +90,6 @@ QCoreApplication* createApplication(int& argc, char* argv[])
     // Check for some specific, GUI related command line options.
     bool forceGui = false;
     for (int i = 1; i < argc; i++) {
-        std::cout << argv[i] << std::endl;
         if (strcmp(argv[i], "--gui") == 0) {
             forceGui = true;
         } else if (strcmp(argv[i], "--test-gui") == 0) {


### PR DESCRIPTION
Don't install the custom message handler when we haven't initialised the text stream.