### PR TITLE
Address segfault due to ifdef hell with a move to c++17

### DIFF
--- a/jacktrip.pro
+++ b/jacktrip.pro
@@ -2,7 +2,7 @@
 # Created by Juan-Pablo Caceres
 #******************************
 
-CONFIG += c++11 console
+CONFIG += c++17 console
 CONFIG -= app_bundle
 
 CONFIG += qt thread debug_and_release build_all
@@ -151,7 +151,7 @@ linux-g++-64 {
 win32 {
   message(Building on win32)
 #cc  CONFIG += x86 console
-  CONFIG += c++11 console
+  CONFIG += c++17 console
   exists("C:\Program Files\JACK2") {
     message("using Jack in C:\Program Files\JACK2")
     INCLUDEPATH += "C:\Program Files\JACK2\include"

--- a/src/gui/AudioInterfaceMode.h
+++ b/src/gui/AudioInterfaceMode.h
@@ -38,13 +38,13 @@
 enum class AudioInterfaceMode {
     JACK,     ///< Jack Mode
     RTAUDIO,  ///< RtAudio Mode
-    BOTH,
+    ALL,
     NONE
 };
 
 #ifdef RT_AUDIO
 #ifndef NO_JACK
-constexpr AudioInterfaceMode mode = AudioInterfaceMode::BOTH;
+constexpr AudioInterfaceMode mode = AudioInterfaceMode::ALL;
 #else
 constexpr AudioInterfaceMode mode = AudioInterfaceMode::RTAUDIO;
 #endif
@@ -60,19 +60,19 @@ template<AudioInterfaceMode backend>
 constexpr auto isBackendAvailable()
 {
     if constexpr (backend == AudioInterfaceMode::RTAUDIO) {
-        if (mode == AudioInterfaceMode::RTAUDIO || mode == AudioInterfaceMode::BOTH) {
+        if (mode == AudioInterfaceMode::RTAUDIO || mode == AudioInterfaceMode::ALL) {
             return true;
         } else {
             return false;
         }
     } else if constexpr (backend == AudioInterfaceMode::JACK) {
-        if (mode == AudioInterfaceMode::JACK || mode == AudioInterfaceMode::BOTH) {
+        if (mode == AudioInterfaceMode::JACK || mode == AudioInterfaceMode::ALL) {
             return true;
         } else {
             return false;
         }
-    } else if constexpr (backend == AudioInterfaceMode::BOTH) {
-        if (mode == AudioInterfaceMode::BOTH) {
+    } else if constexpr (backend == AudioInterfaceMode::ALL) {
+        if (mode == AudioInterfaceMode::ALL) {
             return true;
         } else {
             return false;

--- a/src/gui/AudioInterfaceMode.h
+++ b/src/gui/AudioInterfaceMode.h
@@ -36,7 +36,7 @@
  */
 
 enum class AudioInterfaceMode {
-    JACK,    ///< Jack Mode
+    JACK,     ///< Jack Mode
     RTAUDIO,  ///< RtAudio Mode
     BOTH,
     NONE
@@ -48,7 +48,7 @@ constexpr AudioInterfaceMode mode = AudioInterfaceMode::BOTH;
 #else
 constexpr AudioInterfaceMode mode = AudioInterfaceMode::RTAUDIO;
 #endif
-#else 
+#else
 #ifndef NO_JACK
 constexpr AudioInterfaceMode mode = AudioInterfaceMode::JACK;
 #else
@@ -56,18 +56,18 @@ constexpr AudioInterfaceMode mode = AudioInterfaceMode::NONE;
 #endif
 #endif
 
-template <AudioInterfaceMode backend>
+template<AudioInterfaceMode backend>
 constexpr auto isBackendAvailable()
 {
     if constexpr (backend == AudioInterfaceMode::RTAUDIO) {
         if (mode == AudioInterfaceMode::RTAUDIO || mode == AudioInterfaceMode::BOTH) {
-            return true; 
+            return true;
         } else {
             return false;
         }
     } else if constexpr (backend == AudioInterfaceMode::JACK) {
         if (mode == AudioInterfaceMode::JACK || mode == AudioInterfaceMode::BOTH) {
-            return true; 
+            return true;
         } else {
             return false;
         }

--- a/src/gui/AudioInterfaceMode.h
+++ b/src/gui/AudioInterfaceMode.h
@@ -1,0 +1,83 @@
+//*****************************************************************
+/*
+  JackTrip: A System for High-Quality Audio Network Performance
+  over the Internet
+
+  Copyright (c) 2008-2022 Juan-Pablo Caceres, Chris Chafe.
+  SoundWIRE group at CCRMA, Stanford University.
+
+  Permission is hereby granted, free of charge, to any person
+  obtaining a copy of this software and associated documentation
+  files (the "Software"), to deal in the Software without
+  restriction, including without limitation the rights to use,
+  copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the
+  Software is furnished to do so, subject to the following
+  conditions:
+
+  The above copyright notice and this permission notice shall be
+  included in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+  OTHER DEALINGS IN THE SOFTWARE.
+*/
+//*****************************************************************
+
+/**
+ * \file AudioInterfaceMode.h
+ * \author Matt Horton
+ * \date December 2022
+ */
+
+enum class AudioInterfaceMode {
+    JACK,    ///< Jack Mode
+    RTAUDIO,  ///< RtAudio Mode
+    BOTH,
+    NONE
+};
+
+#ifdef RT_AUDIO
+#ifndef NO_JACK
+constexpr AudioInterfaceMode mode = AudioInterfaceMode::BOTH;
+#else
+constexpr AudioInterfaceMode mode = AudioInterfaceMode::RTAUDIO;
+#endif
+#else 
+#ifndef NO_JACK
+constexpr AudioInterfaceMode mode = AudioInterfaceMode::JACK;
+#else
+constexpr AudioInterfaceMode mode = AudioInterfaceMode::NONE;
+#endif
+#endif
+
+template <AudioInterfaceMode backend>
+constexpr auto isBackendAvailable()
+{
+    if constexpr (backend == AudioInterfaceMode::RTAUDIO) {
+        if (mode == AudioInterfaceMode::RTAUDIO || mode == AudioInterfaceMode::BOTH) {
+            return true; 
+        } else {
+            return false;
+        }
+    } else if constexpr (backend == AudioInterfaceMode::JACK) {
+        if (mode == AudioInterfaceMode::JACK || mode == AudioInterfaceMode::BOTH) {
+            return true; 
+        } else {
+            return false;
+        }
+    } else if constexpr (backend == AudioInterfaceMode::BOTH) {
+        if (mode == AudioInterfaceMode::BOTH) {
+            return true;
+        } else {
+            return false;
+        }
+    } else {
+        return false;
+    }
+}

--- a/src/gui/Settings.qml
+++ b/src/gui/Settings.qml
@@ -245,7 +245,18 @@ Item {
             text: "Using JACK for audio input and output. Use QjackCtl to adjust your sample rate, buffer, and device settings."
             font { family: "Poppins"; pixelSize: fontMedium * virtualstudio.fontScale * virtualstudio.uiScale }
             wrapMode: Text.WordWrap
-            visible: virtualstudio.audioBackend == "JACK" && !virtualstudio.selectableBackend
+            visible: virtualstudio.audioBackend == "JACK" && !virtualstudio.selectableBackend && virtualstudio.backendAvailable
+            color: textColour
+        }
+
+        Text {
+            id: noBackendLabel
+            x: leftMargin * virtualstudio.uiScale; y: 150 * virtualstudio.uiScale
+            width: parent.width - x - (16 * virtualstudio.uiScale)
+            text: "JackTrip has been compiled without an audio backend. Please rebuild with the rtaudio flag or without the nojack flag."
+            font { family: "Poppins"; pixelSize: fontMedium * virtualstudio.fontScale * virtualstudio.uiScale }
+            wrapMode: Text.WordWrap
+            visible: !virtualstudio.backendAvailable
             color: textColour
         }
 
@@ -308,7 +319,7 @@ Item {
                 horizontalAlignment: Text.AlignHLeft
                 verticalAlignment: Text.AlignVCenter
                 elide: Text.ElideRight
-                text: outputCombo.model[outputCombo.currentIndex].text
+                text: outputCombo.model[outputCombo.currentIndex].text ? outputCombo.model[outputCombo.currentIndex].text : ""
             }
         }
 
@@ -323,21 +334,25 @@ Item {
             onClicked: { virtualstudio.playOutputAudio() }
             width: 216 * virtualstudio.uiScale; height: 30 * virtualstudio.uiScale
             x: parent.width - (232 * virtualstudio.uiScale)
-            y: virtualstudio.audioBackend != "JACK" ? outputCombo.y + (48 * virtualstudio.uiScale) : outputCombo.y + (48 * virtualstudio.uiScale)
+            y: virtualstudio.audioBackend != "JACK" ? outputCombo.y + (48 * virtualstudio.uiScale) : jackLabel.y + (72 * virtualstudio.uiScale)
             Text {
                 text: "Test Output Audio"
                 font { family: "Poppins"; pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale }
                 anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter }
                 color: textColour
             }
+            visible: virtualstudio.audioReady
         }
 
         Text {
+            id: inputLabel
             anchors.verticalCenter: inputCombo.verticalCenter
-            x: leftMargin * virtualstudio.uiScale; y: testOutputAudioButton.y + (48 * virtualstudio.uiScale)
+            x: leftMargin * virtualstudio.uiScale
+            anchors.top: virtualstudio.audioBackend != "JACK" ? inputCombo.top : inputDeviceMeters.top
+            anchors.topMargin: virtualstudio.audioBackend != "JACK" ? (inputCombo.height - inputLabel.height)/2 : 0
             text: "Input Device"
             font { family: "Poppins"; pixelSize: fontMedium * virtualstudio.fontScale * virtualstudio.uiScale }
-            visible: virtualstudio.audioBackend != "JACK"
+            visible: virtualstudio.backendAvailable
             color: textColour
         }
 
@@ -361,7 +376,7 @@ Item {
             x: backendCombo.x; y: testOutputAudioButton.y + (48 * virtualstudio.uiScale)
             width: parent.width - x - (16 * virtualstudio.uiScale); height: 36 * virtualstudio.uiScale
             visible: virtualstudio.audioBackend != "JACK"
-                        delegate: ItemDelegate {
+            delegate: ItemDelegate {
                 required property var modelData
                 required property int index
 
@@ -391,7 +406,7 @@ Item {
                 horizontalAlignment: Text.AlignHLeft
                 verticalAlignment: Text.AlignVCenter
                 elide: Text.ElideRight
-                text: inputCombo.model[inputCombo.currentIndex].text
+                text: inputCombo.model[inputCombo.currentIndex].text ? inputCombo.model[inputCombo.currentIndex].text : ""
             }
         }
 
@@ -400,7 +415,7 @@ Item {
             anchors.left: backendCombo.left
             anchors.right: parent.right
             anchors.rightMargin: rightMargin * virtualstudio.uiScale
-            y: virtualstudio.audioBackend != "JACK" ?  inputCombo.y + 48 * virtualstudio.uiScale : virtualstudio.uiScale * (virtualstudio.selectableBackend ? 112 : 64)
+            y: virtualstudio.audioBackend != "JACK" ?  inputCombo.y + 48 * virtualstudio.uiScale : testOutputAudioButton.y + 72 * virtualstudio.uiScale
             height: 100 * virtualstudio.uiScale
             model: inputMeterModel
             clipped: inputClipped

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -122,7 +122,7 @@ VirtualStudio::VirtualStudio(bool firstRun, QObject* parent)
     m_previousInput  = m_inputDevice;
     m_previousOutput = m_outputDevice;
 
-    if constexpr (!isBackendAvailable<AudioInterfaceMode::BOTH>()) {
+    if constexpr (!isBackendAvailable<AudioInterfaceMode::ALL>()) {
         m_selectableBackend = false;
     }
 #else

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -121,6 +121,10 @@ VirtualStudio::VirtualStudio(bool firstRun, QObject* parent)
     refreshDevices();
     m_previousInput  = m_inputDevice;
     m_previousOutput = m_outputDevice;
+
+    if constexpr (!isBackendAvailable<AudioInterfaceMode::BOTH>()) {
+        m_selectableBackend = false;
+    }
 #else
     m_selectableBackend = false;
     m_vsAudioInterface.reset(new VsAudioInterface());
@@ -513,6 +517,16 @@ bool VirtualStudio::audioActivated()
 bool VirtualStudio::audioReady()
 {
     return m_audioReady;
+}
+
+bool VirtualStudio::backendAvailable()
+{
+    if constexpr ((isBackendAvailable<AudioInterfaceMode::JACK>()
+                   || isBackendAvailable<AudioInterfaceMode::RTAUDIO>())) {
+        return true;
+    } else {
+        return false;
+    }
 }
 
 void VirtualStudio::setInputVolume(float multiplier)
@@ -1336,7 +1350,10 @@ void VirtualStudio::slotAuthSucceded()
     m_device->registerApp();
 
     if (m_showDeviceSetup) {
-        setAudioActivated(true);
+        if constexpr (isBackendAvailable<AudioInterfaceMode::JACK>()
+                      || isBackendAvailable<AudioInterfaceMode::RTAUDIO>()) {
+            setAudioActivated(true);
+        }
     }
 
     if (m_userId.isEmpty()) {
@@ -2044,6 +2061,12 @@ void VirtualStudio::toggleAudio()
         return;
     }
 #endif
+
+    if constexpr (!(isBackendAvailable<AudioInterfaceMode::JACK>()
+                    || isBackendAvailable<AudioInterfaceMode::RTAUDIO>())) {
+        return;
+    }
+
     if (!m_audioActivated) {
         stopAudio();
     } else {

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -133,6 +133,7 @@ class VirtualStudio : public QObject
                    audioActivatedChanged)
     Q_PROPERTY(
         bool audioReady READ audioReady WRITE setAudioReady NOTIFY audioReadyChanged)
+    Q_PROPERTY(bool backendAvailable READ backendAvailable CONSTANT)
     Q_PROPERTY(QString windowState READ windowState WRITE setWindowState NOTIFY
                    windowStateUpdated)
 
@@ -206,6 +207,7 @@ class VirtualStudio : public QObject
     Q_INVOKABLE void restartAudio();
     bool audioActivated();
     bool audioReady();
+    bool backendAvailable();
     QString windowState();
 
    public slots:

--- a/src/gui/vsAudioInterface.cpp
+++ b/src/gui/vsAudioInterface.cpp
@@ -69,7 +69,7 @@ VsAudioInterface::VsAudioInterface(int NumChansIn, int NumChansOut,
     m_outMultiplier = settings.value(QStringLiteral("OutMultiplier"), 1).toFloat();
     m_inMuted       = settings.value(QStringLiteral("InMuted"), false).toBool();
     m_outMuted      = settings.value(QStringLiteral("OutMuted"), false).toBool();
-    if constexpr (isBackendAvailable<AudioInterfaceMode::BOTH>()) {
+    if constexpr (isBackendAvailable<AudioInterfaceMode::ALL>()) {
         m_audioInterfaceMode = (settings.value(QStringLiteral("Backend"), 0).toInt() == 1)
                                    ? VsAudioInterface::RTAUDIO
                                    : VsAudioInterface::JACK;
@@ -110,14 +110,13 @@ void VsAudioInterface::setupAudio()
 
         // Create AudioInterface Client Object
         if (m_audioInterfaceMode == VsAudioInterface::JACK) {
-            if constexpr (isBackendAvailable<AudioInterfaceMode::BOTH>()
+            if constexpr (isBackendAvailable<AudioInterfaceMode::ALL>()
                           || isBackendAvailable<AudioInterfaceMode::JACK>()) {
                 setupJackAudio();
             } else {
                 if constexpr (isBackendAvailable<AudioInterfaceMode::RTAUDIO>()) {
                     setupRtAudio();
                 } else {
-                    // oh shit
                     throw std::runtime_error(
                         "JackTrip was compiled without RtAudio and can't find JACK. In "
                         "order to use JackTrip, you'll need to install JACK or rebuild "
@@ -129,7 +128,6 @@ void VsAudioInterface::setupAudio()
             if constexpr (isBackendAvailable<AudioInterfaceMode::RTAUDIO>()) {
                 setupRtAudio();
             } else {
-                // oh shit
                 throw std::runtime_error(
                     "JackTrip was compiled without RtAudio and can't find JACK. In order "
                     "to use JackTrip, you'll need to install JACK or rebuild with "
@@ -158,7 +156,7 @@ void VsAudioInterface::setupAudio()
 void VsAudioInterface::setupJackAudio()
 {
 #ifndef NO_JACK
-    if constexpr (isBackendAvailable<AudioInterfaceMode::BOTH>()
+    if constexpr (isBackendAvailable<AudioInterfaceMode::ALL>()
                   || isBackendAvailable<AudioInterfaceMode::JACK>()) {
         if (gVerboseFlag)
             std::cout << "  JackTrip:setupAudio before new JackAudioInterface"
@@ -211,7 +209,7 @@ void VsAudioInterface::setupJackAudio()
 void VsAudioInterface::setupRtAudio()
 {
 #ifdef RT_AUDIO
-    if constexpr (isBackendAvailable<AudioInterfaceMode::BOTH>()
+    if constexpr (isBackendAvailable<AudioInterfaceMode::ALL>()
                   || isBackendAvailable<AudioInterfaceMode::RTAUDIO>()) {
         m_audioInterface.reset(new RtAudioInterface(m_numAudioChansIn, m_numAudioChansOut,
                                                     m_audioBitResolution));

--- a/src/gui/vsAudioInterface.h
+++ b/src/gui/vsAudioInterface.h
@@ -54,6 +54,7 @@
 #include "../Tone.h"
 #include "../Volume.h"
 #include "../jacktrip_globals.h"
+#include "AudioInterfaceMode.h"
 
 class VsAudioInterface : public QObject
 {
@@ -120,6 +121,9 @@ class VsAudioInterface : public QObject
     void processMeterMeasurements(QVector<float> values);
 
    private:
+    void setupJackAudio();
+    void setupRtAudio();
+
     float m_inMultiplier  = 1.0;
     float m_outMultiplier = 1.0;
     bool m_inMuted        = false;


### PR DESCRIPTION

![CleanShot 2022-12-16 at 12 01 24@2x](https://user-images.githubusercontent.com/5567285/208178185-090614dc-dade-4c52-8d23-0f86f113777c.png)


This **_begins_** work on moving from `#ifdef` of `RT_AUDIO` and `NO_JACK` to `if constexpr`. It uses that pattern to simplify some of the audio setup code and eliminate a couple of instances where VS mode could segfault.

It _does not_ bring that simplification to the underlying `AudioInterface`-based classes yet.