### PR TITLE
Change version to 1.6.7 and update changelog

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -11,6 +11,7 @@
   - (updated) windows opens jacktrip after install
   - (updated) Move to overlapped I/O for Windows Networking
   - (updated) New default device behavior in Virtual Studio mode
+  - (fixed) opening links from Virtual Studio
   - (fixed) send capture volume as int
   - (fixed) connection issues for servers without reverse dns
   - (fixed) flatpak build errors

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -40,7 +40,7 @@
 
 #include "AudioInterface.h"
 
-constexpr const char* const gVersion = "1.6.7-rc.2";  ///< JackTrip version
+constexpr const char* const gVersion = "1.6.7";  ///< JackTrip version
 
 //*******************************************************************************
 /// \name Default Values


### PR DESCRIPTION
Let's release 1.6.7 with the updated windows networking code, classic mode meters, and Non-ASIO devices on Windows