### PR TITLE
Fix for client connection failures on Windows

### DIFF
--- a/src/UdpDataProtocol.cpp
+++ b/src/UdpDataProtocol.cpp
@@ -127,11 +127,7 @@ UdpDataProtocol::~UdpDataProtocol()
 void UdpDataProtocol::setPeerAddress(const char* peerHostOrIP)
 {
     // Get DNS Address
-#ifndef _WIN32
-    // Don't make the following code conditional on windows
-    //(Addresses a weird timing bug when in hub client mode)
     if (!mPeerAddress.setAddress(peerHostOrIP)) {
-#endif
         QHostInfo info = QHostInfo::fromName(peerHostOrIP);
         if (!info.addresses().isEmpty()) {
             // use the first IP address
@@ -139,9 +135,7 @@ void UdpDataProtocol::setPeerAddress(const char* peerHostOrIP)
         }
         // cout << "UdpDataProtocol::setPeerAddress IP Address Number: "
         //    << mPeerAddress.toString().toStdString() << endl;
-#ifndef _WIN32
     }
-#endif
 
     // check if the ip address is valid
     if (mPeerAddress.protocol() == QAbstractSocket::IPv6Protocol) {


### PR DESCRIPTION
Fixes https://github.com/jacktrip/jacktrip/issues/648

I don't claim to understand the comment, but this conditional for Windows causes it to hang for 10 seconds when trying to establish a connection to a hub server. Sadly, 10 seconds is also the amount of time that the hub server waits to receive the first datagram from client. This means that Windows clients are always in a tight race to establish a successful connection in time.

I believe this in particular happens when an IP address is used, causing QHostInfo to perform a reverse lookup, and there is no reverse lookup entry found for it. Windows just seems to deadlock for 10 seconds what that happens.

If this code is good enough for JackTrip.cpp to use when establishing the initial TCP connection to a hub server, it should be good enough for the UDPDataProtocol as well.