### PR TITLE
Fix Network Stats For Studio Starts

### DIFF
--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1460,6 +1460,7 @@ void VirtualStudio::handleWebsocketMessage(const QString& msg)
         if (serverStatus == QLatin1String("Ready") && m_onConnectedScreen) {
             studioInfo->setHost(serverState[QStringLiteral("serverHost")].toString());
             studioInfo->setPort(serverState[QStringLiteral("serverPort")].toInt());
+            studioInfo->setSessionId(serverState[QStringLiteral("sessionId")].toString());
 
             // Call completeConnection after a short timeout
             m_startTimer.setInterval(1000);


### PR DESCRIPTION
Fixes a bug introduced by #842 where network stats don't work under some conditions. I forgot to add the studio session id where I've already included the host IP and port number.