### PR TITLE
Add qtversion option to Meson build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,12 @@ else
   name_suffix = ''
 endif
 
-qt5 = import('qt5')
+if get_option('qtversion') == '5'
+  qt = import('qt5')
+else
+  qt = import('qt6')
+endif
+
 cmake = import('cmake')
 
 compiler = meson.get_compiler('cpp')
@@ -87,7 +92,11 @@ endif
 
 if get_option('nogui') == true
 	defines += '-DNO_GUI'
-	qt5_dep = dependency('qt5', modules: ['Core', 'Network'], include_type: 'system')
+	if get_option('qtversion') == '5'
+		qt_dep = dependency('qt5', modules: ['Core', 'Network'], include_type: 'system')
+	else
+		qt_dep = dependency('qt6', modules: ['Core', 'Network'], include_type: 'system')
+	endif
 else
 	src += [
 		'src/gui/qjacktrip.cpp',
@@ -111,7 +120,11 @@ else
 
 	if get_option('novs') == true
 		defines += '-DNO_VS'
-		qt5_dep = dependency('qt5', modules: ['Core', 'Gui', 'Network', 'Widgets'], include_type: 'system')
+		if get_option('qtversion') == '5'
+			qt_dep = dependency('qt5', modules: ['Core', 'Gui', 'Network', 'Widgets'], include_type: 'system')
+		else
+			qt_dep = dependency('qt6', modules: ['Core', 'Gui', 'Network', 'Widgets'], include_type: 'system')
+		endif
 		qres = ['src/gui/qjacktrip_novs.qrc']
 	else
 		src += [
@@ -145,7 +158,11 @@ else
 			moc_h += ['src/gui/vsMacPermissions.h']
 		endif
 
-		qt5_dep = dependency('qt5', modules: ['Core', 'Gui', 'Network', 'Widgets', 'Quick', 'QuickControls2', 'Qml', 'Svg', 'NetworkAuth', 'WebSockets'], include_type: 'system')
+		if get_option('qtversion') == '5'
+			qt_dep = dependency('qt5', modules: ['Core', 'Gui', 'Network', 'Widgets', 'Quick', 'QuickControls2', 'Qml', 'Svg', 'NetworkAuth', 'WebSockets'], include_type: 'system')
+		else
+			qt_dep = dependency('qt6', modules: ['Core', 'Gui', 'Network', 'Widgets', 'Quick', 'QuickControls2', 'Qml', 'Svg', 'NetworkAuth', 'WebSockets'], include_type: 'system')
+		endif
 		qres = ['src/gui/qjacktrip.qrc']
 	endif
 
@@ -167,9 +184,9 @@ else
 		ui_h += ['src/dblsqd/update_dialog.ui']
 	endif
 endif
-deps += qt5_dep
+deps += qt_dep
 
-prepro_files = qt5.preprocess(moc_headers : moc_h, ui_files : ui_h, qresources : qres)
+prepro_files = qt.preprocess(moc_headers : moc_h, ui_files : ui_h, qresources : qres)
 
 # TODO: QT_OPENSOURCE should only be defined for open source Qt distribution
 # in QMake this can be checked with QT_EDITION == 'OpenSource'

--- a/meson.build
+++ b/meson.build
@@ -186,8 +186,6 @@ else
 endif
 deps += qt_dep
 
-prepro_files = qt.preprocess(moc_headers : moc_h, ui_files : ui_h, qresources : qres)
-
 # TODO: QT_OPENSOURCE should only be defined for open source Qt distribution
 # in QMake this can be checked with QT_EDITION == 'OpenSource'
 defines += '-DQT_OPENSOURCE'
@@ -223,7 +221,11 @@ if host_machine.system() == 'darwin' and get_option('novs') == false
 	deps += apple_av_dep
 endif
 
-jacktrip = executable('jacktrip', src, prepro_files, include_directories: incdirs, dependencies: deps, c_args: c_defines, cpp_args: defines, install: true )
+qres_files = qt.compile_resources(sources: qres)
+moc_files = qt.compile_moc(headers: moc_h, extra_args: defines)
+ui_files = qt.compile_ui(sources: ui_h)
+
+jacktrip = executable('jacktrip', src, qres_files, ui_files, moc_files, include_directories: incdirs, dependencies: deps, c_args: c_defines, cpp_args: defines, install: true )
 
 help2man = find_program('help2man', required: false)
 if not (host_machine.system() == 'windows')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,3 +6,4 @@ option('nogui', type : 'boolean', value : 'false', description: 'Build without g
 option('novs', type : 'boolean', value : 'false', description: 'Build without Virtual Studio support')
 option('noupdater', type : 'boolean', value : 'false', description: 'Build without auto-update support')
 option('profile', type: 'combo', choices: ['default', 'development'], value: 'default', description: 'Choose build profile / Sets desktop id accordingly')
+option('qtversion', type : 'combo', choices: ['5', '6'], description: 'Choose to build with either Qt5 or Qt6')


### PR DESCRIPTION
With `meson configure -Dqtversion=6 -Dnovs=true` it doesn't build currently because of #925 . ~~But when fixing #925 with removing pow(), I get:~~
```
ccache c++ -Ijacktrip.p -I. -I.. -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=c++17 -O2 -g -isystem/usr/include/qt6/QtWidgets -DQT_WIDGETS_LIB -isystem/usr/include/qt6/QtNetwork -DQT_NETWORK_LIB -isystem/usr/include/qt6/QtGui -DQT_GUI_LIB -isystem/usr/include/qt6/QtCore -isystem/usr/include/qt6 -DQT_CORE_LIB -isystem/usr/lib64/qt6/mkspecs/linux-g++ -fPIC -D_REENTRANT -pthread -DWAIRTOHUB -DNO_VS -DNO_UPDATER -DQT_OPENSOURCE -MD -MQ jacktrip.p/meson-generated_moc_qjacktrip.cpp.o -MF jacktrip.p/meson-generated_moc_qjacktrip.cpp.o.d -o jacktrip.p/meson-generated_moc_qjacktrip.cpp.o -c jacktrip.p/moc_qjacktrip.cpp
jacktrip.p/moc_qjacktrip.cpp: In statischer Elementfunktion »static void QJackTrip::qt_static_metacall(QObject*, QMetaObject::Call, int, void**)«:
jacktrip.p/moc_qjacktrip.cpp:272:22: Fehler: »class QJackTrip« hat kein Element namens »virtualStudioMode«
  272 |         case 18: _t->virtualStudioMode(); break;
```

~~Hope German is similar enough to English that you understand. Somehow some Virtual Studio stuff is creeping into the novs build.~~

Fixed: Had to add define macros to moc arguments.