### PR TITLE
Preview docs in Github Actions

### DIFF
--- a/.github/workflows/mkdocs-preview.yml
+++ b/.github/workflows/mkdocs-preview.yml
@@ -19,8 +19,12 @@ jobs:
           echo "use_directory_urls: false" >> mkdocs.yml
       - name: Render docs 
         run: mkdocs build
+      - name: Move to a subdirectory
+        run: |
+          mkdir docs-upload
+          mv site docs-upload/JackTrip-docs-${{ github.sha }}
       - name: Upload docs for preview
         uses: actions/upload-artifact@v3
         with:
           name: JackTrip-docs-${{ github.sha }}
-          path: site/
+          path: docs-upload

--- a/.github/workflows/mkdocs-preview.yml
+++ b/.github/workflows/mkdocs-preview.yml
@@ -1,0 +1,26 @@
+name: Render docs preview
+on:
+  pull_request:
+    paths:
+      - mkdocs.yml
+      - docs/**
+
+jobs:
+  build:
+    name: Render docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: pip install mkdocs-material mkdocs-macros-plugin
+      - name: Prepare for offline browsing
+        run: |
+          echo "use_directory_urls: false" >> mkdocs.yml
+      - name: Render docs 
+        run: mkdocs build
+      - name: Upload docs for preview
+        uses: actions/upload-artifact@v3
+        with:
+          name: JackTrip-docs-${{ github.sha }}
+          path: site/


### PR DESCRIPTION
I wanted to have an option of previewing documentation changes even if I don't have access to configured environment with mkdocs installed.

This PR adds a GHA job that runs _only on PRs_ and _only on docs changes_, creating a static version of the docs. They are then uploaded as GHA artifacts. This allows previewing the changes from a static rendering, without the need to run mkdocs locally.

This still requires to download the archive, uncompress it and open `*.html` file(s) in the browser, it does not create an online-viewable preview.

Not sure if others will find this useful... any feedback is welcomed!