### PR TITLE
Bump to 1.6.6 and update changelog

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -1,3 +1,8 @@
+- Version: "1.6.6"
+  Date: 2022-11-01
+  Description:
+  - (fixed) Notarization scripts for macOS
+  - Note - this version replaces 1.6.5, as that release was mistakenly deleted
 - Version: "1.6.5"
   Date: 2022-10-28
   Description:
@@ -17,7 +22,6 @@
   - (fixed) logout freezing jacktrip
   - (fixed) NO_VS builds work without setting NO_UPDATER
   - (fixed) volume meter-related crash
-
 - Version: "1.6.4"
   Date: 2022-09-16
   Description:

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -40,7 +40,7 @@
 
 #include "AudioInterface.h"
 
-constexpr const char* const gVersion = "1.6.5";  ///< JackTrip version
+constexpr const char* const gVersion = "1.6.6";  ///< JackTrip version
 
 //*******************************************************************************
 /// \name Default Values


### PR DESCRIPTION
Given the discussion in #784, this preps for release of 1.6.6. 

Linking to the high-level plan laid out by @ntonnaett for next steps.

https://github.com/jacktrip/jacktrip/discussions/784#discussioncomment-4029512

We should leave this up for people to comment on across time zones.