### PR TITLE
Adding linux manifests

### DIFF
--- a/releases/stable/linux-manifests.json
+++ b/releases/stable/linux-manifests.json
@@ -1,0 +1,15 @@
+{
+    "app_name": "JackTrip",
+    "releases": [
+        {
+            "version": "1.6.4",
+            "changelog": "Adding volume meters, bugfixes around Windows hanging, device disconnects, and PLC: https://github.com/jacktrip/jacktrip/releases/tag/v1.6.4",
+            "download": {
+                "date": "2022-09-16T00:00:00Z",
+                "url": "https://github.com/jacktrip/jacktrip/releases/download/v1.6.4/JackTrip-v1.6.4-Linux-x64-binary.zip",
+                "downloadSize": 22233485,
+                "sha256": "f1b9585e4eb72c07c735ee6f4dc94ad1d1a4c70474799eb1111bb5a39a99e295"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Only adding this to stable, since there currently is no Linux installer or auto-update functionality. This is only going to be used to automatically redirect download links to the latest version via https://jktp.net/download/linux
