### PR TITLE
Fix exit button in qt6

### DIFF
--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -69,6 +69,7 @@ QJackTrip::QJackTrip(int argc, bool suppressCommandlineWarning, QWidget* parent)
     , m_realCerr(std::cerr.rdbuf())
     , m_jackTripRunning(false)
     , m_isExiting(false)
+    , m_exitSent(false)
     , m_hasIPv4Reply(false)
     , m_argc(argc)
     , m_hideWarning(false)
@@ -314,9 +315,7 @@ QJackTrip::QJackTrip(int argc, bool suppressCommandlineWarning, QWidget* parent)
     // Check if Jack is actually available
     if (have_libjack() != 0) {
 #ifdef RT_AUDIO
-#ifdef PSI
         bool usingRtAudioAlready = m_ui->backendComboBox->currentIndex() == 1;
-#endif  // PSI
         m_ui->backendComboBox->setCurrentIndex(1);
         m_ui->backendComboBox->setEnabled(false);
         m_ui->backendLabel->setEnabled(false);
@@ -384,9 +383,11 @@ QJackTrip::QJackTrip(int argc, bool suppressCommandlineWarning, QWidget* parent)
 
 void QJackTrip::closeEvent(QCloseEvent* event)
 {
-    // Ignore the close event so that we can override the handling of it.
-    event->ignore();
-    exit();
+    if (!m_exitSent) {
+        // Ignore the close event so that we can override the handling of it.
+        event->ignore();
+        exit();
+    }
 }
 
 void QJackTrip::resizeEvent(QResizeEvent* event)
@@ -469,6 +470,7 @@ void QJackTrip::processFinished()
         m_jackTrip.reset();
     }
     if (m_isExiting) {
+        m_exitSent = true;
         emit signalExit();
     } else {
         enableUi(true);
@@ -977,6 +979,7 @@ void QJackTrip::exit()
     if (m_jackTripRunning) {
         stop();
     } else {
+        m_exitSent = true;
         emit signalExit();
     }
 }

--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -315,7 +315,9 @@ QJackTrip::QJackTrip(int argc, bool suppressCommandlineWarning, QWidget* parent)
     // Check if Jack is actually available
     if (have_libjack() != 0) {
 #ifdef RT_AUDIO
+#ifdef PSI
         bool usingRtAudioAlready = m_ui->backendComboBox->currentIndex() == 1;
+#endif  // PSI
         m_ui->backendComboBox->setCurrentIndex(1);
         m_ui->backendComboBox->setEnabled(false);
         m_ui->backendLabel->setEnabled(false);

--- a/src/gui/qjacktrip.h
+++ b/src/gui/qjacktrip.h
@@ -137,6 +137,7 @@ class QJackTrip : public QMainWindow
     std::ostream m_realCerr;
     bool m_jackTripRunning;
     bool m_isExiting;
+    bool m_exitSent;
 
     QMutex m_requestMutex;
     QString m_IPv6Address;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -139,7 +139,9 @@ QCoreApplication* createApplication(int& argc, char* argv[])
 #endif
 #if defined(Q_OS_MACOS) && !defined(NO_VS)
         // Turn on high DPI support.
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
         JTApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
         // Fix for display scaling like 125% or 150% on Windows
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
         QGuiApplication::setHighDpiScaleFactorRoundingPolicy(
@@ -148,7 +150,9 @@ QCoreApplication* createApplication(int& argc, char* argv[])
         return new JTApplication(argc, argv);
 #else
         // Turn on high DPI support.
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
         QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
         // Fix for display scaling like 125% or 150% on Windows
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
         QGuiApplication::setHighDpiScaleFactorRoundingPolicy(


### PR DESCRIPTION
Allows the app to quit as expected when closing the window or hitting the exit button. With this change, the NO_VS build seems to work fine when built with Qt6.