### PR TITLE
Delete network replies and add error handling

### DIFF
--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -326,6 +326,8 @@ class VirtualStudio : public QObject
     void toggleAudio();
     void stopAudio();
     bool readyToJoin();
+    void onError(QNetworkReply::NetworkError);
+    void onSslErrors(const QList<QSslError>& errors);
 #ifdef RT_AUDIO
     QVariant formatDeviceList(const QStringList& devices, const QStringList& categories);
 #endif

--- a/src/gui/vsDevice.h
+++ b/src/gui/vsDevice.h
@@ -96,6 +96,8 @@ class VsDevice : public QObject
    private:
     void registerJTAsDevice();
     bool enabled();
+    void onError(QNetworkReply::NetworkError);
+    void onSslErrors(const QList<QSslError>& errors);
     QString randomString(int stringLength);
 
     VsPinger* m_pinger = NULL;


### PR DESCRIPTION
* Adding signal handling for `QNetworkReply::error` and `QNetworkReply::sslErrors`: https://doc.qt.io/archives/qt-5.12/qnetworkreply.html#signals
* Piping request error strings through `qDebug()` because that shows up in the `log.txt` file
* Rewriting some `QNetworkReply::finished` slots to log errors and always call `reply->deleteLater()` 

There's probably a way to combine `&VsDevice::onError` and `&VirtualStudio::onError` and the other SSL error slot, but I'm not sure how to do so.