### PR TITLE
gha: update clang-format and commit inplace changes

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,9 +1,8 @@
 name: clang-format Check
 on:
   push:
-    paths:
-      - 'src/**'
-  pull_request:
+    branches:
+      - dev
     paths:
       - 'src/**'
 
@@ -14,8 +13,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Clang-Format Check
-      uses: DoozyX/clang-format-lint-action@v0.13
+      uses: DoozyX/clang-format-lint-action@v0.15
       with:
         source: 'src'
         extensions: 'h,cpp'
-        clangFormatVersion: 13
+        clangFormatVersion: 15
+        inplace: True
+    - name: Commit Clang-Format Changes
+      uses: EndBug/add-and-commit@v9
+      with:
+        default_author: github_actions
+        message: 'clang-format version 15'


### PR DESCRIPTION
This updates clang-format to version 15. Instead of checking the formatting on PRs, it does formatting on push to dev.