### PR TITLE
VS: Fix logout freeze

### DIFF
--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1008,7 +1008,7 @@ void VirtualStudio::slotAuthSucceded()
     if (m_regions.isEmpty()) {
         getRegions();
     }
-    if (m_userMetadata.isEmpty()) {
+    if (m_userMetadata.isEmpty() && !m_userId.isEmpty()) {
         getUserMetadata();
     }
 
@@ -1488,6 +1488,11 @@ void VirtualStudio::getUserId()
         settings.setValue(QStringLiteral("UserId"), m_userId);
         settings.endGroup();
         getSubscriptions();
+
+        if (m_userMetadata.isEmpty() && !m_userId.isEmpty()) {
+            getUserMetadata();
+        }
+
         reply->deleteLater();
     });
 }


### PR DESCRIPTION
Before this fix, if you attempt to logout during the same app session that you logged in, the app will hang on "Logging in..." instead of showing you the "Sign In" and "Back" buttons.

This is because `getUserMetadata()` was failing due to `m_userID` being empty when it was run. This meant that technically, auth failed despite us getting a refresh token, etc. So the app was still waiting for a login. 

I just adjusted it to
1. Only `getUserMetadata` if `m_userID` existed
2. Attempt to `getUserMetadata` if it was empty after every `getUserID`

No more `authFailed`.