### PR TITLE
Bugfix/commentwarning

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -442,6 +442,9 @@ jobs:
           if [[ "${{ matrix.weakjack }}" == true ]]; then 
             CONFIG_STRING="-Dweakjack=true $CONFIG_STRING"
           fi
+          if [[ "${{ runner.os }}" == 'Linux' ]]; then
+              CONFIG_STRING="-Dwerror=true $CONFIG_STRING"
+          fi
           meson --buildtype release $CONFIG_STRING $BUILD_PATH
           cd $BUILD_PATH
           meson compile

--- a/src/freeverbmonodsp.h
+++ b/src/freeverbmonodsp.h
@@ -116,7 +116,7 @@ struct FAUST_API dsp_memory_manager {
      * Inform the Memory Manager with the number of expected memory zones.
      * @param count - the number of expected memory zones
      */
-    virtual void begin(size_t /*count*?) {}
+    virtual void begin(size_t /*count*/) {}
 
     /**
      * Give the Memory Manager information on a given memory zone.


### PR DESCRIPTION
This fixes a comment warning that should have been an error. I'm wondering what implications this typo has. Is the reverb working right now?

To catch those kind of bugs in the future, I made warnings errors on the gha Linux Meson builds.