### PR TITLE
Allow the use of a temporary keychain for notarization

### DIFF
--- a/.github/workflows/jacktriplabs.yml
+++ b/.github/workflows/jacktriplabs.yml
@@ -457,7 +457,8 @@ jobs:
           CERTIFICATE: ${{ secrets.APP_CERT_NAME }}
           PACKAGE_CERT: ${{ secrets.INSTALLER_CERT_NAME }}
           USERNAME: app@jacktrip.org
-          PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PWD}}
+          PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PWD }}
+          TEAM_ID: ${{ secrets.TEAM_ID }}
         run: |
           # Copy jacktrip binary where assemple_app.sh looks for it
           cp ${{ env.BUILD_PATH }}/${{ matrix.binary-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-binary.zip ${{ env.BUILD_PATH }}/jacktrip.zip
@@ -466,7 +467,7 @@ jobs:
 
           CONFIG=
           if [[ -n "${{ matrix.installer-path }}" ]]; then 
-            CONFIG="-i -n -k -c \"${CERTIFICATE}\" -d \"${PACKAGE_CERT}\" -u \"${USERNAME}\" -p \"${PASSWORD}\" JackTrip org.jacktrip.jacktrip $CONFIG"
+            CONFIG="-i -n -k -c \"${CERTIFICATE}\" -d \"${PACKAGE_CERT}\" -u \"${USERNAME}\" -p \"${PASSWORD}\" -t \"${TEAM_ID}\" JackTrip org.jacktrip.jacktrip $CONFIG"
           fi
           cd macos
           echo $CONFIG | xargs ./assemble_app.sh

--- a/.github/workflows/jacktriplabs.yml
+++ b/.github/workflows/jacktriplabs.yml
@@ -445,6 +445,7 @@ jobs:
           security create-keychain -p "$KEYCHAIN_PWD" $KEYCHAIN_PATH
           security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
           security default-keychain -s $KEYCHAIN_PATH
+          security login-keychain -s $KEYCHAIN_PATH
           security unlock-keychain -p "$KEYCHAIN_PWD" $KEYCHAIN_PATH
 
           # import certificate to keychain

--- a/.github/workflows/jacktriplabs.yml
+++ b/.github/workflows/jacktriplabs.yml
@@ -445,7 +445,6 @@ jobs:
           security create-keychain -p "$KEYCHAIN_PWD" $KEYCHAIN_PATH
           security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
           security default-keychain -s $KEYCHAIN_PATH
-          security login-keychain -s $KEYCHAIN_PATH
           security unlock-keychain -p "$KEYCHAIN_PWD" $KEYCHAIN_PATH
 
           # import certificate to keychain
@@ -467,7 +466,7 @@ jobs:
 
           CONFIG=
           if [[ -n "${{ matrix.installer-path }}" ]]; then 
-            CONFIG="-i -n -c \"${CERTIFICATE}\" -d \"${PACKAGE_CERT}\" -u \"${USERNAME}\" -p \"${PASSWORD}\" JackTrip org.jacktrip.jacktrip $CONFIG"
+            CONFIG="-i -n -k -c \"${CERTIFICATE}\" -d \"${PACKAGE_CERT}\" -u \"${USERNAME}\" -p \"${PASSWORD}\" JackTrip org.jacktrip.jacktrip $CONFIG"
           fi
           cd macos
           echo $CONFIG | xargs ./assemble_app.sh

--- a/macos/assemble_app.sh
+++ b/macos/assemble_app.sh
@@ -13,12 +13,13 @@ PASSWORD=""
 TEAM_ID=""
 KEY_STORE="AC_PASSWORD"
 TEMP_KEYCHAIN=""
+USE_DEFAULT_KEYCHAIN=false
 BINARY="../builddir/jacktrip"
 PSI=false
 
 OPTIND=1
 
-while getopts ":inhqkc:d:u:p:t:b:" opt; do
+while getopts ":inhqklc:d:u:p:t:b:" opt; do
     case $opt in
       i)
         BUILD_INSTALLER=true
@@ -28,6 +29,9 @@ while getopts ":inhqkc:d:u:p:t:b:" opt; do
         ;;
       k)
         TEMP_KEYCHAIN="$(pwd)/notarytool_temp.db"
+        ;;
+      l)
+        USE_DEFAULT_KEYCHAIN=true
         ;;
       c)
         CERTIFICATE=$OPTARG
@@ -72,7 +76,8 @@ while getopts ":inhqkc:d:u:p:t:b:" opt; do
         echo " -p <password>      App specific password for installer notarization."
         echo " -t <teamid>        Team ID for notarization."
         echo
-        echo " -k                 Use a temporary keychain to store notarization credentials."
+        echo " -k                 Use a temporary keychain to store notarization credentials. (Overrides -l.)"
+        echo " -l                 Use the default keychain instead of the login keychain to store credentials."
         echo " -h                 Display this help screen and exit."
         echo
         echo "By default, appname is set to JackTrip and bundlename is org.jacktrip.jacktrip."
@@ -233,6 +238,10 @@ if [ ! -z "$TEMP_KEYCHAIN" ]; then
     security set-keychain-settings -lut 3600 "$TEMP_KEYCHAIN"
     security unlock-keychain -p "supersecretpassword" "$TEMP_KEYCHAIN"
     KEYCHAIN=" --keychain \"$TEMP_KEYCHAIN\""
+elif [ $USE_DEFAULT_KEYCHAIN = true ]; then
+    echo "Using the default keychain"
+    DEFAULT_KEYCHAIN=$(security default-keychain | cut -d '"' -f2)
+    KEYCHAIN=" --keychain \"$DEFAULT_KEYCHAIN\""
 fi
 
 if [ ! -z "$USERNAME" ]; then

--- a/macos/assemble_app.sh
+++ b/macos/assemble_app.sh
@@ -71,7 +71,7 @@ while getopts ":inhqc:d:u:p:t:b:" opt; do
         echo "(These should be left as is for official builds.)"
         echo
         echo "The username, password, and team ID are saved in the keychain by notarytool."
-        echo "They only need to be supplied once, or in the eventh that you need to change them."
+        echo "They only need to be supplied once, or in the event that you need to change them."
  
         exit 0
         ;;

--- a/macos/assemble_app.sh
+++ b/macos/assemble_app.sh
@@ -218,7 +218,7 @@ if [ $SIGNED = false ]; then
     exit 1
 fi
 
-if [ ! -z "$USERNAME" ] || [ ! -z "$PASSWORD" ] || [ ! -z "$TEAM_ID" ] || [ ! -z $TEMP_KEYCHAIN ]; then
+if [ ! -z "$USERNAME" ] || [ ! -z "$PASSWORD" ] || [ ! -z "$TEAM_ID" ] || [ ! -z "$TEMP_KEYCHAIN" ]; then
     if [ -z "$USERNAME" ] || [ -z "$PASSWORD" ] || [ -z "$TEAM_ID" ]; then
         echo "Error: Missing credentials. Make sure you supply a username, password and team ID."
         exit 1
@@ -226,7 +226,7 @@ if [ ! -z "$USERNAME" ] || [ ! -z "$PASSWORD" ] || [ ! -z "$TEAM_ID" ] || [ ! -z
 fi 
 
 KEYCHAIN=""
-if [ ! -z $TEMP_KEYCHAIN ]; then
+if [ ! -z "$TEMP_KEYCHAIN" ]; then
     echo "Using a temporary keychain"
     [ -e "$TEMP_KEYCHAIN" ] && rm "$TEMP_KEYCHAIN"
     security create-keychain -p "supersecretpassword" "$TEMP_KEYCHAIN"

--- a/macos/sign-stuff.sh
+++ b/macos/sign-stuff.sh
@@ -5,7 +5,6 @@ CERTIFICATE=""
 PACKAGE_CERT=""
 USERNAME=""
 PASSWORD=""
-# Only needed if you belong to more than one dev team
 TEAM_ID=""
 
 if [ -z $1 ]; then


### PR DESCRIPTION
Allow the assembly script to create a temporary keychain for notarization so that it can run regardless of what the system keychain settings are.