### PR TITLE
Replace gVersion with auto-generated buildtime constants

### DIFF
--- a/build
+++ b/build
@@ -4,7 +4,11 @@
 # Parse command line options
 clean=1
 install=0
-CONFIG=
+BUILD_TIME=$(date -u +"%Y-%m-%d-%H-%M-%S")
+COMMIT_HASH=$(git rev-parse --short HEAD)
+LONG_VERSION=$(git describe --tags)
+SHORT_VERSION=$(echo $LONG_VERSION | sed 's/v\([0-9]*\.[0-9]*\.[0-9]*\).*/\1/')
+CONFIG="DEFINES+=JACKTRIP_BUILD_TIME=\\\"$BUILD_TIME\\\"  DEFINES+=JACKTRIP_COMMIT_HASH=\\\"$COMMIT_HASH\\\" DEFINES+=JACKTRIP_SHORT_VERSION=\\\"$SHORT_VERSION\\\" DEFINES+=JACKTRIP_LONG_VERSION=\\\"$LONG_VERSION\\\""
 UNKNOWN_OPTIONS=
 BUILD_RTAUDIO=0
 RTAUDIO=0

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -415,8 +415,10 @@ void Settings::parseInput(int argc, char** argv)
             break;
         case 'v':
             //-------------------------------------------------------
-            cout << "JackTrip VERSION: " << gVersion << endl;
-            cout << "Copyright (c) 2008-2021 Juan-Pablo Caceres, Chris Chafe." << endl;
+            cout << "JackTrip VERSION: " << gShortVersion << endl;
+            cout << "Build Info: " << gLongVersion << " (" << gCommitHash << ") @ "
+                 << gBuildTime << endl;
+            cout << "Copyright (c) 2008-2022 Juan-Pablo Caceres, Chris Chafe." << endl;
             cout << "SoundWIRE group at CCRMA, Stanford University" << endl;
 #ifdef QT_OPENSOURCE
             cout << "This build of JackTrip is subject to LGPL license." << endl;
@@ -688,14 +690,14 @@ void Settings::printUsage()
     cout << "" << endl;
     cout << "JackTrip: A System for High-Quality Audio Network Performance" << endl;
     cout << "over the Internet" << endl;
-    cout << "Copyright (c) 2008-2021 Juan-Pablo Caceres, Chris Chafe." << endl;
+    cout << "Copyright (c) 2008-2022 Juan-Pablo Caceres, Chris Chafe." << endl;
     cout << "SoundWIRE group at CCRMA, Stanford University" << endl;
 #ifdef QT_OPENSOURCE
     cout << "This build of JackTrip is subject to LGPL license." << endl;
 #endif
     cout << "JackTrip source code is released under MIT and GPL licenses." << endl;
     cout << "See LICENSE.md file for more information." << endl;
-    cout << "VERSION: " << gVersion << endl;
+    cout << "VERSION: " << gShortVersion << endl;
     cout << "" << endl;
     cout << "Usage: jacktrip [-s|-c|-S|-C hostIPAddressOrURL] [options]" << endl;
     cout << "" << endl;

--- a/src/gui/about.cpp
+++ b/src/gui/about.cpp
@@ -47,7 +47,7 @@ About::About(QWidget* parent) : QDialog(parent), m_ui(new Ui::About)
     });
 
     m_ui->aboutLabel->setText(
-        m_ui->aboutLabel->text().replace(QLatin1String("%VERSION%"), gVersion));
+        m_ui->aboutLabel->text().replace(QLatin1String("%VERSION%"), gLongVersion));
     m_ui->aboutLabel->setText(
         m_ui->aboutLabel->text().replace(QLatin1String("%QTVERSION%"), qVersion()));
 #ifdef QT_OPENSOURCE

--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -227,7 +227,8 @@ QJackTrip::QJackTrip(int argc, bool suppressCommandlineWarning, QWidget* parent)
     // Use the ipify API to find our external IP address.
     m_netManager->get(QNetworkRequest(QUrl(QStringLiteral("https://api.ipify.org"))));
     m_netManager->get(QNetworkRequest(QUrl(QStringLiteral("https://api6.ipify.org"))));
-    m_ui->statusBar->showMessage(QStringLiteral("JackTrip version ").append(gVersion));
+    m_ui->statusBar->showMessage(
+        QStringLiteral("JackTrip version ").append(gLongVersion));
 
     // Set up our interface for the default Client run mode.
     //(loadSettings will take care of the UI in all other cases.)

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -288,7 +288,7 @@ bool VirtualStudio::hasRefreshToken()
 
 QString VirtualStudio::versionString()
 {
-    return QLatin1String(gVersion);
+    return QLatin1String(gShortVersion);
 }
 
 QString VirtualStudio::logoSection()

--- a/src/gui/vsDevice.cpp
+++ b/src/gui/vsDevice.cpp
@@ -234,7 +234,7 @@ void VsDevice::sendHeartbeat()
     QJsonObject json = {
         {QLatin1String("stats_updated_at"), now},
         {QLatin1String("mac"), m_appUUID},
-        {QLatin1String("version"), QLatin1String(gVersion)},
+        {QLatin1String("version"), QLatin1String(gShortVersion)},
         {QLatin1String("type"), "jacktrip_app"},
         {QLatin1String("apiPrefix"), m_apiPrefix},
         {QLatin1String("apiSecret"), m_apiSecret},
@@ -557,7 +557,7 @@ void VsDevice::registerJTAsDevice()
         {QLatin1String("alsaName"), "jacktripapp"},
         {QLatin1String("overlay"), "jacktrip_app"},
         {QLatin1String("mac"), m_appUUID},
-        {QLatin1String("version"), QLatin1String(gVersion)},
+        {QLatin1String("version"), QLatin1String(gShortVersion)},
         {QLatin1String("apiPrefix"), m_apiPrefix},
         {QLatin1String("apiSecret"), m_apiSecret},
 #if defined(Q_OS_MACOS)

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -40,7 +40,36 @@
 
 #include "AudioInterface.h"
 
-constexpr const char* const gVersion = "1.6.8";  ///< JackTrip version
+#define STR(s)       #s
+#define TO_STRING(s) STR(s)
+
+/// JackTrip build timestamp
+#ifdef JACKTRIP_BUILD_TIME
+constexpr const char* const gBuildTime = TO_STRING(JACKTRIP_BUILD_TIME);
+#else
+constexpr const char* const gBuildTime    = "unknown";
+#endif
+
+/// JackTrip commit hash
+#ifdef JACKTRIP_COMMIT_HASH
+constexpr const char* const gCommitHash = TO_STRING(JACKTRIP_COMMIT_HASH);
+#else
+constexpr const char* const gCommitHash   = "unknown";
+#endif
+
+/// JackTrip short version (x.y.z)
+#ifdef JACKTRIP_SHORT_VERSION
+constexpr const char* const gShortVersion = TO_STRING(JACKTRIP_SHORT_VERSION);
+#else
+constexpr const char* const gShortVersion = "0.0.0";
+#endif
+
+/// JackTrip long version (varies)
+#ifdef JACKTRIP_LONG_VERSION
+constexpr const char* const gLongVersion = TO_STRING(JACKTRIP_LONG_VERSION);
+#else
+constexpr const char* const gLongVersion  = TO_STRING(JACKTRIP_SHORT_VERSION);
+#endif
 
 //*******************************************************************************
 /// \name Default Values

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -309,7 +309,7 @@ int main(int argc, char* argv[])
         app->setOrganizationName(QStringLiteral("jacktrip"));
         app->setOrganizationDomain(QStringLiteral("jacktrip.org"));
         app->setApplicationName(QStringLiteral("JackTrip"));
-        app->setApplicationVersion(gVersion);
+        app->setApplicationVersion(gShortVersion);
 
         QCommandLineParser parser;
         QCommandLineOption verboseOption(QStringList() << QStringLiteral("V")


### PR DESCRIPTION
We are currently calling things "release candidates" which technically are not that, because if nothing else we have to keep changing the version string to represent if it's an RC or not (and which RC it is). A release candidate should not change in any way prior to it being released as final.

We recently ran into a critical problem that was introduced in the last few commits that were made after 1.6.7 rc2 and before the actual 1.6.7 was tagged, which required doing a fire drill to release 1.6.8. We have a manual pre-release process and test case that would have caught this before release, had we actually been testing the final release packages. Instead we tested "rc2" and then changed it.

I propose that release candidates are the final bits that we ship, no approximations that may change in the last minutes. This requires that we not make any manual commits to change the version strings for release candidates. However, it's still necessary to determine if build A is the final release versus build B, and the standard way to do this is using git commit hashes.

This PR eliminates the need to manually maintain the `gVersion` field, replacing it with new `gShortVersion` (semver) and `gLongVersion` (`git describe --tags`) variables that are set at build time. It also introduces two new build time variables: `gCommitHash` and `gBuildTime` for more detailed information about the build.

This modifies the behavior of `-v` so that the "JackTrip VERSION" line will always display semver (x.y.z), which makes it more consistent and easier for downstream things to parse. But it adds a "Build Info" line to display the more detailed information, which is required for anyone testing or debugging a build to know what code was used to generate it. 

This will help us conform to more standard release process conventions, and avoid releases from being broken and published untested with last minute changes.