### PR TITLE
Fix updater crash on Ventura

### DIFF
--- a/macos/entitlements.plist
+++ b/macos/entitlements.plist
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.device.audio-input</key>
 	<true/>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
The updater code makes use of regular expressions - functionality provided by pcre2 which uses a just in time compiler to work its magic. This doesn't seem to be allowed by default in a hardened runtime anymore. We need to explicitly add a jit entitlement when signing.