### PR TITLE
Update static Qt

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -346,7 +346,7 @@ jobs:
         run: |
           QT_FULL_VERSION=${{ matrix.static-qt-version }}
           QT_MAJOR_MINOR_VERSION=`echo $QT_FULL_VERSION | cut -d '.' -f1-2`
-          QT_SRC_URL="https://download.qt.io/official_releases/qt/$QT_MAJOR_MINOR_VERSION/$QT_FULL_VERSION/single/qt-everywhere-src-$QT_FULL_VERSION.tar.xz"
+          QT_SRC_URL="https://download.qt.io/archive/qt/$QT_MAJOR_MINOR_VERSION/$QT_FULL_VERSION/single/qt-everywhere-src-$QT_FULL_VERSION.tar.xz"
           echo "Downloading Qt source from $QT_SRC_URL"
           curl -L $QT_SRC_URL -o qt.tar.xz
           echo "Unpacking Qt source"


### PR DESCRIPTION
The address to qt sources has changed. We haven't noticed it on our builds since we've been using cached Qt. But it would become an issue once we need to rebuild Qt, probably at the release.

~~Moreover, I realized that a newer version of Qt 5 is available (5.15.6) so I updated our builds to use that.~~

EDIT: It turns out that Qt sources 5.15.3 - 5.15.6 have a different filename (`qt-everywhere-opensource-src-5.15.N.tar.xz` instead of `qt-everywhere-src-5.15.N.tar.xz`) so I reverted the update to the Qt version, since that would need some extra work in the workflow file. We can still do it if we have a real need to use 5.15.6, but I don't think that's the case right now, so I'm leaving it as is.

Example of the new link:
`https://download.qt.io/archive/qt/$QT_MAJOR_MINOR_VERSION/$QT_FULL_VERSION/single/qt-everywhere-src-$QT_FULL_VERSION.tar.xz` -> https://download.qt.io/archive/qt/5.15/5.15.2/single/qt-everywhere-src-5.15.2.tar.xz

EDIT: this is intentionally aimed at `main`. Since scheduled builds happen on main (and refresh the cache), we should merge this into `main`, and then `main` into `dev`.