### PR TITLE
Fix for Newly Subscribed Studios Showing Up Under "Public Studios"

### DIFF
--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -825,6 +825,7 @@ void VirtualStudio::logout()
 
 void VirtualStudio::refreshStudios(int index, bool signalRefresh)
 {
+    getSubscriptions();
     getServerList(false, signalRefresh, index);
 }
 
@@ -1246,6 +1247,7 @@ void VirtualStudio::slotAuthSucceded()
         getUserId();
     } else {
         getSubscriptions();
+        getServerList(true, false);
     }
 
     if (m_regions.isEmpty()) {
@@ -1773,6 +1775,7 @@ void VirtualStudio::getUserId()
         settings.setValue(QStringLiteral("UserId"), m_userId);
         settings.endGroup();
         getSubscriptions();
+        getServerList(true, false);
 
         if (m_userMetadata.isEmpty() && !m_userId.isEmpty()) {
             getUserMetadata();
@@ -1807,7 +1810,6 @@ void VirtualStudio::getSubscriptions()
             m_subscribedServers.append(
                 subscriptions.at(i)[QStringLiteral("serverId")].toString());
         }
-        getServerList(true, false);
         reply->deleteLater();
     });
 }


### PR DESCRIPTION
Prior to this change, if a new subscriptions was created for a (private) studio and the "Refresh" button was clicked in-app, the new studio would show up under the "Public Studios" list. This was due to the `VirtualStudio::refreshStudios` function updating the list of studios but not the list of subscriptions, so the app would (incorrectly) by default categorize the newly subscribed studio as public.

These changes cause the subscriptions to be updated. Additionally, calling `getServerList` was a side effect of `getSubscriptions`. However, I think it's better for each function to just do 1 thing without side effects, so I decoupled the two.