### PR TITLE
Use random bind port to avoid client collision

### DIFF
--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -467,11 +467,23 @@ void JackTrip::startProcess(
         // qDebug() << "before mJackTrip->startProcess" << mReceiverBindPort<<
         // mSenderBindPort;
 #endif
-    checkIfPortIsBinded(mReceiverBindPort);
+    if (checkIfPortIsBinded(mReceiverBindPort)) {
+        stop(QStringLiteral("Could not bind %1 UDP socket. It may already be binded by "
+                            "another process on "
+                            "your machine. Try using a different port number")
+                 .arg(mReceiverBindPort));
+        return;
+    }
     if (gVerboseFlag)
         std::cout << "  JackTrip:startProcess before checkIfPortIsBinded(mSenderBindPort)"
                   << std::endl;
-    checkIfPortIsBinded(mSenderBindPort);
+    if (checkIfPortIsBinded(mSenderBindPort)) {
+        stop(QStringLiteral("Could not bind %1 UDP socket. It may already be binded by "
+                            "another process on "
+                            "your machine. Try using a different port number")
+                 .arg(mSenderBindPort));
+        return;
+    }
     // Set all classes and parameters
     // ------------------------------
     if (gVerboseFlag)
@@ -1496,7 +1508,7 @@ bool JackTrip::checkPeerSettings(int8_t* full_packet)
 }
 
 //*******************************************************************************
-void JackTrip::checkIfPortIsBinded(int port)
+bool JackTrip::checkIfPortIsBinded(int port)
 {
     QUdpSocket UdpSockTemp;  // Create socket to wait for client
     // Bind the socket
@@ -1514,10 +1526,9 @@ void JackTrip::checkIfPortIsBinded(int port)
         bool binded = UdpSockTemp.bind(it->second, port, QUdpSocket::DontShareAddress);
         if (!binded) {
             UdpSockTemp.close();  // close the socket
-            throw std::runtime_error(
-            "Could not bind " + it->first + " UDP socket. It may already be binded by another process on "
-            "your machine. Try using a different port number");
+            return true;
         }
         UdpSockTemp.close();
     }
+    return false;
 }

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -1496,11 +1496,22 @@ void JackTrip::checkIfPortIsBinded(int port)
     // Bind the socket
     // cc        if ( !UdpSockTemp.bind(QHostAddress::AnyIPv4, port,
     // QUdpSocket::DontShareAddress) )
-    if (!UdpSockTemp.bind(QHostAddress::Any, port, QUdpSocket::DontShareAddress)) {
-        UdpSockTemp.close();  // close the socket
-        throw std::runtime_error(
-            "Could not bind UDP socket. It may already be binded by another process on "
+
+    // check all combinations to ensure the port is free
+    std::map<std::string, QHostAddress::SpecialAddress> interfaces = {
+        {"IPv4", QHostAddress::AnyIPv4},
+        {"IPv6", QHostAddress::AnyIPv6},
+        {"IPv4+IPv6", QHostAddress::Any}};
+
+    std::map<std::string, QHostAddress::SpecialAddress>::iterator it;
+    for (it = interfaces.begin(); it != interfaces.end(); it++) {
+        bool binded = UdpSockTemp.bind(it->second, port, QUdpSocket::DontShareAddress);
+        if (!binded) {
+            UdpSockTemp.close();  // close the socket
+            throw std::runtime_error(
+            "Could not bind " + it->first + " UDP socket. It may already be binded by another process on "
             "your machine. Try using a different port number");
+        }
+        UdpSockTemp.close();
     }
-    UdpSockTemp.close();  // close the socket
 }

--- a/src/JackTrip.h
+++ b/src/JackTrip.h
@@ -191,7 +191,7 @@ class JackTrip : public QObject
 
     /// \brief Check if UDP port is already binded
     /// \param port Port number
-    virtual void checkIfPortIsBinded(int port);
+    virtual bool checkIfPortIsBinded(int port);
 
     //------------------------------------------------------------------------------------
     /// \name Getters and Setters Methods to change parameters after construction

--- a/src/UdpDataProtocol.cpp
+++ b/src/UdpDataProtocol.cpp
@@ -635,7 +635,7 @@ void UdpDataProtocol::run()
         dataBuf.len = full_redundant_packet_size;
         dataBuf.buf = reinterpret_cast<char *>(full_redundant_packet);
         DWORD recvBytes = 0, flags = 0, index, bytesTransferred = 0;
-        
+
         eventArray[0] = WSACreateEvent();
         if (eventArray == WSA_INVALID_EVENT) {
             emit signalError("Unable to set up network event monitoring");
@@ -644,7 +644,7 @@ void UdpDataProtocol::run()
         }
         ZeroMemory(&socketOverlapped, sizeof(WSAOVERLAPPED));
         socketOverlapped.hEvent = eventArray[0];
-        
+
         if (WSARecv(mSocket, &dataBuf, 1, &recvBytes, &flags, &socketOverlapped, NULL) == SOCKET_ERROR) {
             int result = WSAGetLastError();
             if (result != WSA_IO_PENDING) {
@@ -682,7 +682,7 @@ void UdpDataProtocol::run()
             }
         }
 #else
-            
+
             // OLD CODE WITHOUT REDUNDANCY----------------------------------------------------
             /*
         // This is blocking until we get a packet...

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1122,6 +1122,10 @@ void VirtualStudio::completeConnection()
 #endif
         JackTrip* jackTrip = m_device->initJackTrip(
             m_useRtAudio, input, output, buffer_size, m_bufferStrategy, studioInfo);
+        if (jackTrip == 0) {
+            processError("Could not bind port");
+            return;
+        }
 
         QObject::connect(jackTrip, &JackTrip::signalProcessesStopped, this,
                          &VirtualStudio::processFinished, Qt::QueuedConnection);

--- a/src/gui/vsDevice.cpp
+++ b/src/gui/vsDevice.cpp
@@ -364,6 +364,9 @@ JackTrip* VsDevice::initJackTrip([[maybe_unused]] bool useRtAudio,
     }
 #endif
     int bindPort = selectBindPort();
+    if (bindPort == 0) {
+        return 0;
+    }
     m_jackTrip->setBindPorts(bindPort);
     m_jackTrip->setRemoteClientName(m_appID);
     // increment m_bufferStrategy by 1 for array-index mapping
@@ -674,14 +677,11 @@ int VsDevice::selectBindPort()
     }
     int attempt = 0;
     while (attempt <= 5000) {
-        candidate = qrand() % (gBindPortHigh - gBindPortLow + 1) + gBindPortLow;
+        candidate = QRandomGenerator::global()->bounded(gBindPortLow, gBindPortHigh + 1);
         attempt++;
-        try {
-            m_jackTrip->checkIfPortIsBinded(candidate);
+        if (!m_jackTrip->checkIfPortIsBinded(candidate)) {
             return candidate;
-        } catch (const std::exception& e) {
-            qDebug() << e.what();
         }
     }
-    return candidate;
+    return 0;
 }

--- a/src/gui/vsDevice.cpp
+++ b/src/gui/vsDevice.cpp
@@ -363,6 +363,8 @@ JackTrip* VsDevice::initJackTrip([[maybe_unused]] bool useRtAudio,
         m_jackTrip->setOutputDevice(output);
     }
 #endif
+    int bindPort = selectBindPort();
+    m_jackTrip->setBindPorts(bindPort);
     m_jackTrip->setRemoteClientName(m_appID);
     // increment m_bufferStrategy by 1 for array-index mapping
     m_jackTrip->setBufferStrategy(bufferStrategy + 1);
@@ -661,4 +663,25 @@ QString VsDevice::randomString(int stringLength)
     }
 
     return str;
+}
+
+// selectBindPort finds the next open bind port to use for jacktrip
+int VsDevice::selectBindPort()
+{
+    int candidate = gDefaultPort;
+    if (m_jackTrip.isNull()) {
+        return candidate;
+    }
+    int attempt = 0;
+    while (attempt <= 5000) {
+        candidate = qrand() % (gBindPortHigh - gBindPortLow + 1) + gBindPortLow;
+        attempt++;
+        try {
+            m_jackTrip->checkIfPortIsBinded(candidate);
+            return candidate;
+        } catch (const std::exception& e) {
+            qDebug() << e.what();
+        }
+    }
+    return candidate;
 }

--- a/src/gui/vsDevice.h
+++ b/src/gui/vsDevice.h
@@ -96,6 +96,7 @@ class VsDevice : public QObject
    private:
     void registerJTAsDevice();
     bool enabled();
+    int selectBindPort();
     QString randomString(int stringLength);
 
     VsPinger* m_pinger = NULL;


### PR DESCRIPTION
When in Virtual Studio mode, use a random bind port for the jacktrip client process.

This PR also fixes a bug with `checkIfPortIsBinded`. The `QHostAddress::Any` option is used to check if a port is bound on [both ipv4 + ipv6 interfaces](https://doc.qt.io/qt-5/qhostaddress.html#SpecialAddress-enum). So if the port of interest is only in use by ipv4, the exception will not be raised which allows the client to use the port despite if it's already in-use elsewhere. This is particularly problematic when its allowed to proceed, it kicks the older client out and lets the new client in. 

Also dumping this here because it was helpful to understand: https://learn.microsoft.com/en-us/windows/win32/winsock/using-so-reuseaddr-and-so-exclusiveaddruse