### PR TITLE
Reauthenticate After Sign Out

### DIFF
--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -897,6 +897,7 @@ void VirtualStudio::toVirtualStudio()
                 (*parameters)[QStringLiteral("code")] = QUrl::fromPercentEncoding(code);
             } else if (stage == QAbstractOAuth2::Stage::RequestingAuthorization) {
                 parameters->insert(QStringLiteral("audience"), AUTH_AUDIENCE);
+                parameters->insert(QStringLiteral("prompt"), QStringLiteral("login"));
             }
             if (!parameters->contains("client_id")) {
                 parameters->insert("client_id", AUTH_CLIENT_ID);
@@ -1652,6 +1653,7 @@ void VirtualStudio::setupAuthenticator()
             } else if (stage == QAbstractOAuth2::Stage::RequestingAuthorization) {
                 parameters->insert(QStringLiteral("audience"),
                                    QStringLiteral("https://api.jacktrip.org"));
+                parameters->insert(QStringLiteral("prompt"), QStringLiteral("login"));
             }
         });
 


### PR DESCRIPTION
Use this additional `prompt=login` parameter to force a reauthentication after a user has pressed "Sign Out". Before this, when a user signed out and pressed the sign in button again, they would immediately redirect back to the desktop app without needing to log in via browser again.

https://user-images.githubusercontent.com/26987971/211953821-a90fd8b6-a863-4227-bb75-d87126bda1aa.mov

