### PR TITLE
GHA: correct Qt download link

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -373,7 +373,7 @@ jobs:
           QT_FULL_VERSION=${{ matrix.static-qt-version }}
           QT_MAJOR_MINOR_VERSION=`echo $QT_FULL_VERSION | cut -d '.' -f1-2`
           QT_ARCHIVE_BASE_NAME=qt-everywhere-
-          if [[ ! "$QT_MAJOR_MINOR_VERSION" < "5.15" ]]; then QT_ARCHIVE_BASE_NAME=${QT_ARCHIVE_BASE_NAME}opensource-; fi # filename changed to qt-everywhere-opensource-src-<version> in Qt 5.15
+          if [[ ! "$QT_FULL_VERSION" < "5.15.3" && "$QT_FULL_VERSION" < "6.0.0" ]]; then QT_ARCHIVE_BASE_NAME=${QT_ARCHIVE_BASE_NAME}opensource-; fi # filename changed to qt-everywhere-opensource-src-<version> in Qt 5.15.3
           QT_SRC_URL="https://download.qt.io/archive/qt/$QT_MAJOR_MINOR_VERSION/$QT_FULL_VERSION/single/${QT_ARCHIVE_BASE_NAME}src-$QT_FULL_VERSION.tar.xz"
           echo "Downloading Qt source from $QT_SRC_URL"
           curl -L $QT_SRC_URL -o qt.tar.xz


### PR DESCRIPTION
I think the current logic is broken for Qt 5.15.0-5.15.2, as seen here: https://github.com/jacktrip/jacktrip/actions/runs/4189642206/jobs/7266985031#step:12:29

It seems that `opensource-` in filename is added only for Qt `5.15.3` and up (but not for 5.15.0-5.15.2, and also not for 6.0.0+)