### PR TITLE
Show Qt Version in about dialog

### DIFF
--- a/src/gui/about.cpp
+++ b/src/gui/about.cpp
@@ -48,6 +48,8 @@ About::About(QWidget* parent) : QDialog(parent), m_ui(new Ui::About)
 
     m_ui->aboutLabel->setText(
         m_ui->aboutLabel->text().replace(QLatin1String("%VERSION%"), gVersion));
+    m_ui->aboutLabel->setText(
+        m_ui->aboutLabel->text().replace(QLatin1String("%QTVERSION%"), qVersion()));
 #ifdef QT_OPENSOURCE
     m_ui->aboutLabel->setText(m_ui->aboutLabel->text().replace(
         QLatin1String("%LICENSE%"),

--- a/src/gui/about.ui
+++ b/src/gui/about.ui
@@ -93,7 +93,7 @@ border: 4px solid black; </string>
         </size>
        </property>
        <property name="text">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A system for high quality audio network performance over the internet.&lt;/p&gt;&lt;p&gt;Version %VERSION%%BUILD%&lt;/p&gt;&lt;p&gt;Copyright © 2008-2020 Juan-Pablo Caceres, Chris Chafe, et al. SoundWIRE group at CCRMA, Stanford University.&lt;/p&gt;&lt;p&gt;Graphical user interface component originally released as QJackTrip, Copyright © 2020 Aaron Wyatt.&lt;p&gt;%LICENSE%JackTrip source code is released under MIT and GPL licenses. See LICENSE.md file for more information.&lt;/p&gt;This is free software and is provided &amp;quot;as is&amp;quot;, without warranty of any kind.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A system for high quality audio network performance over the internet.&lt;/p&gt;&lt;p&gt;Version %VERSION%%BUILD%&lt;br/&gt;Using Qt %QTVERSION%&lt;/p&gt;&lt;p&gt;Copyright © 2008-2020 Juan-Pablo Caceres, Chris Chafe, et al. SoundWIRE group at CCRMA, Stanford University.&lt;/p&gt;&lt;p&gt;Graphical user interface component originally released as QJackTrip, Copyright © 2020 Aaron Wyatt.&lt;/p&gt;&lt;p&gt;%LICENSE%JackTrip source code is released under MIT and GPL licenses. See LICENSE.md file for more information.&lt;/p&gt;&lt;p&gt;This is free software and is provided &amp;quot;as is&amp;quot;, without warranty of any kind.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>


### PR DESCRIPTION
Now that people are starting to build with different versions of Qt, show which version the app has been built with in the about dialog box.