### PR TITLE
VS: Adjust default behavior on login

### DIFF
--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -72,7 +72,7 @@ VirtualStudio::VirtualStudio(bool firstRun, QObject* parent)
     m_userId          = settings.value(QStringLiteral("UserId"), "").toString();
     m_uiScale         = settings.value(QStringLiteral("UiScale"), 1).toFloat();
     m_darkMode        = settings.value(QStringLiteral("DarkMode"), false).toBool();
-    m_showInactive    = settings.value(QStringLiteral("ShowInactive"), false).toBool();
+    m_showInactive    = settings.value(QStringLiteral("ShowInactive"), true).toBool();
     m_showSelfHosted  = settings.value(QStringLiteral("ShowSelfHosted"), false).toBool();
     m_showDeviceSetup = settings.value(QStringLiteral("ShowDeviceSetup"), true).toBool();
     m_showWarnings    = settings.value(QStringLiteral("ShowWarnings"), true).toBool();
@@ -647,6 +647,10 @@ void VirtualStudio::logout()
     settings.beginGroup(QStringLiteral("VirtualStudio"));
     settings.remove(QStringLiteral("RefreshToken"));
     settings.remove(QStringLiteral("UserId"));
+    settings.remove(QStringLiteral("ShowInactive"));
+    settings.remove(QStringLiteral("ShowSelfHosted"));
+    settings.remove(QStringLiteral("ShowDeviceSetup"));
+    settings.remove(QStringLiteral("ShowWarnings"));
     settings.endGroup();
 
     m_refreshTimer.stop();

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -281,7 +281,7 @@ class VirtualStudio : public QObject
 
     bool m_onConnectedScreen = false;
     bool m_isExiting         = false;
-    bool m_showInactive      = false;
+    bool m_showInactive      = true;
     bool m_showSelfHosted    = false;
     bool m_showCreateStudio  = false;
     bool m_showDeviceSetup   = true;


### PR DESCRIPTION
Makes inactive studios visible by default and deletes filter and warning preferences on logout.