### PR TITLE
Make Video Button Available to Non-Admins

### DIFF
--- a/src/gui/Browse.qml
+++ b/src/gui/Browse.qml
@@ -81,7 +81,7 @@ Item {
             flagImage: bannerURL ? bannerURL : flag
             studioName: name
             publicStudio: isPublic
-            manageable: isManageable
+            admin: isAdmin
             available: canConnect
             connected: false
             studioId: id ? id : ""

--- a/src/gui/Connected.qml
+++ b/src/gui/Connected.qml
@@ -21,7 +21,7 @@ Item {
     property string studioStatus: (virtualstudio.currentStudio >= 0 ? serverModel[virtualstudio.currentStudio].status : "")
     property bool showReadyScreen: studioStatus === "Ready"
     property bool showStartingScreen: studioStatus === "Starting"
-    property bool showStoppingScreen: (virtualstudio.currentStudio >= 0 ? serverModel[virtualstudio.currentStudio].isManageable && !serverModel[virtualstudio.currentStudio].enabled && serverModel[virtualstudio.currentStudio].cloudId !== "" : false)
+    property bool showStoppingScreen: (virtualstudio.currentStudio >= 0 ? serverModel[virtualstudio.currentStudio].isAdmin && !serverModel[virtualstudio.currentStudio].enabled && serverModel[virtualstudio.currentStudio].cloudId !== "" : false)
     property bool showWaitingScreen: !showStoppingScreen && !showStartingScreen && !showReadyScreen
 
     property string buttonColour: virtualstudio.darkMode ? "#494646" : "#EAECEC"
@@ -109,7 +109,7 @@ Item {
         flagImage: virtualstudio.currentStudio >= 0 ? ( serverModel[virtualstudio.currentStudio].bannerURL ? serverModel[virtualstudio.currentStudio].bannerURL : serverModel[virtualstudio.currentStudio].flag ) : "flags/DE.svg"
         studioName: virtualstudio.currentStudio >= 0 ? serverModel[virtualstudio.currentStudio].name : "Test Studio"
         publicStudio: virtualstudio.currentStudio >= 0 ? serverModel[virtualstudio.currentStudio].isPublic : false
-        manageable: virtualstudio.currentStudio >= 0 ? serverModel[virtualstudio.currentStudio].isManageable : false
+        admin: virtualstudio.currentStudio >= 0 ? serverModel[virtualstudio.currentStudio].isAdmin : false
         available: virtualstudio.currentStudio >= 0 ? serverModel[virtualstudio.currentStudio].canConnect : false
         studioId: virtualstudio.currentStudio >= 0 ? serverModel[virtualstudio.currentStudio].id : ""
         inviteKeyString: virtualstudio.currentStudio >= 0 ? serverModel[virtualstudio.currentStudio].inviteKey : ""
@@ -422,7 +422,7 @@ Item {
         x: bodyMargin * virtualstudio.uiScale; y: 230 * virtualstudio.uiScale
         width: parent.width - (2 * x)
 
-        property bool isManageable: (virtualstudio.currentStudio >= 0 ? serverModel[virtualstudio.currentStudio].isManageable : false)
+        property bool isAdmin: (virtualstudio.currentStudio >= 0 ? serverModel[virtualstudio.currentStudio].isAdmin : false)
 
         Text {
             id: waitingText0
@@ -430,7 +430,7 @@ Item {
             width: parent.width
             color: textColour
             font {family: "Poppins"; pixelSize: fontMedium * virtualstudio.fontScale * virtualstudio.uiScale }
-            text: parent.isManageable
+            text: parent.isAdmin
                     ? "Waiting for this studio to start. Please start the studio using one of the options below."
                     : "This studio is currently inactive. Please contact an owner or admin for this studio to start it."
             wrapMode: Text.WordWrap
@@ -441,7 +441,7 @@ Item {
             anchors.top: waitingText0.bottom
             anchors.topMargin: 16 * virtualstudio.uiScale
             anchors.bottomMargin: 16 * virtualstudio.uiScale
-            visible: parent.isManageable
+            visible: parent.isAdmin
 
             height: 64 * virtualstudio.uiScale
 
@@ -494,10 +494,10 @@ Item {
             x: 0
             width: parent.width
             color: textColour
-            anchors.top: parent.isManageable ? startButtonsBox.bottom : waitingText0.bottom
+            anchors.top: parent.isAdmin ? startButtonsBox.bottom : waitingText0.bottom
             anchors.topMargin: 16 * virtualstudio.uiScale
             anchors.bottomMargin: 16 * virtualstudio.uiScale
-            visible: parent.isManageable
+            visible: parent.isAdmin
             font {family: "Poppins"; pixelSize: fontMedium * virtualstudio.fontScale * virtualstudio.uiScale }
             text: "You will be automatically connected to the studio when it is ready."
             wrapMode: Text.WordWrap

--- a/src/gui/Studio.qml
+++ b/src/gui/Studio.qml
@@ -26,7 +26,7 @@ Rectangle {
     property string studioId: ""
     property string inviteKeyString: ""
     property bool publicStudio: false
-    property bool manageable: false
+    property bool admin: false
     property bool available: true
     property bool connected: false
     property bool inviteCopied: false
@@ -153,7 +153,7 @@ Rectangle {
     
     Text {
         x: leftMargin * virtualstudio.uiScale; y: 11 * virtualstudio.uiScale;
-        width: manageable ? parent.width - (310 * virtualstudio.uiScale) : parent.width - (233 * virtualstudio.uiScale)
+        width: (admin || connected) ? parent.width - (310 * virtualstudio.uiScale) : parent.width - (233 * virtualstudio.uiScale)
         text: studioName
         fontSizeMode: Text.HorizontalFit
         font { family: "Poppins"; weight: Font.Bold; pixelSize: fontBig * virtualstudio.fontScale * virtualstudio.uiScale }
@@ -181,7 +181,7 @@ Rectangle {
     Text {
         anchors.verticalCenter: publicRect.verticalCenter
         x: (leftMargin + 22) * virtualstudio.uiScale
-        width: manageable ? parent.width - (255 * virtualstudio.uiScale) : parent.width - (178 * virtualstudio.uiScale)
+        width: (admin || connected) ? parent.width - (255 * virtualstudio.uiScale) : parent.width - (178 * virtualstudio.uiScale)
         text: publicStudio ? "Public hub studio " + serverLocation : "Private hub studio " + serverLocation
         font { family: "Poppins"; pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale }
         elide: Text.ElideRight
@@ -190,7 +190,7 @@ Rectangle {
     
     Button {
         id: joinButton
-        x: manageable ? parent.width - (219 * virtualstudio.uiScale) : parent.width - (142 * virtualstudio.uiScale)
+        x: (admin || connected) ? parent.width - (219 * virtualstudio.uiScale) : parent.width - (142 * virtualstudio.uiScale)
         y: topMargin * virtualstudio.uiScale; width: 40 * virtualstudio.uiScale; height: width
         background: Rectangle {
             radius: width / 2
@@ -217,7 +217,7 @@ Rectangle {
 
     Button {
         id: leaveButton
-        x: manageable ? parent.width - (219 * virtualstudio.uiScale) : parent.width - (142 * virtualstudio.uiScale)
+        x: (admin || connected) ? parent.width - (219 * virtualstudio.uiScale) : parent.width - (142 * virtualstudio.uiScale)
         y: topMargin * virtualstudio.uiScale; width: 40 * virtualstudio.uiScale; height: width
         background: Rectangle {
             radius: width / 2
@@ -251,7 +251,7 @@ Rectangle {
 
     Button {
         id: inviteButton
-        x: manageable ? parent.width - (142 * virtualstudio.uiScale) : parent.width - (65 * virtualstudio.uiScale)
+        x: (admin || connected) ? parent.width - (142 * virtualstudio.uiScale) : parent.width - (65 * virtualstudio.uiScale)
         y: topMargin * virtualstudio.uiScale; width: 40 * virtualstudio.uiScale; height: width
         background: Rectangle {
             radius: width / 2
@@ -330,30 +330,30 @@ Rectangle {
     }
     
     Button {
-        id: manageButton
+        id: manageOrVideoButton
         x: parent.width - (65 * virtualstudio.uiScale); y: topMargin * virtualstudio.uiScale
         width: 40 * virtualstudio.uiScale; height: width
         background: Rectangle {
             radius: width / 2
-            color: manageButton.down ? managePressedColour : (manageButton.hovered ? manageHoverColour : manageColour)
-            border.width:  manageButton.down ? 1 : 0
+            color: manageOrVideoButton.down ? managePressedColour : (manageOrVideoButton.hovered ? manageHoverColour : manageColour)
+            border.width:  manageOrVideoButton.down ? 1 : 0
             border.color: manageStroke
         }
         onClicked: { 
-            if (manageable && connected) {
+            if (connected) {
                 virtualstudio.launchVideo(-1)
-            } else if (connected) {
+            } else if (admin) {
                 virtualstudio.manageStudio(-1);
             } else {
                 virtualstudio.manageStudio(index);
             }
         }
-        visible: manageable
+        visible: admin || connected
         Image {
             id: manageImg
             width: 20 * virtualstudio.uiScale; height: width
             anchors { verticalCenter: parent.verticalCenter; horizontalCenter: parent.horizontalCenter }
-            source: manageable && connected ? "video.svg" : "manage.svg"
+            source: connected ? "video.svg" : "manage.svg"
             sourceSize: Qt.size(manageImg.width,manageImg.height)
             fillMode: Image.PreserveAspectFit
             smooth: true
@@ -361,11 +361,11 @@ Rectangle {
     }
     
     Text {
-        anchors.horizontalCenter: manageButton.horizontalCenter
+        anchors.horizontalCenter: manageOrVideoButton.horizontalCenter
         y: 56 * virtualstudio.uiScale
-        text: manageable && connected ? "Video" : "Manage"
+        text: connected ? "Video" : "Manage"
         font { family: "Poppins"; pixelSize: fontMedium * virtualstudio.fontScale * virtualstudio.uiScale }
-        visible: manageable
+        visible: admin || connected
         color: textColour
     }
 }

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1081,7 +1081,7 @@ void VirtualStudio::connectToStudio(int studioIndex)
     m_studioSocket->openSocket();
 
     // Check if we have an address for our server
-    if (studioInfo->status() != "Ready" && studioInfo->isManageable() == true) {
+    if (studioInfo->status() != "Ready" && studioInfo->isAdmin() == true) {
         m_connectionState = QStringLiteral("Waiting...");
         emit connectionStateChanged();
     } else {
@@ -1744,20 +1744,20 @@ void VirtualStudio::getServerList(bool firstLoad, bool signalRefresh, int index)
                 if (servers.at(i)[QStringLiteral("type")].toString().contains(
                         QStringLiteral("JackTrip"))) {
                     VsServerInfo* serverInfo = new VsServerInfo(this);
-                    serverInfo->setIsManageable(
+                    serverInfo->setIsAdmin(
                         servers.at(i)[QStringLiteral("admin")].toBool());
                     QString status = servers.at(i)[QStringLiteral("status")].toString();
                     bool activeStudio = status == QLatin1String("Ready");
                     bool hostedStudio = servers.at(i)[QStringLiteral("managed")].toBool();
                     // Only iterate through servers that we want to show
                     if (!m_showSelfHosted && !hostedStudio) {
-                        if (activeStudio || (serverInfo->isManageable())) {
+                        if (activeStudio || (serverInfo->isAdmin())) {
                             skippedStudios++;
                         }
                         continue;
                     }
                     if (!m_showInactive && !activeStudio) {
-                        if (serverInfo->isManageable()) {
+                        if (serverInfo->isAdmin()) {
                             skippedStudios++;
                         }
                         continue;
@@ -1767,6 +1767,8 @@ void VirtualStudio::getServerList(bool firstLoad, bool signalRefresh, int index)
                             servers.at(i)[QStringLiteral("name")].toString());
                         serverInfo->setHost(
                             servers.at(i)[QStringLiteral("serverHost")].toString());
+                        serverInfo->setIsManaged(
+                            servers.at(i)[QStringLiteral("managed")].toBool());
                         serverInfo->setStatus(
                             servers.at(i)[QStringLiteral("status")].toString());
                         serverInfo->setPort(
@@ -1794,8 +1796,6 @@ void VirtualStudio::getServerList(bool firstLoad, bool signalRefresh, int index)
                             servers.at(i)[QStringLiteral("enabled")].toBool());
                         serverInfo->setIsOwner(
                             servers.at(i)[QStringLiteral("owner")].toBool());
-                        serverInfo->setIsAdmin(
-                            servers.at(i)[QStringLiteral("admin")].toBool());
                         if (servers.at(i)[QStringLiteral("owner")].toBool()) {
                             yourServers.append(serverInfo);
                             serverInfo->setSection(VsServerInfo::YOUR_STUDIOS);

--- a/src/gui/vsServerInfo.cpp
+++ b/src/gui/vsServerInfo.cpp
@@ -181,14 +181,14 @@ void VsServerInfo::setRegion(const QString& region)
     m_region = region;
 }
 
-bool VsServerInfo::isManageable() const
+bool VsServerInfo::isManaged() const
 {
-    return m_isManageable;
+    return m_isManaged;
 }
 
-void VsServerInfo::setIsManageable(bool isManageable)
+void VsServerInfo::setIsManaged(bool isManaged)
 {
-    m_isManageable = isManageable;
+    m_isManaged = isManaged;
 }
 
 quint16 VsServerInfo::period() const

--- a/src/gui/vsServerInfo.h
+++ b/src/gui/vsServerInfo.h
@@ -54,7 +54,8 @@ class VsServerInfo : public QObject
     Q_PROPERTY(QString flag READ flag CONSTANT)
     Q_PROPERTY(QString bannerURL READ bannerURL CONSTANT)
     Q_PROPERTY(QString location READ location CONSTANT)
-    Q_PROPERTY(bool isManageable READ isManageable CONSTANT)
+    Q_PROPERTY(bool isAdmin READ isAdmin CONSTANT)
+    Q_PROPERTY(bool isManaged READ isManaged CONSTANT)
     Q_PROPERTY(quint16 period READ period CONSTANT)
     Q_PROPERTY(quint32 sampleRate READ sampleRate CONSTANT)
     Q_PROPERTY(quint16 queueBuffer READ queueBuffer CONSTANT)
@@ -93,8 +94,8 @@ class VsServerInfo : public QObject
     QString flag() const;
     QString location() const;
     void setRegion(const QString& region);
-    bool isManageable() const;
-    void setIsManageable(bool isManageable);
+    bool isManaged() const;
+    void setIsManaged(bool isManageable);
     quint16 period() const;
     void setPeriod(quint16 period);
     quint32 sampleRate() const;
@@ -126,9 +127,9 @@ class VsServerInfo : public QObject
     bool m_enabled;
     bool m_owner;
     bool m_admin;
+    bool m_isManaged;
     bool m_isPublic;
     QString m_region;
-    bool m_isManageable;
     quint16 m_period;
     quint32 m_sampleRate;
     quint16 m_queueBuffer;
@@ -143,7 +144,6 @@ class VsServerInfo : public QObject
     "loopback": true,
     "stereo": true,
     "type": "JackTrip",
-    "managed": true,
     "size": "c5.large",
     "mixBranch": "main",
     "mixCode": "SimpleMix(~maxClients).masterVolume_(1).connect.start;",


### PR DESCRIPTION
Fixes a bug where video buttons are hidden from people who are not studio admins. Also renames/repurposes the `isManageable` button to `isManaged`, changing it's definition from "current user is a studio admin" to "is managed by JackTrip Labs." In lieu of `isManaged`, those variables have been replaced by `isAdmin`.

Owner:
![Screen Shot 2023-01-26 at 2 13 22 PM](https://user-images.githubusercontent.com/26987971/214963795-2a0dbbc1-f2b2-43ae-831f-ee33aff6a11b.png)
![Screen Shot 2023-01-26 at 2 13 14 PM](https://user-images.githubusercontent.com/26987971/214963796-8cb01cb5-e59b-4d5a-a599-eb08dec923e0.png)

Admin
![Screen Shot 2023-01-26 at 2 17 17 PM](https://user-images.githubusercontent.com/26987971/214963870-4aa1b28f-f859-420f-af43-e77f5e2470d2.png)
![Screen Shot 2023-01-26 at 2 17 22 PM](https://user-images.githubusercontent.com/26987971/214963872-e5a6b376-5f70-4a6c-bb06-7efa2b25c45b.png)

Subscriber
![Screen Shot 2023-01-26 at 2 13 50 PM](https://user-images.githubusercontent.com/26987971/214963917-544c77fa-03e7-438a-94ea-f647b06bc39d.png)
![Screen Shot 2023-01-26 at 2 13 55 PM](https://user-images.githubusercontent.com/26987971/214963919-9c387d8d-5740-4908-9788-54abad7c9fdb.png)

