### PR TITLE
Parse command line for GUI

### DIFF
--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -273,19 +273,16 @@ void Settings::parseInput(int argc, char** argv)
         case 's':  // Run in P2P server mode
             //-------------------------------------------------------
             mJackTripMode = JackTrip::SERVER;
-            mRunMode      = P2P_SERVER;
             checkMode();
             break;
         case 'S':  // Run in Hub server mode
             //-------------------------------------------------------
-            mJackTripServer = true;
-            mRunMode        = HUB_SERVER;
+            mJackTripMode = JackTrip::SERVERPINGSERVER;
             checkMode();
             break;
         case 'c':  // P2P client mode
             //-------------------------------------------------------
             mJackTripMode = JackTrip::CLIENT;
-            mRunMode      = P2P_CLIENT;
             mPeerAddress  = optarg;
             checkMode();
             break;
@@ -297,7 +294,6 @@ void Settings::parseInput(int argc, char** argv)
         case 'C':  // Ping to server
             //-------------------------------------------------------
             mJackTripMode = JackTrip::CLIENTTOPINGSERVER;
-            mRunMode      = HUB_CLIENT;
             mPeerAddress  = optarg;
             checkMode();
             break;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -651,7 +651,6 @@ void Settings::parseInput(int argc, char** argv)
                 optarg = argv[optind++];
             }
             mPassword = optarg;
-            std::cout << mPassword.toStdString() << std::endl;
             break;
         case 'x': {  // examine connection (test mode)
             //-------------------------------------------------------

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -640,7 +640,10 @@ void Settings::parseInput(int argc, char** argv)
             mCredsFile = optarg;
             break;
         case OPT_AUTHUSER:
-            // Need to manually check if we have our optional argument
+            // Need to manually check if we have our optional argument.
+            // (getopt_long will only find an optional parameter for long arguments if
+            // there's a '=' rather than a space between them. If we don't manually check,
+            // the paramater will be interpreted as an unknown argument.)
             if (optarg == NULL && optind < argc && argv[optind][0] != '-') {
                 optarg = argv[optind++];
             }

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -291,7 +291,7 @@ void Settings::parseInput(int argc, char** argv)
             break;
         case 'L':  // set optional local host address
             //-------------------------------------------------------
-            mGuiIgnoresArgemunts = true;
+            mGuiIgnoresArguments = true;
             mLocalAddress        = optarg;
             break;
         case 'C':  // Ping to server
@@ -380,17 +380,17 @@ void Settings::parseInput(int argc, char** argv)
             break;
         case 'l':  // loopback
             //-------------------------------------------------------
-            mGuiIgnoresArgemunts = true;
+            mGuiIgnoresArguments = true;
             mLoopBack            = true;
             break;
         case 'e':  // jamlink
             //-------------------------------------------------------
-            mGuiIgnoresArgemunts = true;
+            mGuiIgnoresArguments = true;
             mEmptyHeader         = true;
             break;
         case 'j':  // jamlink
             //-------------------------------------------------------
-            mGuiIgnoresArgemunts = true;
+            mGuiIgnoresArguments = true;
             mJamLink             = true;
             break;
         case 'J':  // Set client Name
@@ -407,18 +407,18 @@ void Settings::parseInput(int argc, char** argv)
 #ifdef RT_AUDIO
         case 'R':  // RtAudio
             //-------------------------------------------------------
-            mGuiIgnoresArgemunts = true;
+            mGuiIgnoresArguments = true;
             mUseJack             = false;
             break;
         case 'T':  // Sampling Rate
             //-------------------------------------------------------
-            mGuiIgnoresArgemunts = true;
+            mGuiIgnoresArguments = true;
             mChangeDefaultSR     = true;
             mSampleRate          = atoi(optarg);
             break;
         case 'd':  // RTAudio device id
             //-------------------------------------------------------
-            mGuiIgnoresArgemunts = true;
+            mGuiIgnoresArguments = true;
             cout << "WARNING: Setting device ID is deprecated and will be removed in the "
                     "future."
                  << endl;
@@ -427,29 +427,29 @@ void Settings::parseInput(int argc, char** argv)
             break;
         case 'F':  // Buffer Size
             //-------------------------------------------------------
-            mGuiIgnoresArgemunts = true;
+            mGuiIgnoresArguments = true;
             mChangeDefaultBS     = true;
             mAudioBufferSize     = atoi(optarg);
             break;
         case OPT_AUDIODEVICE:  // Set audio device
             //-------------------------------------------------------
-            mGuiIgnoresArgemunts = true;
+            mGuiIgnoresArguments = true;
             if (!mGuiEnabled) {
                 // Don't try to parse this if we're in the GUI and ignoring it.
                 setDevicesByString(optarg);
             }
             break;
         case OPT_AUDIOINPUTDEVICE:
-            mGuiIgnoresArgemunts = true;
+            mGuiIgnoresArguments = true;
             mInputDeviceName     = optarg;
             break;
         case OPT_AUDIOOUTPUTDEVICE:
-            mGuiIgnoresArgemunts = true;
+            mGuiIgnoresArguments = true;
             mOutputDeviceName    = optarg;
             break;
         case OPT_LISTDEVICES:  // List audio devices
             //-------------------------------------------------------
-            mGuiIgnoresArgemunts = true;
+            mGuiIgnoresArguments = true;
             if (!mGuiEnabled) {
                 RtAudioInterface::printDevices();
                 std::exit(0);
@@ -513,7 +513,7 @@ void Settings::parseInput(int argc, char** argv)
             break;
         case 'I':  // IO Stat timeout
             //-------------------------------------------------------
-            mGuiIgnoresArgemunts = true;
+            mGuiIgnoresArguments = true;
             mIOStatTimeout       = atoi(optarg);
             if (0 > mIOStatTimeout && !mGuiEnabled) {
                 printUsage();
@@ -524,7 +524,7 @@ void Settings::parseInput(int argc, char** argv)
         case 'G':  // IO Stat log file
             //-------------------------------------------------------
             {
-                mGuiIgnoresArgemunts = true;
+                mGuiIgnoresArguments = true;
                 if (mGuiEnabled) {
                     break;
                 }
@@ -547,11 +547,11 @@ void Settings::parseInput(int argc, char** argv)
             }
             break;
         case OPT_SIMLOSS:  // Simulate packet loss
-            mGuiIgnoresArgemunts = true;
+            mGuiIgnoresArguments = true;
             mSimulatedLossRate   = atof(optarg);
             break;
         case OPT_SIMJITTER:  // Simulate jitter
-            mGuiIgnoresArgemunts = true;
+            mGuiIgnoresArguments = true;
             char* endp;
             mSimulatedJitterRate = strtod(optarg, &endp);
             if (0 == *endp) {
@@ -573,7 +573,7 @@ void Settings::parseInput(int argc, char** argv)
             break;
         case 'O': {  // Overflow limiter (i, o, or io)
             //-------------------------------------------------------
-            mGuiIgnoresArgemunts = true;
+            mGuiIgnoresArguments = true;
             if (mGuiEnabled) {
                 break;
             }
@@ -594,7 +594,7 @@ void Settings::parseInput(int argc, char** argv)
         }
         case 'a': {  // assumed number of clients (applies to outgoing limiter)
             //-------------------------------------------------------
-            mGuiIgnoresArgemunts = true;
+            mGuiIgnoresArguments = true;
             if (mGuiEnabled) {
                 break;
             }
@@ -615,7 +615,7 @@ void Settings::parseInput(int argc, char** argv)
         }
         case 'f': {  // --effects (-f) effectsSpecArg
             //-------------------------------------------------------
-            mGuiIgnoresArgemunts = true;
+            mGuiIgnoresArguments = true;
             if (mGuiEnabled) {
                 break;
             }
@@ -659,7 +659,7 @@ void Settings::parseInput(int argc, char** argv)
             break;
         case 'x': {  // examine connection (test mode)
             //-------------------------------------------------------
-            mGuiIgnoresArgemunts = true;
+            mGuiIgnoresArguments = true;
             if (mGuiEnabled) {
                 break;
             }
@@ -951,7 +951,7 @@ void Settings::printUsage()
     cout << " --password                               The password to use when connecting as a hub client (if not supplied here, this is read from standard input)" << endl;
     cout << endl;
     cout << "ARGUMENTS FOR THE GUI:" << endl;
-    cout << " --gui                                   Force JackTrip to run with the GUI. If not using VirtualStudio mode, command line switches in the required arguments, optional arguments (except -l, -j, -L, --appendthreadid), audio patching, and authentication sections will be honoured, and default settings will be used where arguments aren't supplied. Options from other sections will be ignored (and the last used settings will be loaded), except for -V, and the --version and --holp switches which will override this." << endl;
+    cout << " --gui                                   Force JackTrip to run with the GUI. If not using VirtualStudio mode, command line switches in the required arguments, optional arguments (except -l, -j, -L, --appendthreadid), audio patching, and authentication sections will be honoured, and default settings will be used where arguments aren't supplied. Options from other sections will be ignored (and the last used settings will be loaded), except for -V, and the --version and --help switches which will override this." << endl;
     cout << endl;
     cout << "HELP ARGUMENTS: " << endl;
     cout << " -v, --version                            Prints Version Number" << endl;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -38,7 +38,7 @@
 #include "Settings.h"
 
 #include "LoopBack.h"
-//#include "NetKS.h"
+// #include "NetKS.h"
 #include "Effects.h"
 
 #ifdef WAIR  // wair
@@ -46,7 +46,7 @@
 #include "ap8x2.dsp.h"
 #endif  // endwhere
 
-//#include "JackTripWorker.h"
+// #include "JackTripWorker.h"
 #include <getopt.h>  // for command line parsing
 
 #include <cassert>
@@ -73,7 +73,7 @@
 #define PRINT_BUILD_INFO cout << "Build Info: " << TO_STRING(JACKTRIP_BUILD_INFO) << endl;
 #endif
 
-//#include "ThreadPoolTest.h"
+// #include "ThreadPoolTest.h"
 
 using std::cout;
 using std::endl;
@@ -97,7 +97,9 @@ enum JTLongOptIDS {
     OPT_LISTDEVICES,
     OPT_AUDIODEVICE,
     OPT_AUDIOINPUTDEVICE,
-    OPT_AUDIOOUTPUTDEVICE
+    OPT_AUDIOOUTPUTDEVICE,
+    OPT_GUI,
+    OPT_DEEPLINK
 };
 
 //*******************************************************************************
@@ -106,7 +108,7 @@ void Settings::parseInput(int argc, char** argv)
     // Always use decimal point for floating point numbers
     setlocale(LC_NUMERIC, "C");
     // If no command arguments are given, print instructions
-    if (argc == 1) {
+    if (argc == 1 && !mGuiEnabled) {
         printUsage();
         std::exit(0);
     }
@@ -198,13 +200,15 @@ void Settings::parseInput(int argc, char** argv)
          OPT_AUTHKEY},  // Private key for server authentication
         {"credsfile", required_argument, NULL,
          OPT_AUTHCREDS},  // Username and password store for server authentication
-        {"username", required_argument, NULL,
+        {"username", optional_argument, NULL,
          OPT_AUTHUSER},  // Username when using authentication as a hub client
-        {"password", required_argument, NULL,
+        {"password", optional_argument, NULL,
          OPT_AUTHPASS},  // Password when using authentication as a hub client
         {"help", no_argument, NULL, 'h'},  // Print Help
         {"examine-audio-delay", required_argument, NULL,
          'x'},  // test mode - measure audio round-trip latency statistics
+        {"gui", no_argument, NULL, OPT_GUI},                  // Force GUI mode
+        {"deeplink", optional_argument, NULL, OPT_DEEPLINK},  // VirtualStudio Deeplink
         {NULL, 0, NULL, 0}};
 
     // Parse Command Line Arguments
@@ -213,9 +217,9 @@ void Settings::parseInput(int argc, char** argv)
     int ch;
     while ((ch = getopt_long(
                 argc, argv,
-                "n:N:H:sc:SC:o:B:P:U:q:r:b:ztlwjeJ:K:RTd:F:p:uiDvVhI:G:f:O:a:x:A",
+                "n:N:H:sc:SC:L:o:B:P:U:q:r:b:ztlwjeJ:K:RTd:F:p:uiDvVhI:G:f:O:a:x:A",
                 longopts, NULL))
-           != -1)
+           != -1) {
         switch (ch) {
         case OPT_NUMRECEIVE:
             if (0 < atoi(optarg)) {
@@ -269,24 +273,33 @@ void Settings::parseInput(int argc, char** argv)
         case 's':  // Run in P2P server mode
             //-------------------------------------------------------
             mJackTripMode = JackTrip::SERVER;
+            mRunMode      = P2P_SERVER;
+            checkMode();
             break;
         case 'S':  // Run in Hub server mode
             //-------------------------------------------------------
             mJackTripServer = true;
+            mRunMode        = HUB_SERVER;
+            checkMode();
             break;
         case 'c':  // P2P client mode
             //-------------------------------------------------------
             mJackTripMode = JackTrip::CLIENT;
+            mRunMode      = P2P_CLIENT;
             mPeerAddress  = optarg;
+            checkMode();
             break;
         case 'L':  // set optional local host address
             //-------------------------------------------------------
-            mLocalAddress = optarg;
+            mGuiIgnoresArgemunts = true;
+            mLocalAddress        = optarg;
             break;
         case 'C':  // Ping to server
             //-------------------------------------------------------
             mJackTripMode = JackTrip::CLIENTTOPINGSERVER;
+            mRunMode      = HUB_CLIENT;
             mPeerAddress  = optarg;
+            checkMode();
             break;
         case 'o':  // Port Offset
             //-------------------------------------------------------
@@ -367,15 +380,18 @@ void Settings::parseInput(int argc, char** argv)
             break;
         case 'l':  // loopback
             //-------------------------------------------------------
-            mLoopBack = true;
+            mGuiIgnoresArgemunts = true;
+            mLoopBack            = true;
             break;
         case 'e':  // jamlink
             //-------------------------------------------------------
-            mEmptyHeader = true;
+            mGuiIgnoresArgemunts = true;
+            mEmptyHeader         = true;
             break;
         case 'j':  // jamlink
             //-------------------------------------------------------
-            mJamLink = true;
+            mGuiIgnoresArgemunts = true;
+            mJamLink             = true;
             break;
         case 'J':  // Set client Name
             //-------------------------------------------------------
@@ -391,15 +407,18 @@ void Settings::parseInput(int argc, char** argv)
 #ifdef RT_AUDIO
         case 'R':  // RtAudio
             //-------------------------------------------------------
-            mUseJack = false;
+            mGuiIgnoresArgemunts = true;
+            mUseJack             = false;
             break;
         case 'T':  // Sampling Rate
             //-------------------------------------------------------
-            mChangeDefaultSR = true;
-            mSampleRate      = atoi(optarg);
+            mGuiIgnoresArgemunts = true;
+            mChangeDefaultSR     = true;
+            mSampleRate          = atoi(optarg);
             break;
         case 'd':  // RTAudio device id
             //-------------------------------------------------------
+            mGuiIgnoresArgemunts = true;
             cout << "WARNING: Setting device ID is deprecated and will be removed in the "
                     "future."
                  << endl;
@@ -408,23 +427,33 @@ void Settings::parseInput(int argc, char** argv)
             break;
         case 'F':  // Buffer Size
             //-------------------------------------------------------
-            mChangeDefaultBS = true;
-            mAudioBufferSize = atoi(optarg);
+            mGuiIgnoresArgemunts = true;
+            mChangeDefaultBS     = true;
+            mAudioBufferSize     = atoi(optarg);
             break;
         case OPT_AUDIODEVICE:  // Set audio device
             //-------------------------------------------------------
-            setDevicesByString(optarg);
+            mGuiIgnoresArgemunts = true;
+            if (!mGuiEnabled) {
+                // Don't try to parse this if we're in the GUI and ignoring it.
+                setDevicesByString(optarg);
+            }
             break;
         case OPT_AUDIOINPUTDEVICE:
-            mInputDeviceName = optarg;
+            mGuiIgnoresArgemunts = true;
+            mInputDeviceName     = optarg;
             break;
         case OPT_AUDIOOUTPUTDEVICE:
-            mOutputDeviceName = optarg;
+            mGuiIgnoresArgemunts = true;
+            mOutputDeviceName    = optarg;
             break;
         case OPT_LISTDEVICES:  // List audio devices
             //-------------------------------------------------------
-            RtAudioInterface::printDevices();
-            std::exit(0);
+            mGuiIgnoresArgemunts = true;
+            if (!mGuiEnabled) {
+                RtAudioInterface::printDevices();
+                std::exit(0);
+            }
             break;
 #endif
         case 'D':
@@ -484,8 +513,9 @@ void Settings::parseInput(int argc, char** argv)
             break;
         case 'I':  // IO Stat timeout
             //-------------------------------------------------------
-            mIOStatTimeout = atoi(optarg);
-            if (0 > mIOStatTimeout) {
+            mGuiIgnoresArgemunts = true;
+            mIOStatTimeout       = atoi(optarg);
+            if (0 > mIOStatTimeout && !mGuiEnabled) {
                 printUsage();
                 std::cerr << "--iostat ERROR: negative timeout." << endl;
                 std::exit(1);
@@ -494,6 +524,10 @@ void Settings::parseInput(int argc, char** argv)
         case 'G':  // IO Stat log file
             //-------------------------------------------------------
             {
+                mGuiIgnoresArgemunts = true;
+                if (mGuiEnabled) {
+                    break;
+                }
                 std::ofstream* outStream = new std::ofstream(optarg);
                 if (!outStream->is_open()) {
                     printUsage();
@@ -513,9 +547,11 @@ void Settings::parseInput(int argc, char** argv)
             }
             break;
         case OPT_SIMLOSS:  // Simulate packet loss
-            mSimulatedLossRate = atof(optarg);
+            mGuiIgnoresArgemunts = true;
+            mSimulatedLossRate   = atof(optarg);
             break;
         case OPT_SIMJITTER:  // Simulate jitter
+            mGuiIgnoresArgemunts = true;
             char* endp;
             mSimulatedJitterRate = strtod(optarg, &endp);
             if (0 == *endp) {
@@ -537,6 +573,10 @@ void Settings::parseInput(int argc, char** argv)
             break;
         case 'O': {  // Overflow limiter (i, o, or io)
             //-------------------------------------------------------
+            mGuiIgnoresArgemunts = true;
+            if (mGuiEnabled) {
+                break;
+            }
             char cmd[]{"--overflowlimiting (-O)"};
             if (gVerboseFlag) {
                 printf("%s argument = %s\n", cmd, optarg);
@@ -554,6 +594,10 @@ void Settings::parseInput(int argc, char** argv)
         }
         case 'a': {  // assumed number of clients (applies to outgoing limiter)
             //-------------------------------------------------------
+            mGuiIgnoresArgemunts = true;
+            if (mGuiEnabled) {
+                break;
+            }
             char cmd[]{"--assumednumclients (-a)"};
             if (gVerboseFlag) {
                 printf("%s argument = %s\n", cmd, optarg);
@@ -571,6 +615,10 @@ void Settings::parseInput(int argc, char** argv)
         }
         case 'f': {  // --effects (-f) effectsSpecArg
             //-------------------------------------------------------
+            mGuiIgnoresArgemunts = true;
+            if (mGuiEnabled) {
+                break;
+            }
             char cmd[]{"--effects (-f)"};
             int returnCode = mEffects.parseEffectsOptArg(cmd, optarg);
             if (returnCode > 1) {
@@ -596,13 +644,25 @@ void Settings::parseInput(int argc, char** argv)
             mCredsFile = optarg;
             break;
         case OPT_AUTHUSER:
+            // Need to manually check if we have our optional argument
+            if (optarg == NULL && optind < argc && argv[optind][0] != '-') {
+                optarg = argv[optind++];
+            }
             mUsername = optarg;
             break;
         case OPT_AUTHPASS:
+            if (optarg == NULL && optind < argc && argv[optind][0] != '-') {
+                optarg = argv[optind++];
+            }
             mPassword = optarg;
+            std::cout << mPassword.toStdString() << std::endl;
             break;
         case 'x': {  // examine connection (test mode)
             //-------------------------------------------------------
+            mGuiIgnoresArgemunts = true;
+            if (mGuiEnabled) {
+                break;
+            }
             char cmd[]{"--examine-audio-delay (-x)"};
             if (tolower(optarg[0]) == 'h') {
                 mAudioTester->printHelp(cmd, ch);
@@ -620,6 +680,15 @@ void Settings::parseInput(int argc, char** argv)
             mAudioTester->setPrintIntervalSec(atof(optarg));
             break;
         }
+        // The following two options need to be handled earlier, so are all parsed in
+        // main. Included here so that we don't get an unrecognized option error.
+        case OPT_GUI:
+            break;
+        case OPT_DEEPLINK:
+            if (optarg == NULL && optind < argc && argv[optind][0] != '-') {
+                optarg = argv[optind++];
+            }
+            break;
         case ':': {
             printUsage();
             printf("*** Missing option argument *** see above for usage\n\n");
@@ -641,6 +710,7 @@ void Settings::parseInput(int argc, char** argv)
             break;
         }
         }
+    }
 
     // Warn user if undefined options where entered
     //----------------------------------------------------------------------------
@@ -669,6 +739,11 @@ void Settings::parseInput(int argc, char** argv)
     }
     // Exit if options are incompatible
     //----------------------------------------------------------------------------
+    if (mGuiEnabled) {
+        // The following tests aren't yet needed for the supported GUI options.
+        return;
+    }
+
     bool haveSomeServerMode = not((mJackTripMode == JackTrip::CLIENT)
                                   || (mJackTripMode == JackTrip::CLIENTTOPINGSERVER));
     if (mEffects.getHaveEffect() && haveSomeServerMode) {
@@ -874,6 +949,9 @@ void Settings::printUsage()
     cout << " --credsfile                              The file containing the stored usernames and passwords" << endl;
     cout << " --username                               The username to use when connecting as a hub client (if not supplied here, this is read from standard input)" << endl;
     cout << " --password                               The password to use when connecting as a hub client (if not supplied here, this is read from standard input)" << endl;
+    cout << endl;
+    cout << "ARGUMENTS FOR THE GUI:" << endl;
+    cout << " --gui                                   Force JackTrip to run with the GUI. If not using VirtualStudio mode, command line switches in the required arguments, optional arguments (except -l, -j, -L, --appendthreadid), audio patching, and authentication sections will be honoured, and default settings will be used where arguments aren't supplied. Options from other sections will be ignored (and the last used settings will be loaded), except for -V, and the --version and --holp switches which will override this." << endl;
     cout << endl;
     cout << "HELP ARGUMENTS: " << endl;
     cout << " -v, --version                            Prints Version Number" << endl;
@@ -1175,4 +1253,16 @@ void Settings::disableEcho(bool disabled)
     }
     tcsetattr(STDIN_FILENO, TCSANOW, &tty);
 #endif
+}
+
+void Settings::checkMode()
+{
+    if (mModeSet) {
+        std::cerr
+            << "Conflicting arguments given. Please choose only one of -c, -s, -C or -S."
+            << std::endl;
+        std::exit(1);
+    } else {
+        mModeSet = true;
+    }
 }

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -85,7 +85,7 @@ class Settings : public QObject
 
     bool getLoopBack() { return mLoopBack; }
     bool isHubServer() { return mRunMode == HUB_SERVER; }
-    bool guiIgnoresArguments() { return mGuiIgnoresArgemunts; }
+    bool guiIgnoresArguments() { return mGuiIgnoresArguments; }
     bool isModeSet() { return mModeSet; }
 
     runTypeT getRunMode() { return mRunMode; }
@@ -124,7 +124,7 @@ class Settings : public QObject
     void checkMode();
 
     bool mGuiEnabled          = false;
-    bool mGuiIgnoresArgemunts = false;
+    bool mGuiIgnoresArguments = false;
 
     runTypeT mRunMode = P2P_SERVER;
     JackTrip::jacktripModeT mJackTripMode =

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -60,9 +60,16 @@ class Settings : public QObject
     Q_OBJECT;
 
    public:
-    Settings(QObject* parent = nullptr) : QObject(parent), mAudioTester(new AudioTester)
+    Settings(bool guiEnabled = false, QObject* parent = nullptr)
+        : QObject(parent)
+#ifndef NO_GUI
+        , mGuiEnabled(guiEnabled)
+#endif
+        , mAudioTester(new AudioTester)
     {
     }
+
+    enum runTypeT { P2P_CLIENT, P2P_SERVER, HUB_CLIENT, HUB_SERVER };
 
     /// \brief Parses command line input
     void parseInput(int argc, char** argv);
@@ -77,13 +84,52 @@ class Settings : public QObject
 #endif
 
     bool getLoopBack() { return mLoopBack; }
-    bool isHubServer() { return mJackTripServer; }
+    bool isHubServer() { return mRunMode == HUB_SERVER; }
+    bool guiIgnoresArguments() { return mGuiIgnoresArgemunts; }
+    bool isModeSet() { return mModeSet; }
+
+    runTypeT getRunMode() { return mRunMode; }
+    int getNumAudioInputChans() { return mNumAudioInputChans; }
+    int getNumAudioOutputChans() { return mNumAudioOutputChans; }
+    int getQueueLength() { return mBufferQueueLength; }
+    unsigned int getRedundancy() { return mRedundancy; }
+    QString getPeerAddress() { return mPeerAddress; }
+    int getBindPort() { return mBindPortNum; }
+    int getPeerPort() { return mPeerPortNum; }
+    int getServerUdpPort() { return mServerUdpPortNum; }
+    AudioInterface::audioBitResolutionT getAudioBitResolution()
+    {
+        return mAudioBitResolution;
+    }
+    JackTrip::underrunModeT getUnderrunMode() { return mUnderrunMode; }
+    bool getStopOnTimeout() { return mStopOnTimeout; }
+    QString getClientName() { return mClientName; }
+    QString getRemoteClientName() { return mRemoteClientName; }
+    bool getConnectDefaultAudioPorts() { return mConnectDefaultAudioPorts; }
+    int getBufferStrategry() { return mBufferStrategy; }
+    int getBroadCastQueue() { return mBroadcastQueue; }
+    bool getUseRtUdpPriority() { return mUseRtUdpPriority; }
+    unsigned int getHubConnectionMode() { return mHubConnectionMode; }
+    bool getPatchServerAudio() { return mPatchServerAudio; }
+    bool getStereoUpmix() { return mStereoUpmix; }
+    bool getUseAuthentication() { return mAuth; }
+    QString getCertFile() { return mCertFile; }
+    QString getKeyFile() { return mKeyFile; }
+    QString getCredsFile() { return mCredsFile; }
+    QString getUsername() { return mUsername; }
+    QString getPassword() { return mPassword; }
 
    private:
     void disableEcho(bool disabled);
+    void checkMode();
 
+    bool mGuiEnabled          = false;
+    bool mGuiIgnoresArgemunts = false;
+
+    runTypeT mRunMode = P2P_SERVER;
     JackTrip::jacktripModeT mJackTripMode =
-        JackTrip::SERVER;                                   ///< JackTrip::jacktripModeT
+        JackTrip::SERVER;  ///< JackTrip::jacktripModeT
+    bool mModeSet                         = false;
     JackTrip::dataProtocolT mDataProtocol = JackTrip::UDP;  ///< Data Protocol
     int mNumAudioInputChans               = 2;              ///< Number of Input Channels
     int mNumAudioOutputChans              = 2;              ///< Number of Output Channels

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -104,7 +104,7 @@ class Settings : public QObject
     QString getClientName() { return mClientName; }
     QString getRemoteClientName() { return mRemoteClientName; }
     bool getConnectDefaultAudioPorts() { return mConnectDefaultAudioPorts; }
-    int getBufferStrategry() { return mBufferStrategy; }
+    int getBufferStrategy() { return mBufferStrategy; }
     int getBroadCastQueue() { return mBroadcastQueue; }
     bool getUseRtUdpPriority() { return mUseRtUdpPriority; }
     unsigned int getHubConnectionMode() { return mHubConnectionMode; }

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -69,8 +69,6 @@ class Settings : public QObject
     {
     }
 
-    enum runTypeT { P2P_CLIENT, P2P_SERVER, HUB_CLIENT, HUB_SERVER };
-
     /// \brief Parses command line input
     void parseInput(int argc, char** argv);
 
@@ -84,11 +82,11 @@ class Settings : public QObject
 #endif
 
     bool getLoopBack() { return mLoopBack; }
-    bool isHubServer() { return mRunMode == HUB_SERVER; }
+    bool isHubServer() { return mJackTripMode == JackTrip::SERVERPINGSERVER; }
     bool guiIgnoresArguments() { return mGuiIgnoresArguments; }
     bool isModeSet() { return mModeSet; }
 
-    runTypeT getRunMode() { return mRunMode; }
+    JackTrip::jacktripModeT getJackTripMode() { return mJackTripMode; }
     int getNumAudioInputChans() { return mNumAudioInputChans; }
     int getNumAudioOutputChans() { return mNumAudioOutputChans; }
     int getQueueLength() { return mBufferQueueLength; }
@@ -126,7 +124,6 @@ class Settings : public QObject
     bool mGuiEnabled          = false;
     bool mGuiIgnoresArguments = false;
 
-    runTypeT mRunMode = P2P_SERVER;
     JackTrip::jacktripModeT mJackTripMode =
         JackTrip::SERVER;  ///< JackTrip::jacktripModeT
     bool mModeSet                         = false;
@@ -157,7 +154,6 @@ class Settings : public QObject
     bool mLoopBack           = false;                 ///< Loop-back mode
     bool mJamLink            = false;                 ///< JamLink mode
     bool mEmptyHeader        = false;                 ///< EmptyHeader mode
-    bool mJackTripServer     = false;                 ///< JackTrip Server mode
     QString mLocalAddress    = gDefaultLocalAddress;  ///< Local Address
     unsigned int mRedundancy = 1;      ///< Redundancy factor for data in the network
     bool mUseJack            = true;   ///< Use or not JackAduio

--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -1229,7 +1229,7 @@ void QJackTrip::loadSettings(Settings* cliSettings)
 
         settings.beginGroup(QStringLiteral("JitterBuffer"));
         settings.setValue(QStringLiteral("JitterAnnounce"), true);
-        int bufferStrategy = cliSettings->getBufferStrategry();
+        int bufferStrategy = cliSettings->getBufferStrategy();
         m_ui->jitterCheckBox->setChecked(bufferStrategy > 0);
         m_ui->broadcastCheckBox->setChecked(cliSettings->getBroadCastQueue() > 0);
         m_ui->broadcastQueueSpinBox->setValue(

--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -1167,14 +1167,21 @@ void QJackTrip::loadSettings(Settings* cliSettings)
         m_ui->channelSendSpinBox->setValue(cliSettings->getNumAudioInputChans());
         m_ui->channelRecvSpinBox->setValue(cliSettings->getNumAudioOutputChans());
 
-        // Accomodate for the fact that the GUI doesn't support the reserved patching mode
         unsigned int patchMode = cliSettings->getHubConnectionMode();
-        if (patchMode == JackTrip::RESERVEDMATRIX) {
-            patchMode = NOAUTO;
-        } else if (patchMode > JackTrip::RESERVEDMATRIX) {
-            patchMode--;
+        if (patchMode == JackTrip::SERVERTOCLIENT) {
+            m_ui->autoPatchComboBox->setCurrentIndex(SERVERTOCLIENT);
+        } else if (patchMode == JackTrip::CLIENTECHO) {
+            m_ui->autoPatchComboBox->setCurrentIndex(CLIENTECHO);
+        } else if (patchMode == JackTrip::CLIENTFOFI) {
+            m_ui->autoPatchComboBox->setCurrentIndex(CLIENTFOFI);
+        } else if (patchMode == JackTrip::FULLMIX) {
+            m_ui->autoPatchComboBox->setCurrentIndex(FULLMIX);
+        } else {
+            // Accomodate for the fact that the GUI doesn't support the reserved patching
+            // mode by disabling patching if selected.
+            m_ui->autoPatchComboBox->setCurrentIndex(NOAUTO);
         }
-        m_ui->autoPatchComboBox->setCurrentIndex(patchMode);
+
         m_ui->patchServerCheckBox->setChecked(cliSettings->getPatchServerAudio());
         m_ui->upmixCheckBox->setChecked(cliSettings->getPatchServerAudio());
         m_ui->zeroCheckBox->setChecked(cliSettings->getUnderrunMode() == JackTrip::ZEROS);

--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -1081,8 +1081,6 @@ void QJackTrip::advancedOptionsForHubServer(bool isHubServer)
     m_ui->clientNameEdit->setVisible(!isHubServer);
     m_ui->redundancyLabel->setVisible(!isHubServer);
     m_ui->redundancySpinBox->setVisible(!isHubServer);
-    m_ui->resolutionLabel->setVisible(!isHubServer);
-    m_ui->resolutionComboBox->setVisible(!isHubServer);
     m_ui->connectAudioCheckBox->setVisible(!isHubServer);
     m_ui->basePortLabel->setVisible(isHubServer);
     m_ui->basePortSpinBox->setVisible(isHubServer);
@@ -1255,56 +1253,16 @@ void QJackTrip::loadSettings(Settings* cliSettings)
     } else {
         m_ui->typeComboBox->setCurrentIndex(
             settings.value(QStringLiteral("RunMode"), 2).toInt());
-        m_ui->channelSendSpinBox->setValue(
-            settings.value(QStringLiteral("ChannelsSend"), gDefaultNumInChannels)
-                .toInt());
-        m_ui->channelRecvSpinBox->setValue(
-            settings.value(QStringLiteral("ChannelsRecv"), gDefaultNumOutChannels)
-                .toInt());
-        m_ui->autoPatchComboBox->setCurrentIndex(
-            settings.value(QStringLiteral("AutoPatchMode"), 0).toInt());
-        m_ui->patchServerCheckBox->setChecked(
-            settings.value(QStringLiteral("PatchIncludesServer"), false).toBool());
-        m_ui->upmixCheckBox->setChecked(
-            settings.value(QStringLiteral("StereoUpmix"), false).toBool());
         m_ui->zeroCheckBox->setChecked(
             settings.value(QStringLiteral("ZeroUnderrun"), false).toBool());
-        m_ui->timeoutCheckBox->setChecked(
-            settings.value(QStringLiteral("Timeout"), false).toBool());
-        m_ui->clientNameEdit->setText(
-            settings.value(QStringLiteral("ClientName"), "").toString());
-        m_ui->remoteNameEdit->setText(
-            settings.value(QStringLiteral("RemoteName"), "").toString());
         m_ui->localPortSpinBox->setValue(
             settings.value(QStringLiteral("LocalPort"), gDefaultPort).toInt());
-        m_ui->remotePortSpinBox->setValue(
-            settings.value(QStringLiteral("RemotePort"), gDefaultPort).toInt());
-        m_ui->basePortSpinBox->setValue(
-            settings.value(QStringLiteral("BasePort"), 61002).toInt());
         m_ui->queueLengthSpinBox->setValue(
             settings.value(QStringLiteral("QueueLength"), gDefaultQueueLength).toInt());
-        m_ui->redundancySpinBox->setValue(
-            settings.value(QStringLiteral("Redundancy"), gDefaultRedundancy).toInt());
         m_ui->resolutionComboBox->setCurrentIndex(
             settings.value(QStringLiteral("Resolution"), 1).toInt());
-        m_ui->connectAudioCheckBox->setChecked(
-            settings.value(QStringLiteral("ConnectAudio"), true).toBool());
         m_ui->realTimeCheckBox->setChecked(
             settings.value(QStringLiteral("RTNetworking"), true).toBool());
-
-        settings.beginGroup(QStringLiteral("Auth"));
-        m_ui->requireAuthCheckBox->setChecked(
-            settings.value(QStringLiteral("Require"), false).toBool());
-        m_ui->certEdit->setText(
-            settings.value(QStringLiteral("CertFile"), "").toString());
-        m_ui->keyEdit->setText(settings.value(QStringLiteral("KeyFile"), "").toString());
-        m_ui->credsEdit->setText(
-            settings.value(QStringLiteral("CredsFile"), "").toString());
-        m_ui->authCheckBox->setChecked(
-            settings.value(QStringLiteral("Use"), false).toBool());
-        m_ui->usernameEdit->setText(
-            settings.value(QStringLiteral("Username"), "").toString());
-        settings.endGroup();
 
         settings.beginGroup(QStringLiteral("JitterBuffer"));
         bool jitterAnnounce =
@@ -1336,6 +1294,64 @@ void QJackTrip::loadSettings(Settings* cliSettings)
             settings.value(QStringLiteral("TuningParameter"), 500).toInt());
         settings.endGroup();
     }
+
+    // These settings may need to be loaded even if we were using our command line.
+    // (This depends on the mode that was selected.)
+    if (!useCommandLine || m_ui->typeComboBox->currentIndex() == HUB_SERVER) {
+        m_ui->channelSendSpinBox->setValue(
+            settings.value(QStringLiteral("ChannelsSend"), gDefaultNumInChannels)
+                .toInt());
+        m_ui->channelRecvSpinBox->setValue(
+            settings.value(QStringLiteral("ChannelsRecv"), gDefaultNumOutChannels)
+                .toInt());
+        m_ui->timeoutCheckBox->setChecked(
+            settings.value(QStringLiteral("Timeout"), false).toBool());
+        m_ui->clientNameEdit->setText(
+            settings.value(QStringLiteral("ClientName"), "").toString());
+        m_ui->redundancySpinBox->setValue(
+            settings.value(QStringLiteral("Redundancy"), gDefaultRedundancy).toInt());
+        m_ui->connectAudioCheckBox->setChecked(
+            settings.value(QStringLiteral("ConnectAudio"), true).toBool());
+    }
+    if (!useCommandLine || !(m_ui->typeComboBox->currentIndex() == HUB_SERVER)) {
+        m_ui->autoPatchComboBox->setCurrentIndex(
+            settings.value(QStringLiteral("AutoPatchMode"), 0).toInt());
+        m_ui->patchServerCheckBox->setChecked(
+            settings.value(QStringLiteral("PatchIncludesServer"), false).toBool());
+        m_ui->upmixCheckBox->setChecked(
+            settings.value(QStringLiteral("StereoUpmix"), false).toBool());
+        m_ui->basePortSpinBox->setValue(
+            settings.value(QStringLiteral("BasePort"), 61002).toInt());
+    }
+    if (!useCommandLine || !(m_ui->typeComboBox->currentIndex() == HUB_CLIENT)) {
+        m_ui->remoteNameEdit->setText(
+            settings.value(QStringLiteral("RemoteName"), "").toString());
+    }
+    if (!useCommandLine
+        || !(m_ui->typeComboBox->currentIndex() == HUB_CLIENT
+             || m_ui->typeComboBox->currentIndex() == P2P_CLIENT)) {
+        m_ui->remotePortSpinBox->setValue(
+            settings.value(QStringLiteral("RemotePort"), gDefaultPort).toInt());
+    }
+
+    settings.beginGroup(QStringLiteral("Auth"));
+    if (!useCommandLine || !(m_ui->typeComboBox->currentIndex() == HUB_SERVER)) {
+        m_ui->requireAuthCheckBox->setChecked(
+            settings.value(QStringLiteral("Require"), false).toBool());
+        m_ui->certEdit->setText(
+            settings.value(QStringLiteral("CertFile"), "").toString());
+        m_ui->keyEdit->setText(settings.value(QStringLiteral("KeyFile"), "").toString());
+        m_ui->credsEdit->setText(
+            settings.value(QStringLiteral("CredsFile"), "").toString());
+    }
+    if (!useCommandLine || !(m_ui->typeComboBox->currentIndex() == HUB_CLIENT)) {
+        m_ui->authCheckBox->setChecked(
+            settings.value(QStringLiteral("Use"), false).toBool());
+        m_ui->usernameEdit->setText(
+            settings.value(QStringLiteral("Username"), "").toString());
+        m_ui->passwordEdit->setText("");
+    }
+    settings.endGroup();
 
     // Settings from this point onwards are currently read only from the previously stored
     // values and not from the commmand line.

--- a/src/gui/qjacktrip.h
+++ b/src/gui/qjacktrip.h
@@ -105,6 +105,7 @@ class QJackTrip : public QMainWindow
 #endif
 
    private:
+    enum runTypeT { P2P_CLIENT, P2P_SERVER, HUB_CLIENT, HUB_SERVER };
     enum patchTypeT { SERVERTOCLIENT, CLIENTECHO, CLIENTFOFI, FULLMIX, NOAUTO };
 
     int findTab(const QString& tabName);
@@ -124,6 +125,8 @@ class QJackTrip : public QMainWindow
 
     QString commandLineFromCurrentOptions();
     void showCommandLineMessageBox();
+
+    JackTrip::hubConnectionModeT hubModeFromPatchType(patchTypeT patchType);
 
     QScopedPointer<Ui::QJackTrip> m_ui;
     QScopedPointer<UdpHubListener> m_udpHub;

--- a/src/gui/qjacktrip.h
+++ b/src/gui/qjacktrip.h
@@ -39,6 +39,7 @@
 #include <QTemporaryFile>
 
 #include "../JackTrip.h"
+#include "../Settings.h"
 #include "../UdpHubListener.h"
 #include "messageDialog.h"
 #include "vuMeter.h"
@@ -65,7 +66,7 @@ class QJackTrip : public QMainWindow
     Q_OBJECT
 
    public:
-    explicit QJackTrip(int argc = 0, bool suppressCommandlineWarning = false,
+    explicit QJackTrip(Settings* settings, bool suppressCommandlineWarning = false,
                        QWidget* parent = nullptr);
     ~QJackTrip() override;
 
@@ -104,14 +105,13 @@ class QJackTrip : public QMainWindow
 #endif
 
    private:
-    enum runTypeT { P2P_CLIENT, P2P_SERVER, HUB_CLIENT, HUB_SERVER };
     enum patchTypeT { SERVERTOCLIENT, CLIENTECHO, CLIENTFOFI, FULLMIX, NOAUTO };
 
     int findTab(const QString& tabName);
     void enableUi(bool enabled);
     void advancedOptionsForHubServer(bool isHubServer);
     void migrateSettings();
-    void loadSettings();
+    void loadSettings(Settings* cliSettings = nullptr);
     void saveSettings();
 
 #ifdef RT_AUDIO
@@ -153,7 +153,6 @@ class QJackTrip : public QMainWindow
     QString m_lastPath;
 
     QLabel m_autoQueueIndicator;
-    int m_argc;
     bool m_hideWarning;
     bool m_firstShow = true;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -311,8 +311,8 @@ int main(int argc, char* argv[])
         app->setApplicationName(QStringLiteral("JackTrip"));
         app->setApplicationVersion(gVersion);
 
-        Settings settings(true);
-        settings.parseInput(argc, argv);
+        Settings cliSettings(true);
+        cliSettings.parseInput(argc, argv);
 
 #ifndef NO_VS
         // Register clipboard Qml type
@@ -432,9 +432,9 @@ int main(int argc, char* argv[])
         instanceCheckSocket->connectToServer("jacktripExists");
 
 #endif  // _WIN32
-        window.reset(new QJackTrip(&settings, !deeplink.isEmpty()));
+        window.reset(new QJackTrip(&cliSettings, !deeplink.isEmpty()));
 #else
-        window.reset(new QJackTrip(&settings));
+        window.reset(new QJackTrip(&cliSettings));
 #endif  // NO_VS
         QObject::connect(window.data(), &QJackTrip::signalExit, app.data(),
                          &QCoreApplication::quit, Qt::QueuedConnection);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,7 +37,6 @@
 
 #ifndef NO_GUI
 #include <QApplication>
-#include <QCommandLineParser>
 
 #ifndef NO_UPDATER
 #include "dblsqd/feed.h"
@@ -45,6 +44,7 @@
 #endif
 
 #ifndef NO_VS
+#include <QCommandLineParser>
 #include <QDebug>
 #include <QFile>
 #include <QLocalServer>
@@ -311,20 +311,15 @@ int main(int argc, char* argv[])
         app->setApplicationName(QStringLiteral("JackTrip"));
         app->setApplicationVersion(gVersion);
 
-        QCommandLineParser parser;
-        QCommandLineOption verboseOption(QStringList() << QStringLiteral("V")
-                                                       << QStringLiteral("verbose"));
-        parser.addOption(verboseOption);
-        parser.parse(app->arguments());
-        if (parser.isSet(verboseOption)) {
-            gVerboseFlag = true;
-        }
+        Settings settings(true);
+        settings.parseInput(argc, argv);
 
 #ifndef NO_VS
         // Register clipboard Qml type
         qmlRegisterType<VsQmlClipboard>("VS", 1, 0, "Clipboard");
 
         // Parse command line for deep link
+        QCommandLineParser parser;
         QCommandLineOption deeplinkOption(QStringList() << QStringLiteral("deeplink"));
         deeplinkOption.setValueName(QStringLiteral("deeplink"));
         parser.addOption(deeplinkOption);
@@ -437,9 +432,9 @@ int main(int argc, char* argv[])
         instanceCheckSocket->connectToServer("jacktripExists");
 
 #endif  // _WIN32
-        window.reset(new QJackTrip(argc, !deeplink.isEmpty()));
+        window.reset(new QJackTrip(&settings, !deeplink.isEmpty()));
 #else
-        window.reset(new QJackTrip(argc));
+        window.reset(new QJackTrip(&settings));
 #endif  // NO_VS
         QObject::connect(window.data(), &QJackTrip::signalExit, app.data(),
                          &QCoreApplication::quit, Qt::QueuedConnection);
@@ -522,7 +517,9 @@ int main(int argc, char* argv[])
     } else {
 #endif  // NO_GUI
         // Otherwise use the non-GUI version, and parse our command line.
+#ifndef PSI
         QLoggingCategory::setFilterRules(QStringLiteral("*.debug=true"));
+#endif
         try {
             Settings settings;
             settings.parseInput(argc, argv);


### PR DESCRIPTION
Initial work to allow the GUI (standard mode) to parse command line options. Currently works for all required arguments, optional arguments (with a couple of exceptions), audio patching, and authentication options. This is all outlined in the --help screen.

If someone can test that this has no ill effects for VirtualStudio mode, that would be greatly appreciated. (It shouldn't do, but it would be good to test that deeplinks aren't affected.)