### PR TITLE
Potential fix for crash involving vumeters

### DIFF
--- a/src/Meter.cpp
+++ b/src/Meter.cpp
@@ -122,6 +122,11 @@ void Meter::compute(int nframes, float** inputs, float** /*_*/)
 //*******************************************************************************
 void Meter::updateNumChannels(int nChansIn, int nChansOut)
 {
+    // this should only be called before init!
+    if (inited) {
+        return;
+    }
+
     if (outgoingPluginToNetwork) {
         mNumChannels = nChansIn;
     } else {
@@ -140,7 +145,9 @@ void Meter::onTick()
 {
     if (hasProcessedAudio) {
         /* Send the measurements to whatever other component requests it */
-        emit onComputedVolumeMeasurements(mValues);
+        QVector<float> valuesCopy(mValues);
+        valuesCopy.detach();
+        emit onComputedVolumeMeasurements(valuesCopy);
 
         /* Set meter values to the default floor */
         QVector<float>::iterator it;

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1309,7 +1309,7 @@ void VirtualStudio::updatedStats(const QJsonObject& stats)
     return;
 }
 
-void VirtualStudio::updatedInputVuMeasurements(const QVector<float> valuesInDecibels)
+void VirtualStudio::updatedInputVuMeasurements(const QVector<float>& valuesInDecibels)
 {
     QJsonArray uiValues;
     bool detectedClip = false;
@@ -1341,7 +1341,7 @@ void VirtualStudio::updatedInputVuMeasurements(const QVector<float> valuesInDeci
                                                        QVariant::fromValue(uiValues));
 }
 
-void VirtualStudio::updatedOutputVuMeasurements(const QVector<float> valuesInDecibels)
+void VirtualStudio::updatedOutputVuMeasurements(const QVector<float>& valuesInDecibels)
 {
     QJsonArray uiValues;
     bool detectedClip = false;

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -189,8 +189,8 @@ class VirtualStudio : public QObject
     void createStudio();
     void editProfile();
     void showAbout();
-    void updatedInputVuMeasurements(const QVector<float> valuesInDecibels);
-    void updatedOutputVuMeasurements(const QVector<float> valuesInDecibels);
+    void updatedInputVuMeasurements(const QVector<float>& valuesInDecibels);
+    void updatedOutputVuMeasurements(const QVector<float>& valuesInDecibels);
     void setInputVolume(float multiplier);
     void setOutputVolume(float multiplier);
     void setInputMuted(bool muted);


### PR DESCRIPTION
This just creates a detached copy of the vector before emitting it

Added a check to ensure updateNumChannels can only be called before init; otherwise, resetting the mValues vector could cause corruption

Update virtual studio slots for vumeters to use const references, since it should not be necessary to create unique copies on every trigger of the signals