### PR TITLE
GHA: reuse output values

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -52,6 +52,9 @@ jobs:
     needs: check-secrets
     runs-on: ${{ matrix.runs-on }}
     name: ${{ matrix.name }}
+    outputs: 
+      version: ${{ steps.set-version.outputs.version }}
+      name: ${{ steps.set-version.outputs.name }}
     strategy:
       fail-fast: false # don't abort if one of the build failse
       matrix:
@@ -638,33 +641,17 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
-      - name: set version string for artifacts
-        shell: bash
-        id: set-version
-        run: |
-          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/}
-          else
-            VERSION=${GITHUB_SHA::7}
-          fi
-          if [[ -n "${{ matrix.release-name }}" && "$GITHUB_REF" == refs/tags/* ]]; then
-            NAME="${{ matrix.release-name }}"
-          else
-            NAME="${{ matrix.build-job-name }}"
-          fi
-          echo "::set-output name=version::$VERSION"
-          echo "::set-output name=name::$NAME"
       - name: Retrieve binary artifact
         uses: actions/download-artifact@v2
         if: matrix.binary-path && (!startsWith(github.ref, 'refs/tags/') || (startsWith(github.ref, 'refs/tags/') && matrix.release-name))
         with:
-          name: JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-binary
+          name: JackTrip-${{ needs.build.outputs.version }}-${{ needs.build.outputs.name }}-binary
           path: ${{ env.BUILD_PATH }}/${{ matrix.binary-path }}
       - name: Retrieve Windows installer artifact
         uses: actions/download-artifact@v2
         if: runner.os == 'Linux' && matrix.installer-path && (!startsWith(github.ref, 'refs/tags/') || (startsWith(github.ref, 'refs/tags/') && matrix.release-name))
         with:
-          name: JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer
+          name: JackTrip-${{ needs.build.outputs.version }}-${{ needs.build.outputs.name }}-installer
           path: ${{ env.BUILD_PATH }}/${{ matrix.installer-path }}
       - name: sign artifacts for Windows
         if: runner.os == 'Linux' && matrix.installer-path
@@ -678,14 +665,14 @@ jobs:
           curl -L -O -J https://storage.googleapis.com/files.jacktrip.org/binaries/CodeSignTool/CodeSignTool-jars.zip
           unzip CodeSignTool-jars.zip
           mkdir signed
-          ./CodeSignTool.sh sign -credential_id=$CRED_ID -username=$USERNAME -password=$PASSWORD -totp_secret=$TOTP -output_dir_path=signed -input_file_path=$BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi
-          cp signed/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer.msi
-          rm $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi
+          ./CodeSignTool.sh sign -credential_id=$CRED_ID -username=$USERNAME -password=$PASSWORD -totp_secret=$TOTP -output_dir_path=signed -input_file_path=$BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ needs.build.outputs.version }}-${{ needs.build.outputs.name }}-installer.msi
+          cp signed/JackTrip-${{ needs.build.outputs.version }}-${{ needs.build.outputs.name }}-installer.msi $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ needs.build.outputs.version }}-${{ needs.build.outputs.name }}-signed-installer.msi
+          rm $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ needs.build.outputs.version }}-${{ needs.build.outputs.name }}-installer.msi
       - name: upload installer
         uses: actions/upload-artifact@v2
         if: matrix.installer-path && (!startsWith(github.ref, 'refs/tags/') || (startsWith(github.ref, 'refs/tags/') && matrix.release-name))
         with:
-          name: JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer
+          name: JackTrip-${{ needs.build.outputs.version }}-${{ needs.build.outputs.name }}-signed-installer
           path: ${{ env.BUILD_PATH }}/${{ matrix.installer-path }}
   # release - list of files uploaded to GH release is specified in the *upload* step
   deploy_gh:


### PR DESCRIPTION
GHA deprecated the old method of setting output value a while back. #883 brought back the old method in the signing step, so I'd like to try my suggestion and re-use the value from the build job.
@mattahorton could you please run this in JTL to confirm the signing works fine?