### PR TITLE
Attempting to fix memory-related crash

### DIFF
--- a/src/Meter.cpp
+++ b/src/Meter.cpp
@@ -145,8 +145,10 @@ void Meter::onTick()
 {
     if (hasProcessedAudio) {
         /* Send the measurements to whatever other component requests it */
-        QVector<float> valuesCopy(mValues);
-        valuesCopy.detach();
+        QVector<float> valuesCopy(mValues.size());
+        for (int i = 0; i < mValues.size(); ++i) {
+            valuesCopy[i] = mValues.at(i);
+        }
         emit onComputedVolumeMeasurements(valuesCopy);
 
         /* Set meter values to the default floor */


### PR DESCRIPTION
I'm not sure if this fixes it, but I found that `QVector` does not implement a `detach()` method: https://doc.qt.io/qt-5/qvector-members.html

This change should effectively do the same thing, but manually