### PR TITLE
Bump global to 1.6.3 for release

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -1,3 +1,9 @@
+- Version: "1.6.3"
+  Date: 2022-08-23
+  Description:
+  - (fixed) Segfault when creating a hub server via cmd line
+  - (fixed) Linux desktop file is no longer invalid
+  - (fixed) Command line arguments no longer print to console
 - Version: "1.6.2"
   Date: 2022-08-05
   Description:

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -40,7 +40,7 @@
 
 #include "AudioInterface.h"
 
-constexpr const char* const gVersion = "1.6.3-dev";  ///< JackTrip version
+constexpr const char* const gVersion = "1.6.3";  ///< JackTrip version
 
 //*******************************************************************************
 /// \name Default Values


### PR DESCRIPTION
Given the work by @psiborg112 in #704 to solve the segfault when creating servers and myself #706 to make sure the linux desktop file validates correctly, we should release 1.6.3. This is prep for that PR.