### PR TITLE
Adding release-acquire ordering on the Regulator pull packet queue

### DIFF
--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -155,11 +155,11 @@ Regulator::Regulator(int rcvChannels, int bit_res, int FPP, int qLen, int bqLen)
 
     if (gVerboseFlag)
         cout << "mHist = " << mHist << " at " << mFPP << "\n";
-    mBytes      = mFPP * mNumChannels * mBitResolutionMode;
-    mPullQueue  = new int8_t[mBytes * 2];
-    mXfrBuffer  = mPullQueue;
-    mNextPacket = mPullQueue + mBytes;
-    mPacketCnt  = 0;  // burg initialization
+    mBytes     = mFPP * mNumChannels * mBitResolutionMode;
+    mPullQueue = new int8_t[mBytes * 2];
+    mXfrBuffer = mPullQueue;
+    mPacketCnt = 0;  // burg initialization
+    mNextPacket.store(mPullQueue + mBytes, std::memory_order_release);
     mFadeUp.resize(mFPP, 0.0);
     mFadeDown.resize(mFPP, 0.0);
     for (int i = 0; i < mFPP; i++) {
@@ -422,7 +422,7 @@ ZERO_OUTPUT:
 
 OUTPUT:
     // swap positions of mXfrBuffer and mNextPacket
-    mNextPacket = mXfrBuffer;
+    mNextPacket.store(mXfrBuffer, std::memory_order_release);
     if (mXfrBuffer == mPullQueue) {
         mXfrBuffer = mPullQueue + mBytes;
     } else {

--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -46,6 +46,7 @@
 
 #include <QDebug>
 #include <QElapsedTimer>
+#include <atomic>
 #include <cstring>
 
 #include "AudioInterface.h"
@@ -147,7 +148,7 @@ class Regulator : public RingBuffer
 
     virtual void readSlotNonBlocking(int8_t* ptrToReadSlot)
     {
-        ::memcpy(ptrToReadSlot, mNextPacket, mBytes);
+        ::memcpy(ptrToReadSlot, mNextPacket.load(std::memory_order_acquire), mBytes);
     }
 
     virtual void readBroadcastSlot(int8_t* ptrToReadSlot)
@@ -176,7 +177,7 @@ class Regulator : public RingBuffer
     int mBytesPeerPacket;
     int8_t* mPullQueue;
     int8_t* mXfrBuffer;
-    const void* mNextPacket;
+    std::atomic<const void*> mNextPacket;
     int8_t* mAssembledPacket;
     int mPacketCnt;
     sample_t bitsToSample(int ch, int frame);


### PR DESCRIPTION
mNextPacket is used to provide a memory barrier to ensure that all write operations performed by the Regulator thread (to the transfer buffer) will be visible to the jack callback thread that pulls packets