### PR TITLE
Attempting to fix immediate disconnects

### DIFF
--- a/src/gui/vsDevice.cpp
+++ b/src/gui/vsDevice.cpp
@@ -84,8 +84,6 @@ VsDevice::VsDevice(QOAuth2AuthorizationCodeFlow* authenticator, bool testMode,
                 reply->attribute(QNetworkRequest::HttpStatusCodeAttribute);
             if (!statusCode.isValid()) {
                 std::cout << "Error: " << reply->errorString().toStdString() << std::endl;
-                // TODO: Fix me
-                // emit authFailed();
                 reply->deleteLater();
                 return;
             }
@@ -132,8 +130,6 @@ void VsDevice::registerApp()
                 reply->attribute(QNetworkRequest::HttpStatusCodeAttribute);
             if (!statusCode.isValid()) {
                 std::cout << "Error: " << reply->errorString().toStdString() << std::endl;
-                // TODO: Fix me
-                // emit authFailed();
                 reply->deleteLater();
                 return;
             }
@@ -152,8 +148,6 @@ void VsDevice::registerApp()
             } else {
                 // Other error status. Won't create device.
                 std::cout << "Error: " << reply->errorString().toStdString() << std::endl;
-                // TODO: Fix me
-                // emit authFailed();
                 reply->deleteLater();
                 return;
             }
@@ -184,8 +178,6 @@ void VsDevice::removeApp()
     connect(reply, &QNetworkReply::finished, this, [=]() {
         if (reply->error() != QNetworkReply::NoError) {
             std::cout << "Error: " << reply->errorString().toStdString() << std::endl;
-            // TODO: Fix me
-            // emit authFailed();
             reply->deleteLater();
             return;
         } else {
@@ -280,8 +272,6 @@ void VsDevice::sendHeartbeat()
         connect(reply, &QNetworkReply::finished, this, [=]() {
             if (reply->error() != QNetworkReply::NoError) {
                 std::cout << "Error: " << reply->errorString().toStdString() << std::endl;
-                // TODO: Fix me
-                // emit authFailed();
                 reply->deleteLater();
                 return;
             } else {
@@ -307,8 +297,6 @@ void VsDevice::setServerId(QString serverId)
     connect(reply, &QNetworkReply::finished, this, [=]() {
         if (reply->error() != QNetworkReply::NoError) {
             std::cout << "Error: " << reply->errorString().toStdString() << std::endl;
-            // TODO: Fix me
-            // emit authFailed();
             reply->deleteLater();
             return;
         }
@@ -330,8 +318,6 @@ void VsDevice::sendLevels()
     connect(reply, &QNetworkReply::finished, this, [=]() {
         if (reply->error() != QNetworkReply::NoError) {
             std::cout << "Error: " << reply->errorString().toStdString() << std::endl;
-            // TODO: Fix me
-            // emit authFailed();
             reply->deleteLater();
             return;
         }
@@ -415,10 +401,12 @@ void VsDevice::reconcileAgentConfig(QJsonDocument newState)
         return;
     }
     for (auto it = newObject.constBegin(); it != newObject.constEnd(); it++) {
+        // if currently enabled but new config is not enabled, disconnect immediately
+        if (enabled() && it.key() == "enabled" && !it.value().toBool()
+            && !m_jackTrip.isNull()) {
+            stopJackTrip();
+        }
         m_deviceAgentConfig.insert(it.key(), it.value());
-    }
-    if (!enabled() && !m_jackTrip.isNull()) {
-        stopJackTrip();
     }
 }
 
@@ -575,8 +563,6 @@ void VsDevice::registerJTAsDevice()
     connect(reply, &QNetworkReply::finished, this, [=]() {
         if (reply->error() != QNetworkReply::NoError) {
             std::cout << "Error: " << reply->errorString().toStdString() << std::endl;
-            // TODO: Fix me
-            // emit authFailed();
             reply->deleteLater();
             return;
         } else {


### PR DESCRIPTION
Sometimes when manually connecting to a studio with VS mode I get a "Connected" and immediate "Disconnected" screen, landing me back into the studio list view.

I did some troubleshooting to see why that's happening. Here's a brief log dump with print of `newObject` in `VsDevice::reconcileAgentConfig`:
```
step 1
  JackTrip:startProcess before checkIfPortIsBinded(mReceiverBindPort)
  JackTrip:startProcess before checkIfPortIsBinded(mSenderBindPort)
  JackTrip:startProcess before setupAudio
Setting Up RtAudio Interface
...
step 4
    UdpDataProtocol:run0 before Setup Audio Packet buffer, Full Packet buffer, Redundancy Variables
    UdpDataProtocol:run0 before setRealtimeProcessPriority()
step 5
  JackTrip:startProcess before mAudioInterface->startProcess
Initializing Faust plugins (have 4) at sampling rate 48000
100ms  100ms
    UdpDataProtocol:run1 before mJackTrip->checkPeerSettings()
step 7
    UdpDataProtocol:run1 before mJackTrip->parseAudioPacket()
Received Connection from Peer!
step 8
Received connection
UDP waiting too long (more than 30ms) for 54.219.137.24...

newObject is QJsonObject({"authToken":"591cff3f11ab9e23f844d6693de5fe68a99849300837b59149517537405ec797","bufferStrategy":1,"captureBoost":true,"captureMute":false,"captureVolume":100,"compressor":false,"devicePort":4464,"enableUsb":true,"enabled":false,"inputChannels":2,"limiter":true,"loopback":true,"monitorMute":false,"monitorVolume":100,"name":"neltest","outputChannels":2,"period":128,"playbackBoost":true,"playbackMute":false,"playbackVolume":50,"public":false,"quality":2,"queueBuffer":0,"reverb":0,"sampleRate":48000,"serverHost":"1671129078dfl1biej.jacktrip.cloud","serverPort":4464,"stereo":true,"type":"JackTrip"})
Stopping JackTrip...
sending exit packet
JackTrip Processes STOPPED!
```

versus a log dump of a successful connection attempt:
```
step 1
  JackTrip:startProcess before checkIfPortIsBinded(mReceiverBindPort)
  JackTrip:startProcess before checkIfPortIsBinded(mSenderBindPort)
  JackTrip:startProcess before setupAudio
...
step 4
    UdpDataProtocol:run0 before Setup Audio Packet buffer, Full Packet buffer, Redundancy Variables
    UdpDataProtocol:run0 before setRealtimeProcessPriority()
step 5
  JackTrip:startProcess before mAudioInterface->startProcess
Initializing Faust plugins (have 4) at sampling rate 48000
100ms  100ms
    UdpDataProtocol:run1 before mJackTrip->checkPeerSettings()
step 7
    UdpDataProtocol:run1 before mJackTrip->parseAudioPacket()
Received Connection from Peer!
step 8
Received connection

newObject is QJsonObject({"authToken":"591cff3f11ab9e23f844d6693de5fe68a99849300837b59149517537405ec797","bufferStrategy":1,"captureBoost":true,"captureMute":false,"captureVolume":100,"compressor":false,"devicePort":4464,"enableUsb":true,"enabled":true,"inputChannels":2,"limiter":true,"loopback":true,"monitorMute":false,"monitorVolume":100,"name":"neltest","outputChannels":2,"period":128,"playbackBoost":true,"playbackMute":false,"playbackVolume":50,"public":false,"quality":2,"queueBuffer":0,"reverb":0,"sampleRate":48000,"serverHost":"1671129078dfl1biej.jacktrip.cloud","serverPort":4464,"stereo":true,"type":"JackTrip"})
```

Notably, in the case where it's not working we get `enabled: false` as the first response when we expect `enabled: true`. I'm guessing this is likely due async behavior as we switch from the HTTP heartbeat -> websocket heartbeat? Although it's strange that the `serverHost` and other fields are properly filled out.

In any case, we still need to act on the `enabled` key because that's the only field that changes if you disconnect via web. I'm changing the disconnect logic here to only stop jacktrip if we've previously detected that enabled was true and the incoming message says it is now false.

This PR also removes a bunch of `emit authFailed()` TODOs - we're using the same `m_authenticator` as virtualstudio.cpp so the constructor for that should already handle it via `VirtualStudio::slotAuthFailed` (I think?)