### PR TITLE
Update for notarization

### DIFF
--- a/macos/assemble_app.sh
+++ b/macos/assemble_app.sh
@@ -120,7 +120,7 @@ sed -i '' "s/%BUNDLEID%/$BUNDLE_ID/" "$APPNAME.app/Contents/Info.plist"
 
 if [ ! -z "$DYNAMIC_QT" ]; then
     QT_VERSION="qt$(echo "$DYNAMIC_QT" | sed -E '1!d;s/.*compatibility version ([0-9]+)\.[0-9]+\.[0-9]+.*/\1/g')"
-    echo "$QT_VERSION"
+    echo "Detected a Qt$QT_VERSION binary"
     DEPLOY_CMD="$(which macdeployqt)"
     if [ -z "$DEPLOY_CMD" ]; then
         # Attempt to find macdeployqt. Try macports location first, then brew.

--- a/macos/assemble_app.sh
+++ b/macos/assemble_app.sh
@@ -64,11 +64,14 @@ while getopts ":inhqc:d:u:p:t:b:" opt; do
         echo " -d <certname>      Name of the certificate to use for package signing. (No signing by default.)"
         echo " -u <username>      Apple ID username (email address) for installer notarization."
         echo " -p <password>      App specific password for installer notarization."
-        echo " -t <team id>       Team ID for notarization. (Only required if you belong to multiple dev teams.)"
+        echo " -t <teamid>        Team ID for notarization. (Only required if you belong to multiple dev teams.)"
         echo " -h                 Display this help screen and exit."
         echo
         echo "By default, appname is set to JackTrip and bundlename is org.jacktrip.jacktrip."
         echo "(These should be left as is for official builds.)"
+        echo
+        echo "The username, password, and team ID are saved in the keychain by notarytool."
+        echo "They only need to be supplied once, or in the eventh that you need to change them."
  
         exit 0
         ;;

--- a/macos/assemble_app.sh
+++ b/macos/assemble_app.sh
@@ -8,14 +8,16 @@ NOTARIZE=false
 #If you're lazy like I am, you can pre-populate these variables to save you stuffing about with command line options.
 #CERTIFICATE=""
 #PACKAGE_CERT=""
-#USERNAME=""
-#PASSWORD=""
-#ASC_PROVIDER=""
+USERNAME=""
+PASSWORD=""
+TEAM_ID=""
+KEY_STORE="AC_PASSWORD"
 BINARY="../builddir/jacktrip"
+PSI=false
 
 OPTIND=1
 
-while getopts ":inhc:d:u:p:a:b:" opt; do
+while getopts ":inhqc:d:u:p:t:b:" opt; do
     case $opt in
       i)
         BUILD_INSTALLER=true
@@ -35,11 +37,14 @@ while getopts ":inhc:d:u:p:a:b:" opt; do
       p)
         PASSWORD=$OPTARG
         ;;
-      a)
-        ASC_PROVIDER=$OPTARG
+      t)
+        TEAM_ID=$OPTARG
         ;;
       b)
         BINARY=$OPTARG
+        ;;
+      q)
+        PSI=true
         ;;
       \?)
         echo "Invalid option -$OPTARG ignored."
@@ -59,7 +64,7 @@ while getopts ":inhc:d:u:p:a:b:" opt; do
         echo " -d <certname>      Name of the certificate to use for package signing. (No signing by default.)"
         echo " -u <username>      Apple ID username (email address) for installer notarization."
         echo " -p <password>      App specific password for installer notarization."
-        echo " -a <ascprovider>   ASC provider for notarization. (Only required if you belong to multiple dev teams.)"
+        echo " -t <team id>       Team ID for notarization. (Only required if you belong to multiple dev teams.)"
         echo " -h                 Display this help screen and exit."
         echo
         echo "By default, appname is set to JackTrip and bundlename is org.jacktrip.jacktrip."
@@ -97,6 +102,8 @@ cp -f $BINARY "$APPNAME.app/Contents/MacOS/"
 cp -f ../LICENSE.md "$APPNAME.app/Contents/Resources/"
 cp -Rf ../LICENSES "$APPNAME.app/Contents/Resources/"
 
+[ $PSI = true ] && cp jacktrip_alt.icns "$APPNAME.app/Contents/Resources/jacktrip.icns"
+
 DYNAMIC_QT=$(otool -L $BINARY | grep QtCore)
 DYNAMIC_VS=$(otool -L $BINARY | grep QtQml)
 
@@ -109,13 +116,15 @@ sed -i '' "s/%BUNDLENAME%/$APPNAME/" "$APPNAME.app/Contents/Info.plist"
 sed -i '' "s/%BUNDLEID%/$BUNDLE_ID/" "$APPNAME.app/Contents/Info.plist"
 
 if [ ! -z "$DYNAMIC_QT" ]; then
+    QT_VERSION="qt$(echo "$DYNAMIC_QT" | sed -E '1!d;s/.*compatibility version ([0-9]+)\.[0-9]+\.[0-9]+.*/\1/g')"
+    echo "$QT_VERSION"
     DEPLOY_CMD="$(which macdeployqt)"
     if [ -z "$DEPLOY_CMD" ]; then
         # Attempt to find macdeployqt. Try macports location first, then brew.
-        if [ -x "/opt/local/libexec/qt5/bin/macdeployqt" ]; then
-            DEPLOY_CMD="/opt/local/libexec/qt5/bin/macdeployqt"
-        elif [ ! -z $(which brew) ] && [ ! -z $(brew --prefix qt5) ]; then
-            DEPLOY_CMD="$(brew --prefix qt5)/bin/macdeployqt"
+        if [ -x "/opt/local/libexec/$QT_VERSION/bin/macdeployqt" ]; then
+            DEPLOY_CMD="/opt/local/libexec/$QT_VERSION/bin/macdeployqt"
+        elif [ ! -z $(which brew) ] && [ ! -z $(brew --prefix $QT_VERSION) ]; then
+            DEPLOY_CMD="$(brew --prefix $QT_VERSION)/bin/macdeployqt"
         else
             echo "The Qt bin folder needs to be in your PATH for this script to work."
             exit 1
@@ -136,6 +145,11 @@ fi
 
 # If you have Packages installed, you can build an installer for the newly created app bundle.
 [ -z $(which packagesbuild) ] && { echo "You need to have Packages installed to build a package."; exit 1; }
+
+if [ $PSI = true ]; then
+    cp "package/postinstall.sh" "package/postinstall.sh.bak"
+    sed -i '' "s/^open/#open/" "package/postinstall.sh"
+fi
 
 # Needed for notarization.
 [ ! -z "$CERTIFICATE" ] && codesign -f -s "$CERTIFICATE" --entitlements entitlements.plist --options "runtime" "$APPNAME.app"
@@ -165,6 +179,7 @@ sed -i '' "s/%BUNDLENAME%/$APPNAME/" package/JackTrip.pkgproj
 sed -i '' "s/%BUNDLEID%/$BUNDLE_ID/" package/JackTrip.pkgproj
 
 packagesbuild package/JackTrip.pkgproj
+[ $PSI = true ] && mv "package/postinstall.sh.bak" "package/postinstall.sh"
 if pkgutil --check-signature package/build/JackTrip.pkg; then
     echo "Package already signed."
     SIGNED=true
@@ -185,39 +200,24 @@ fi
 
 [ $NOTARIZE = true ] || exit 0
 
-# Submit a notarization request to apple if we have the required credentials.
-if [ -z "$CERTIFICATE" ] || [ -z "$USERNAME" ] || [ -z "$PASSWORD" ] || [ $SIGNED = false ] ; then
-    echo "Not sending notarization request: incomplete credentials."
+# Submit a notarization request to apple if we've chosen to and signed our package.
+if [ $SIGNED = false ] ; then
+    echo "Not sending notarization request: package not signed."
     exit 1
 fi
 
-ASC=""
-if [ ! -z "$ASC_PROVIDER" ]; then
-    ASC=" --asc-provider $ASC_PROVIDER"
+if [ ! -z "$USERNAME" ] && [ ! -z "$PASSWORD" ]; then
+    # We have new credentials. Store them in the keychain so we can use them.
+    TEAM=""
+    if [ ! -z "$TEAM_ID" ]; then
+        TEAM=" --team-id $TEAM_ID"
+    fi
+    xcrun notarytool store-credentials "$KEY_STORE" --apple-id "$USERNAME" --password "$PASSWORD"$TEAM
 fi
-CREDENTIALS="--username $USERNAME --password $PASSWORD$ASC"
 
 echo "Sending notarization request"
-UUID=$(xcrun altool --notarize-app --primary-bundle-id "$BUNDLE_ID" $CREDENTIALS --file "package/build/$APPNAME.pkg" | awk '/RequestUUID/{print $NF}')
-if [ -z "$UUID" ]; then
-    echo "Error sending notarization request"
-    exit 1
-fi
-echo "Package uploaded"
-echo "Request UUID is $UUID"
-echo "Awaiting response from Apple"
-STATUS="in progress"
-ELAPSED=0
-while [ "$STATUS" = "in progress" ]; do
-    sleep 60
-    ((ELAPSED++))
-    STATUS=$(xcrun altool --notarization-info "$UUID" $CREDENTIALS | awk '/Status:/{for(i = 2; i <= NF - 1; i++) printf $i" "; print $NF}')
-    echo "Waited $ELAPSED minute(s). Current status: $STATUS"
-done
-#read -n1 -rsp "Press any key to staple the notarization once it's been approved..."
-#echo
-
-if [ "$STATUS" = "success" ]; then
+xcrun notarytool submit "package/build/$APPNAME.pkg" --keychain-profile "$KEY_STORE" --wait
+if [ $? -eq 0 ]; then
     xcrun stapler staple "package/build/$APPNAME.pkg"
 else
     echo "Notarization failed"

--- a/macos/sign-stuff.sh
+++ b/macos/sign-stuff.sh
@@ -18,7 +18,7 @@ if [ ! -z $2 ]; then
 	SCRIPT_BRANCH="$2"
 fi
 
-CHECK=$(echo "$1" | sed "s/-/./g") 
+CHECK=$(echo "$1" | sed "s/-/./g")
 MAJOR=$(echo $CHECK | cut -d. -f1)
 MINOR=$(echo $CHECK | cut -d. -f2)
 REVISION=$(echo $CHECK | cut -d. -f3)

--- a/macos/sign-stuff.sh
+++ b/macos/sign-stuff.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+# Set these for signing
+CERTIFICATE=""
+PACKAGE_CERT=""
+USERNAME=""
+PASSWORD=""
+# Only needed if you belong to more than one dev team
+TEAM_ID=""
+
+if [ -z $1 ]; then
+	echo "You need to provide a version number as an argument"
+	exit 1
+fi
+VERSION="v$1"
+
+if [ ! -z $2 ]; then
+	SCRIPT_BRANCH="$2"
+fi
+
+CHECK=$(echo "$1" | sed "s/-/./g") 
+MAJOR=$(echo $CHECK | cut -d. -f1)
+MINOR=$(echo $CHECK | cut -d. -f2)
+REVISION=$(echo $CHECK | cut -d. -f3)
+
+if [ $MAJOR -le 1 ] && [ $MINOR -le 6 ] && [ $REVISION -lt 5 ] && [ -z "$SCRIPT_BRANCH" ]; then
+	echo "\033[1mVersion earlier than 1.6.5 detected\033[0m"
+	echo "\033[1mUsing assemble_app.sh script from dev branch\033[1m"
+	echo
+	SCRIPT_BRANCH="dev"
+fi
+
+if [ -d "$VERSION" ]; then
+	rm -rf $VERSION
+fi
+echo "\033[1mDownloading $VERSION from Github\033[0m"
+git clone --branch $VERSION https://github.com/jacktrip/jacktrip.git $VERSION || { echo "\n\033[1mCould not find tagged release for $VERSION\033[0m"; exit 1; }
+if [ ! -z "$SCRIPT_BRANCH" ]; then
+	if ! curl "https://raw.githubusercontent.com/jacktrip/jacktrip/$SCRIPT_BRANCH/macos/assemble_app.sh" -f -o "$VERSION/macos/assemble_app.sh"; then
+		echo "\033[1mUnable to download assemble_app.sh from $SCRIPT_BRANCH\033[0m"
+		echo "(Does this branch exist?)"
+		exit 1
+	fi
+fi
+echo "\n\033[1mDownloading compiled binary\033[0m"
+if ! curl "https://github.com/jacktrip/jacktrip/releases/download/$VERSION/JackTrip-$VERSION-macOS-x64-application.zip" -f -L -o binary.zip; then
+	echo "\033[1mUnable to download binary\033[0m"
+	exit 1
+fi
+echo "\n\033[1mExtracting binary\033[0m"
+mkdir -p "$VERSION/builddir"
+unzip -j binary.zip "JackTrip.app/Contents/MacOS/jacktrip" -d "$VERSION/builddir"
+rm binary.zip
+echo "\n\033[1mBuilding installer\033[0m"
+cd "$VERSION/macos"
+if ./assemble_app.sh -in -c "$CERTIFICATE" -d "$PACKAGE_CERT" -u "$USERNAME" -p "$PASSWORD" -t "$TEAM_ID"; then
+	echo "\n\033[1mCopying signed package to current directory and performing clean up\033[0m"
+	cp "package/build/JackTrip.pkg" ../../
+else
+	echo "\n\033[1mBuilding installer failed. Performing clean up.\033[0m"
+fi
+cd "../.."
+rm -rf $VERSION


### PR DESCRIPTION
Apple has deprecated altool and will stop supporting it from next year. Switch to using the new notarytool in the app assembly script.