### PR TITLE
Include git commit hash in display of version

### DIFF
--- a/build
+++ b/build
@@ -4,7 +4,8 @@
 # Parse command line options
 clean=1
 install=0
-CONFIG=
+HASH=`git rev-parse --short HEAD`
+CONFIG="DEFINES+=JACKTRIP_COMMIT_HASH=\\\"$HASH\\\""
 UNKNOWN_OPTIONS=
 BUILD_RTAUDIO=0
 RTAUDIO=0

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -63,6 +63,14 @@
 #include <unistd.h>
 #endif
 
+#ifdef JACKTRIP_COMMIT_HASH
+#define STR(s)       #s
+#define TO_STRING(s) STR(s)
+#define LONG_VERSION gVersion << "-" << TO_STRING(JACKTRIP_COMMIT_HASH)
+#else
+#define LONG_VERSION gVersion
+#endif
+
 #ifdef RT_AUDIO
 #include "RtAudioInterface.h"
 #endif
@@ -415,8 +423,8 @@ void Settings::parseInput(int argc, char** argv)
             break;
         case 'v':
             //-------------------------------------------------------
-            cout << "JackTrip VERSION: " << gVersion << endl;
-            cout << "Copyright (c) 2008-2021 Juan-Pablo Caceres, Chris Chafe." << endl;
+            cout << "JackTrip VERSION: " << LONG_VERSION << endl;
+            cout << "Copyright (c) 2008-2022 Juan-Pablo Caceres, Chris Chafe." << endl;
             cout << "SoundWIRE group at CCRMA, Stanford University" << endl;
 #ifdef QT_OPENSOURCE
             cout << "This build of JackTrip is subject to LGPL license." << endl;
@@ -688,14 +696,14 @@ void Settings::printUsage()
     cout << "" << endl;
     cout << "JackTrip: A System for High-Quality Audio Network Performance" << endl;
     cout << "over the Internet" << endl;
-    cout << "Copyright (c) 2008-2021 Juan-Pablo Caceres, Chris Chafe." << endl;
+    cout << "Copyright (c) 2008-2022 Juan-Pablo Caceres, Chris Chafe." << endl;
     cout << "SoundWIRE group at CCRMA, Stanford University" << endl;
 #ifdef QT_OPENSOURCE
     cout << "This build of JackTrip is subject to LGPL license." << endl;
 #endif
     cout << "JackTrip source code is released under MIT and GPL licenses." << endl;
     cout << "See LICENSE.md file for more information." << endl;
-    cout << "VERSION: " << gVersion << endl;
+    cout << "VERSION: " << LONG_VERSION << endl;
     cout << "" << endl;
     cout << "Usage: jacktrip [-s|-c|-S|-C hostIPAddressOrURL] [options]" << endl;
     cout << "" << endl;


### PR DESCRIPTION
We are currently calling things "release candidates" which technically are not that, because if nothing else we have to keep changing the version string to represent if it's an RC or not (and which RC it is). A release candidate should not change in any way prior to it being released as final.

We recently ran into a critical problem that was introduced in the last few commits that were made after 1.6.7 rc2 and before the actual 1.6.7 was tagged, which required doing a fire drill to release 1.6.8. We have a manual pre-release process and test case that would have caught this before release, had we actually been testing the final release packages. Instead we tested "rc2" and then changed it.

I propose that release candidates are the final bits that we ship, no approximations that may change in the last minutes. This requires that we not make any manual commits to change the version strings for release candidates. However, it's still necessary to determine if build A is the final release versus build B, and the standard way to do this is using git commit hashes.

This PR changes the build scripts so that the version string is always (automatically) appended with the git commit hash that was used to build it. Whether any particular build is "rc1" or "rc2" etc would simply be determined by a mapping of commit hashes. i.e. "1.6.9 14f4d619" may be rc1 which "1.6.9 ca16e8bb" may be rc2. The process of making something final would simply be a matter of promoting rc2 to the final release (for example). This could further be represented using tags.

This will help us conform to more standard release process conventions, and avoid releases from being broken and published untested with last minute changes.