### PR TITLE
Automatically delete QNetworkReplies

### DIFF
--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1341,8 +1341,10 @@ void VirtualStudio::slotAuthSucceded()
         m_apiHost = TEST_API_HOST;
     }
 
-    m_authenticated = true;
-    m_refreshToken  = m_authenticator->refreshToken();
+    m_authenticated            = true;
+    QNetworkAccessManager* nam = m_authenticator->networkAccessManager();
+    nam->setAutoDeleteReplies(true);
+    m_refreshToken = m_authenticator->refreshToken();
     emit hasRefreshTokenChanged();
     QSettings settings;
     settings.setValue(QStringLiteral("UiMode"), QJackTrip::VIRTUAL_STUDIO);

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -41,6 +41,7 @@
 #include <QEventLoop>
 #include <QList>
 #include <QMutex>
+#include <QNetworkAccessManager>
 #include <QScopedPointer>
 #include <QSharedPointer>
 #include <QTimer>


### PR DESCRIPTION
I don't know how this works but by default this is false. Seems like a sane feature to turn on?