### PR TITLE
Audiointerface refactory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,8 +133,8 @@ set(qjacktrip_SRC
   src/JackTripWorker.cpp
   src/DataProtocol.cpp
   src/UdpDataProtocol.cpp
-  src/AudioInterface.cpp
-  src/JackAudioInterface.cpp
+  src/audio/AudioInterface.cpp
+  src/audio/JackAudioInterface.cpp
   src/JMess.cpp
   src/LoopBack.cpp
   src/PacketHeader.cpp
@@ -154,7 +154,7 @@ set(qjacktrip_SRC
 if (rtaudio)
   add_compile_definitions(RT_AUDIO)
   set (qjacktrip_SRC ${qjacktrip_SRC}
-    src/RtAudioInterface.cpp
+    src/audio/RtAudioInterface.cpp
   )
 endif ()
 

--- a/jacktrip.pro
+++ b/jacktrip.pro
@@ -222,7 +222,7 @@ HEADERS += src/DataProtocol.h \
            src/Settings.h \
            src/UdpDataProtocol.h \
            src/UdpHubListener.h \
-           src/AudioInterface.h \
+           src/audio/AudioInterface.h \
            src/compressordsp.h \
            src/limiterdsp.h \
            src/freeverbdsp.h \
@@ -234,7 +234,7 @@ HEADERS += src/DataProtocol.h \
 #(Removed JackTripThread.h JackTripWorkerMessages.h NetKS.h TestRingBuffer.h ThreadPoolTest.h)
 
 !nojack {
-  HEADERS += src/JackAudioInterface.h \
+  HEADERS += src/audio/JackAudioInterface.h \
              src/JMess.h \
              src/Patcher.h
 }
@@ -268,7 +268,7 @@ HEADERS += src/DataProtocol.h \
 }
 
 rtaudio|bundled_rtaudio {
-  HEADERS += src/RtAudioInterface.h
+  HEADERS += src/audio/RtAudioInterface.h
 }
 
 SOURCES += src/DataProtocol.cpp \
@@ -290,14 +290,14 @@ SOURCES += src/DataProtocol.cpp \
            src/Settings.cpp \
            src/UdpDataProtocol.cpp \
            src/UdpHubListener.cpp \
-           src/AudioInterface.cpp \
+           src/audio/AudioInterface.cpp \
            src/main.cpp \
            src/SslServer.cpp \
            src/Auth.cpp
 #(Removed jacktrip_main.cpp jacktrip_tests.cpp JackTripThread.cpp ProcessPlugin.cpp)
 
 !nojack {
-  SOURCES += src/JackAudioInterface.cpp \
+  SOURCES += src/audio/JackAudioInterface.cpp \
              src/JMess.cpp \
              src/Patcher.cpp
 }
@@ -351,7 +351,7 @@ SOURCES += src/DataProtocol.cpp \
 }
 
 rtaudio|bundled_rtaudio {
-  SOURCES += src/RtAudioInterface.cpp
+  SOURCES += src/audio/RtAudioInterface.cpp
 }
 
 weakjack {

--- a/meson.build
+++ b/meson.build
@@ -37,7 +37,7 @@ src = [	'src/DataProtocol.cpp',
 	'src/Settings.cpp',
 	'src/UdpDataProtocol.cpp',
 	'src/UdpHubListener.cpp',
-	'src/AudioInterface.cpp',
+	'src/audio/AudioInterface.cpp',
 	'src/Compressor.cpp',
 	'src/Limiter.cpp',
 	'src/Meter.cpp',
@@ -74,7 +74,7 @@ jack_dep = dependency('jack', required: get_option('jack'))
 if not jack_dep.found()
 	defines += '-DNO_JACK'
 else
-	src += 	['src/JackAudioInterface.cpp',
+	src += 	['src/audio/JackAudioInterface.cpp',
 		'src/JMess.cpp',
 		'src/Patcher.cpp']
 	moc_h += ['src/Patcher.h']
@@ -193,7 +193,7 @@ defines += '-DQT_OPENSOURCE'
 rtaudio_dep = dependency('rtaudio', required: get_option('rtaudio'))
 if rtaudio_dep.found() == true
 	defines += '-DRT_AUDIO'
-	src += 'src/RtAudioInterface.cpp'
+	src += 'src/audio/RtAudioInterface.cpp'
 	deps += rtaudio_dep
 endif
 

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -38,7 +38,7 @@
 #include "JackTrip.h"
 
 #ifndef NO_JACK
-#include "JackAudioInterface.h"
+#include "audio/JackAudioInterface.h"
 #endif
 #include "Auth.h"
 #include "JitterBuffer.h"
@@ -47,7 +47,7 @@
 #include "UdpDataProtocol.h"
 #include "jacktrip_globals.h"
 #ifdef RT_AUDIO
-#include "RtAudioInterface.h"
+#include "audio/RtAudioInterface.h"
 #endif
 
 #include <QDateTime>

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -96,7 +96,7 @@ JackTrip::JackTrip(jacktripModeT JacktripMode, dataProtocolT DataProtocolType,
     , mJackTripMode(JacktripMode)
     , mDataProtocol(DataProtocolType)
     , mPacketHeaderType(PacketHeaderType)
-    , mAudiointerfaceMode(JackTrip::JACK)
+    , mAudiointerfaceMode(AudioInterfaceMode::JACK)
     , mNumAudioChansIn(NumChansIn)
     , mNumAudioChansOut(NumChansOut)
 #ifdef WAIR  // WAIR
@@ -184,7 +184,7 @@ void JackTrip::setupAudio(
     }
 
     // Create AudioInterface Client Object
-    if (mAudiointerfaceMode == JackTrip::JACK) {
+    if (mAudiointerfaceMode == AudioInterfaceMode::JACK) {
 #ifndef NO_JACK
         if (gVerboseFlag)
             std::cout << "  JackTrip:setupAudio before new JackAudioInterface"
@@ -252,7 +252,7 @@ void JackTrip::setupAudio(
         mAudioBufferSize = mAudioInterface->getBufferSizeInSamples();
 #endif
 #endif
-    } else if (mAudiointerfaceMode == JackTrip::RTAUDIO) {
+    } else if (mAudiointerfaceMode == AudioInterfaceMode::RTAUDIO) {
 #ifdef RT_AUDIO
         mAudioInterface = new RtAudioInterface(this, mNumAudioChansIn, mNumAudioChansOut,
                                                mAudioBitResolution);

--- a/src/JackTrip.h
+++ b/src/JackTrip.h
@@ -47,11 +47,12 @@
 #include <QUdpSocket>
 #include <stdexcept>
 
-#include "AudioInterface.h"
 #include "DataProtocol.h"
+#include "audio/AudioInterface.h"
+#include "audio/AudioInterfaceMode.h"
 
 #ifndef NO_JACK
-#include "JackAudioInterface.h"
+#include "audio/JackAudioInterface.h"
 #endif  // NO_JACK
 
 #include "AudioTester.h"

--- a/src/JackTrip.h
+++ b/src/JackTrip.h
@@ -95,12 +95,6 @@ class JackTrip : public QObject
         ZEROS       ///< Set new buffers to zero if there are no new ones
     };
 
-    /// \brief Enum for Audio Interface Mode
-    enum audiointerfaceModeT {
-        JACK,    ///< Jack Mode
-        RTAUDIO  ///< RtAudio Mode
-    };
-
     /// \brief Enum for Connection Mode (in packet header)
     enum connectionModeT {
         NORMAL,   ///< Normal Mode
@@ -334,7 +328,7 @@ class JackTrip : public QObject
         return getTotalAudioOutputPacketSizeInBytes();
     }
 
-    virtual void setAudiointerfaceMode(JackTrip::audiointerfaceModeT audiointerface_mode)
+    virtual void setAudiointerfaceMode(AudioInterfaceMode audiointerface_mode)
     {
         mAudiointerfaceMode = audiointerface_mode;
     }
@@ -438,7 +432,7 @@ class JackTrip : public QObject
 #ifndef NO_JACK
     QString getAssignedClientName()
     {
-        if (mAudioInterface && mAudiointerfaceMode == JackTrip::JACK) {
+        if (mAudioInterface && mAudiointerfaceMode == AudioInterfaceMode::JACK) {
             return static_cast<JackAudioInterface*>(mAudioInterface)
                 ->getAssignedClientName();
         } else {
@@ -623,7 +617,7 @@ class JackTrip : public QObject
     jacktripModeT mJackTripMode;                        ///< JackTrip::jacktripModeT
     dataProtocolT mDataProtocol;                        ///< Data Protocol Tipe
     DataProtocol::packetHeaderTypeT mPacketHeaderType;  ///< Packet Header Type
-    JackTrip::audiointerfaceModeT mAudiointerfaceMode;
+    AudioInterfaceMode mAudiointerfaceMode;
 
     int mNumAudioChansIn;   ///< Number of Audio Input Channels
     int mNumAudioChansOut;  ///< Number of Audio Output Channels

--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -49,8 +49,8 @@
 #include <atomic>
 #include <cstring>
 
-#include "AudioInterface.h"
 #include "RingBuffer.h"
+#include "audio/AudioInterface.h"
 
 class BurgAlgorithm
 {

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -64,7 +64,7 @@
 #endif
 
 #ifdef RT_AUDIO
-#include "RtAudioInterface.h"
+#include "audio/RtAudioInterface.h"
 #endif
 
 #ifdef JACKTRIP_BUILD_INFO

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -391,7 +391,7 @@ void Settings::parseInput(int argc, char** argv)
 #ifdef RT_AUDIO
         case 'R':  // RtAudio
             //-------------------------------------------------------
-            mUseJack = false;
+            mAudioInterfaceMode = AudioInterfaceMode::RTAUDIO;
             break;
         case 'T':  // Sampling Rate
             //-------------------------------------------------------
@@ -1028,11 +1028,8 @@ JackTrip* Settings::getConfiguredJackTrip()
         jackTrip->setPacketHeaderType(DataProtocol::EMPTY);
     }
 
-    // Set RtAudio
-#ifdef RT_AUDIO
-    if (!mUseJack) {
-        jackTrip->setAudiointerfaceMode(JackTrip::RTAUDIO);
-    }
+    // Set Audio Backend Mode
+    jackTrip->setAudiointerfaceMode(mAudioInterfaceMode);
 
     // Change default Sampling Rate
     if (mChangeDefaultSR) {
@@ -1052,7 +1049,6 @@ JackTrip* Settings::getConfiguredJackTrip()
     // Set device names
     jackTrip->setInputDevice(mInputDeviceName);
     jackTrip->setOutputDevice(mOutputDeviceName);
-#endif
 
     jackTrip->setBufferStrategy(mBufferStrategy);
     jackTrip->setNetIssuesSimulation(mSimulatedLossRate, mSimulatedJitterRate,

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -99,6 +99,7 @@ enum JTLongOptIDS {
     OPT_AUDIOINPUTDEVICE,
     OPT_AUDIOOUTPUTDEVICE,
     OPT_AUDIOBACKENDS,
+    OPT_BACKEND,
 };
 
 //*******************************************************************************
@@ -156,6 +157,7 @@ void Settings::parseInput(int argc, char** argv)
         {"appendthreadid", no_argument, NULL,
          OPT_APPENDTHREADID},  // Append thread id to client names
         {"audiobackends", no_argument, NULL, OPT_AUDIOBACKENDS},
+        {"backend", required_argument, NULL, OPT_BACKEND},
 #ifdef RT_AUDIO
         {"rtaudio", no_argument, NULL, 'R'},      // Run in JamLink mode
         {"srate", required_argument, NULL, 'T'},  // Set Sample Rate
@@ -398,6 +400,17 @@ void Settings::parseInput(int argc, char** argv)
             }
             std::exit(0);
             break;
+        case OPT_BACKEND:
+            if (mAudio.setAudioBackendByString(optarg)) {
+                std::cout << "Set audio backend to " << optarg << ".\n";
+                break;
+            } else {
+                std::cout << "There's no audio backend with the name " << optarg << ".\n"
+                          << "Please use a backend name according to the output of\n"
+                          << "jacktrip --audiobackends!\n\n";
+                std::exit(0);
+            };
+
 #ifdef RT_AUDIO
         case 'R':  // RtAudio
             //-------------------------------------------------------
@@ -836,6 +849,7 @@ void Settings::printUsage()
     cout << endl;
     cout << "ARGUMENTS FOR AUDIO BACKENDS:\n";
     cout << "     --audiobackends                      List all available audio backends\n";
+    cout << "     --backend <backend name>             Set the audio backend\n";
 #ifdef RT_AUDIO
     cout << " -R, --rtaudio                            Use system's default sound system "
             "instead of Jack"

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -97,7 +97,8 @@ enum JTLongOptIDS {
     OPT_LISTDEVICES,
     OPT_AUDIODEVICE,
     OPT_AUDIOINPUTDEVICE,
-    OPT_AUDIOOUTPUTDEVICE
+    OPT_AUDIOOUTPUTDEVICE,
+    OPT_AUDIOBACKENDS,
 };
 
 //*******************************************************************************
@@ -154,6 +155,7 @@ void Settings::parseInput(int argc, char** argv)
         {"remotename", required_argument, NULL, 'K'},  // Client name on hub server
         {"appendthreadid", no_argument, NULL,
          OPT_APPENDTHREADID},  // Append thread id to client names
+        {"audiobackends", no_argument, NULL, OPT_AUDIOBACKENDS},
 #ifdef RT_AUDIO
         {"rtaudio", no_argument, NULL, 'R'},      // Run in JamLink mode
         {"srate", required_argument, NULL, 'T'},  // Set Sample Rate
@@ -387,6 +389,14 @@ void Settings::parseInput(int argc, char** argv)
             break;
         case OPT_APPENDTHREADID:
             mAppendThreadID = true;
+            break;
+        case OPT_AUDIOBACKENDS:
+            mAudio.getAvailableBackendNames(mBackendNames);
+            std::cout << "Available Audio Backends:\n";
+            for (const auto& backend : mBackendNames) {
+                std::cout << "\t" << backend << "\n";
+            }
+            std::exit(0);
             break;
 #ifdef RT_AUDIO
         case 'R':  // RtAudio
@@ -824,8 +834,9 @@ void Settings::printUsage()
             "(sources) mixing at Hub Server (otherwise 2 assumed by -O)"
          << endl;
     cout << endl;
+    cout << "ARGUMENTS FOR AUDIO BACKENDS:\n";
+    cout << "     --audiobackends                      List all available audio backends\n";
 #ifdef RT_AUDIO
-    cout << "ARGUMENTS TO USE JACKTRIP WITHOUT JACK:" << endl;
     cout << " -R, --rtaudio                            Use system's default sound system "
             "instead of Jack"
          << endl;

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -144,6 +144,9 @@ class Settings : public QObject
     QString mUsername;
     QString mPassword;
 
+    std::vector<std::string> mBackendNames;
+    Audio mAudio;
+
     QSharedPointer<AudioTester> mAudioTester;
 };
 

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -45,13 +45,14 @@
 #include "DataProtocol.h"
 
 #ifndef NO_JACK
-#include "JackAudioInterface.h"
+#include "audio/JackAudioInterface.h"
 #endif  // NO_JACK
 
 #include "AudioTester.h"
 #include "Effects.h"
 #include "JackTrip.h"
 #include "UdpHubListener.h"
+#include "audio/AudioInterfaceMode.h"
 
 /** \brief Class to set usage options and parse settings from input
  */

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -114,17 +114,16 @@ class Settings : public QObject
     bool mEmptyHeader        = false;                 ///< EmptyHeader mode
     bool mJackTripServer     = false;                 ///< JackTrip Server mode
     QString mLocalAddress    = gDefaultLocalAddress;  ///< Local Address
-    unsigned int mRedundancy = 1;      ///< Redundancy factor for data in the network
-    bool mUseJack            = true;   ///< Use or not JackAduio
-    bool mChangeDefaultSR    = false;  ///< Change Default Sampling Rate
-    bool mChangeDefaultID    = 0;      ///< Change Default device ID
-    bool mChangeDefaultBS    = false;  ///< Change Default Buffer Size
-#ifdef RT_AUDIO
+    unsigned int mRedundancy = 1;  ///< Redundancy factor for data in the network
+    AudioInterfaceMode mAudioInterfaceMode =
+        AudioInterfaceMode::JACK;   ///< Audio Backend / AudioInterface mode
+    bool mChangeDefaultSR = false;  ///< Change Default Sampling Rate
+    bool mChangeDefaultID = 0;      ///< Change Default device ID
+    bool mChangeDefaultBS = false;  ///< Change Default Buffer Size
     unsigned int mSampleRate;
     unsigned int mDeviceID;
     unsigned int mAudioBufferSize;
     std::string mInputDeviceName, mOutputDeviceName;
-#endif
     unsigned int mHubConnectionMode = JackTrip::SERVERTOCLIENT;
     bool mPatchServerAudio          = false;
     bool mStereoUpmix               = false;

--- a/src/audio/AudioInterface.cpp
+++ b/src/audio/AudioInterface.cpp
@@ -41,7 +41,7 @@
 #include <cmath>
 #include <iostream>
 
-#include "JackTrip.h"
+#include "../JackTrip.h"
 
 using std::cout;
 using std::endl;

--- a/src/audio/AudioInterface.h
+++ b/src/audio/AudioInterface.h
@@ -41,9 +41,9 @@
 #include <QVarLengthArray>
 #include <QVector>
 
-#include "AudioTester.h"
-#include "ProcessPlugin.h"
-#include "jacktrip_types.h"
+#include "../AudioTester.h"
+#include "../ProcessPlugin.h"
+#include "../jacktrip_types.h"
 //#include "jacktrip_globals.h"
 
 // Forward declarations

--- a/src/audio/AudioInterfaceMode.h
+++ b/src/audio/AudioInterfaceMode.h
@@ -37,12 +37,18 @@
 
 #pragma once
 
+#include <type_traits>
+#include <vector>
+
+#if defined(RT_AUDIO)
+#include <RtAudio.h>
+#endif
+
 #if defined(__cpp_lib_to_underlying)
 #include <utility>
 using std::to_underlying(auto value);
 
 #else
-#include <type_traits>
 template<class T>
 constexpr std::underlying_type_t<T> to_underlying(T value) noexcept
 {

--- a/src/audio/AudioInterfaceMode.h
+++ b/src/audio/AudioInterfaceMode.h
@@ -148,8 +148,22 @@ class Audio
         }
     }
 
+    auto getAudioBackend() -> Backend { return mBackend; }
+
+    bool setAudioBackendByString(std::string backend)
+    {
+        for (const auto& [available_enum, available_string] : m_availableBackends) {
+            if (backend == available_string) {
+                mBackend = available_enum;
+                return true;
+            }
+        }
+        return false;
+    }
+
    private:
     std::unordered_map<Backend, std::string> m_availableBackends;
+    Backend mBackend = Backend::JACK;
 };
 
 #ifdef RT_AUDIO

--- a/src/audio/JackAudioInterface.cpp
+++ b/src/audio/JackAudioInterface.cpp
@@ -42,8 +42,8 @@
 #include <cstring>
 #include <stdexcept>
 
-#include "JackTrip.h"
-#include "jacktrip_globals.h"
+#include "../JackTrip.h"
+#include "../jacktrip_globals.h"
 
 ///************PROTORYPE FOR CELT**************************
 //#include <celt/celt.h>

--- a/src/audio/JackAudioInterface.h
+++ b/src/audio/JackAudioInterface.h
@@ -51,9 +51,9 @@
 #include <QVector>
 #include <functional>  //for mem_fun_ref
 
+#include "../ProcessPlugin.h"
+#include "../jacktrip_types.h"
 #include "AudioInterface.h"
-#include "ProcessPlugin.h"
-#include "jacktrip_types.h"
 
 // class JackTrip; //forward declaration
 

--- a/src/audio/RtAudioInterface.cpp
+++ b/src/audio/RtAudioInterface.cpp
@@ -40,8 +40,8 @@
 #include <QString>
 #include <cstdlib>
 
-#include "JackTrip.h"
-#include "jacktrip_globals.h"
+#include "../JackTrip.h"
+#include "../jacktrip_globals.h"
 
 using std::cout;
 using std::endl;

--- a/src/audio/RtAudioInterface.h
+++ b/src/audio/RtAudioInterface.h
@@ -42,8 +42,8 @@
 
 #include <QQueue>
 
+#include "../jacktrip_globals.h"
 #include "AudioInterface.h"
-#include "jacktrip_globals.h"
 class JackTrip;  // Forward declaration
 
 /// \brief Base Class that provides an interface with RtAudio

--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -32,6 +32,9 @@
 #include <QVector>
 #include <cstdlib>
 #include <ctime>
+#ifdef RT_AUDIO
+#include <RtAudio.h>
+#endif
 
 #include "about.h"
 #ifndef NO_VS
@@ -42,15 +45,12 @@
 #include "weak_libjack.h"
 #endif
 
-#ifdef RT_AUDIO
-#include "RtAudio.h"
-#endif
-
 #include "../Compressor.h"
 #include "../CompressorPresets.h"
 #include "../Limiter.h"
 #include "../Meter.h"
 #include "../Reverb.h"
+#include "../audio/AudioInterfaceMode.h"
 
 QJackTrip::QJackTrip(int argc, bool suppressCommandlineWarning, QWidget* parent)
     : QMainWindow(parent)

--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -844,7 +844,7 @@ void QJackTrip::start()
 
 #ifdef RT_AUDIO
             if (m_ui->backendComboBox->currentIndex() == 1) {
-                m_jackTrip->setAudiointerfaceMode(JackTrip::RTAUDIO);
+                m_jackTrip->setAudiointerfaceMode(AudioInterfaceMode::RTAUDIO);
                 m_jackTrip->setSampleRate(
                     m_ui->sampleRateComboBox->currentText().toInt());
                 m_jackTrip->setAudioBufferSizeInSamples(

--- a/src/gui/vsAudioInterface.h
+++ b/src/gui/vsAudioInterface.h
@@ -44,17 +44,17 @@
 #include <QString>
 
 #ifndef NO_JACK
-#include "../JackAudioInterface.h"
+#include "../audio/JackAudioInterface.h"
 #endif
 #ifdef RT_AUDIO
-#include "../RtAudioInterface.h"
+#include "../audio/RtAudioInterface.h"
 #endif
 
 #include "../Meter.h"
 #include "../Tone.h"
 #include "../Volume.h"
+#include "../audio/AudioInterfaceMode.h"
 #include "../jacktrip_globals.h"
-#include "AudioInterfaceMode.h"
 
 class VsAudioInterface : public QObject
 {

--- a/src/gui/vsDevice.cpp
+++ b/src/gui/vsDevice.cpp
@@ -358,7 +358,7 @@ JackTrip* VsDevice::initJackTrip([[maybe_unused]] bool useRtAudio,
     m_jackTrip->setConnectDefaultAudioPorts(true);
 #ifdef RT_AUDIO
     if (useRtAudio) {
-        m_jackTrip->setAudiointerfaceMode(JackTrip::RTAUDIO);
+        m_jackTrip->setAudiointerfaceMode(AudioInterfaceMode::RTAUDIO);
         m_jackTrip->setSampleRate(studioInfo->sampleRate());
         m_jackTrip->setAudioBufferSizeInSamples(bufferSize);
         m_jackTrip->setInputDevice(input);

--- a/src/gui/vsDevice.cpp
+++ b/src/gui/vsDevice.cpp
@@ -39,6 +39,8 @@
 
 #include <QDebug>
 
+#include "../audio/AudioInterfaceMode.h"
+
 // Constructor
 VsDevice::VsDevice(QOAuth2AuthorizationCodeFlow* authenticator, bool testMode,
                    QObject* parent)

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -38,7 +38,7 @@
 #ifndef __JACKTRIP_GLOBALS_H__
 #define __JACKTRIP_GLOBALS_H__
 
-#include "AudioInterface.h"
+#include "audio/AudioInterface.h"
 
 constexpr const char* const gVersion = "1.7.1";  ///< JackTrip version
 


### PR DESCRIPTION
This moves all AudioInterface related files to a new *audio* subfolder. 

~~The AudioInterfaceMode enum class was nice and modern, but you couldn't do things like `AudioInterfaceMode::JACK | AudioInterfaceMode::RTAUDIO`. If there is a method for ORing enum classes, please tell me, because I really don't like the drawback of potentially clashing with C macros.~~

Edit: I mixed now the enum class approach with the possibility of ORing the underlying type with std::to_underlying(). I didn't test this with the real C++23 implementation but the fallback I've added.
https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p1682r3.html

We later have to decide how to proceed with the AudioInterfaceMode setting that is saved as an integer derived by the location in the list of backends in the gui.

There is only one AudioInterfaceMode enum. I deleted *audiointerfaceModeT*.