### PR TITLE
Bugfix/plcBigFPP

### DIFF
--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -664,6 +664,9 @@ void BurgAlgorithm::predict(std::vector<long double>& coeffs, std::vector<float>
 //*******************************************************************************
 ChanData::ChanData(int i, int FPP, int hist) : ch(i)
 {
+    int shrinkCoeffsFactor = 1;
+    if (FPP == 1024)
+        shrinkCoeffsFactor = 8;
     trainSamps = (hist * FPP);
     mTruth.resize(FPP, 0.0);
     mXfadedPred.resize(FPP, 0.0);
@@ -674,7 +677,7 @@ ChanData::ChanData(int i, int FPP, int hist) : ch(i)
     }
     mTrain.resize(trainSamps, 0.0);
     mPrediction.resize(trainSamps - 1, 0.0);  // ORDER
-    mCoeffs.resize(trainSamps - 2, 0.0);
+    mCoeffs.resize(trainSamps / shrinkCoeffsFactor - 2, 0.0);
     mCrossFadeDown.resize(FPP, 0.0);
     mCrossFadeUp.resize(FPP, 0.0);
     mCrossfade.resize(FPP, 0.0);

--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -90,7 +90,7 @@ class StdDev
    public:
     StdDev(int id, QElapsedTimer* timer, int w);
     void tick();
-    double calcAuto(double autoHeadroom, double localFPPdur);
+    double calcAuto(double autoHeadroom, double localFPPdur, double peerFPPdur);
     int mId;
     int plcOverruns;
     int plcUnderruns;
@@ -207,6 +207,7 @@ class Regulator : public RingBuffer
     int mModSeqNumPeer;
     double mAutoHeadroom;
     double mFPPdurMsec;
+    double mPeerFPPdurMsec;
     void changeGlobal(double);
     void changeGlobal_2(int);
     void changeGlobal_3(int);


### PR DESCRIPTION
fixes issue #896 related to bufstrategy 3 and FPP 1024

the problem was encountered with a linux pipewire laptop client which was running the default 1024
it could not peer with a bufstrategy 3 server without major distortion 

there are two parts to this PR 
it reduces local DSP load for long predictions (by cheating and running with fewer coefficients) 
and it increases receiver mMsecTolerance when a peer is transmitting to it at 1024

1) in the DSP code, ChanData constructor shrinkCoeffsFactor will be 8 if local FPP is 1024

2) in the auto adjust code, calcAuto takes into account mPeerFPPdurMsec
(there was an old comment in the method suggesting this would need to be implemented some day)

This is a deep change and so far runs fine, stress tested with 50% packet loss outgoing from a client

wifi client (running on a linux pipewire machine with default FPP 1024)
`jacktrip  -C <server> --bufstrategy 3 -q auto3 --udprt`

server (mimics a typical VS configuration with FPP 128)
` jacktrip -S -t -z --bindport 4464 --nojackportsconnect --broadcast 97 --bufstrategy 3 -q auto3 -p1 --udprt`

(this is specific to 1024, and could possibly benefit 512, though that's not been looked at)