### PR TITLE
Remove (default) from Device Lists in Virtual Studio Mode

### DIFF
--- a/src/AudioInterface.cpp
+++ b/src/AudioInterface.cpp
@@ -806,19 +806,19 @@ void AudioInterface::setDevicesErrorMsg(errorMessageT msg)
 #ifdef _WIN32
         mErrorHelpUrl = "https://help.jacktrip.org/hc/en-us/articles/4409919243155";
 #else
-        mErrorHelpUrl = "";
+        mErrorHelpUrl   = "";
 #endif
         break;
     case DEVICE_ERR_NO_INPUTS:
-        mErrorMsg = "JackTrip couldn't find any input devices!";
+        mErrorMsg     = "JackTrip couldn't find any input devices!";
         mErrorHelpUrl = "";
         break;
     case DEVICE_ERR_NO_OUTPUTS:
-        mErrorMsg = "JackTrip couldn't find any output devices!";
+        mErrorMsg     = "JackTrip couldn't find any output devices!";
         mErrorHelpUrl = "";
         break;
     case DEVICE_ERR_NO_DEVICES:
-        mErrorMsg = "JackTrip couldn't find any audio devices!";
+        mErrorMsg     = "JackTrip couldn't find any audio devices!";
         mErrorHelpUrl = "";
         break;
     default:

--- a/src/AudioInterface.cpp
+++ b/src/AudioInterface.cpp
@@ -804,10 +804,22 @@ void AudioInterface::setDevicesErrorMsg(errorMessageT msg)
             "The two devices you have selected are not compatible. Please select a "
             "different pair of devices.";
 #ifdef _WIN32
-        mWarningHelpUrl = "https://help.jacktrip.org/hc/en-us/articles/4409919243155";
+        mErrorHelpUrl = "https://help.jacktrip.org/hc/en-us/articles/4409919243155";
 #else
-        mWarningHelpUrl = "";
+        mErrorHelpUrl = "";
 #endif
+        break;
+    case DEVICE_ERR_NO_INPUTS:
+        mErrorMsg = "JackTrip couldn't find any input devices!";
+        mErrorHelpUrl = "";
+        break;
+    case DEVICE_ERR_NO_OUTPUTS:
+        mErrorMsg = "JackTrip couldn't find any output devices!";
+        mErrorHelpUrl = "";
+        break;
+    case DEVICE_ERR_NO_DEVICES:
+        mErrorMsg = "JackTrip couldn't find any audio devices!";
+        mErrorHelpUrl = "";
         break;
     default:
         mErrorMsg     = "";

--- a/src/AudioInterface.h
+++ b/src/AudioInterface.h
@@ -78,7 +78,7 @@ class AudioInterface
 
     enum warningMessageT { DEVICE_WARN_NONE, DEVICE_WARN_LATENCY };
 
-    enum errorMessageT { DEVICE_ERR_NONE, DEVICE_ERR_INCOMPATIBLE };
+    enum errorMessageT { DEVICE_ERR_NONE, DEVICE_ERR_INCOMPATIBLE, DEVICE_ERR_NO_INPUTS, DEVICE_ERR_NO_OUTPUTS, DEVICE_ERR_NO_DEVICES };
 
     /** \brief The class constructor
      * \param jacktrip Pointer to the JackTrip class that connects all classes (mediator)

--- a/src/AudioInterface.h
+++ b/src/AudioInterface.h
@@ -78,7 +78,13 @@ class AudioInterface
 
     enum warningMessageT { DEVICE_WARN_NONE, DEVICE_WARN_LATENCY };
 
-    enum errorMessageT { DEVICE_ERR_NONE, DEVICE_ERR_INCOMPATIBLE, DEVICE_ERR_NO_INPUTS, DEVICE_ERR_NO_OUTPUTS, DEVICE_ERR_NO_DEVICES };
+    enum errorMessageT {
+        DEVICE_ERR_NONE,
+        DEVICE_ERR_INCOMPATIBLE,
+        DEVICE_ERR_NO_INPUTS,
+        DEVICE_ERR_NO_OUTPUTS,
+        DEVICE_ERR_NO_DEVICES
+    };
 
     /** \brief The class constructor
      * \param jacktrip Pointer to the JackTrip class that connects all classes (mediator)

--- a/src/RtAudioInterface.cpp
+++ b/src/RtAudioInterface.cpp
@@ -105,6 +105,7 @@ void RtAudioInterface::setup(bool verbose)
 
     // unsigned int n_devices = mRtAudio->getDeviceCount();
     if (n_devices_total < 1) {
+        AudioInterface::setDevicesErrorMsg(AudioInterface::DEVICE_ERR_NO_DEVICES);
         cout << "No audio devices found!" << endl;
         std::exit(0);
     } else {
@@ -186,6 +187,12 @@ void RtAudioInterface::setup(bool verbose)
 
         printDeviceInfo(api_out, index_out);
         cout << gPrintSeparator << endl;
+    }
+
+    if (n_devices_input == 0) {
+        AudioInterface::setDevicesErrorMsg(AudioInterface::DEVICE_ERR_NO_INPUTS);
+    } else if (n_devices_output == 0) {
+        AudioInterface::setDevicesErrorMsg(AudioInterface::DEVICE_ERR_NO_OUTPUTS);
     }
 
     delete rtAudioIn;

--- a/src/RtAudioInterface.cpp
+++ b/src/RtAudioInterface.cpp
@@ -452,7 +452,7 @@ void RtAudioInterface::getDeviceList(QStringList* list, QStringList* categories,
 
     if (defaultDeviceIdx != 0) {
         RtAudio::DeviceInfo info = baseRtAudio.getDeviceInfo(defaultDeviceIdx);
-        defaultDeviceName = QString::fromStdString(info.name);
+        defaultDeviceName        = QString::fromStdString(info.name);
     }
 
     if (defaultDeviceName != "") {
@@ -495,7 +495,8 @@ void RtAudioInterface::getDeviceList(QStringList* list, QStringList* categories,
                 }
 
                 // Skip the default device, since we already added it
-                if (QString::fromStdString(info.name) == defaultDeviceName && api == baseRtAudioApi) {
+                if (QString::fromStdString(info.name) == defaultDeviceName
+                    && api == baseRtAudioApi) {
                     continue;
                 }
 

--- a/src/gui/Settings.qml
+++ b/src/gui/Settings.qml
@@ -381,7 +381,6 @@ Item {
                             inputCombo.currentIndex = index
                             inputCombo.popup.close()
                             virtualstudio.inputDevice = index - inputCombo.model.filter((elem, idx) => idx < index && elem.type === "header").length
-                            console.log("SETTING INPUTDEVICE: ", index - inputCombo.model.filter((elem, idx) => idx < index && elem.type === "header").length)
                         }
                     }
                 }

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -301,7 +301,14 @@ int VirtualStudio::inputDevice()
 {
 #ifdef RT_AUDIO
     if (m_useRtAudio) {
-        int index = m_inputDeviceList.indexOf(m_inputDevice);
+        QStringList filteredInputDeviceList;
+        for (int i = 0; i < m_inputDeviceList.size(); i++) {
+            if (m_inputDeviceList.at(i) != "(default)") {
+                filteredInputDeviceList += m_inputDeviceList.at(i);
+            }
+        }
+
+        int index = filteredInputDeviceList.indexOf(m_inputDevice);
         return index >= 0 ? index : 0;
     }
 #endif
@@ -314,7 +321,15 @@ void VirtualStudio::setInputDevice([[maybe_unused]] int device)
         return;
     }
 #ifdef RT_AUDIO
-    m_inputDevice = m_inputDeviceList.at(device);
+    std::cout << "Setting Input Device: " << device << std::endl;
+    QStringList filteredInputDeviceList;
+    for (int i = 0; i < m_inputDeviceList.size(); i++) {
+        if (m_inputDeviceList.at(i) != "(default)") {
+            filteredInputDeviceList += m_inputDeviceList.at(i);
+        }
+    }
+
+    m_inputDevice = filteredInputDeviceList.at(device);
     emit inputDeviceSelected(m_inputDevice);
 #endif
 }
@@ -323,7 +338,14 @@ int VirtualStudio::outputDevice()
 {
 #ifdef RT_AUDIO
     if (m_useRtAudio) {
-        int index = m_outputDeviceList.indexOf(m_outputDevice);
+        QStringList filteredOutputDeviceList;
+        for (int i = 0; i < m_outputDeviceList.size(); i++) {
+            if (m_outputDeviceList.at(i) != "(default)") {
+                filteredOutputDeviceList += m_outputDeviceList.at(i);
+            }
+        }
+
+        int index = filteredOutputDeviceList.indexOf(m_outputDevice);
         return index >= 0 ? index : 0;
     }
 #endif
@@ -336,7 +358,14 @@ void VirtualStudio::setOutputDevice([[maybe_unused]] int device)
         return;
     }
 #ifdef RT_AUDIO
-    m_outputDevice = m_outputDeviceList.at(device);
+    QStringList filteredOutputDeviceList;
+    for (int i = 0; i < m_outputDeviceList.size(); i++) {
+        if (m_outputDeviceList.at(i) != "(default)") {
+            filteredOutputDeviceList += m_outputDeviceList.at(i);
+        }
+    }
+
+    m_outputDevice = filteredOutputDeviceList.at(device);
     emit outputDeviceSelected(m_outputDevice);
 #endif
 }
@@ -1889,7 +1918,16 @@ void VirtualStudio::stopStudio()
 QVariant VirtualStudio::formatDeviceList(const QStringList& devices,
                                          const QStringList& categories)
 {
-    QStringList uniqueCategories = QStringList(categories);
+    QStringList filteredDevices;
+    QStringList filteredCategories;
+
+    for (int i = 0; i < devices.size(); i++) {
+        if (!devices[i].contains("(default)"))
+            filteredDevices += devices[i];
+            filteredCategories += categories[i];
+    }
+
+    QStringList uniqueCategories = QStringList(filteredCategories);
     uniqueCategories.removeDuplicates();
 
     bool containsCategories = true;
@@ -1911,10 +1949,10 @@ QVariant VirtualStudio::formatDeviceList(const QStringList& devices,
             items.push_back(QVariant(QJsonValue(header)));
         }
 
-        for (int j = 0; j < devices.size(); j++) {
-            if (categories.at(j).toStdString() == category.toStdString()) {
+        for (int j = 0; j < filteredDevices.size(); j++) {
+            if (filteredCategories.at(j).toStdString() == category.toStdString()) {
                 QJsonObject element = QJsonObject();
-                element.insert(QString::fromStdString("text"), devices.at(j));
+                element.insert(QString::fromStdString("text"), filteredDevices.at(j));
                 element.insert(QString::fromStdString("type"),
                                QString::fromStdString("element"));
                 items.push_back(QVariant(QJsonValue(element)));

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1922,9 +1922,10 @@ QVariant VirtualStudio::formatDeviceList(const QStringList& devices,
     QStringList filteredCategories;
 
     for (int i = 0; i < devices.size(); i++) {
-        if (!devices[i].contains("(default)"))
+        if (!devices[i].contains("(default)")) {
             filteredDevices += devices[i];
-        filteredCategories += categories[i];
+            filteredCategories += categories[i];
+        }
     }
 
     QStringList uniqueCategories = QStringList(filteredCategories);

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1924,7 +1924,7 @@ QVariant VirtualStudio::formatDeviceList(const QStringList& devices,
     for (int i = 0; i < devices.size(); i++) {
         if (!devices[i].contains("(default)"))
             filteredDevices += devices[i];
-            filteredCategories += categories[i];
+        filteredCategories += categories[i];
     }
 
     QStringList uniqueCategories = QStringList(filteredCategories);


### PR DESCRIPTION
Handles https://app.asana.com/0/1203374736990005/1203374736990008/f. Removes `(default)` from the device lists and instead "pre-selects" that device by moving it to the top of the list. Additionally, it does not allow the user to proceed if there are no input or output devices.

This should not affect classic mode.