### PR TITLE
QMake updates

### DIFF
--- a/build
+++ b/build
@@ -102,15 +102,9 @@ if [[ $platform == 'linux' ]]; then
   echo "Using qmake"
   QCMD=qmake
 fi
-QSPEC=linux-g++
 MCMD=make
 elif [[ $platform == 'macosx' ]]; then
   QCMD=qmake
-  QSPEC=macx-clang
-  arch=`arch`
-  if [[ "$arch" == 'arm64' ]]; then
-    QSPEC=macx-clang-arm64
-  fi  
   # if qmake is not in path, try homebrew qt5
   echo "path to qmake"
   echo "$(which qmake)"
@@ -128,12 +122,15 @@ elif [[ $platform == 'macosx' ]]; then
   MCMD=make
 elif [[ $platform == 'mingw' ]]; then
   QCMD=qmake
-  QSPEC=win32-g++
   MCMD=mingw32-make
 elif [[ $platform == 'unknown' ]]; then
   echo "Unregonized platform, exiting"
   exit
 fi
+
+# detect spec
+QSPEC=`$QCMD -query | grep QMAKE_SPEC`
+QSPEC=${QSPEC##QMAKE_SPEC:}
 
 # check for RtAudio
 if [[ $RTAUDIO == 1 ]]; then

--- a/build
+++ b/build
@@ -164,13 +164,14 @@ cd builddir
 set -e
 
 # Build
+QCMDARGS=(-spec $QSPEC $CONFIG "$UNKNOWN_OPTIONS" $PRO_FILE)
 echo "qmake command:"
-echo "$QCMD -spec $QSPEC $CONFIG $PRO_FILE" $UNKNOWN_OPTIONS
+echo $QCMD ${QCMDARGS[@]}
 if [[ $clean == 1 ]]; then
-  $QCMD -spec $QSPEC $CONFIG $PRO_FILE $UNKNOWN_OPTIONS
+  $QCMD ${QCMDARGS[@]}
   $MCMD clean
 fi
-$QCMD -spec $QSPEC $CONFIG $PRO_FILE $UNKNOWN_OPTIONS
+$QCMD ${QCMDARGS[@]}
 $MCMD release
 if [[ "$install" == 1 ]]; then
   echo "*** Installing JackTrip ***"

--- a/jacktrip.pro
+++ b/jacktrip.pro
@@ -103,11 +103,7 @@ bundled_rtaudio {
 
 macx {
   message(Building on MAC OS X)
-  QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.9
-  #QMAKE_MAC_SDK = macosx10.9
   CONFIG -= app_bundle
-  #CONFIG += x86 #ppc #### If you have both libraries installed, you
-  # can change between 32bits (x86) or 64bits(x86_64) Change this to go back to 32 bits (x86)
   LIBS += -framework CoreAudio -framework CoreFoundation
   !nogui {
     LIBS += -framework Foundation

--- a/rtaudio.pro
+++ b/rtaudio.pro
@@ -15,7 +15,6 @@ linux-g++ | linux-g++-64 {
 }
 macx {
   QMAKE_CXXFLAGS += -D__MACOSX_CORE__
-  QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.9 # the same deployment target as in jacktrip.pro
 }
 win32 {
   QMAKE_CXXFLAGS += -D__WINDOWS_ASIO__ -D__WINDOWS_WASAPI__


### PR DESCRIPTION
I wanted to test building with Qt6 and in the process made changes that make the build script more flexible.

The script now extracts the qmake spec from `qmake -query` command, instead of hardcoding it for each platform. I'm not sure that's even needed (it returns the default spec), but I'm leaving it in for now.

I removed macos deployment target setting, since I realized that the [qt documentation](https://doc.qt.io/qt-6.2/macos.html) says:

> Note: You should not lower the deployment target beyond the default value set by Qt. Doing so will likely lead to crashes at runtime if the binary is then deployed to a macOS version lower than what Qt expected to run on.

So, IIUC, deployment target setting should only be used to set a deployment target _higher_ than the one set by Qt.

I believe this will not change our platform support, but I'll test that once the CI builds by running the macOS build on macOS 10.13.

EDIT: I have confirmed that the macOS build still runs on macOS 10.13 (High Sierra), which is the oldest macOS platform we currently support.