### PR TITLE
Sign bundled_rtaudio build

### DIFF
--- a/.github/workflows/jacktriplabs.yml
+++ b/.github/workflows/jacktriplabs.yml
@@ -365,7 +365,7 @@ jobs:
         include:
           - name: Sign macOS artifacts
             release-name: macOS-x64
-            build-job-name: macOS-x64-qmake-clang-static
+            build-job-name: macOS-x64-qmake-clang-static-bundled_rtaudio
             runs-on: macos-11
             binary-path: binary
             bundle-path: bundle


### PR DESCRIPTION
We didn't fully update `jacktriplabs.yml` when we bundled rtaudio with the macOS release to fix High Sierra.