### PR TITLE
Update version and changelog for 1.6.4 release

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -14,6 +14,7 @@
   - (fixed) UI hanging when connecting to Studios in VS mode
   - (fixed) "Refresh list" button disabling ui interaction in VS mode
   - (fixed) Network stats not displaying on first connect after login (VS mode)
+  - (fixed) VS mode won't join studios when on warning or device setup screens
 - Version: "1.6.3"
   Date: 2022-08-23
   Description:

--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -1,5 +1,5 @@
 - Version: "1.6.4"
-  Date: 2022-09-01
+  Date: 2022-09-16
   Description:
   - (added) Volume meters when connected to a Studio in VS mode
   - (added) Validation of Linux desktop file in build steps

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -40,7 +40,7 @@
 
 #include "AudioInterface.h"
 
-constexpr const char* const gVersion = "1.6.4-rc.2";  ///< JackTrip version
+constexpr const char* const gVersion = "1.6.4";  ///< JackTrip version
 
 //*******************************************************************************
 /// \name Default Values


### PR DESCRIPTION
There's a **_LOT_** that's ready to go, so let's get 1.6.4 out the door.