### PR TITLE
Fix save/cancel hang

### DIFF
--- a/src/RtAudioInterface.cpp
+++ b/src/RtAudioInterface.cpp
@@ -450,6 +450,7 @@ void RtAudioInterface::getDeviceList(QStringList* list, QStringList* categories,
 #endif
     }
 
+    cout << "getting default device" << endl;
     // Explicitly add default device
     QString defaultDeviceName = "";
     uint32_t defaultDeviceIdx;
@@ -458,12 +459,12 @@ void RtAudioInterface::getDeviceList(QStringList* list, QStringList* categories,
     } else {
         defaultDeviceIdx = baseRtAudio.getDefaultOutputDevice();
     }
-
+    cout << "getting default device info" << endl;
     if (defaultDeviceIdx != 0) {
         RtAudio::DeviceInfo info = baseRtAudio.getDeviceInfo(defaultDeviceIdx);
         defaultDeviceName        = QString::fromStdString(info.name);
     }
-
+    cout << "appending default device and categories" << endl;
     if (defaultDeviceName != "") {
         list->append(defaultDeviceName);
         if (categories != NULL) {
@@ -487,10 +488,10 @@ void RtAudioInterface::getDeviceList(QStringList* list, QStringList* categories,
 #endif
         }
     }
-
+    cout << "getting APIs" << endl;
     std::vector<RtAudio::Api> apis;
     RtAudio::getCompiledApi(apis);
-
+    cout << "adding other devices" << endl;
     for (uint32_t i = 0; i < apis.size(); i++) {
 #ifdef _WIN32
         if (apis.at(i) == RtAudio::UNIX_JACK) {
@@ -501,7 +502,9 @@ void RtAudioInterface::getDeviceList(QStringList* list, QStringList* categories,
         RtAudio rtaudio(api);
         unsigned int devices = rtaudio.getDeviceCount();
         for (unsigned int j = 0; j < devices; j++) {
+            cout << "getting device info" << endl;
             RtAudio::DeviceInfo info = rtaudio.getDeviceInfo(j);
+            cout << "got device info" << endl;
             if (info.probed == true) {
                 // Don't include duplicate entries
                 if (list->contains(QString::fromStdString(info.name))) {
@@ -521,7 +524,7 @@ void RtAudioInterface::getDeviceList(QStringList* list, QStringList* categories,
                 if (info.probed == false) {
                     continue;
                 }
-
+                cout << "appending device" << endl;
                 if (isInput && info.inputChannels > 0) {
                     list->append(QString::fromStdString(info.name));
                 } else if (!isInput && info.outputChannels > 0) {

--- a/src/RtAudioInterface.cpp
+++ b/src/RtAudioInterface.cpp
@@ -93,10 +93,8 @@ void RtAudioInterface::setup(bool verbose)
 
     QStringList all_input_devices;
     QStringList all_output_devices;
-    cout << "getting device list" << endl;
     getDeviceList(&all_input_devices, NULL, true);
     getDeviceList(&all_output_devices, NULL, false);
-    cout << "got device list" << endl;
 
     unsigned int n_devices_input  = all_input_devices.size();
     unsigned int n_devices_output = all_output_devices.size();
@@ -169,10 +167,8 @@ void RtAudioInterface::setup(bool verbose)
         }
     }
 
-    cout << "getting device info" << endl;
     auto dev_info_input  = rtAudioIn->getDeviceInfo(index_in);
     auto dev_info_output = rtAudioOut->getDeviceInfo(index_out);
-    cout << "got device info" << endl;
 
     if (static_cast<unsigned int>(getNumInputChannels()) > dev_info_input.inputChannels) {
         setNumInputChannels(dev_info_input.inputChannels);
@@ -450,7 +446,6 @@ void RtAudioInterface::getDeviceList(QStringList* list, QStringList* categories,
 #endif
     }
 
-    cout << "getting default device" << endl;
     // Explicitly add default device
     QString defaultDeviceName = "";
     uint32_t defaultDeviceIdx;
@@ -459,12 +454,12 @@ void RtAudioInterface::getDeviceList(QStringList* list, QStringList* categories,
     } else {
         defaultDeviceIdx = baseRtAudio.getDefaultOutputDevice();
     }
-    cout << "getting default device info" << endl;
+
     if (defaultDeviceIdx != 0) {
         RtAudio::DeviceInfo info = baseRtAudio.getDeviceInfo(defaultDeviceIdx);
         defaultDeviceName        = QString::fromStdString(info.name);
     }
-    cout << "appending default device and categories" << endl;
+
     if (defaultDeviceName != "") {
         list->append(defaultDeviceName);
         if (categories != NULL) {
@@ -488,10 +483,10 @@ void RtAudioInterface::getDeviceList(QStringList* list, QStringList* categories,
 #endif
         }
     }
-    cout << "getting APIs" << endl;
+
     std::vector<RtAudio::Api> apis;
     RtAudio::getCompiledApi(apis);
-    cout << "adding other devices" << endl;
+
     for (uint32_t i = 0; i < apis.size(); i++) {
 #ifdef _WIN32
         if (apis.at(i) == RtAudio::UNIX_JACK) {
@@ -502,9 +497,7 @@ void RtAudioInterface::getDeviceList(QStringList* list, QStringList* categories,
         RtAudio rtaudio(api);
         unsigned int devices = rtaudio.getDeviceCount();
         for (unsigned int j = 0; j < devices; j++) {
-            cout << "getting device info" << endl;
             RtAudio::DeviceInfo info = rtaudio.getDeviceInfo(j);
-            cout << "got device info" << endl;
             if (info.probed == true) {
                 // Don't include duplicate entries
                 if (list->contains(QString::fromStdString(info.name))) {
@@ -524,7 +517,7 @@ void RtAudioInterface::getDeviceList(QStringList* list, QStringList* categories,
                 if (info.probed == false) {
                     continue;
                 }
-                cout << "appending device" << endl;
+
                 if (isInput && info.inputChannels > 0) {
                     list->append(QString::fromStdString(info.name));
                 } else if (!isInput && info.outputChannels > 0) {

--- a/src/RtAudioInterface.cpp
+++ b/src/RtAudioInterface.cpp
@@ -93,8 +93,10 @@ void RtAudioInterface::setup(bool verbose)
 
     QStringList all_input_devices;
     QStringList all_output_devices;
+    cout << "getting device list" << endl;
     getDeviceList(&all_input_devices, NULL, true);
     getDeviceList(&all_output_devices, NULL, false);
+    cout << "got device list" << endl;
 
     unsigned int n_devices_input  = all_input_devices.size();
     unsigned int n_devices_output = all_output_devices.size();
@@ -167,8 +169,10 @@ void RtAudioInterface::setup(bool verbose)
         }
     }
 
+    cout << "getting device info" << endl;
     auto dev_info_input  = rtAudioIn->getDeviceInfo(index_in);
     auto dev_info_output = rtAudioOut->getDeviceInfo(index_out);
+    cout << "got device info" << endl;
 
     if (static_cast<unsigned int>(getNumInputChannels()) > dev_info_input.inputChannels) {
         setNumInputChannels(dev_info_input.inputChannels);

--- a/src/RtAudioInterface.cpp
+++ b/src/RtAudioInterface.cpp
@@ -100,7 +100,7 @@ void RtAudioInterface::setup(bool verbose)
     unsigned int n_devices_output = all_output_devices.size();
     unsigned int n_devices_total  = n_devices_input + n_devices_output;
 
-    RtAudio* rtAudioIn = NULL;
+    RtAudio* rtAudioIn  = NULL;
     RtAudio* rtAudioOut = NULL;
 
     // unsigned int n_devices = mRtAudio->getDeviceCount();
@@ -507,6 +507,14 @@ void RtAudioInterface::getDeviceList(QStringList* list, QStringList* categories,
                 // Skip the default device, since we already added it
                 if (QString::fromStdString(info.name) == defaultDeviceName
                     && api == baseRtAudioApi) {
+                    continue;
+                }
+
+                if (QString::fromStdString(info.name) == "JackRouter") {
+                    continue;
+                }
+
+                if (info.probed == false) {
                     continue;
                 }
 

--- a/src/RtAudioInterface.cpp
+++ b/src/RtAudioInterface.cpp
@@ -100,8 +100,8 @@ void RtAudioInterface::setup(bool verbose)
     unsigned int n_devices_output = all_output_devices.size();
     unsigned int n_devices_total  = n_devices_input + n_devices_output;
 
-    RtAudio* rtAudioIn;
-    RtAudio* rtAudioOut;
+    RtAudio* rtAudioIn = NULL;
+    RtAudio* rtAudioOut = NULL;
 
     // unsigned int n_devices = mRtAudio->getDeviceCount();
     if (n_devices_total < 1) {
@@ -257,6 +257,11 @@ void RtAudioInterface::printDevices()
     RtAudio::getCompiledApi(apis);
 
     for (uint32_t i = 0; i < apis.size(); i++) {
+#ifdef _WIN32
+        if (apis.at(i) == RtAudio::UNIX_JACK) {
+            continue;
+        }
+#endif
         RtAudio rtaudio(apis.at(i));
         unsigned int devices = rtaudio.getDeviceCount();
         for (unsigned int j = 0; j < devices; j++) {
@@ -483,6 +488,11 @@ void RtAudioInterface::getDeviceList(QStringList* list, QStringList* categories,
     RtAudio::getCompiledApi(apis);
 
     for (uint32_t i = 0; i < apis.size(); i++) {
+#ifdef _WIN32
+        if (apis.at(i) == RtAudio::UNIX_JACK) {
+            continue;
+        }
+#endif
         RtAudio::Api api = apis.at(i);
         RtAudio rtaudio(api);
         unsigned int devices = rtaudio.getDeviceCount();
@@ -541,6 +551,11 @@ void RtAudioInterface::getDeviceInfoFromName(std::string deviceName, int* index,
     RtAudio::getCompiledApi(apis);
 
     for (uint32_t i = 0; i < apis.size(); i++) {
+#ifdef _WIN32
+        if (apis.at(i) == RtAudio::UNIX_JACK) {
+            continue;
+        }
+#endif
         RtAudio rtaudio(apis.at(i));
         unsigned int devices = rtaudio.getDeviceCount();
         for (unsigned int j = 0; j < devices; j++) {

--- a/src/gui/Browse.qml
+++ b/src/gui/Browse.qml
@@ -294,12 +294,7 @@ Item {
                 border.width: 1
                 border.color: settingsButton.down ? buttonPressedStroke : (settingsButton.hovered ? buttonHoverStroke : buttonStroke)
             }
-            Timer {
-                id: restartAudioTimer
-                interval: 500; running: false; repeat: false
-                onTriggered: virtualstudio.restartAudio();
-            }
-            onClicked: { window.state = "settings"; restartAudioTimer.restart(); }
+            onClicked: { window.state = "settings"; virtualstudio.audioActivated = true }
             display: AbstractButton.TextBesideIcon
             font {
                 family: "Poppins"; 

--- a/src/gui/Browse.qml
+++ b/src/gui/Browse.qml
@@ -294,7 +294,7 @@ Item {
                 border.width: 1
                 border.color: settingsButton.down ? buttonPressedStroke : (settingsButton.hovered ? buttonHoverStroke : buttonStroke)
             }
-            onClicked: window.state = "settings"
+            onClicked: { window.state = "settings"; virtualstudio.restartAudio() }
             display: AbstractButton.TextBesideIcon
             font {
                 family: "Poppins"; 

--- a/src/gui/Browse.qml
+++ b/src/gui/Browse.qml
@@ -294,7 +294,12 @@ Item {
                 border.width: 1
                 border.color: settingsButton.down ? buttonPressedStroke : (settingsButton.hovered ? buttonHoverStroke : buttonStroke)
             }
-            onClicked: { virtualstudio.windowState = "settings"; virtualstudio.audioActivated = true }
+            Timer {
+                id: restartAudioTimer
+                interval: 805; running: false; repeat: false
+                onTriggered: virtualstudio.audioActivated = true;
+            }
+            onClicked: { virtualstudio.windowState = "settings"; restartAudioTimer.restart(); }
             display: AbstractButton.TextBesideIcon
             font {
                 family: "Poppins"; 

--- a/src/gui/Browse.qml
+++ b/src/gui/Browse.qml
@@ -294,7 +294,12 @@ Item {
                 border.width: 1
                 border.color: settingsButton.down ? buttonPressedStroke : (settingsButton.hovered ? buttonHoverStroke : buttonStroke)
             }
-            onClicked: { window.state = "settings"; virtualstudio.restartAudio() }
+            Timer {
+                id: restartAudioTimer
+                interval: 500; running: false; repeat: false
+                onTriggered: virtualstudio.restartAudio();
+            }
+            onClicked: { window.state = "settings"; restartAudioTimer.restart(); }
             display: AbstractButton.TextBesideIcon
             font {
                 family: "Poppins"; 

--- a/src/gui/Settings.qml
+++ b/src/gui/Settings.qml
@@ -720,7 +720,12 @@ Item {
                 border.width: 1
                 border.color: cancelButton.down ? buttonPressedStroke : (cancelButton.hovered ? buttonHoverStroke : buttonStroke)
             }
-            onClicked: { window.state = "browse"; virtualstudio.revertSettings() }
+            Timer {
+                id: revertSettingsTimer
+                interval: 500; running: false; repeat: false
+                onTriggered: virtualstudio.revertSettings();
+            }
+            onClicked: { window.state = "browse"; revertSettingsTimer.restart() }
             anchors.verticalCenter: parent.verticalCenter
             x: parent.width - (230 * virtualstudio.uiScale)
             width: buttonWidth * virtualstudio.uiScale; height: buttonHeight * virtualstudio.uiScale
@@ -741,7 +746,12 @@ Item {
                 border.width: 1
                 border.color: saveButton.down ? buttonPressedStroke : (saveButton.hovered ? buttonHoverStroke : buttonStroke)
             }
-            onClicked: { window.state = "browse"; virtualstudio.applySettings() }
+            Timer {
+                id: applySettingsTimer
+                interval: 500; running: false; repeat: false
+                onTriggered: virtualstudio.applySettings();
+            }
+            onClicked: { window.state = "browse"; applySettingsTimer.restart() }
             anchors.verticalCenter: parent.verticalCenter
             x: parent.width - (119 * virtualstudio.uiScale)
             width: buttonWidth * virtualstudio.uiScale; height: buttonHeight * virtualstudio.uiScale

--- a/src/gui/Settings.qml
+++ b/src/gui/Settings.qml
@@ -345,7 +345,6 @@ Item {
             id: inputCombo
             model: inputComboModel
             currentIndex: (() => {
-                console.log("currentIndex fired");
                 let count = 0;
                 for (let i = 0; i < inputCombo.model.length; i++) {
                     if (inputCombo.model[i].type === "element") {
@@ -353,7 +352,6 @@ Item {
                     }
 
                     if (count > virtualstudio.inputDevice) {
-                        console.log(i);
                         return i;
                     }
                 }
@@ -379,14 +377,9 @@ Item {
                 MouseArea {
                     anchors.fill: parent
                     onClicked: {
-                        console.log("in mouseArea onclick");
-                        console.log(modelData.type);
                         if (modelData.type == "element") {
-                            console.log("setting current index");
-                            console.log(index);
                             inputCombo.currentIndex = index
                             inputCombo.popup.close()
-                            console.log(index - inputCombo.model.filter((elem, idx) => idx < index && elem.type === "header").length);
                             virtualstudio.inputDevice = index - inputCombo.model.filter((elem, idx) => idx < index && elem.type === "header").length
                         }
                     }
@@ -727,7 +720,12 @@ Item {
                 border.width: 1
                 border.color: cancelButton.down ? buttonPressedStroke : (cancelButton.hovered ? buttonHoverStroke : buttonStroke)
             }
-            onClicked: { virtualstudio.windowState = "browse"; virtualstudio.revertSettings() }
+            onClicked: {
+                virtualstudio.windowState = "browse";
+                inputCombo.currentIndex = virtualstudio.previousInput;
+                outputCombo.currentIndex = virtualstudio.previousOutput;
+                virtualstudio.revertSettings()
+            }
             anchors.verticalCenter: parent.verticalCenter
             x: parent.width - (230 * virtualstudio.uiScale)
             width: buttonWidth * virtualstudio.uiScale; height: buttonHeight * virtualstudio.uiScale

--- a/src/gui/Settings.qml
+++ b/src/gui/Settings.qml
@@ -345,6 +345,7 @@ Item {
             id: inputCombo
             model: inputComboModel
             currentIndex: (() => {
+                console.log("currentIndex fired");
                 let count = 0;
                 for (let i = 0; i < inputCombo.model.length; i++) {
                     if (inputCombo.model[i].type === "element") {
@@ -352,6 +353,7 @@ Item {
                     }
 
                     if (count > virtualstudio.inputDevice) {
+                        console.log(i);
                         return i;
                     }
                 }
@@ -377,9 +379,14 @@ Item {
                 MouseArea {
                     anchors.fill: parent
                     onClicked: {
+                        console.log("in mouseArea onclick");
+                        console.log(modelData.type);
                         if (modelData.type == "element") {
+                            console.log("setting current index");
+                            console.log(index);
                             inputCombo.currentIndex = index
                             inputCombo.popup.close()
+                            console.log(index - inputCombo.model.filter((elem, idx) => idx < index && elem.type === "header").length);
                             virtualstudio.inputDevice = index - inputCombo.model.filter((elem, idx) => idx < index && elem.type === "header").length
                         }
                     }

--- a/src/gui/Settings.qml
+++ b/src/gui/Settings.qml
@@ -720,12 +720,7 @@ Item {
                 border.width: 1
                 border.color: cancelButton.down ? buttonPressedStroke : (cancelButton.hovered ? buttonHoverStroke : buttonStroke)
             }
-            Timer {
-                id: revertSettingsTimer
-                interval: 500; running: false; repeat: false
-                onTriggered: virtualstudio.revertSettings();
-            }
-            onClicked: { window.state = "browse"; revertSettingsTimer.restart() }
+            onClicked: { window.state = "browse"; virtualstudio.revertSettings() }
             anchors.verticalCenter: parent.verticalCenter
             x: parent.width - (230 * virtualstudio.uiScale)
             width: buttonWidth * virtualstudio.uiScale; height: buttonHeight * virtualstudio.uiScale
@@ -746,12 +741,7 @@ Item {
                 border.width: 1
                 border.color: saveButton.down ? buttonPressedStroke : (saveButton.hovered ? buttonHoverStroke : buttonStroke)
             }
-            Timer {
-                id: applySettingsTimer
-                interval: 500; running: false; repeat: false
-                onTriggered: virtualstudio.applySettings();
-            }
-            onClicked: { window.state = "browse"; applySettingsTimer.restart() }
+            onClicked: { window.state = "browse"; virtualstudio.applySettings() }
             anchors.verticalCenter: parent.verticalCenter
             x: parent.width - (119 * virtualstudio.uiScale)
             width: buttonWidth * virtualstudio.uiScale; height: buttonHeight * virtualstudio.uiScale

--- a/src/gui/Settings.qml
+++ b/src/gui/Settings.qml
@@ -405,6 +405,19 @@ Item {
             model: inputMeterModel
             clipped: inputClipped
             enabled: !Boolean(virtualstudio.devicesError)
+            visible: virtualstudio.audioReady
+        }
+
+        Text {
+            anchors.left: backendCombo.left
+            anchors.right: parent.right
+            anchors.rightMargin: rightMargin * virtualstudio.uiScale
+            y: virtualstudio.audioBackend != "JACK" ?  inputCombo.y + 48 * virtualstudio.uiScale : virtualstudio.uiScale * (virtualstudio.selectableBackend ? 112 : 64)
+            height: 100 * virtualstudio.uiScale
+            text: "Preparing audio..."
+            font { family: "Poppins"; pixelSize: 13 * virtualstudio.fontScale * virtualstudio.uiScale }
+            visible: virtualstudio.audioBackend != "JACK" && !virtualstudio.audioReady
+            color: textColour
         }
 
         Button {

--- a/src/gui/Setup.qml
+++ b/src/gui/Setup.qml
@@ -848,7 +848,12 @@ Item {
                 }
             }
             enabled: !Boolean(virtualstudio.devicesError)
-            onClicked: { window.state = "browse"; virtualstudio.applySettings() }
+            Timer {
+                id: applySettingsTimer
+                interval: 500; running: false; repeat: false
+                onTriggered: virtualstudio.applySettings();
+            }
+            onClicked: { window.state = "browse"; applySettingsTimer.restart() }
             anchors.right: parent.right
             anchors.rightMargin: rightMargin * virtualstudio.uiScale
             anchors.bottomMargin: rightMargin * virtualstudio.uiScale

--- a/src/gui/Setup.qml
+++ b/src/gui/Setup.qml
@@ -848,12 +848,7 @@ Item {
                 }
             }
             enabled: !Boolean(virtualstudio.devicesError)
-            Timer {
-                id: applySettingsTimer
-                interval: 500; running: false; repeat: false
-                onTriggered: virtualstudio.applySettings();
-            }
-            onClicked: { window.state = "browse"; applySettingsTimer.restart() }
+            onClicked: { window.state = "browse"; virtualstudio.applySettings(); }
             anchors.right: parent.right
             anchors.rightMargin: rightMargin * virtualstudio.uiScale
             anchors.bottomMargin: rightMargin * virtualstudio.uiScale

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -512,6 +512,11 @@ bool VirtualStudio::audioActivated()
     return m_audioActivated;
 }
 
+bool VirtualStudio::audioReady()
+{
+    return m_audioReady;
+}
+
 void VirtualStudio::setInputVolume(float multiplier)
 {
     m_inMultiplier = multiplier;
@@ -595,6 +600,12 @@ void VirtualStudio::setAudioActivated(bool activated)
 {
     m_audioActivated = activated;
     emit audioActivatedChanged();
+}
+
+void VirtualStudio::setAudioReady(bool ready)
+{
+    m_audioReady = ready;
+    emit audioReadyChanged();
 }
 
 int VirtualStudio::currentStudio()
@@ -1265,9 +1276,6 @@ void VirtualStudio::disconnect()
         m_allowRefresh = true;
         m_refreshTimer.start();
     }
-
-    // Start VsAudioInterface again
-    setAudioActivated(true);
 
     m_connectionState = QStringLiteral("Disconnected");
     emit connectionStateChanged();
@@ -2005,6 +2013,9 @@ void VirtualStudio::startAudio()
 
     m_vsAudioInterface->setupPlugins();
 
+    m_audioReady = true;
+    emit audioReadyChanged();
+
     m_view.engine()->rootContext()->setContextProperty(
         QStringLiteral("inputMeterModel"),
         QVariant::fromValue(QVector<float>(m_vsAudioInterface->getNumInputChannels())));
@@ -2026,6 +2037,9 @@ void VirtualStudio::restartAudio()
         m_vsAudioInterface->setupAudio();
         m_vsAudioInterface->setupPlugins();
 
+        m_audioReady = true;
+        emit audioReadyChanged();
+
         m_view.engine()->rootContext()->setContextProperty(
             QStringLiteral("inputMeterModel"),
             QVariant::fromValue(
@@ -2043,6 +2057,7 @@ void VirtualStudio::stopAudio()
     // Stop VsAudioInterface
     if (!m_vsAudioInterface.isNull()) {
         m_vsAudioInterface->closeAudio();
+        setAudioReady(false);
     }
 }
 

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -338,6 +338,7 @@ int VirtualStudio::inputDevice()
 
 void VirtualStudio::setInputDevice([[maybe_unused]] int device)
 {
+    qDebug() << "setInputDevice called with" << device;
     if (!m_useRtAudio) {
         return;
     }
@@ -351,6 +352,7 @@ void VirtualStudio::setInputDevice([[maybe_unused]] int device)
     }
 
     m_inputDevice = filteredInputDeviceList.at(device);
+    qDebug() << m_inputDevice;
     emit inputDeviceChanged(m_inputDevice, false);
     emit inputDeviceSelected(m_inputDevice);
 #endif
@@ -390,6 +392,78 @@ void VirtualStudio::setOutputDevice([[maybe_unused]] int device)
     m_outputDevice = filteredOutputDeviceList.at(device);
     emit outputDeviceChanged(m_outputDevice, false);
     emit outputDeviceSelected(m_outputDevice);
+#endif
+}
+
+int VirtualStudio::previousInput()
+{
+#ifdef RT_AUDIO
+    if (m_useRtAudio) {
+        QStringList filteredInputDeviceList;
+        for (int i = 0; i < m_inputDeviceList.size(); i++) {
+            if (m_inputDeviceList.at(i) != "(default)") {
+                filteredInputDeviceList += m_inputDeviceList.at(i);
+            }
+        }
+
+        int index = filteredInputDeviceList.indexOf(m_previousInput);
+        return index >= 0 ? index : 0;
+    }
+#endif
+    return 0;
+}
+
+void VirtualStudio::setPreviousInput([[maybe_unused]] int device)
+{
+    if (!m_useRtAudio) {
+        return;
+    }
+#ifdef RT_AUDIO
+    QStringList filteredInputDeviceList;
+    for (int i = 0; i < m_inputDeviceList.size(); i++) {
+        if (m_inputDeviceList.at(i) != "(default)") {
+            filteredInputDeviceList += m_inputDeviceList.at(i);
+        }
+    }
+
+    m_previousInput = filteredInputDeviceList.at(device);
+    emit previousInputChanged();
+#endif
+}
+
+int VirtualStudio::previousOutput()
+{
+#ifdef RT_AUDIO
+    if (m_useRtAudio) {
+        QStringList filteredOutputDeviceList;
+        for (int i = 0; i < m_outputDeviceList.size(); i++) {
+            if (m_outputDeviceList.at(i) != "(default)") {
+                filteredOutputDeviceList += m_outputDeviceList.at(i);
+            }
+        }
+
+        int index = filteredOutputDeviceList.indexOf(m_previousOutput);
+        return index >= 0 ? index : 0;
+    }
+#endif
+    return 0;
+}
+
+void VirtualStudio::setPreviousOutput([[maybe_unused]] int device)
+{
+    if (!m_useRtAudio) {
+        return;
+    }
+#ifdef RT_AUDIO
+    QStringList filteredOutputDeviceList;
+    for (int i = 0; i < m_outputDeviceList.size(); i++) {
+        if (m_outputDeviceList.at(i) != "(default)") {
+            filteredOutputDeviceList += m_outputDeviceList.at(i);
+        }
+    }
+
+    m_previousOutput = filteredOutputDeviceList.at(device);
+    emit previousOutputChanged();
 #endif
 }
 
@@ -896,13 +970,15 @@ void VirtualStudio::revertSettings()
     setAudioActivated(false);
     qDebug() << "Audio Deactivated";
 #ifdef RT_AUDIO
+    qDebug() << m_inputDevice;
+    qDebug() << m_previousInput;
     // Restore our previous settings
     m_inputDevice  = m_previousInput;
     m_outputDevice = m_previousOutput;
     m_bufferSize   = m_previousBuffer;
     m_useRtAudio   = m_previousUseRtAudio;
     qDebug() << "RtAudio Variables set";
-    
+
     emit inputDeviceChanged(m_inputDevice, false);
     emit outputDeviceChanged(m_outputDevice, false);
     emit bufferSizeChanged();
@@ -946,6 +1022,8 @@ void VirtualStudio::applySettings()
     m_previousOutput     = m_outputDevice;
     qDebug() << "RtAudio prev variables set";
 
+    emit previousInputChanged();
+    emit previousOutputChanged();
     emit inputDeviceChanged(m_inputDevice, false);
     emit outputDeviceChanged(m_outputDevice, false);
     qDebug() << "RtAudio signals emitted";

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -902,7 +902,7 @@ void VirtualStudio::applySettings()
     m_previousUiScale = m_uiScale;
     emit newScale();
     qDebug() << "UI Scale set";
-    
+
     setAudioActivated(false);
     qDebug() << "Audio Deactivated";
 

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -351,6 +351,7 @@ void VirtualStudio::setInputDevice([[maybe_unused]] int device)
     }
 
     m_inputDevice = filteredInputDeviceList.at(device);
+    emit inputDeviceChanged(m_inputDevice, false);
     emit inputDeviceSelected(m_inputDevice);
 #endif
 }
@@ -387,6 +388,7 @@ void VirtualStudio::setOutputDevice([[maybe_unused]] int device)
     }
 
     m_outputDevice = filteredOutputDeviceList.at(device);
+    emit outputDeviceChanged(m_outputDevice, false);
     emit outputDeviceSelected(m_outputDevice);
 #endif
 }

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -996,7 +996,6 @@ void VirtualStudio::applySettings()
     m_previousUiScale = m_uiScale;
     emit newScale();
 
-
     setAudioActivated(false);
 
     QSettings settings;

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -874,8 +874,8 @@ void VirtualStudio::refreshDevices()
         m_outputDevice = QStringLiteral("(default)");
     }
 
-    emit inputDeviceChanged(m_inputDevice);
-    emit outputDeviceChanged(m_outputDevice);
+    emit inputDeviceChanged(m_inputDevice, false);
+    emit outputDeviceChanged(m_outputDevice, false);
 #endif
 }
 
@@ -900,10 +900,13 @@ void VirtualStudio::revertSettings()
     m_bufferSize   = m_previousBuffer;
     m_useRtAudio   = m_previousUseRtAudio;
     qDebug() << "RtAudio Variables set";
-    emit inputDeviceChanged(m_inputDevice);
-    emit outputDeviceChanged(m_outputDevice);
+    
+    emit inputDeviceChanged(m_inputDevice, false);
+    emit outputDeviceChanged(m_outputDevice, false);
     emit bufferSizeChanged();
-    emit audioBackendChanged(m_useRtAudio);
+    if (m_useRtAudio != m_previousUseRtAudio) {
+        emit audioBackendChanged(m_useRtAudio, false);
+    }
     qDebug() << "RtAudio signals emitted";
 #endif
 
@@ -942,7 +945,7 @@ void VirtualStudio::applySettings()
     qDebug() << "RtAudio prev variables set";
 
     emit inputDeviceChanged(m_inputDevice, false);
-    emit outputDeviceChanged(m_outputDevice);
+    emit outputDeviceChanged(m_outputDevice, false);
     qDebug() << "RtAudio signals emitted";
 #endif
 

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -338,7 +338,6 @@ int VirtualStudio::inputDevice()
 
 void VirtualStudio::setInputDevice([[maybe_unused]] int device)
 {
-    qDebug() << "setInputDevice called with" << device;
     if (!m_useRtAudio) {
         return;
     }
@@ -352,7 +351,6 @@ void VirtualStudio::setInputDevice([[maybe_unused]] int device)
     }
 
     m_inputDevice = filteredInputDeviceList.at(device);
-    qDebug() << m_inputDevice;
     emit inputDeviceChanged(m_inputDevice, false);
     emit inputDeviceSelected(m_inputDevice);
 #endif
@@ -973,22 +971,16 @@ void VirtualStudio::playOutputAudio()
 
 void VirtualStudio::revertSettings()
 {
-    qDebug() << "Reverting";
     m_uiScale = m_previousUiScale;
     emit uiScaleChanged();
-    qDebug() << "UI Scale Reverted";
 
     setAudioActivated(false);
-    qDebug() << "Audio Deactivated";
 #ifdef RT_AUDIO
-    qDebug() << m_inputDevice;
-    qDebug() << m_previousInput;
     // Restore our previous settings
     m_inputDevice  = m_previousInput;
     m_outputDevice = m_previousOutput;
     m_bufferSize   = m_previousBuffer;
     m_useRtAudio   = m_previousUseRtAudio;
-    qDebug() << "RtAudio Variables set";
 
     emit inputDeviceChanged(m_inputDevice, false);
     emit outputDeviceChanged(m_outputDevice, false);
@@ -996,28 +988,22 @@ void VirtualStudio::revertSettings()
     if (m_useRtAudio != m_previousUseRtAudio) {
         emit audioBackendChanged(m_useRtAudio, false);
     }
-    qDebug() << "RtAudio signals emitted";
 #endif
-
-    qDebug() << "Reverted";
 }
 
 void VirtualStudio::applySettings()
 {
-    qDebug() << "Applying";
     m_previousUiScale = m_uiScale;
     emit newScale();
-    qDebug() << "UI Scale set";
+
 
     setAudioActivated(false);
-    qDebug() << "Audio Deactivated";
 
     QSettings settings;
     settings.beginGroup(QStringLiteral("VirtualStudio"));
     settings.setValue(QStringLiteral("UiScale"), m_uiScale);
     settings.setValue(QStringLiteral("ShowDeviceSetup"), m_showDeviceSetup);
     settings.endGroup();
-    qDebug() << "UI Scale preferences saved";
 #ifdef RT_AUDIO
     settings.beginGroup(QStringLiteral("Audio"));
     settings.setValue(QStringLiteral("Backend"), m_useRtAudio ? 1 : 0);
@@ -1025,19 +1011,16 @@ void VirtualStudio::applySettings()
     settings.setValue(QStringLiteral("InputDevice"), m_inputDevice);
     settings.setValue(QStringLiteral("OutputDevice"), m_outputDevice);
     settings.endGroup();
-    qDebug() << "RtAudio preferences saved";
 
     m_previousUseRtAudio = m_useRtAudio;
     m_previousBuffer     = m_bufferSize;
     m_previousInput      = m_inputDevice;
     m_previousOutput     = m_outputDevice;
-    qDebug() << "RtAudio prev variables set";
 
     emit previousInputChanged();
     emit previousOutputChanged();
     emit inputDeviceChanged(m_inputDevice, false);
     emit outputDeviceChanged(m_outputDevice, false);
-    qDebug() << "RtAudio signals emitted";
 #endif
 
     // attempt to join studio if requested
@@ -1047,8 +1030,6 @@ void VirtualStudio::applySettings()
         // We're done waiting to be on the browse page
         joinStudio();
     }
-
-    qDebug() << "Applied";
 }
 
 void VirtualStudio::connectToStudio(int studioIndex)
@@ -1968,7 +1949,6 @@ void VirtualStudio::getUserMetadata()
 
 void VirtualStudio::startAudio()
 {
-    qDebug() << m_permissions->micPermission();
 #ifdef __APPLE__
     if (m_permissions->micPermission() != "granted") {
         return;
@@ -2025,7 +2005,6 @@ void VirtualStudio::startAudio()
 
 void VirtualStudio::restartAudio()
 {
-    qDebug() << m_permissions->micPermission();
 #ifdef __APPLE__
     if (m_permissions->micPermission() != "granted") {
         return;
@@ -2033,7 +2012,6 @@ void VirtualStudio::restartAudio()
 #endif
     // Start VsAudioInterface again
     if (!m_vsAudioInterface.isNull()) {
-        qDebug() << "restarting in restart";
         m_vsAudioInterface->setupAudio();
         m_vsAudioInterface->setupPlugins();
 
@@ -2047,7 +2025,6 @@ void VirtualStudio::restartAudio()
 
         m_vsAudioInterface->startProcess();
     } else {
-        qDebug() << "starting in restart";
         startAudio();
     }
 }
@@ -2063,18 +2040,14 @@ void VirtualStudio::stopAudio()
 
 void VirtualStudio::toggleAudio()
 {
-    qDebug() << m_permissions->micPermission() << m_audioActivated;
 #ifdef __APPLE__
     if (m_permissions->micPermission() != "granted") {
         return;
     }
 #endif
-    qDebug() << "passed toggle mac permissiosn check";
     if (!m_audioActivated) {
-        qDebug() << "stopping in toggle";
         stopAudio();
     } else {
-        qDebug() << "restarting in toggle";
         restartAudio();
     }
 }

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -941,7 +941,7 @@ void VirtualStudio::applySettings()
     m_previousOutput     = m_outputDevice;
     qDebug() << "RtAudio prev variables set";
 
-    emit inputDeviceChanged(m_inputDevice);
+    emit inputDeviceChanged(m_inputDevice, false);
     emit outputDeviceChanged(m_outputDevice);
     qDebug() << "RtAudio signals emitted";
 #endif
@@ -1889,8 +1889,8 @@ void VirtualStudio::startAudio()
             QStringLiteral("audioInterface"), m_vsAudioInterface.data());
     }
 #ifdef RT_AUDIO
-    m_vsAudioInterface->setInputDevice(m_inputDevice);
-    m_vsAudioInterface->setOutputDevice(m_outputDevice);
+    m_vsAudioInterface->setInputDevice(m_inputDevice, false);
+    m_vsAudioInterface->setOutputDevice(m_outputDevice, false);
     m_vsAudioInterface->setAudioInterfaceMode(m_useRtAudio);
 #endif
     connect(m_vsAudioInterface.data(), &VsAudioInterface::devicesErrorMsgChanged, this,

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -235,11 +235,11 @@ class VirtualStudio : public QObject
     void showFirstRunChanged();
     void hasRefreshTokenChanged();
     void logoSectionChanged();
-    void audioBackendChanged(bool useRtAudio);
-    void inputDeviceChanged(QString device);
-    void outputDeviceChanged(QString device);
-    void inputDeviceSelected(QString device);
-    void outputDeviceSelected(QString device);
+    void audioBackendChanged(bool useRtAudio, bool shouldRestart = true);
+    void inputDeviceChanged(QString device, bool shouldRestart = true);
+    void outputDeviceChanged(QString device, bool shouldRestart = true);
+    void inputDeviceSelected(QString device, bool shouldRestart = true);
+    void outputDeviceSelected(QString device, bool shouldRestart = true);
     void devicesWarningChanged();
     void devicesErrorChanged();
     void devicesWarningHelpUrlChanged();

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -126,6 +126,8 @@ class VirtualStudio : public QObject
                    updatedOutputVolume)
     Q_PROPERTY(
         bool inputMuted READ inputMuted WRITE setInputMuted NOTIFY updatedInputMuted)
+    Q_PROPERTY(bool audioActivated READ audioActivated WRITE setAudioActivated NOTIFY
+                   audioActivatedChanged)
 
    public:
     explicit VirtualStudio(bool firstRun = false, QObject* parent = nullptr);
@@ -192,6 +194,7 @@ class VirtualStudio : public QObject
     bool inputMuted();
     bool outputMuted();
     Q_INVOKABLE void restartAudio();
+    bool audioActivated();
 
    public slots:
     void toStandard();
@@ -217,6 +220,7 @@ class VirtualStudio : public QObject
     void setOutputVolume(float multiplier);
     void setInputMuted(bool muted);
     void setOutputMuted(bool muted);
+    void setAudioActivated(bool activated);
     void exit();
 
    signals:
@@ -264,6 +268,7 @@ class VirtualStudio : public QObject
     void updatedOutputVolume(float multiplier);
     void updatedInputMuted(bool muted);
     void updatedOutputMuted(bool muted);
+    void audioActivatedChanged();
 
    private slots:
     void slotAuthSucceded();
@@ -293,6 +298,8 @@ class VirtualStudio : public QObject
     void getRegions();
     void getUserMetadata();
     void stopStudio();
+    void toggleAudio();
+    void stopAudio();
 #ifdef RT_AUDIO
     QVariant formatDeviceList(const QStringList& devices, const QStringList& categories);
 #endif
@@ -350,7 +357,8 @@ class VirtualStudio : public QObject
     bool m_testMode         = false;
     QString m_failedMessage = "";
     QUrl m_studioToJoin;
-    bool m_authenticated = false;
+    bool m_authenticated  = false;
+    bool m_audioActivated = false;
 
     Meter* m_inputMeter;
     Meter* m_outputMeter;

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -82,6 +82,10 @@ class VirtualStudio : public QObject
         int inputDevice READ inputDevice WRITE setInputDevice NOTIFY inputDeviceChanged)
     Q_PROPERTY(int outputDevice READ outputDevice WRITE setOutputDevice NOTIFY
                    outputDeviceChanged)
+    Q_PROPERTY(int previousInput READ previousInput WRITE setPreviousInput NOTIFY
+                   previousInputChanged)
+    Q_PROPERTY(int previousOutput READ previousOutput WRITE setPreviousOutput NOTIFY
+                   previousOutputChanged)
 
     Q_PROPERTY(QString devicesWarning READ devicesWarning NOTIFY devicesWarningChanged)
     Q_PROPERTY(QString devicesError READ devicesError NOTIFY devicesErrorChanged)
@@ -150,6 +154,10 @@ class VirtualStudio : public QObject
     void setInputDevice(int device);
     int outputDevice();
     void setOutputDevice(int device);
+    int previousInput();
+    void setPreviousInput(int device);
+    int previousOutput();
+    void setPreviousOutput(int device);
     QString devicesWarning();
     QString devicesError();
     QString devicesWarningHelpUrl();
@@ -240,6 +248,8 @@ class VirtualStudio : public QObject
     void outputDeviceChanged(QString device, bool shouldRestart = true);
     void inputDeviceSelected(QString device, bool shouldRestart = true);
     void outputDeviceSelected(QString device, bool shouldRestart = true);
+    void previousInputChanged();
+    void previousOutputChanged();
     void devicesWarningChanged();
     void devicesErrorChanged();
     void devicesWarningHelpUrlChanged();

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -191,6 +191,7 @@ class VirtualStudio : public QObject
     float outputVolume();
     bool inputMuted();
     bool outputMuted();
+    Q_INVOKABLE void restartAudio();
 
    public slots:
     void toStandard();

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -131,6 +131,8 @@ class VirtualStudio : public QObject
         bool inputMuted READ inputMuted WRITE setInputMuted NOTIFY updatedInputMuted)
     Q_PROPERTY(bool audioActivated READ audioActivated WRITE setAudioActivated NOTIFY
                    audioActivatedChanged)
+    Q_PROPERTY(
+        bool audioReady READ audioReady WRITE setAudioReady NOTIFY audioReadyChanged)
     Q_PROPERTY(QString windowState READ windowState WRITE setWindowState NOTIFY
                    windowStateUpdated)
 
@@ -203,6 +205,7 @@ class VirtualStudio : public QObject
     bool outputMuted();
     Q_INVOKABLE void restartAudio();
     bool audioActivated();
+    bool audioReady();
     QString windowState();
 
    public slots:
@@ -230,6 +233,7 @@ class VirtualStudio : public QObject
     void setInputMuted(bool muted);
     void setOutputMuted(bool muted);
     void setAudioActivated(bool activated);
+    void setAudioReady(bool ready);
     void setWindowState(QString state);
     void exit();
 
@@ -281,6 +285,7 @@ class VirtualStudio : public QObject
     void updatedInputMuted(bool muted);
     void updatedOutputMuted(bool muted);
     void audioActivatedChanged();
+    void audioReadyChanged();
     void windowStateUpdated();
 
    private slots:
@@ -372,6 +377,7 @@ class VirtualStudio : public QObject
     QUrl m_studioToJoin;
     bool m_authenticated  = false;
     bool m_audioActivated = false;
+    bool m_audioReady     = false;
 
     Meter* m_inputMeter;
     Meter* m_outputMeter;

--- a/src/gui/vsAudioInterface.cpp
+++ b/src/gui/vsAudioInterface.cpp
@@ -100,7 +100,6 @@ void VsAudioInterface::setupAudio()
         // Create AudioInterface Client Object
         if (m_audioInterfaceMode == VsAudioInterface::JACK) {
 #ifndef NO_JACK
-            qDebug() << "using JACK";
             if (gVerboseFlag)
                 std::cout << "  JackTrip:setupAudio before new JackAudioInterface"
                           << std::endl;
@@ -182,7 +181,6 @@ void VsAudioInterface::setupAudio()
 #endif
         } else if (m_audioInterfaceMode == VsAudioInterface::RTAUDIO) {
 #ifdef RT_AUDIO
-            qDebug() << "Using RtAudio";
             m_audioInterface.reset(new RtAudioInterface(
                 m_numAudioChansIn, m_numAudioChansOut, m_audioBitResolution));
             m_audioInterface->setSampleRate(m_sampleRate);

--- a/src/gui/vsAudioInterface.cpp
+++ b/src/gui/vsAudioInterface.cpp
@@ -100,6 +100,7 @@ void VsAudioInterface::setupAudio()
         // Create AudioInterface Client Object
         if (m_audioInterfaceMode == VsAudioInterface::JACK) {
 #ifndef NO_JACK
+            qDebug << "using JACK";
             if (gVerboseFlag)
                 std::cout << "  JackTrip:setupAudio before new JackAudioInterface"
                           << std::endl;
@@ -181,6 +182,7 @@ void VsAudioInterface::setupAudio()
 #endif
         } else if (m_audioInterfaceMode == VsAudioInterface::RTAUDIO) {
 #ifdef RT_AUDIO
+            qDebug() << "Using RtAudio";
             m_audioInterface.reset(new RtAudioInterface(
                 m_numAudioChansIn, m_numAudioChansOut, m_audioBitResolution));
             m_audioInterface->setSampleRate(m_sampleRate);

--- a/src/gui/vsAudioInterface.cpp
+++ b/src/gui/vsAudioInterface.cpp
@@ -100,7 +100,7 @@ void VsAudioInterface::setupAudio()
         // Create AudioInterface Client Object
         if (m_audioInterfaceMode == VsAudioInterface::JACK) {
 #ifndef NO_JACK
-            qDebug << "using JACK";
+            qDebug() << "using JACK";
             if (gVerboseFlag)
                 std::cout << "  JackTrip:setupAudio before new JackAudioInterface"
                           << std::endl;

--- a/src/gui/vsAudioInterface.cpp
+++ b/src/gui/vsAudioInterface.cpp
@@ -288,7 +288,7 @@ void VsAudioInterface::addOutputPlugin(ProcessPlugin* plugin)
     m_audioInterface->appendProcessPluginFromNetwork(plugin);
 }
 
-void VsAudioInterface::setInputDevice(QString deviceName)
+void VsAudioInterface::setInputDevice(QString deviceName, bool shouldRestart)
 {
     m_inputDeviceName = deviceName.toStdString();
     if (m_inputDeviceName == "(default)") {
@@ -297,13 +297,13 @@ void VsAudioInterface::setInputDevice(QString deviceName)
 
     if (!m_audioInterface.isNull()) {
         m_audioInterface->setInputDevice(m_inputDeviceName);
-        if (m_audioActive) {
+        if (m_audioActive && shouldRestart) {
             emit settingsUpdated();
         }
     }
 }
 
-void VsAudioInterface::setOutputDevice(QString deviceName)
+void VsAudioInterface::setOutputDevice(QString deviceName, bool shouldRestart)
 {
     m_outputDeviceName = deviceName.toStdString();
     if (m_outputDeviceName == "(default)") {
@@ -312,20 +312,20 @@ void VsAudioInterface::setOutputDevice(QString deviceName)
 
     if (!m_audioInterface.isNull()) {
         m_audioInterface->setOutputDevice(m_outputDeviceName);
-        if (m_audioActive) {
+        if (m_audioActive && shouldRestart) {
             emit settingsUpdated();
         }
     }
 }
 
-void VsAudioInterface::setAudioInterfaceMode(bool useRtAudio)
+void VsAudioInterface::setAudioInterfaceMode(bool useRtAudio, bool shouldRestart)
 {
     if (useRtAudio) {
         m_audioInterfaceMode = VsAudioInterface::RTAUDIO;
     } else {
         m_audioInterfaceMode = VsAudioInterface::JACK;
     }
-    if (!m_audioInterface.isNull() || m_hasBeenActive) {
+    if ((!m_audioInterface.isNull() || m_hasBeenActive) && shouldRestart) {
         emit modeUpdated();
     }
 }

--- a/src/gui/vsAudioInterface.h
+++ b/src/gui/vsAudioInterface.h
@@ -91,9 +91,9 @@ class VsAudioInterface : public QObject
     };
 
    public slots:
-    void setInputDevice(QString deviceName);
-    void setOutputDevice(QString deviceName);
-    void setAudioInterfaceMode(bool useRtAudio);
+    void setInputDevice(QString deviceName, bool shouldRestart = true);
+    void setOutputDevice(QString deviceName, bool shouldRestart = true);
+    void setAudioInterfaceMode(bool useRtAudio, bool shouldRestart = true);
     void setInputVolume(float multiplier);
     void setOutputVolume(float multiplier);
     void setInputMuted(bool muted);


### PR DESCRIPTION
Fixes by disabling vsAudioInterface on browse and closing the audio session before saving or reverting so that emitted signals don't trigger unnecessary audio restarts. Also addresses blocked UI thread.

https://user-images.githubusercontent.com/5567285/206810570-8a5defcd-cb82-4e87-a4e5-96b6f5448e42.mp4

