### PR TITLE
Fix windows signing

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -583,7 +583,9 @@ jobs:
           bash -c "set -e; cp $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi signed/installer.msi"
           ls CodeSignTool.bat
           ls signed
-          call "dir; dir signed; CodeSignTool.bat sign -credential_id=%CRED_ID% -username=%USERNAME% -password=%PASSWORD% -totp_secret=%TOTP% -output_dir_path=signed -input_file_path=signed\installer.msi"
+          call "dir"
+          call "dir signed"
+          call "CodeSignTool.bat sign -credential_id=%CRED_ID% -username=%USERNAME% -password=%PASSWORD% -totp_secret=%TOTP% -output_dir_path=signed -input_file_path=signed\installer.msi"
           ls signed
           bash -c "set -e; cp signed/installer.msi $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi"
           bash -c "ls $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi"

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -576,9 +576,9 @@ jobs:
           unzip CodeSignTool-v1.2.6-windows.zip
           mkdir signed
           echo "before print"
-          ls $BUILD_PATH/
-          ls $BUILD_PATH/${{ matrix.installer-path }}/
-          ls $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi
+          ls $BUILD_PATH
+          ls $BUILD_PATH\${{ matrix.installer-path }}
+          ls $BUILD_PATH\${{ matrix.installer-path }}\JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi
           echo "before cp"
           bash -c "cp $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi signed/installer.msi"
           ls CodeSignTool.bat

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -583,10 +583,11 @@ jobs:
           bash -c "set -e; cp $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi signed/installer.msi"
           ls CodeSignTool.bat
           ls signed
-          call "dir .\signed /S"
-          call "CodeSignTool.bat sign -credential_id=%CRED_ID% -username=%USERNAME% -password=%PASSWORD% -totp_secret=%TOTP% -output_dir_path=signed -input_file_path=.\signed\installer.msi"
+          bash -c "ls signed"
+          bash -c "set -e; ./CodeSignTool.sh sign -credential_id=$CRED_ID -username=$USERNAME -password=$PASSWORD -totp_secret=$TOTP -output_dir_path=signed -input_file_path=signed/installer.msi"
+          # call "CodeSignTool.bat sign -credential_id=%CRED_ID% -username=%USERNAME% -password=%PASSWORD% -totp_secret=%TOTP% -output_dir_path=signed -input_file_path=signed\installer.msi"
           ls signed
-          bash -c "set -e; cp signed/installer.msi $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi"
+          bash -c "cp signed/installer.msi $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi"
           bash -c "ls $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi"
           bash -c "rm $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi"
       - name: upload jacktrip binary

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -557,9 +557,13 @@ jobs:
         shell: cmd
         run: |
           cd win
+          ls build_installer.bat
           call "build_installer.bat"
           bash -c "mkdir -p $BUILD_PATH/${{ matrix.installer-path }}"
+          ls $BUILD_PATH/${{ matrix.installer-path }}
+          ls deploy
           bash -c "cp deploy/*.msi $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi"
+          ls $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi
       - name: sign artifacts on Windows
         if: runner.os == 'Windows' && matrix.installer-path && steps.check-secrets.outputs.available == 'true'
         shell: cmd

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -583,8 +583,8 @@ jobs:
           bash -c "set -e; cp $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi signed/installer.msi"
           ls CodeSignTool.bat
           ls signed
-          call "dir signed\ /S"
-          call "CodeSignTool.bat sign -credential_id=%CRED_ID% -username=%USERNAME% -password=%PASSWORD% -totp_secret=%TOTP% -output_dir_path=signed -input_file_path=signed\installer.msi"
+          call "dir .\signed /S"
+          call "CodeSignTool.bat sign -credential_id=%CRED_ID% -username=%USERNAME% -password=%PASSWORD% -totp_secret=%TOTP% -output_dir_path=signed -input_file_path=.\signed\installer.msi"
           ls signed
           bash -c "set -e; cp signed/installer.msi $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi"
           bash -c "ls $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi"

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -580,13 +580,13 @@ jobs:
           path: ${{ env.BUILD_PATH }}/${{ matrix.bundle-path }}
       - name: upload installer
         uses: actions/upload-artifact@v2
-        if: matrix.installer-path && (!startsWith(github.ref, 'refs/tags/') || (startsWith(github.ref, 'refs/tags/') && matrix.release-name)) && steps.check-secrets.outputs.available != 'true'
+        if: matrix.installer-path && (!startsWith(github.ref, 'refs/tags/') || (startsWith(github.ref, 'refs/tags/') && matrix.release-name)) && (steps.check-secrets.outputs.available != 'true' || runner.os == 'Windows')
         with:
           name: JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer
           path: ${{ env.BUILD_PATH }}/${{ matrix.installer-path }}
       - name: upload signed installer
         uses: actions/upload-artifact@v2
-        if: matrix.installer-path && (!startsWith(github.ref, 'refs/tags/') || (startsWith(github.ref, 'refs/tags/') && matrix.release-name)) && steps.check-secrets.outputs.available == 'true'
+        if: matrix.installer-path && (!startsWith(github.ref, 'refs/tags/') || (startsWith(github.ref, 'refs/tags/') && matrix.release-name)) && steps.check-secrets.outputs.available == 'true' && runner.os != 'Windows'
         with:
           name: JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer
           path: ${{ env.BUILD_PATH }}/${{ matrix.installer-path }}

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -575,7 +575,11 @@ jobs:
           ls CodeSignTool-v1.2.6-windows.zip
           unzip CodeSignTool-v1.2.6-windows.zip
           mkdir signed
+          echo "before print"
+          ls $BUILD_PATH/
+          ls $BUILD_PATH/${{ matrix.installer-path }}/
           ls $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi
+          echo "before cp"
           bash -c "cp $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi signed/installer.msi"
           ls CodeSignTool.bat
           ls signed

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -562,34 +562,20 @@ jobs:
           bash -c "cp deploy/*.msi $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi"
       - name: sign artifacts on Windows
         if: runner.os == 'Windows' && matrix.installer-path && steps.check-secrets.outputs.available == 'true'
-        shell: cmd
+        shell: bash
         env:
           TOTP: ${{ secrets.TOTP_SECRET }}
           CRED_ID: ${{ secrets.ESIGNER_CREDENTIAL_ID }}
           USERNAME: jacktrip
           PASSWORD: ${{ secrets.SSL_COM_PWD}}
         run: |
-          ls win\CodeSignTool
-          cd win\CodeSignTool
-          curl -L -O -J https://files.jacktrip.org/contrib/CodeSignTool-v1.2.6-windows.zip
-          ls CodeSignTool-v1.2.6-windows.zip
-          unzip CodeSignTool-v1.2.6-windows.zip
-          dir
+          cd win/CodeSignTool
+          curl -L -O -J https://storage.googleapis.com/files.jacktrip.org/binaries/CodeSignTool/CodeSignTool-jars.zip
+          unzip CodeSignTool-jars.zip
           mkdir signed
-          echo "before print"
-          bash -c "ls $BUILD_PATH/"
-          bash -c "ls $BUILD_PATH/${{ matrix.installer-path }}/"
-          bash -c "ls $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi"
-          echo "before cp"
-          bash -c "set -e; cp $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi signed/installer.msi"
-          ls CodeSignTool.bat
-          ls signed
-          call "dir .\signed /S"
-          call "CodeSignTool.bat sign -credential_id=%CRED_ID% -username=%USERNAME% -password=%PASSWORD% -totp_secret=%TOTP% -output_dir_path=signed -input_file_path=.\signed\installer.msi"
-          ls signed
-          bash -c "set -e; cp signed/installer.msi $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi"
-          bash -c "ls $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi"
-          bash -c "rm $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi"
+          ./CodeSignTool.sh sign -credential_id=$CRED_ID -username=$USERNAME -password=$PASSWORD -totp_secret=$TOTP -output_dir_path=signed -input_file_path=$BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi
+          cp signed/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi
+          rm $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi
       - name: upload jacktrip binary
         uses: actions/upload-artifact@v2
         if: matrix.binary-path && (!startsWith(github.ref, 'refs/tags/') || (startsWith(github.ref, 'refs/tags/') && matrix.release-name))

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -584,31 +584,6 @@ jobs:
         with:
           name: JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer
           path: ${{ env.BUILD_PATH }}/${{ matrix.installer-path }}
-      - name: upload signed installer
-        uses: actions/upload-artifact@v2
-        if: matrix.installer-path && (!startsWith(github.ref, 'refs/tags/') || (startsWith(github.ref, 'refs/tags/') && matrix.release-name)) && steps.check-secrets.outputs.available == 'true' && runner.os != 'Windows'
-        with:
-          name: JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer
-          path: ${{ env.BUILD_PATH }}/${{ matrix.installer-path }}
-      - name: analyze build
-        if: github.event_name == 'pull_request' && matrix.static-analysis == true
-        shell: bash
-        run: |
-          mkdir $CLANG_TIDY_PATH
-          git diff -U0 origin/${{ github.base_ref }} | clang-tidy-diff -p1 -path $BUILD_PATH -export-fixes $CLANG_TIDY_PATH/fixes.yml
-      - name: save PR metadata for static analysis
-        if: github.event_name == 'pull_request' && matrix.static-analysis == true
-        shell: bash
-        run: |
-          echo ${{ github.event.number }} > $CLANG_TIDY_PATH/pr-id.txt
-          echo ${{ github.event.pull_request.head.repo.full_name }} > $CLANG_TIDY_PATH/pr-head-repo.txt
-          echo ${{ github.event.pull_request.head.ref }} > $CLANG_TIDY_PATH/pr-head-ref.txt
-      - name: upload static analysis
-        if: github.event_name == 'pull_request' && matrix.static-analysis == true
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.CLANG_TIDY_NAME }}
-          path: ${{ env.CLANG_TIDY_PATH }}/
   check-secrets:
     name: Check if secrets exist to determine if build & sign run
     runs-on: ubuntu-latest

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -583,7 +583,7 @@ jobs:
           bash -c "set -e; cp $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi signed/installer.msi"
           ls CodeSignTool.bat
           ls signed
-          call "CodeSignTool.bat sign -credential_id=%CRED_ID% -username=%USERNAME% -password=%PASSWORD% -totp_secret=%TOTP% -output_dir_path=signed -input_file_path=signed\installer.msi"
+          call "CodeSignTool.bat sign -credential_id=%CRED_ID% -username=%USERNAME% -password=%PASSWORD% -totp_secret=%TOTP% -output_dir_path=signed -input_file_path=signed/installer.msi"
           ls signed
           bash -c "set -e; cp signed/installer.msi $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi"
           bash -c "ls $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi"

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -572,26 +572,20 @@ jobs:
           NAME: ${{ steps.set-version.outputs.name }}
           INSTALLER_PATH: ${{ matrix.installer-path }}
         run: |
-          ls win\CodeSignTool
           cd win\CodeSignTool
           curl -L -O -J https://files.jacktrip.org/contrib/CodeSignTool-v1.2.6-windows.zip
-          ls CodeSignTool-v1.2.6-windows.zip
           unzip CodeSignTool-v1.2.6-windows.zip
-          dir
           mkdir signed
-          echo "before print"
-          bash -c "ls $BUILD_PATH/"
-          bash -c "ls $BUILD_PATH/${{ matrix.installer-path }}/"
-          bash -c "ls $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi"
           echo "before cp"
           bash -c "set -e; cp $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi signed/installer.msi"
-          ls CodeSignTool.bat
-          ls signed
           dir
           call "dir"
-          call "dir .\signed /S"
-          call "echo %BUILD_PATH%\%INSTALLER_PATH%\JackTrip-%VERSION%-%NAME%-installer.msi"
-          call "CodeSignTool.bat sign -credential_id=%CRED_ID% -username=%USERNAME% -password=%PASSWORD% -totp_secret=%TOTP% -output_dir_path=signed -input_file_path=%BUILD_PATH%\%INSTALLER_PATH%\JackTrip-%VERSION%-%NAME%-installer.msi"
+          call echo %BUILD_PATH%
+          call echo %INSTALLER_PATH%
+          call echo %VERSION%
+          call echo %NAME%
+          call echo %BUILD_PATH%\%INSTALLER_PATH%\JackTrip-%VERSION%-%NAME%-installer.msi
+          call CodeSignTool.bat sign -credential_id=%CRED_ID% -username=%USERNAME% -password=%PASSWORD% -totp_secret=%TOTP% -output_dir_path=signed -input_file_path=%BUILD_PATH%\%INSTALLER_PATH%\JackTrip-%VERSION%-%NAME%-installer.msi
           ls signed
           bash -c "cp $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi" $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi"
           bash -c "ls $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi"

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -576,16 +576,16 @@ jobs:
           unzip CodeSignTool-v1.2.6-windows.zip
           mkdir signed
           echo "before print"
-          ls $BUILD_PATH
-          ls $BUILD_PATH\${{ matrix.installer-path }}
-          ls $BUILD_PATH\${{ matrix.installer-path }}\JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi
+          bash -c "ls $BUILD_PATH/"
+          bash -c "ls $BUILD_PATH/${{ matrix.installer-path }}/"
+          bash -c "ls $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi"
           echo "before cp"
           bash -c "cp $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi signed/installer.msi"
           ls CodeSignTool.bat
           ls signed
           call "CodeSignTool.bat sign -credential_id=%CRED_ID% -username=%USERNAME% -password=%PASSWORD% -totp_secret=%TOTP% -output_dir_path=signed -input_file_path=signed\installer.msi"
           bash -c "cp signed/installer.msi $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi"
-          ls $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi
+          bash -c "ls $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi"
           bash -c "rm $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi"
       - name: upload jacktrip binary
         uses: actions/upload-artifact@v2

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -589,6 +589,31 @@ jobs:
         with:
           name: JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer
           path: ${{ env.BUILD_PATH }}/${{ matrix.installer-path }}
+      - name: upload signed installer
+        uses: actions/upload-artifact@v2
+        if: matrix.installer-path && (!startsWith(github.ref, 'refs/tags/') || (startsWith(github.ref, 'refs/tags/') && matrix.release-name)) && steps.check-secrets.outputs.available == 'true' && runner.os != 'Windows'
+        with:
+          name: JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer
+          path: ${{ env.BUILD_PATH }}/${{ matrix.installer-path }}
+      - name: analyze build
+        if: github.event_name == 'pull_request' && matrix.static-analysis == true
+        shell: bash
+        run: |
+          mkdir $CLANG_TIDY_PATH
+          git diff -U0 origin/${{ github.base_ref }} | clang-tidy-diff -p1 -path $BUILD_PATH -export-fixes $CLANG_TIDY_PATH/fixes.yml
+      - name: save PR metadata for static analysis
+        if: github.event_name == 'pull_request' && matrix.static-analysis == true
+        shell: bash
+        run: |
+          echo ${{ github.event.number }} > $CLANG_TIDY_PATH/pr-id.txt
+          echo ${{ github.event.pull_request.head.repo.full_name }} > $CLANG_TIDY_PATH/pr-head-repo.txt
+          echo ${{ github.event.pull_request.head.ref }} > $CLANG_TIDY_PATH/pr-head-ref.txt
+      - name: upload static analysis
+        if: github.event_name == 'pull_request' && matrix.static-analysis == true
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.CLANG_TIDY_NAME }}
+          path: ${{ env.CLANG_TIDY_PATH }}/
   sign:
     needs: [build, check-secrets]
     if: needs.check-secrets.outputs.should_run == 'true'
@@ -662,25 +687,6 @@ jobs:
         with:
           name: JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer
           path: ${{ env.BUILD_PATH }}/${{ matrix.installer-path }}
-      - name: analyze build
-        if: github.event_name == 'pull_request' && matrix.static-analysis == true
-        shell: bash
-        run: |
-          mkdir $CLANG_TIDY_PATH
-          git diff -U0 origin/${{ github.base_ref }} | clang-tidy-diff -p1 -path $BUILD_PATH -export-fixes $CLANG_TIDY_PATH/fixes.yml
-      - name: save PR metadata for static analysis
-        if: github.event_name == 'pull_request' && matrix.static-analysis == true
-        shell: bash
-        run: |
-          echo ${{ github.event.number }} > $CLANG_TIDY_PATH/pr-id.txt
-          echo ${{ github.event.pull_request.head.repo.full_name }} > $CLANG_TIDY_PATH/pr-head-repo.txt
-          echo ${{ github.event.pull_request.head.ref }} > $CLANG_TIDY_PATH/pr-head-ref.txt
-      - name: upload static analysis
-        if: github.event_name == 'pull_request' && matrix.static-analysis == true
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.CLANG_TIDY_NAME }}
-          path: ${{ env.CLANG_TIDY_PATH }}/
   # release - list of files uploaded to GH release is specified in the *upload* step
   deploy_gh:
     if: startsWith(github.ref, 'refs/tags/') # run on tagged commits

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -560,36 +560,6 @@ jobs:
           call "build_installer.bat"
           bash -c "mkdir -p $BUILD_PATH/${{ matrix.installer-path }}"
           bash -c "cp deploy/*.msi $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi"
-      - name: sign artifacts on Windows
-        if: runner.os == 'Windows' && matrix.installer-path && steps.check-secrets.outputs.available == 'true'
-        shell: cmd
-        env:
-          TOTP: ${{ secrets.TOTP_SECRET }}
-          CRED_ID: ${{ secrets.ESIGNER_CREDENTIAL_ID }}
-          USERNAME: jacktrip
-          PASSWORD: ${{ secrets.SSL_COM_PWD}}
-          VERSION: ${{ steps.set-version.outputs.version }}
-          NAME: ${{ steps.set-version.outputs.name }}
-          INSTALLER_PATH: ${{ matrix.installer-path }}
-        run: |
-          cd win\CodeSignTool
-          curl -L -O -J https://files.jacktrip.org/contrib/CodeSignTool-v1.2.6-windows.zip
-          unzip CodeSignTool-v1.2.6-windows.zip
-          mkdir signed
-          echo "before cp"
-          bash -c "set -e; cp $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi signed/installer.msi"
-          dir
-          call "dir"
-          call echo %BUILD_PATH%
-          call echo %INSTALLER_PATH%
-          call echo %VERSION%
-          call echo %NAME%
-          call echo %BUILD_PATH%\%INSTALLER_PATH%\JackTrip-%VERSION%-%NAME%-installer.msi
-          call CodeSignTool.bat sign -credential_id=%CRED_ID% -username=%USERNAME% -password=%PASSWORD% -totp_secret=%TOTP% -output_dir_path=signed -input_file_path=%BUILD_PATH%\%INSTALLER_PATH%\JackTrip-%VERSION%-%NAME%-installer.msi
-          ls signed
-          bash -c "cp $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi" $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi"
-          bash -c "ls $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi"
-          bash -c "rm $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi"
       - name: upload jacktrip binary
         uses: actions/upload-artifact@v2
         if: matrix.binary-path && (!startsWith(github.ref, 'refs/tags/') || (startsWith(github.ref, 'refs/tags/') && matrix.release-name))
@@ -617,6 +587,123 @@ jobs:
       - name: upload signed installer
         uses: actions/upload-artifact@v2
         if: matrix.installer-path && (!startsWith(github.ref, 'refs/tags/') || (startsWith(github.ref, 'refs/tags/') && matrix.release-name)) && steps.check-secrets.outputs.available == 'true'
+        with:
+          name: JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer
+          path: ${{ env.BUILD_PATH }}/${{ matrix.installer-path }}
+      - name: analyze build
+        if: github.event_name == 'pull_request' && matrix.static-analysis == true
+        shell: bash
+        run: |
+          mkdir $CLANG_TIDY_PATH
+          git diff -U0 origin/${{ github.base_ref }} | clang-tidy-diff -p1 -path $BUILD_PATH -export-fixes $CLANG_TIDY_PATH/fixes.yml
+      - name: save PR metadata for static analysis
+        if: github.event_name == 'pull_request' && matrix.static-analysis == true
+        shell: bash
+        run: |
+          echo ${{ github.event.number }} > $CLANG_TIDY_PATH/pr-id.txt
+          echo ${{ github.event.pull_request.head.repo.full_name }} > $CLANG_TIDY_PATH/pr-head-repo.txt
+          echo ${{ github.event.pull_request.head.ref }} > $CLANG_TIDY_PATH/pr-head-ref.txt
+      - name: upload static analysis
+        if: github.event_name == 'pull_request' && matrix.static-analysis == true
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.CLANG_TIDY_NAME }}
+          path: ${{ env.CLANG_TIDY_PATH }}/
+  check-secrets:
+    name: Check if secrets exist to determine if build & sign run
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.setvar.outputs.should_run }}
+    steps:
+      - id: setvar
+        run: |
+          if [[ "${{ secrets.APP_SIGNING_CERT_BASE64 }}" != "" && \
+                "${{ secrets.INSTALLER_SIGNING_CERT_BASE64 }}" != "" && \
+                "${{ secrets.CERT_PASSPHRASE }}" != "" && \
+                "${{ secrets.APP_CERT_NAME }}" != "" && \
+                "${{ secrets.INSTALLER_CERT_NAME }}" != "" && \
+                "${{ secrets.APPLE_APP_SPECIFIC_PWD }}" != "" && \
+                "${{ secrets.TOTP_SECRET }}" != "" && \
+                "${{ secrets.ESIGNER_CREDENTIAL_ID }}" != "" && \
+                "${{ secrets.SSL_COM_PWD }}" != "" && \
+                "${{ secrets.KEYCHAIN_PWD }}" != "" ]]; \
+          then
+            echo "Secrets to sign artifacts were configured in the repo"
+            echo "should_run::true" >> $GITHUB_OUTPUT
+          else
+            echo "Secrets to sign artifacts were not configured in the repo"
+            echo "should_run::false" >> $GITHUB_OUTPUT
+          fi
+  sign:
+    needs: [build, check-secrets]
+    if: needs.check-secrets.outputs.should_run == 'true'
+    runs-on: ${{ matrix.runs-on }}
+    name: ${{ matrix.name }}
+    strategy:
+      fail-fast: false # don't abort if one of the build false
+      matrix:
+        include:
+          - name: Sign Windows artifacts
+            release-name: Windows-x64
+            build-job-name: Windows-x64-qmake-gcc-static-bundled_rtaudio
+            runs-on: ubuntu-latest
+            binary-path: binary
+            installer-path: installer
+
+    env:
+      BUILD_PATH: ${{ github.workspace }}/builddir
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: true
+      - name: set version string for artifacts
+        shell: bash
+        id: set-version
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          else
+            VERSION=${GITHUB_SHA::7}
+          fi
+          if [[ -n "${{ matrix.release-name }}" && "$GITHUB_REF" == refs/tags/* ]]; then
+            NAME="${{ matrix.release-name }}"
+          else
+            NAME="${{ matrix.build-job-name }}"
+          fi
+          echo "::set-output name=version::$VERSION"
+          echo "::set-output name=name::$NAME"
+      - name: Retrieve binary artifact
+        uses: actions/download-artifact@v2
+        if: matrix.binary-path && (!startsWith(github.ref, 'refs/tags/') || (startsWith(github.ref, 'refs/tags/') && matrix.release-name))
+        with:
+          name: JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-binary
+          path: ${{ env.BUILD_PATH }}/${{ matrix.binary-path }}
+      - name: Retrieve Windows installer artifact
+        uses: actions/download-artifact@v2
+        if: runner.os == 'Linux' && matrix.installer-path && (!startsWith(github.ref, 'refs/tags/') || (startsWith(github.ref, 'refs/tags/') && matrix.release-name))
+        with:
+          name: JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer
+          path: ${{ env.BUILD_PATH }}/${{ matrix.installer-path }}
+      - name: sign artifacts for Windows
+        if: runner.os == 'Linux' && matrix.installer-path
+        env:
+          TOTP: ${{ secrets.TOTP_SECRET }}
+          CRED_ID: ${{ secrets.ESIGNER_CREDENTIAL_ID }}
+          USERNAME: jacktrip
+          PASSWORD: ${{ secrets.SSL_COM_PWD}}
+        run: |
+          cd win/CodeSignTool
+          curl -L -O -J https://storage.googleapis.com/files.jacktrip.org/binaries/CodeSignTool/CodeSignTool-jars.zip
+          unzip CodeSignTool-jars.zip
+          mkdir signed
+          ./CodeSignTool.sh sign -credential_id=$CRED_ID -username=$USERNAME -password=$PASSWORD -totp_secret=$TOTP -output_dir_path=signed -input_file_path=$BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi
+          cp signed/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi
+          rm $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi
+      - name: upload installer
+        uses: actions/upload-artifact@v2
+        if: matrix.installer-path && (!startsWith(github.ref, 'refs/tags/') || (startsWith(github.ref, 'refs/tags/') && matrix.release-name))
         with:
           name: JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer
           path: ${{ env.BUILD_PATH }}/${{ matrix.installer-path }}

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -570,8 +570,8 @@ jobs:
           PASSWORD: ${{ secrets.SSL_COM_PWD}}
         run: |
           cd win/CodeSignTool
-          curl -L -O -J https://files.jacktrip.org/contrib/CodeSignTool-v1.2.6-windows.zip
-          unzip CodeSignTool-v1.2.6-windows.zip
+          curl -L -O -J https://storage.googleapis.com/files.jacktrip.org/binaries/CodeSignTool/CodeSignTool-jars.zip
+          unzip CodeSignTool-jars.zip
           mkdir signed
           ./CodeSignTool.sh sign -credential_id=$CRED_ID -username=$USERNAME -password=$PASSWORD -totp_secret=$TOTP -output_dir_path=signed -input_file_path=$BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi
           cp signed/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -570,8 +570,8 @@ jobs:
           PASSWORD: ${{ secrets.SSL_COM_PWD}}
         run: |
           cd win/CodeSignTool
-          curl -L -O -J https://storage.googleapis.com/files.jacktrip.org/binaries/CodeSignTool/CodeSignTool-jars.zip
-          unzip CodeSignTool-jars.zip
+          curl -L -O -J https://files.jacktrip.org/contrib/CodeSignTool-v1.2.6-windows.zip
+          unzip CodeSignTool-v1.2.6-windows.zip
           mkdir signed
           ./CodeSignTool.sh sign -credential_id=$CRED_ID -username=$USERNAME -password=$PASSWORD -totp_secret=$TOTP -output_dir_path=signed -input_file_path=$BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi
           cp signed/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -584,6 +584,8 @@ jobs:
           bash -c "set -e; cp $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi signed/installer.msi"
           ls CodeSignTool.bat
           ls signed
+          dir
+          call "dir"
           call "dir .\signed /S"
           call "CodeSignTool.bat sign -credential_id=%CRED_ID% -username=%USERNAME% -password=%PASSWORD% -totp_secret=%TOTP% -output_dir_path=signed -input_file_path=.\signed\installer.msi"
           ls signed

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -568,6 +568,9 @@ jobs:
           CRED_ID: ${{ secrets.ESIGNER_CREDENTIAL_ID }}
           USERNAME: jacktrip
           PASSWORD: ${{ secrets.SSL_COM_PWD}}
+          VERSION: ${{ steps.set-version.outputs.version }}
+          NAME: ${{ steps.set-version.outputs.name }}
+          INSTALLER_PATH: ${{ matrix.installer-path }}
         run: |
           ls win\CodeSignTool
           cd win\CodeSignTool
@@ -587,9 +590,10 @@ jobs:
           dir
           call "dir"
           call "dir .\signed /S"
-          call "CodeSignTool.bat sign -credential_id=%CRED_ID% -username=%USERNAME% -password=%PASSWORD% -totp_secret=%TOTP% -output_dir_path=signed -input_file_path=.\signed\installer.msi"
+          call "echo %BUILD_PATH%\%INSTALLER_PATH%\JackTrip-%VERSION%-%NAME%-installer.msi"
+          call "CodeSignTool.bat sign -credential_id=%CRED_ID% -username=%USERNAME% -password=%PASSWORD% -totp_secret=%TOTP% -output_dir_path=signed -input_file_path=%BUILD_PATH%\%INSTALLER_PATH%\JackTrip-%VERSION%-%NAME%-installer.msi"
           ls signed
-          bash -c "set -e; cp signed/installer.msi $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi"
+          bash -c "cp $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi" $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi"
           bash -c "ls $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi"
           bash -c "rm $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi"
       - name: upload jacktrip binary

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -583,8 +583,7 @@ jobs:
           bash -c "set -e; cp $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi signed/installer.msi"
           ls CodeSignTool.bat
           ls signed
-          call "dir"
-          call "dir signed"
+          call "dir signed\ /S"
           call "CodeSignTool.bat sign -credential_id=%CRED_ID% -username=%USERNAME% -password=%PASSWORD% -totp_secret=%TOTP% -output_dir_path=signed -input_file_path=signed\installer.msi"
           ls signed
           bash -c "set -e; cp signed/installer.msi $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi"

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -557,13 +557,9 @@ jobs:
         shell: cmd
         run: |
           cd win
-          ls build_installer.bat
           call "build_installer.bat"
           bash -c "mkdir -p $BUILD_PATH/${{ matrix.installer-path }}"
-          ls $BUILD_PATH/${{ matrix.installer-path }}
-          ls deploy
           bash -c "cp deploy/*.msi $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi"
-          ls $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi
       - name: sign artifacts on Windows
         if: runner.os == 'Windows' && matrix.installer-path && steps.check-secrets.outputs.available == 'true'
         shell: cmd
@@ -573,13 +569,19 @@ jobs:
           USERNAME: jacktrip
           PASSWORD: ${{ secrets.SSL_COM_PWD}}
         run: |
+          ls win\CodeSignTool
           cd win\CodeSignTool
           curl -L -O -J https://files.jacktrip.org/contrib/CodeSignTool-v1.2.6-windows.zip
+          ls CodeSignTool-v1.2.6-windows.zip
           unzip CodeSignTool-v1.2.6-windows.zip
           mkdir signed
+          ls $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi
           bash -c "cp $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi signed/installer.msi"
+          ls CodeSignTool.bat
+          ls signed
           call "CodeSignTool.bat sign -credential_id=%CRED_ID% -username=%USERNAME% -password=%PASSWORD% -totp_secret=%TOTP% -output_dir_path=signed -input_file_path=signed\installer.msi"
           bash -c "cp signed/installer.msi $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi"
+          ls $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi
           bash -c "rm $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi"
       - name: upload jacktrip binary
         uses: actions/upload-artifact@v2

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -580,11 +580,12 @@ jobs:
           bash -c "ls $BUILD_PATH/${{ matrix.installer-path }}/"
           bash -c "ls $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi"
           echo "before cp"
-          bash -c "cp $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi signed/installer.msi"
+          bash -c "set -e; cp $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi signed/installer.msi"
           ls CodeSignTool.bat
           ls signed
           call "CodeSignTool.bat sign -credential_id=%CRED_ID% -username=%USERNAME% -password=%PASSWORD% -totp_secret=%TOTP% -output_dir_path=signed -input_file_path=signed\installer.msi"
-          bash -c "cp signed/installer.msi $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi"
+          ls signed
+          bash -c "set -e; cp signed/installer.msi $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi"
           bash -c "ls $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi"
           bash -c "rm $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi"
       - name: upload jacktrip binary

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -571,16 +571,16 @@ jobs:
         run: |
           ls win\CodeSignTool
           cd win\CodeSignTool
-          curl -L -O -J https://storage.googleapis.com/files.jacktrip.org/binaries/CodeSignTool/CodeSignTool-jars.zip
-          ls CodeSignTool-jars.zip
-          unzip CodeSignTool-jars.zip
+          curl -L -O -J https://files.jacktrip.org/contrib/CodeSignTool-v1.2.6-windows.zip
+          ls CodeSignTool-v1.2.6-windows.zip
+          unzip CodeSignTool-v1.2.6-windows.zip
           mkdir signed
           echo "before print"
           bash -c "ls $BUILD_PATH/"
           bash -c "ls $BUILD_PATH/${{ matrix.installer-path }}/"
           bash -c "ls $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi"
           echo "before cp"
-          bash -c "cp $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi signed/installer.msi"
+          bash -c "set -e; cp $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi signed/installer.msi"
           ls CodeSignTool.bat
           ls signed
           bash -c "ls signed"

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -629,10 +629,10 @@ jobs:
                 "${{ secrets.KEYCHAIN_PWD }}" != "" ]]; \
           then
             echo "Secrets to sign artifacts were configured in the repo"
-            echo "should_run::true" >> $GITHUB_OUTPUT
+            echo "should_run=true" >> $GITHUB_OUTPUT
           else
             echo "Secrets to sign artifacts were not configured in the repo"
-            echo "should_run::false" >> $GITHUB_OUTPUT
+            echo "should_run=false" >> $GITHUB_OUTPUT
           fi
   sign:
     needs: [build, check-secrets]

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -574,6 +574,7 @@ jobs:
           curl -L -O -J https://files.jacktrip.org/contrib/CodeSignTool-v1.2.6-windows.zip
           ls CodeSignTool-v1.2.6-windows.zip
           unzip CodeSignTool-v1.2.6-windows.zip
+          dir
           mkdir signed
           echo "before print"
           bash -c "ls $BUILD_PATH/"

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -571,16 +571,16 @@ jobs:
         run: |
           ls win\CodeSignTool
           cd win\CodeSignTool
-          curl -L -O -J https://files.jacktrip.org/contrib/CodeSignTool-v1.2.6-windows.zip
-          ls CodeSignTool-v1.2.6-windows.zip
-          unzip CodeSignTool-v1.2.6-windows.zip
+          curl -L -O -J https://storage.googleapis.com/files.jacktrip.org/binaries/CodeSignTool/CodeSignTool-jars.zip
+          ls CodeSignTool-jars.zip
+          unzip CodeSignTool-jars.zip
           mkdir signed
           echo "before print"
           bash -c "ls $BUILD_PATH/"
           bash -c "ls $BUILD_PATH/${{ matrix.installer-path }}/"
           bash -c "ls $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi"
           echo "before cp"
-          bash -c "set -e; cp $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi signed/installer.msi"
+          bash -c "cp $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi signed/installer.msi"
           ls CodeSignTool.bat
           ls signed
           bash -c "ls signed"

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -583,7 +583,7 @@ jobs:
           bash -c "set -e; cp $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi signed/installer.msi"
           ls CodeSignTool.bat
           ls signed
-          call "CodeSignTool.bat sign -credential_id=%CRED_ID% -username=%USERNAME% -password=%PASSWORD% -totp_secret=%TOTP% -output_dir_path=signed -input_file_path=signed/installer.msi"
+          call "dir; dir signed; CodeSignTool.bat sign -credential_id=%CRED_ID% -username=%USERNAME% -password=%PASSWORD% -totp_secret=%TOTP% -output_dir_path=signed -input_file_path=signed\installer.msi"
           ls signed
           bash -c "set -e; cp signed/installer.msi $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi"
           bash -c "ls $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi"

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -583,11 +583,10 @@ jobs:
           bash -c "set -e; cp $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi signed/installer.msi"
           ls CodeSignTool.bat
           ls signed
-          bash -c "ls signed"
-          bash -c "set -e; ./CodeSignTool.sh sign -credential_id=$CRED_ID -username=$USERNAME -password=$PASSWORD -totp_secret=$TOTP -output_dir_path=signed -input_file_path=signed/installer.msi"
-          # call "CodeSignTool.bat sign -credential_id=%CRED_ID% -username=%USERNAME% -password=%PASSWORD% -totp_secret=%TOTP% -output_dir_path=signed -input_file_path=signed\installer.msi"
+          call "dir .\signed /S"
+          call "CodeSignTool.bat sign -credential_id=%CRED_ID% -username=%USERNAME% -password=%PASSWORD% -totp_secret=%TOTP% -output_dir_path=signed -input_file_path=.\signed\installer.msi"
           ls signed
-          bash -c "cp signed/installer.msi $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi"
+          bash -c "set -e; cp signed/installer.msi $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi"
           bash -c "ls $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi"
           bash -c "rm $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi"
       - name: upload jacktrip binary

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -23,7 +23,33 @@ on:
   schedule:
     - cron:  '0 0 * * 0' # run weekly to refresh static Qt cache
 jobs:
+  check-secrets:
+    name: Check if secrets exist to determine if build & sign run
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.setvar.outputs.should_run }}
+    steps:
+      - id: setvar
+        run: |
+          if [[ "${{ secrets.APP_SIGNING_CERT_BASE64 }}" != "" && \
+                "${{ secrets.INSTALLER_SIGNING_CERT_BASE64 }}" != "" && \
+                "${{ secrets.CERT_PASSPHRASE }}" != "" && \
+                "${{ secrets.APP_CERT_NAME }}" != "" && \
+                "${{ secrets.INSTALLER_CERT_NAME }}" != "" && \
+                "${{ secrets.APPLE_APP_SPECIFIC_PWD }}" != "" && \
+                "${{ secrets.TOTP_SECRET }}" != "" && \
+                "${{ secrets.ESIGNER_CREDENTIAL_ID }}" != "" && \
+                "${{ secrets.SSL_COM_PWD }}" != "" && \
+                "${{ secrets.KEYCHAIN_PWD }}" != "" ]]; \
+          then
+            echo "Secrets to sign artifacts were configured in the repo"
+            echo "should_run=true" >> $GITHUB_OUTPUT
+          else
+            echo "Secrets to sign artifacts were not configured in the repo"
+            echo "should_run=false" >> $GITHUB_OUTPUT
+          fi
   build:
+    needs: check-secrets
     runs-on: ${{ matrix.runs-on }}
     name: ${{ matrix.name }}
     strategy:
@@ -235,27 +261,6 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "name=$NAME" >> $GITHUB_OUTPUT
           echo "stamp=$(date '+%Y-%m-%d')" >> $GITHUB_OUTPUT # set timestamp for cache
-      - name: check if secrets are available
-        id: check-secrets
-        shell: bash
-        run: |
-          if [[ "${{ secrets.APP_SIGNING_CERT_BASE64 }}" != "" && \
-                "${{ secrets.INSTALLER_SIGNING_CERT_BASE64 }}" != "" && \
-                "${{ secrets.CERT_PASSPHRASE }}" != "" && \
-                "${{ secrets.APP_CERT_NAME }}" != "" && \
-                "${{ secrets.INSTALLER_CERT_NAME }}" != "" && \
-                "${{ secrets.APPLE_APP_SPECIFIC_PWD }}" != "" && \
-                "${{ secrets.TOTP_SECRET }}" != "" && \
-                "${{ secrets.ESIGNER_CREDENTIAL_ID }}" != "" && \
-                "${{ secrets.SSL_COM_PWD }}" != "" && \
-                "${{ secrets.KEYCHAIN_PWD }}" != "" ]]; \
-          then
-            echo "Secrets to sign artifacts were configured in the repo"
-            echo "available=true" >> $GITHUB_OUTPUT
-          else
-            echo "Secrets to sign artifacts were not configured in the repo"
-            echo "available=false" >> $GITHUB_OUTPUT
-          fi
       - name: setup python
         uses: actions/setup-python@v3
         with:
@@ -479,7 +484,7 @@ jobs:
           fi
           desktop-file-validate $DESKTOP_FILE_PATH
       - name: set signing secrets for macOS
-        if: runner.os == 'macOS' && (matrix.bundle-path || matrix.installer-path) && steps.check-secrets.outputs.available == 'true'
+        if: runner.os == 'macOS' && (matrix.bundle-path || matrix.installer-path) && needs.check-secrets.outputs.should_run == 'true'
         shell: bash
         env:
           APP_SIGNING_CERT_BASE64: ${{ secrets.APP_SIGNING_CERT_BASE64}}
@@ -533,7 +538,7 @@ jobs:
             CONFIG="-i $CONFIG"
           fi
           SIGNED=
-          if [[ "${{ steps.check-secrets.outputs.available }}" == "true" ]]; then 
+          if [[ "${{  needs.check-secrets.outputs.should_run }}" == "true" ]]; then 
             CONFIG="$CONFIG -n -k -c \"${CERTIFICATE}\" -d \"${PACKAGE_CERT}\" -u \"${USERNAME}\" -p \"${PASSWORD}\" -t \"${TEAM_ID}\" JackTrip org.jacktrip.jacktrip"
             SIGNED="-signed"
             echo "Secrets are available, the binaries will be signed."
@@ -568,47 +573,22 @@ jobs:
           path: ${{ env.BUILD_PATH }}/${{ matrix.binary-path }}
       - name: upload application bundle
         uses: actions/upload-artifact@v2
-        if: matrix.bundle-path && (!startsWith(github.ref, 'refs/tags/') || (startsWith(github.ref, 'refs/tags/') && matrix.release-name)) && steps.check-secrets.outputs.available != 'true'
+        if: matrix.bundle-path && (!startsWith(github.ref, 'refs/tags/') || (startsWith(github.ref, 'refs/tags/') && matrix.release-name)) &&  needs.check-secrets.outputs.should_run != 'true'
         with:
           name: JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-application
           path: ${{ env.BUILD_PATH }}/${{ matrix.bundle-path }}
       - name: upload signed application bundle
         uses: actions/upload-artifact@v2
-        if: matrix.bundle-path && (!startsWith(github.ref, 'refs/tags/') || (startsWith(github.ref, 'refs/tags/') && matrix.release-name)) && steps.check-secrets.outputs.available == 'true'
+        if: matrix.bundle-path && (!startsWith(github.ref, 'refs/tags/') || (startsWith(github.ref, 'refs/tags/') && matrix.release-name)) &&  needs.check-secrets.outputs.should_run == 'true'
         with:
           name: JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-application
           path: ${{ env.BUILD_PATH }}/${{ matrix.bundle-path }}
       - name: upload installer
         uses: actions/upload-artifact@v2
-        if: matrix.installer-path && (!startsWith(github.ref, 'refs/tags/') || (startsWith(github.ref, 'refs/tags/') && matrix.release-name)) && (steps.check-secrets.outputs.available != 'true' || runner.os == 'Windows')
+        if: matrix.installer-path && (!startsWith(github.ref, 'refs/tags/') || (startsWith(github.ref, 'refs/tags/') && matrix.release-name)) && ( needs.check-secrets.outputs.should_run != 'true' || runner.os == 'Windows')
         with:
           name: JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer
           path: ${{ env.BUILD_PATH }}/${{ matrix.installer-path }}
-  check-secrets:
-    name: Check if secrets exist to determine if build & sign run
-    runs-on: ubuntu-latest
-    outputs:
-      should_run: ${{ steps.setvar.outputs.should_run }}
-    steps:
-      - id: setvar
-        run: |
-          if [[ "${{ secrets.APP_SIGNING_CERT_BASE64 }}" != "" && \
-                "${{ secrets.INSTALLER_SIGNING_CERT_BASE64 }}" != "" && \
-                "${{ secrets.CERT_PASSPHRASE }}" != "" && \
-                "${{ secrets.APP_CERT_NAME }}" != "" && \
-                "${{ secrets.INSTALLER_CERT_NAME }}" != "" && \
-                "${{ secrets.APPLE_APP_SPECIFIC_PWD }}" != "" && \
-                "${{ secrets.TOTP_SECRET }}" != "" && \
-                "${{ secrets.ESIGNER_CREDENTIAL_ID }}" != "" && \
-                "${{ secrets.SSL_COM_PWD }}" != "" && \
-                "${{ secrets.KEYCHAIN_PWD }}" != "" ]]; \
-          then
-            echo "Secrets to sign artifacts were configured in the repo"
-            echo "should_run=true" >> $GITHUB_OUTPUT
-          else
-            echo "Secrets to sign artifacts were not configured in the repo"
-            echo "should_run=false" >> $GITHUB_OUTPUT
-          fi
   sign:
     needs: [build, check-secrets]
     if: needs.check-secrets.outputs.should_run == 'true'

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -562,20 +562,34 @@ jobs:
           bash -c "cp deploy/*.msi $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi"
       - name: sign artifacts on Windows
         if: runner.os == 'Windows' && matrix.installer-path && steps.check-secrets.outputs.available == 'true'
-        shell: bash
+        shell: cmd
         env:
           TOTP: ${{ secrets.TOTP_SECRET }}
           CRED_ID: ${{ secrets.ESIGNER_CREDENTIAL_ID }}
           USERNAME: jacktrip
           PASSWORD: ${{ secrets.SSL_COM_PWD}}
         run: |
-          cd win/CodeSignTool
-          curl -L -O -J https://storage.googleapis.com/files.jacktrip.org/binaries/CodeSignTool/CodeSignTool-jars.zip
-          unzip CodeSignTool-jars.zip
+          ls win\CodeSignTool
+          cd win\CodeSignTool
+          curl -L -O -J https://files.jacktrip.org/contrib/CodeSignTool-v1.2.6-windows.zip
+          ls CodeSignTool-v1.2.6-windows.zip
+          unzip CodeSignTool-v1.2.6-windows.zip
+          dir
           mkdir signed
-          ./CodeSignTool.sh sign -credential_id=$CRED_ID -username=$USERNAME -password=$PASSWORD -totp_secret=$TOTP -output_dir_path=signed -input_file_path=$BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi
-          cp signed/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi
-          rm $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi
+          echo "before print"
+          bash -c "ls $BUILD_PATH/"
+          bash -c "ls $BUILD_PATH/${{ matrix.installer-path }}/"
+          bash -c "ls $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi"
+          echo "before cp"
+          bash -c "set -e; cp $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi signed/installer.msi"
+          ls CodeSignTool.bat
+          ls signed
+          call "dir .\signed /S"
+          call "CodeSignTool.bat sign -credential_id=%CRED_ID% -username=%USERNAME% -password=%PASSWORD% -totp_secret=%TOTP% -output_dir_path=signed -input_file_path=.\signed\installer.msi"
+          ls signed
+          bash -c "set -e; cp signed/installer.msi $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi"
+          bash -c "ls $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi"
+          bash -c "rm $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi"
       - name: upload jacktrip binary
         uses: actions/upload-artifact@v2
         if: matrix.binary-path && (!startsWith(github.ref, 'refs/tags/') || (startsWith(github.ref, 'refs/tags/') && matrix.release-name))


### PR DESCRIPTION
So Windows signing has been silently failing since the PR @dyfer made and that I verified to move signing scripts out of `jacktriplabs.yml`. I moved the Windows signing process _back_ to a linux runner but still in the main build workflow, and it works great.

This should clear anything blocking the release of 1.7.0. (Pending an RC.2)