### PR TITLE
Fix Window Resize Rendering

### DIFF
--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -199,6 +199,7 @@ VirtualStudio::VirtualStudio(bool firstRun, QObject* parent)
     m_view.setSource(QUrl(QStringLiteral("qrc:/vs/vs.qml")));
     m_view.setMinimumSize(QSize(594, 519));
     // m_view.setMaximumSize(QSize(696, 577));
+    m_view.setResizeMode(QQuickView::SizeRootObjectToView);
     m_view.resize(696 * m_uiScale, 577 * m_uiScale);
 
     // Connect our timers


### PR DESCRIPTION
Should take care of https://app.asana.com/0/1200778084029081/1203387632317029/f

I'm not sure if it makes the issue completely go away but at least on my Windows machine the rendering performs much better on resize. (I also don't really understand what Qt is doing internally here to know why this makes a difference).

I don't think this is an urgent enough fix to warrant trying to squeeze it into 1.6.7. It can wait until after the current release is done.