### PR TITLE
PLC avoid processing same packet -- zero instead when extreme underrun 

### DIFF
--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -382,6 +382,11 @@ void Regulator::pullPacket(int8_t* buf)
                 goto PACKETOK;
             }
         }
+        if (mLastSeqNumOut == mLastSeqNumIn) {
+            //            std::cout << "mLastSeqNumIn: " << mLastSeqNumIn <<
+            //            "\tmLastSeqNumOut: " << mLastSeqNumOut << std::endl;
+            goto ZERO_OUTPUT;
+        }
         goto UNDERRUN;
     }
 


### PR DESCRIPTION
if a client stalls out, a worker using PLC was uselessly processing the last good packet and driving up load