### PR TITLE
Attempting to fix detached QVector crash

### DIFF
--- a/src/Meter.cpp
+++ b/src/Meter.cpp
@@ -112,7 +112,9 @@ void Meter::compute(int nframes, float** inputs, float** /*_*/)
         }
 
         /* Update mValues */
+        mValuesMutex.lock();
         mValues[i] = max;
+        mValuesMutex.unlock();
     }
 
     /* Set processed audio flag */
@@ -129,10 +131,12 @@ void Meter::updateNumChannels(int nChansIn, int nChansOut)
     }
 
     mValues.resize(mNumChannels);
+    mValuesMutex.lock();
     QVector<float>::iterator it;
     for (it = mValues.begin(); it != mValues.end(); ++it) {
         *it = threshold;
     }
+    mValuesMutex.unlock();
 }
 
 //*******************************************************************************
@@ -143,9 +147,11 @@ void Meter::onTick()
         emit onComputedVolumeMeasurements(mValues);
 
         /* Set meter values to the default floor */
+        mValuesMutex.lock();
         QVector<float>::iterator it;
         for (it = mValues.begin(); it != mValues.end(); ++it) {
             *it = threshold;
         }
+        mValuesMutex.unlock();
     }
 }

--- a/src/Meter.h
+++ b/src/Meter.h
@@ -39,6 +39,7 @@
 #ifndef __METER_H__
 #define __METER_H__
 
+#include <QMutex>
 #include <QObject>
 #include <QTimer>
 #include <QVector>
@@ -90,6 +91,7 @@ class Meter : public ProcessPlugin
     std::vector<meterdsp*> meterP;
     bool hasProcessedAudio = false;
 
+    QMutex mValuesMutex;
     QTimer mTimer;
     QVector<float> mValues;
 


### PR DESCRIPTION
There's something in VS gui mode that's periodically causing jacktrip to crash. It happens very rarely for me, but the last log line I get is:
```
ASSERT: "isDetached()" in file /opt/homebrew/opt/qt@5/include/QtCore/qvector.h, line 407
```
Some initial research suggests there's a thread-safety problem when using QVectors:
* https://forum.qt.io/topic/90180/assert-isdetached-with-multithreaded-qvectors
* https://interest.qt-project.narkive.com/aVUB82lb/assert-isdetached-with-multithreaded-qvectors
* https://blog.actorsfit.com/a?ID=01150-35eca5ca-9371-43ac-bbcd-5e3757c9940d

I'm not 100% certain it's coming from here, but seems like a possibility? This probably requires more testing