### PR TITLE
Let's cut RC1 of 1.6.4

### DIFF
--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -40,7 +40,7 @@
 
 #include "AudioInterface.h"
 
-constexpr const char* const gVersion = "1.6.3";  ///< JackTrip version
+constexpr const char* const gVersion = "1.6.4-rc1";  ///< JackTrip version
 
 //*******************************************************************************
 /// \name Default Values


### PR DESCRIPTION
There's a lot to test with volume meters in VS mode, so can we go ahead and cut a release candidate for 1.6.4?