### PR TITLE
Bump version and changelog for 1.6.8

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -1,3 +1,9 @@
+- Version: "1.6.8"
+  Date: 2022-12-05
+  Description:
+  - (fixed) broken "Yes" button on launch
+  - (fixed) window resizing issues
+  - (fixed) subscribed studios showing up under Public in VS mode
 - Version: "1.6.7"
   Date: 2022-11-03
   Description:

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -40,7 +40,7 @@
 
 #include "AudioInterface.h"
 
-constexpr const char* const gVersion = "1.6.7";  ///< JackTrip version
+constexpr const char* const gVersion = "1.6.8";  ///< JackTrip version
 
 //*******************************************************************************
 /// \name Default Values


### PR DESCRIPTION
We have a critical usability issue addressed by #830. We need to release the fix asap.

Merge 830 and then we'll merge this and release.