### PR TITLE
GHA: run clang format only on changes in src

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,5 +1,11 @@
 name: clang-format Check
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - 'src/**'
+  pull-request:
+    paths:
+      - 'src/**'
 
 jobs:
   clang-format-check:


### PR DESCRIPTION
Since clang-format action [is only checking files in `src`](https://github.com/jacktrip/jacktrip/blob/dev/.github/workflows/clang-format.yml#L13), then it should probably run only on changes in that directory.