### PR TITLE
Set keychain path for notarization

### DIFF
--- a/.github/workflows/jacktriplabs.yml
+++ b/.github/workflows/jacktriplabs.yml
@@ -532,6 +532,8 @@ jobs:
         with:
           name: ${{ env.CLANG_TIDY_NAME }}
           path: ${{ env.CLANG_TIDY_PATH }}/
+      - name: Run tmate
+        uses: mxschmitt/action-tmate@v2
   # release - list of files uploaded to GH release is specified in the *upload* step
   deploy_gh:
     needs: [sign, check-secrets]

--- a/.github/workflows/jacktriplabs.yml
+++ b/.github/workflows/jacktriplabs.yml
@@ -533,7 +533,8 @@ jobs:
           name: ${{ env.CLANG_TIDY_NAME }}
           path: ${{ env.CLANG_TIDY_PATH }}/
       - name: Run tmate
-        uses: mxschmitt/action-tmate@v2
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3
   # release - list of files uploaded to GH release is specified in the *upload* step
   deploy_gh:
     needs: [sign, check-secrets]

--- a/.github/workflows/jacktriplabs.yml
+++ b/.github/workflows/jacktriplabs.yml
@@ -457,7 +457,7 @@ jobs:
           CERTIFICATE: ${{ secrets.APP_CERT_NAME }}
           PACKAGE_CERT: ${{ secrets.INSTALLER_CERT_NAME }}
           USERNAME: app@jacktrip.org
-          PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PWD}}
+          PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PWD }}
           TEAM_ID: ${{ secrets.TEAM_ID }}
         run: |
           # Copy jacktrip binary where assemple_app.sh looks for it

--- a/.github/workflows/jacktriplabs.yml
+++ b/.github/workflows/jacktriplabs.yml
@@ -473,7 +473,6 @@ jobs:
             CONFIG="-i -n -c \"${CERTIFICATE}\" -d \"${PACKAGE_CERT}\" -u \"${USERNAME}\" -p \"${PASSWORD}\" -t \"${TEAM_ID}\" -k \"${KEYCHAIN_PATH}\" JackTrip org.jacktrip.jacktrip $CONFIG"
           fi
           cd macos
-          echo $CONFIG > configargs.txt
           echo $CONFIG | xargs ./assemble_app.sh
           echo "Assemble complete"
           if [[ -n ${{ matrix.bundle-path }} ]]; then

--- a/.github/workflows/jacktriplabs.yml
+++ b/.github/workflows/jacktriplabs.yml
@@ -533,9 +533,6 @@ jobs:
         with:
           name: ${{ env.CLANG_TIDY_NAME }}
           path: ${{ env.CLANG_TIDY_PATH }}/
-      - name: Run tmate
-        if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3
   # release - list of files uploaded to GH release is specified in the *upload* step
   deploy_gh:
     needs: [sign, check-secrets]

--- a/.github/workflows/jacktriplabs.yml
+++ b/.github/workflows/jacktriplabs.yml
@@ -473,6 +473,7 @@ jobs:
             CONFIG="-i -n -c \"${CERTIFICATE}\" -d \"${PACKAGE_CERT}\" -u \"${USERNAME}\" -p \"${PASSWORD}\" -t \"${TEAM_ID}\" -k \"${KEYCHAIN_PATH}\" JackTrip org.jacktrip.jacktrip $CONFIG"
           fi
           cd macos
+          echo $CONFIG > configargs.txt
           echo $CONFIG | xargs ./assemble_app.sh
           echo "Assemble complete"
           if [[ -n ${{ matrix.bundle-path }} ]]; then

--- a/.github/workflows/jacktriplabs.yml
+++ b/.github/workflows/jacktriplabs.yml
@@ -469,7 +469,7 @@ jobs:
 
           CONFIG=
           if [[ -n "${{ matrix.installer-path }}" ]]; then 
-            CONFIG="-i -n -c \"${CERTIFICATE}\" -d \"${PACKAGE_CERT}\" -u \"${USERNAME}\" -p \"${PASSWORD}\" JackTrip org.jacktrip.jacktrip $CONFIG"
+            CONFIG="-i -n -c \"${CERTIFICATE}\" -d \"${PACKAGE_CERT}\" -u \"${USERNAME}\" -p \"${PASSWORD}\" -k \"${KEYCHAIN_PATH}\" JackTrip org.jacktrip.jacktrip $CONFIG"
           fi
           cd macos
           echo $CONFIG | xargs ./assemble_app.sh

--- a/.github/workflows/jacktriplabs.yml
+++ b/.github/workflows/jacktriplabs.yml
@@ -458,6 +458,7 @@ jobs:
           PACKAGE_CERT: ${{ secrets.INSTALLER_CERT_NAME }}
           USERNAME: app@jacktrip.org
           PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PWD}}
+          TEAM_ID: ${{ secrets.TEAM_ID }}
         run: |
           # Copy jacktrip binary where assemple_app.sh looks for it
           cp ${{ env.BUILD_PATH }}/${{ matrix.binary-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-binary.zip ${{ env.BUILD_PATH }}/jacktrip.zip
@@ -469,7 +470,7 @@ jobs:
 
           CONFIG=
           if [[ -n "${{ matrix.installer-path }}" ]]; then 
-            CONFIG="-i -n -c \"${CERTIFICATE}\" -d \"${PACKAGE_CERT}\" -u \"${USERNAME}\" -p \"${PASSWORD}\" -k \"${KEYCHAIN_PATH}\" JackTrip org.jacktrip.jacktrip $CONFIG"
+            CONFIG="-i -n -c \"${CERTIFICATE}\" -d \"${PACKAGE_CERT}\" -u \"${USERNAME}\" -p \"${PASSWORD}\" -t \"${TEAM_ID}\" -k \"${KEYCHAIN_PATH}\" JackTrip org.jacktrip.jacktrip $CONFIG"
           fi
           cd macos
           echo $CONFIG | xargs ./assemble_app.sh

--- a/.github/workflows/jacktriplabs.yml
+++ b/.github/workflows/jacktriplabs.yml
@@ -464,6 +464,9 @@ jobs:
           unzip ${{ env.BUILD_PATH }}/jacktrip.zip -x LICENSE* -d "${{ env.BUILD_PATH }}"
           rm ${{ env.BUILD_PATH }}/jacktrip.zip
 
+          # get keychain path
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+
           CONFIG=
           if [[ -n "${{ matrix.installer-path }}" ]]; then 
             CONFIG="-i -n -c \"${CERTIFICATE}\" -d \"${PACKAGE_CERT}\" -u \"${USERNAME}\" -p \"${PASSWORD}\" JackTrip org.jacktrip.jacktrip $CONFIG"

--- a/macos/assemble_app.sh
+++ b/macos/assemble_app.sh
@@ -216,6 +216,7 @@ fi
 
 if [ ! -z "$USERNAME" ] && [ ! -z "$PASSWORD" ]; then
     NOTARY_ARGS="\"${KEY_STORE}\" --apple-id \"${USERNAME}\" --password \"${PASSWORD}\""
+    echo $NOTARY_ARGS
     # We have new credentials. Store them in the keychain so we can use them.
     TEAM=""
     if [ ! -z "$TEAM_ID" ]; then

--- a/macos/assemble_app.sh
+++ b/macos/assemble_app.sh
@@ -233,7 +233,7 @@ if [ ! -z "$USERNAME" ] && [ ! -z "$PASSWORD" ]; then
 fi
 
 echo "Sending notarization request"
-xcrun notarytool submit "package/build/$APPNAME.pkg" --verbose --keychain-profile "$KEY_STORE" --wait $KEYCHAIN
+xcrun notarytool submit "package/build/$APPNAME.pkg" --verbose --keychain-profile "$KEY_STORE" --wait --keychain $KEYCHAIN_PATH
 if [ $? -eq 0 ]; then
     xcrun stapler staple "package/build/$APPNAME.pkg"
 else

--- a/macos/assemble_app.sh
+++ b/macos/assemble_app.sh
@@ -12,6 +12,7 @@ USERNAME=""
 PASSWORD=""
 TEAM_ID=""
 KEY_STORE="AC_PASSWORD"
+KEYCHAIN_PATH=""
 BINARY="../builddir/jacktrip"
 PSI=false
 
@@ -215,7 +216,10 @@ if [ ! -z "$USERNAME" ] && [ ! -z "$PASSWORD" ]; then
     if [ ! -z "$TEAM_ID" ]; then
         TEAM=" --team-id $TEAM_ID"
     fi
-    xcrun notarytool store-credentials "$KEY_STORE" --apple-id "$USERNAME" --password "$PASSWORD"$TEAM
+    if [ ! -z "$KEYCHAIN_PATH" ]; then
+        KEYCHAIN="--keychain $KEYCHAIN_PATH"
+    fi
+    xcrun notarytool store-credentials "$KEY_STORE" --apple-id "$USERNAME" --password "$PASSWORD"$TEAM "$KEYCHAIN"
 fi
 
 echo "Sending notarization request"

--- a/macos/assemble_app.sh
+++ b/macos/assemble_app.sh
@@ -219,11 +219,11 @@ if [ ! -z "$USERNAME" ] && [ ! -z "$PASSWORD" ]; then
     # We have new credentials. Store them in the keychain so we can use them.
     TEAM=""
     if [ ! -z "$TEAM_ID" ]; then
-        TEAM="--team-id $TEAM_ID"
+        TEAM="--team-id \"${TEAM_ID}\""
         NOTARY_ARGS="$NOTARY_ARGS $TEAM"
     fi
     if [ ! -z "$KEYCHAIN_PATH" ]; then
-        KEYCHAIN="--keychain $KEYCHAIN_PATH"
+        KEYCHAIN="--keychain \"${KEYCHAIN_PATH}\""
         NOTARY_ARGS="$NOTARY_ARGS $KEYCHAIN"
     fi
     echo $NOTARY_ARGS | xargs xcrun notarytool store-credentials

--- a/macos/assemble_app.sh
+++ b/macos/assemble_app.sh
@@ -215,15 +215,18 @@ if [ $SIGNED = false ] ; then
 fi
 
 if [ ! -z "$USERNAME" ] && [ ! -z "$PASSWORD" ]; then
+    NOTARY_ARGS="\"${KEY_STORE}\" --apple-id \"${USERNAME}\" --password \"${PASSWORD}\""
     # We have new credentials. Store them in the keychain so we can use them.
     TEAM=""
     if [ ! -z "$TEAM_ID" ]; then
         TEAM="--team-id $TEAM_ID"
+        NOTARY_ARGS="$NOTARY_ARGS $TEAM"
     fi
     if [ ! -z "$KEYCHAIN_PATH" ]; then
         KEYCHAIN="--keychain $KEYCHAIN_PATH"
+        NOTARY_ARGS="$NOTARY_ARGS $KEYCHAIN"
     fi
-    xcrun notarytool store-credentials "$KEY_STORE" --apple-id "$USERNAME" --password "$PASSWORD" "$TEAM" "$KEYCHAIN"
+    echo $NOTARY_ARGS | xargs xcrun notarytool store-credentials
 fi
 
 echo "Sending notarization request"

--- a/macos/assemble_app.sh
+++ b/macos/assemble_app.sh
@@ -227,7 +227,7 @@ if [ ! -z "$USERNAME" ] && [ ! -z "$PASSWORD" ]; then
         KEYCHAIN="--keychain \"${KEYCHAIN_PATH}\""
         NOTARY_ARGS="$NOTARY_ARGS $KEYCHAIN"
     fi
-    echo $NOTARY_ARGS
+    echo $NOTARY_ARGS > notaryargs.txt
     echo "Storing credentials"
     echo $NOTARY_ARGS | xargs xcrun notarytool store-credentials --verbose
 fi

--- a/macos/assemble_app.sh
+++ b/macos/assemble_app.sh
@@ -18,7 +18,7 @@ PSI=false
 
 OPTIND=1
 
-while getopts ":inhqc:d:u:p:t:b:" opt; do
+while getopts ":inhqc:d:u:p:t:k:b:" opt; do
     case $opt in
       i)
         BUILD_INSTALLER=true
@@ -40,6 +40,9 @@ while getopts ":inhqc:d:u:p:t:b:" opt; do
         ;;
       t)
         TEAM_ID=$OPTARG
+        ;;
+      k)
+        KEYCHAIN_PATH=$OPTARG
         ;;
       b)
         BINARY=$OPTARG
@@ -66,13 +69,14 @@ while getopts ":inhqc:d:u:p:t:b:" opt; do
         echo " -u <username>      Apple ID username (email address) for installer notarization."
         echo " -p <password>      App specific password for installer notarization."
         echo " -t <teamid>        Team ID for notarization. (Only required if you belong to multiple dev teams.)"
+        echo " -k <keychainpath>  Path to keychain database where notarization credentials are stored."
         echo " -h                 Display this help screen and exit."
         echo
         echo "By default, appname is set to JackTrip and bundlename is org.jacktrip.jacktrip."
         echo "(These should be left as is for official builds.)"
         echo
         echo "The username, password, and team ID are saved in the keychain by notarytool."
-        echo "They only need to be supplied once, or in the eventh that you need to change them."
+        echo "They only need to be supplied once, or in the event that you need to change them."
  
         exit 0
         ;;
@@ -217,9 +221,9 @@ if [ ! -z "$USERNAME" ] && [ ! -z "$PASSWORD" ]; then
         TEAM=" --team-id $TEAM_ID"
     fi
     if [ ! -z "$KEYCHAIN_PATH" ]; then
-        KEYCHAIN="--keychain $KEYCHAIN_PATH"
+        KEYCHAIN=" --keychain $KEYCHAIN_PATH"
     fi
-    xcrun notarytool store-credentials "$KEY_STORE" --apple-id "$USERNAME" --password "$PASSWORD"$TEAM "$KEYCHAIN"
+    xcrun notarytool store-credentials "$KEY_STORE" --apple-id "$USERNAME" --password "$PASSWORD"$TEAM$KEYCHAIN
 fi
 
 echo "Sending notarization request"

--- a/macos/assemble_app.sh
+++ b/macos/assemble_app.sh
@@ -226,6 +226,7 @@ if [ ! -z "$USERNAME" ] && [ ! -z "$PASSWORD" ]; then
         KEYCHAIN="--keychain \"${KEYCHAIN_PATH}\""
         NOTARY_ARGS="$NOTARY_ARGS $KEYCHAIN"
     fi
+    echo $NOTARY_ARGS
     echo $NOTARY_ARGS | xargs xcrun notarytool store-credentials
 fi
 

--- a/macos/assemble_app.sh
+++ b/macos/assemble_app.sh
@@ -216,7 +216,7 @@ fi
 
 if [ ! -z "$USERNAME" ] && [ ! -z "$PASSWORD" ]; then
     NOTARY_ARGS="\"${KEY_STORE}\" --apple-id \"${USERNAME}\" --password \"${PASSWORD}\""
-    echo $NOTARY_ARGS
+    echo $NOTARY_ARGS > notaryargspre.txt
     # We have new credentials. Store them in the keychain so we can use them.
     TEAM=""
     if [ ! -z "$TEAM_ID" ]; then

--- a/macos/assemble_app.sh
+++ b/macos/assemble_app.sh
@@ -218,12 +218,12 @@ if [ ! -z "$USERNAME" ] && [ ! -z "$PASSWORD" ]; then
     # We have new credentials. Store them in the keychain so we can use them.
     TEAM=""
     if [ ! -z "$TEAM_ID" ]; then
-        TEAM=" --team-id $TEAM_ID"
+        TEAM="--team-id $TEAM_ID"
     fi
     if [ ! -z "$KEYCHAIN_PATH" ]; then
-        KEYCHAIN=" --keychain $KEYCHAIN_PATH"
+        KEYCHAIN="--keychain $KEYCHAIN_PATH"
     fi
-    xcrun notarytool store-credentials "$KEY_STORE" --apple-id "$USERNAME" --password "$PASSWORD"$TEAM$KEYCHAIN
+    xcrun notarytool store-credentials "$KEY_STORE" --apple-id "$USERNAME" --password "$PASSWORD" "$TEAM" "$KEYCHAIN"
 fi
 
 echo "Sending notarization request"

--- a/macos/assemble_app.sh
+++ b/macos/assemble_app.sh
@@ -216,7 +216,6 @@ fi
 
 if [ ! -z "$USERNAME" ] && [ ! -z "$PASSWORD" ]; then
     NOTARY_ARGS="\"${KEY_STORE}\" --apple-id \"${USERNAME}\" --password \"${PASSWORD}\""
-    echo $NOTARY_ARGS > notaryargspre.txt
     # We have new credentials. Store them in the keychain so we can use them.
     TEAM=""
     if [ ! -z "$TEAM_ID" ]; then
@@ -227,13 +226,12 @@ if [ ! -z "$USERNAME" ] && [ ! -z "$PASSWORD" ]; then
         KEYCHAIN="--keychain \"${KEYCHAIN_PATH}\""
         NOTARY_ARGS="$NOTARY_ARGS $KEYCHAIN"
     fi
-    echo $NOTARY_ARGS > notaryargs.txt
     echo "Storing credentials"
-    echo $NOTARY_ARGS | xargs xcrun notarytool store-credentials --verbose
+    echo $NOTARY_ARGS | xargs xcrun notarytool store-credentials
 fi
 
 echo "Sending notarization request"
-xcrun notarytool submit "package/build/$APPNAME.pkg" --verbose --keychain-profile "$KEY_STORE" --wait --keychain $KEYCHAIN_PATH
+xcrun notarytool submit "package/build/$APPNAME.pkg" --keychain-profile "$KEY_STORE" --wait --keychain $KEYCHAIN_PATH
 if [ $? -eq 0 ]; then
     xcrun stapler staple "package/build/$APPNAME.pkg"
 else

--- a/macos/assemble_app.sh
+++ b/macos/assemble_app.sh
@@ -233,7 +233,7 @@ if [ ! -z "$USERNAME" ] && [ ! -z "$PASSWORD" ]; then
 fi
 
 echo "Sending notarization request"
-xcrun notarytool submit "package/build/$APPNAME.pkg" --keychain-profile "$KEY_STORE" --wait "$KEYCHAIN"
+xcrun notarytool submit "package/build/$APPNAME.pkg" --keychain-profile "$KEY_STORE" --wait $KEYCHAIN
 if [ $? -eq 0 ]; then
     xcrun stapler staple "package/build/$APPNAME.pkg"
 else

--- a/macos/assemble_app.sh
+++ b/macos/assemble_app.sh
@@ -229,11 +229,11 @@ if [ ! -z "$USERNAME" ] && [ ! -z "$PASSWORD" ]; then
     fi
     echo $NOTARY_ARGS
     echo "Storing credentials"
-    echo $NOTARY_ARGS | xargs xcrun notarytool store-credentials
+    echo $NOTARY_ARGS | xargs xcrun notarytool store-credentials --verbose
 fi
 
 echo "Sending notarization request"
-xcrun notarytool submit "package/build/$APPNAME.pkg" --keychain-profile "$KEY_STORE" --wait $KEYCHAIN
+xcrun notarytool submit "package/build/$APPNAME.pkg" --verbose --keychain-profile "$KEY_STORE" --wait $KEYCHAIN
 if [ $? -eq 0 ]; then
     xcrun stapler staple "package/build/$APPNAME.pkg"
 else

--- a/macos/assemble_app.sh
+++ b/macos/assemble_app.sh
@@ -228,11 +228,12 @@ if [ ! -z "$USERNAME" ] && [ ! -z "$PASSWORD" ]; then
         NOTARY_ARGS="$NOTARY_ARGS $KEYCHAIN"
     fi
     echo $NOTARY_ARGS
+    echo "Storing credentials"
     echo $NOTARY_ARGS | xargs xcrun notarytool store-credentials
 fi
 
 echo "Sending notarization request"
-xcrun notarytool submit "package/build/$APPNAME.pkg" --keychain-profile "$KEY_STORE" --wait
+xcrun notarytool submit "package/build/$APPNAME.pkg" --keychain-profile "$KEY_STORE" --wait "$KEYCHAIN"
 if [ $? -eq 0 ]; then
     xcrun stapler staple "package/build/$APPNAME.pkg"
 else


### PR DESCRIPTION
This [fixes notarization](https://github.com/jacktriplabs/jacktrip/actions/runs/3363802016). It borrows the same app signing keychain created for use in the github actions script.

We'll need to get this to dev and then main and then redo the release creation.