### PR TITLE
Allow updater to build with Qt6

### DIFF
--- a/src/dblsqd/feed.cpp
+++ b/src/dblsqd/feed.cpp
@@ -277,14 +277,14 @@ void Feed::handleDownloadReadyRead()
         QString host = url.host();
         if (host.contains("github", Qt::CaseInsensitive) && url.hasQuery()) {
             QString query = url.query();
-            QRegExp rx("filename%3D(.*)(&|$)");
-            rx.setMinimal(true);
-            if (rx.indexIn(query) > -1) {
-                fileName = rx.cap(1);
+            QRegularExpression rx("filename%3D(.*?)(&|$)");
+            QRegularExpressionMatch match = rx.match(query);
+            if (match.hasMatch()) {
+                fileName = match.captured(1);
             }
         }
         // End workaround
-        int extensionPos = fileName.indexOf(QRegExp("(?:\\.tar)?\\.[a-zA-Z0-9]+$"));
+        int extensionPos = fileName.indexOf(QRegularExpression("(?:\\.tar)?\\.[a-zA-Z0-9]+$"));
         if (extensionPos > -1) {
             fileName.insert(extensionPos, "-XXXXXX");
         }

--- a/src/dblsqd/feed.cpp
+++ b/src/dblsqd/feed.cpp
@@ -284,7 +284,8 @@ void Feed::handleDownloadReadyRead()
             }
         }
         // End workaround
-        int extensionPos = fileName.indexOf(QRegularExpression("(?:\\.tar)?\\.[a-zA-Z0-9]+$"));
+        int extensionPos =
+            fileName.indexOf(QRegularExpression("(?:\\.tar)?\\.[a-zA-Z0-9]+$"));
         if (extensionPos > -1) {
             fileName.insert(extensionPos, "-XXXXXX");
         }

--- a/src/dblsqd/semver.cpp
+++ b/src/dblsqd/semver.cpp
@@ -14,13 +14,14 @@ namespace dblsqd
  */
 SemVer::SemVer(QString version) : original(version), valid(false)
 {
-    QRegExp rx(getRegExp());
-    if (rx.indexIn(version) > -1) {
-        this->major      = rx.cap(1).toInt();
-        this->minor      = rx.cap(2).toInt();
-        this->patch      = rx.cap(3).toInt();
-        this->prerelease = rx.cap(4);
-        this->build      = rx.cap(5);
+    QRegularExpression rx(getRegExp());
+    QRegularExpressionMatch match = rx.match(version);
+    if (match.hasMatch()) {
+        this->major      = match.captured(1).toInt();
+        this->minor      = match.captured(2).toInt();
+        this->patch      = match.captured(3).toInt();
+        this->prerelease = match.captured(4);
+        this->build      = match.captured(5);
         this->valid      = true;
     } else {
         this->major      = 0;

--- a/src/dblsqd/semver.h
+++ b/src/dblsqd/semver.h
@@ -2,7 +2,7 @@
 #define DBLSQD_SEMVER_H
 
 #include <QObject>
-#include <QRegExp>
+#include <QRegularExpression>
 
 namespace dblsqd
 {


### PR DESCRIPTION
Change from the deprecated QRexExp class to the QRegularExpression class to allow dblsqd to compile under Qt6.