### PR TITLE
Fixing TCP error upon connecting from desktop app start

### DIFF
--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -1077,11 +1077,17 @@ void JackTrip::tcpTimerTick()
     // Use randomized exponential backoff to reconnect the TCP client
     QRandomGenerator randomizer;
     mRetries++;
+    // exponential backoff sleep with 6s maximum + jitter
     int newInterval = 2000 * pow(2, mRetries);
-    newInterval     = randomizer.bounded(0, newInterval);
+    newInterval     = std::min(newInterval, 6000);
+    newInterval += randomizer.bounded(0, 500);
+    QString now = QDateTime::currentDateTime().toString(Qt::ISODate);
+    qDebug() << "Sleep time " << newInterval << " ms at " << now;
     mRetryTimer.setInterval(newInterval);
 
-    cout << "Connection timed out. Retrying again using exponential backoff." << endl;
+    qDebug() << "Connection timed out. Retrying again using exponential backoff";
+
+    mTcpClient.abort();
 
     // Create Socket Objects
     QHostAddress serverHostAddress;
@@ -1092,9 +1098,8 @@ void JackTrip::tcpTimerTick()
             serverHostAddress = info.addresses().constFirst();
         }
     }
-
-    mTcpClient.disconnectFromHost();
     mTcpClient.connectToHost(serverHostAddress, mTcpServerPort);
+
     mRetryTimer.start();
 }
 

--- a/src/gui/Connected.qml
+++ b/src/gui/Connected.qml
@@ -5,9 +5,9 @@ import QtGraphicalEffects 1.12
 Item {
     width: parent.width; height: parent.height
     clip: true
-    
+
     property bool connecting: false
-    
+
     property int leftHeaderMargin: 16
     property int fontBig: 28
     property int fontMedium: 12
@@ -21,8 +21,9 @@ Item {
     property string studioStatus: (virtualstudio.currentStudio >= 0 ? serverModel[virtualstudio.currentStudio].status : "")
     property bool showReadyScreen: studioStatus === "Ready"
     property bool showStartingScreen: studioStatus === "Starting"
-    property bool showWaitingScreen: !showStartingScreen && !showReadyScreen
-    
+    property bool showStoppingScreen: (virtualstudio.currentStudio >= 0 ? serverModel[virtualstudio.currentStudio].isManageable && !serverModel[virtualstudio.currentStudio].enabled && serverModel[virtualstudio.currentStudio].cloudId !== "" : false)
+    property bool showWaitingScreen: !showStoppingScreen && !showStartingScreen && !showReadyScreen
+
     property string buttonColour: virtualstudio.darkMode ? "#494646" : "#EAECEC"
 
     property string browserButtonColour: virtualstudio.darkMode ? "#494646" : "#EAECEC"
@@ -91,7 +92,7 @@ Item {
         fillMode: Image.PreserveAspectFit
         smooth: true
     }
-    
+
     Text {
         id: heading
         text: virtualstudio.connectionState
@@ -99,7 +100,7 @@ Item {
         font { family: "Poppins"; weight: Font.Bold; pixelSize: fontBig * virtualstudio.fontScale * virtualstudio.uiScale }
         color: textColour
     }
-    
+
     Studio {
         x: leftHeaderMargin * virtualstudio.uiScale; y: 96 * virtualstudio.uiScale
         width: parent.width - (2 * x)
@@ -430,8 +431,8 @@ Item {
             color: textColour
             font {family: "Poppins"; pixelSize: fontMedium * virtualstudio.fontScale * virtualstudio.uiScale }
             text: parent.isManageable
-                ? "Waiting for this studio to start. To start this studio, please choose one of the options below."
-                : "This studio is currently inactive. Please contact an owner or admin for this studio to start it."
+                    ? "Waiting for this studio to start. To start this studio, please choose one of the options below."
+                    : "This studio is currently inactive. Please contact an owner or admin for this studio to start it."
             wrapMode: Text.WordWrap
         }
 
@@ -496,6 +497,7 @@ Item {
             anchors.top: parent.isManageable ? startButtonsBox.bottom : waitingText0.bottom
             anchors.topMargin: 16 * virtualstudio.uiScale
             anchors.bottomMargin: 16 * virtualstudio.uiScale
+            visible: parent.isManageable
             font {family: "Poppins"; pixelSize: fontMedium * virtualstudio.fontScale * virtualstudio.uiScale }
             text: "You will be automatically connected to the studio when it is ready."
             wrapMode: Text.WordWrap
@@ -515,6 +517,23 @@ Item {
             color: textColour
             font {family: "Poppins"; pixelSize: fontMedium * virtualstudio.fontScale * virtualstudio.uiScale }
             text: "This studio is currently starting up. You will be connected automatically when it is ready."
+            wrapMode: Text.WordWrap
+        }
+    }
+
+    Item {
+        id: studioStoppingScreen
+        visible: showStoppingScreen
+        x: bodyMargin * virtualstudio.uiScale; y: 230 * virtualstudio.uiScale
+        width: parent.width - (2 * x)
+
+        Text {
+            id: studioStoppingText0
+            x: 0
+            width: parent.width
+            color: textColour
+            font {family: "Poppins"; pixelSize: fontMedium * virtualstudio.fontScale * virtualstudio.uiScale }
+            text: "This studio is shutting down, please wait to start it again."
             wrapMode: Text.WordWrap
         }
     }

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1474,8 +1474,12 @@ void VirtualStudio::handleWebsocketMessage(const QString& msg)
 {
     QJsonObject serverState  = QJsonDocument::fromJson(msg.toUtf8()).object();
     QString serverStatus     = serverState[QStringLiteral("status")].toString();
+    bool serverEnabled       = serverState[QStringLiteral("enabled")].toBool();
+    QString serverCloudId    = serverState[QStringLiteral("cloudId")].toString();
     VsServerInfo* studioInfo = static_cast<VsServerInfo*>(m_servers.at(m_currentStudio));
     studioInfo->setStatus(serverStatus);
+    studioInfo->setEnabled(serverEnabled);
+    studioInfo->setCloudId(serverCloudId);
     if (!m_jackTripRunning) {
         if (serverStatus == QLatin1String("Ready") && m_onConnectedScreen) {
             studioInfo->setHost(serverState[QStringLiteral("serverHost")].toString());
@@ -1778,6 +1782,10 @@ void VirtualStudio::getServerList(bool firstLoad, bool signalRefresh, int index)
                             servers.at(i)[QStringLiteral("sessionId")].toString());
                         serverInfo->setInviteKey(
                             servers.at(i)[QStringLiteral("inviteKey")].toString());
+                        serverInfo->setCloudId(
+                            servers.at(i)[QStringLiteral("cloudId")].toString());
+                        serverInfo->setEnabled(
+                            servers.at(i)[QStringLiteral("enabled")].toBool());
                         serverInfo->setIsOwner(
                             servers.at(i)[QStringLiteral("owner")].toBool());
                         serverInfo->setIsAdmin(

--- a/src/gui/vsServerInfo.cpp
+++ b/src/gui/vsServerInfo.cpp
@@ -112,6 +112,16 @@ void VsServerInfo::setPort(quint16 port)
     m_port = port;
 }
 
+bool VsServerInfo::enabled() const
+{
+    return m_enabled;
+}
+
+void VsServerInfo::setEnabled(bool enabled)
+{
+    m_enabled = enabled;
+}
+
 bool VsServerInfo::isOwner() const
 {
     return m_owner;
@@ -249,6 +259,16 @@ QString VsServerInfo::inviteKey() const
 void VsServerInfo::setInviteKey(const QString& inviteKey)
 {
     m_inviteKey = inviteKey;
+}
+
+QString VsServerInfo::cloudId() const
+{
+    return m_cloudId;
+}
+
+void VsServerInfo::setCloudId(const QString& cloudId)
+{
+    m_cloudId = cloudId;
 }
 
 bool VsServerInfo::operator<(const VsServerInfo& other) const

--- a/src/gui/vsServerInfo.h
+++ b/src/gui/vsServerInfo.h
@@ -59,6 +59,8 @@ class VsServerInfo : public QObject
     Q_PROPERTY(quint32 sampleRate READ sampleRate CONSTANT)
     Q_PROPERTY(quint16 queueBuffer READ queueBuffer CONSTANT)
     Q_PROPERTY(QString status READ status CONSTANT)
+    Q_PROPERTY(bool enabled READ enabled CONSTANT)
+    Q_PROPERTY(QString cloudId READ cloudId CONSTANT)
     Q_PROPERTY(QString id READ id CONSTANT)
     Q_PROPERTY(QString inviteKey READ inviteKey CONSTANT)
 
@@ -79,6 +81,8 @@ class VsServerInfo : public QObject
     void setHost(const QString& host);
     quint16 port() const;
     void setPort(quint16 port);
+    bool enabled() const;
+    void setEnabled(bool enabled);
     bool isOwner() const;
     void setIsOwner(bool owner);
     bool isAdmin() const;
@@ -107,6 +111,8 @@ class VsServerInfo : public QObject
     void setStatus(const QString& status);
     QString inviteKey() const;
     void setInviteKey(const QString& inviteKey);
+    QString cloudId() const;
+    void setCloudId(const QString& cloudId);
     bool operator<(const VsServerInfo& other) const;
 
    signals:
@@ -117,6 +123,7 @@ class VsServerInfo : public QObject
     QString m_name;
     QString m_host;
     quint16 m_port;
+    bool m_enabled;
     bool m_owner;
     bool m_admin;
     bool m_isPublic;
@@ -129,6 +136,7 @@ class VsServerInfo : public QObject
     QString m_id;
     QString m_sessionId;
     QString m_status;
+    QString m_cloudId;
     QString m_inviteKey;
 
     /* Remaining JSON fields
@@ -139,8 +147,6 @@ class VsServerInfo : public QObject
     "size": "c5.large",
     "mixBranch": "main",
     "mixCode": "SimpleMix(~maxClients).masterVolume_(1).connect.start;",
-    "enabled": true,
-    "cloudId": "string",
     "ownerId": "string",
     "subStatus": "Active",
     "createdAt": "2021-09-07T17:15:38Z",


### PR DESCRIPTION
This should fix the "TCP Socket Error 19". I believe the root cause of this was:
```
newInterval = randomizer.bounded(0, newInterval);
```
which would pick a random number from 0 to `{newInterval}` which governs the sleep period between retries. This has some non-deterministic effects because it could exhaust all retries but not sleep for the full period we need to.

This also fixes a bug where you can start a studio that is shutting down which may have some bad outcomes. I handled this case with a text blurb:
![Screenshot 2023-01-19 at 9 21 46 AM](https://user-images.githubusercontent.com/6201822/213515676-d16f0ef6-3809-494c-8c63-21217718df38.png)
