### PR TITLE
Use default keychain for notarization

### DIFF
--- a/.github/workflows/jacktriplabs.yml
+++ b/.github/workflows/jacktriplabs.yml
@@ -457,7 +457,8 @@ jobs:
           CERTIFICATE: ${{ secrets.APP_CERT_NAME }}
           PACKAGE_CERT: ${{ secrets.INSTALLER_CERT_NAME }}
           USERNAME: app@jacktrip.org
-          PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PWD}}
+          PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PWD }}
+          TEAM_ID: ${{ secrets.TEAM_ID }}
         run: |
           # Copy jacktrip binary where assemple_app.sh looks for it
           cp ${{ env.BUILD_PATH }}/${{ matrix.binary-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-binary.zip ${{ env.BUILD_PATH }}/jacktrip.zip
@@ -466,7 +467,7 @@ jobs:
 
           CONFIG=
           if [[ -n "${{ matrix.installer-path }}" ]]; then 
-            CONFIG="-i -n -k -c \"${CERTIFICATE}\" -d \"${PACKAGE_CERT}\" -u \"${USERNAME}\" -p \"${PASSWORD}\" JackTrip org.jacktrip.jacktrip $CONFIG"
+            CONFIG="-i -n -k -c \"${CERTIFICATE}\" -d \"${PACKAGE_CERT}\" -u \"${USERNAME}\" -p \"${PASSWORD}\" -t \"${TEAM_ID}\" JackTrip org.jacktrip.jacktrip $CONFIG"
           fi
           cd macos
           echo $CONFIG | xargs ./assemble_app.sh

--- a/.github/workflows/jacktriplabs.yml
+++ b/.github/workflows/jacktriplabs.yml
@@ -445,6 +445,7 @@ jobs:
           security create-keychain -p "$KEYCHAIN_PWD" $KEYCHAIN_PATH
           security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
           security default-keychain -s $KEYCHAIN_PATH
+          security login-keychain -s $KEYCHAIN_PATH
           security unlock-keychain -p "$KEYCHAIN_PWD" $KEYCHAIN_PATH
 
           # import certificate to keychain

--- a/.github/workflows/jacktriplabs.yml
+++ b/.github/workflows/jacktriplabs.yml
@@ -445,7 +445,6 @@ jobs:
           security create-keychain -p "$KEYCHAIN_PWD" $KEYCHAIN_PATH
           security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
           security default-keychain -s $KEYCHAIN_PATH
-          security login-keychain -s $KEYCHAIN_PATH
           security unlock-keychain -p "$KEYCHAIN_PWD" $KEYCHAIN_PATH
 
           # import certificate to keychain
@@ -467,7 +466,7 @@ jobs:
 
           CONFIG=
           if [[ -n "${{ matrix.installer-path }}" ]]; then 
-            CONFIG="-i -n -c \"${CERTIFICATE}\" -d \"${PACKAGE_CERT}\" -u \"${USERNAME}\" -p \"${PASSWORD}\" JackTrip org.jacktrip.jacktrip $CONFIG"
+            CONFIG="-i -n -k -c \"${CERTIFICATE}\" -d \"${PACKAGE_CERT}\" -u \"${USERNAME}\" -p \"${PASSWORD}\" JackTrip org.jacktrip.jacktrip $CONFIG"
           fi
           cd macos
           echo $CONFIG | xargs ./assemble_app.sh

--- a/macos/assemble_app.sh
+++ b/macos/assemble_app.sh
@@ -70,7 +70,7 @@ while getopts ":inhqkc:d:u:p:t:b:" opt; do
         echo "Important: If supplying one of the next three options, you must supply all of them."
         echo " -u <username>      Apple ID username (email address) for installer notarization."
         echo " -p <password>      App specific password for installer notarization."
-        echo " -t <teamid>        Team ID for notarization. (Only required if you belong to multiple dev teams.)"
+        echo " -t <teamid>        Team ID for notarization."
         echo
         echo " -k                 Use the default keychain rather than the login keychain to store credentials."
         echo " -h                 Display this help screen and exit."

--- a/macos/assemble_app.sh
+++ b/macos/assemble_app.sh
@@ -71,7 +71,7 @@ while getopts ":inhqc:d:u:p:t:b:" opt; do
         echo "(These should be left as is for official builds.)"
         echo
         echo "The username, password, and team ID are saved in the keychain by notarytool."
-        echo "They only need to be supplied once, or in the eventh that you need to change them."
+        echo "They only need to be supplied once, or in the event that you need to change them."
  
         exit 0
         ;;

--- a/macos/assemble_app.sh
+++ b/macos/assemble_app.sh
@@ -217,7 +217,7 @@ if [ $SIGNED = false ] ; then
     exit 1
 fi
 
-if [ ! -z "$USERNAME" ] || [ ! -z "$PASSWORD" ] || [ ! -z "$TEAM_ID" ] || [ $TEMP_KEYCHAIN = true ]; then
+if [ ! -z "$USERNAME" ] || [ ! -z "$PASSWORD" ] || [ ! -z "$TEAM_ID" ] || [ $USE_DEFAULT_KEYCHAIN = true ]; then
     if [ -z "$USERNAME" ] || [ -z "$PASSWORD" ] || [ -z "$TEAM_ID" ]; then
         echo "Error: Missing credentials. Make sure you supply a username, password and team ID."
         exit 1

--- a/macos/assemble_app.sh
+++ b/macos/assemble_app.sh
@@ -217,7 +217,7 @@ if [ $SIGNED = false ] ; then
     exit 1
 fi
 
-if [ ! -z "$USERNAME" ] || [ ! -z "$PASSWORD" ] || [ ! -z "$TEAM_ID" ] || [ $USE_DEFAULT_KEYCHAIN = true ]; then
+if [ ! -z "$USERNAME" ] || [ ! -z "$PASSWORD" ] || [ ! -z "$TEAM_ID" ]; then
     if [ -z "$USERNAME" ] || [ -z "$PASSWORD" ] || [ -z "$TEAM_ID" ]; then
         echo "Error: Missing credentials. Make sure you supply a username, password and team ID."
         exit 1

--- a/macos/sign-stuff.sh
+++ b/macos/sign-stuff.sh
@@ -5,7 +5,6 @@ CERTIFICATE=""
 PACKAGE_CERT=""
 USERNAME=""
 PASSWORD=""
-# Only needed if you belong to more than one dev team
 TEAM_ID=""
 
 if [ -z $1 ]; then


### PR DESCRIPTION
Notarytool seems to use the login keychain by default for credential storage. Make sure this is set.