### PR TITLE
Remove unused shared-modules git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "subprojects/weakjack"]
 	path = externals/weakjack
 	url = https://github.com/x42/weakjack.git
-[submodule "linux/flatpak/shared-modules"]
-	path = linux/flatpak/shared-modules
-	url = https://github.com/flathub/shared-modules.git
 [submodule "documentation/doxygen-awesome-css"]
 	path = externals/doxygen-awesome-css
 	url = https://github.com/jothepro/doxygen-awesome-css.git


### PR DESCRIPTION
The flatpak builds needed a JACK2 module provided by the shared-modules git submodule. Flathub provides pipewire's own jack headers now. I already removed the module from all flatpak manifests but forgot to also remove the git submodule.