### PR TITLE
Automatically release to auto-updater

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -690,21 +690,6 @@ jobs:
           name: JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer
           path: ${{ env.BUILD_PATH }}/${{ matrix.installer-path }}
   # release - list of files uploaded to GH release is specified in the *upload* step
-  deploy_test:
-    needs: [build, sign]
-    runs-on: ubuntu-latest
-    name: 'deploy release'
-    env:
-      DOWNLOAD_PATH: ${{ github.workspace }}/Install
-    steps:
-      - name: download artifacts
-        uses: actions/download-artifact@v2
-        with:
-          path: ${{ env.DOWNLOAD_PATH }} # no "name" parameter - download all artifacts
-      - name: print files names downloaded
-        run: |
-          ls ${{ env.DOWNLOAD_PATH }}
-          ls ${{ env.DOWNLOAD_PATH }}/JackTrip*/*
   deploy_gh:
     if: startsWith(github.ref, 'refs/tags/') # run on tagged commits
     needs: [build, sign]
@@ -725,3 +710,27 @@ jobs:
           draft: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # deploy_jtl:
+  #   if:  startsWith(github.ref, 'refs/tags/') && needs.check-secrets.outputs.should_run == 'true'
+  #   needs: [build, sign]
+  #   runs-on: ubuntu-latest
+  #   name: 'deploy to updater'
+  #   permissions:
+  #     contents: "read"
+  #     id-token: "write"
+  #   env:
+  #     DOWNLOAD_PATH: ${{ github.workspace }}/Install
+  #   steps:
+  #     - name: download artifacts
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         path: ${{ env.DOWNLOAD_PATH }} # no "name" parameter - download all artifacts
+  #     - name: Authenticate to GCS
+  #       uses: google-github-actions/auth@v1
+  #       with:
+  #         workload_identity_provider: ${{ env.GCP_IDP }}
+  #         service_account: ${{ env.GCS_SVC_ACCT }}
+  #         create_credentials_file: true
+  #     - name: Upload file
+  #       run: |
+  #         gcloud storage cp ./somefile.txt gs://files.jacktrip.org/app-builds/somefile.txt

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -690,6 +690,21 @@ jobs:
           name: JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer
           path: ${{ env.BUILD_PATH }}/${{ matrix.installer-path }}
   # release - list of files uploaded to GH release is specified in the *upload* step
+  deploy_test:
+    needs: build
+    runs-on: ubuntu-latest
+    name: 'deploy release'
+    env:
+      DOWNLOAD_PATH: ${{ github.workspace }}/Install
+    steps:
+      - name: download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: ${{ env.DOWNLOAD_PATH }} # no "name" parameter - download all artifacts
+      - name: print files names downloaded
+        run: |
+          ls ${{ env.DOWNLOAD_PATH }}
+          ls ${{ env.DOWNLOAD_PATH }}/JackTrip*/*
   deploy_gh:
     if: startsWith(github.ref, 'refs/tags/') # run on tagged commits
     needs: build

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -778,6 +778,7 @@ jobs:
           # gcloud storage cp ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-binary.zip gs://files.jacktrip.org/app-builds
           gcloud storage cp ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer${{ steps.set-version.outputs.extension}} gs://files.jacktrip.org/app-builds
       - name: Update edge manifests
+        shell: bash
         run: |
           mkdir ${{ env.DOWNLOAD_PATH }}/app-releases
           gcloud storage cp --recursive gs://files.jacktrip.org/app-releases/* ${{ env.DOWNLOAD_PATH }}/app-releases

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -826,8 +826,7 @@ jobs:
             # Update the "releases" key in the root object with the new array
             jq '.releases = '"$new_array" ${{ env.DOWNLOAD_PATH }}/app-releases/edge/${{ matrix.platform-name }}-manifests.json > tmpfile && mv tmpfile ${{ env.DOWNLOAD_PATH }}/app-releases/edge/${{ matrix.platform-name }}-manifests.json
 
-            cat ${{ env.DOWNLOAD_PATH }}/app-releases/edge/${{ matrix.platform-name }}-manifests.json
-            gcloud storage cp ${{ env.DOWNLOAD_PATH }}/app-releases/edge/${{ matrix.platform-name }}-manifests.json ${{ env.DOWNLOAD_PATH }}/app-releases/edge
+            gcloud storage cp ${{ env.DOWNLOAD_PATH }}/app-releases/edge/${{ matrix.platform-name }}-manifests.json gs://files.jacktrip.org/app-releases/edge
           fi
       - name: Update stable manifests
         if: "!github.event.release.prerelease"
@@ -862,6 +861,5 @@ jobs:
           # Update the "releases" key in the root object with the new array
           jq '.releases = '"$new_array" ${{ env.DOWNLOAD_PATH }}/app-releases/stable/${{ matrix.platform-name }}-manifests.json > tmpfile && mv tmpfile ${{ env.DOWNLOAD_PATH }}/app-releases/stable/${{ matrix.platform-name }}-manifests.json
 
-          cat ${{ env.DOWNLOAD_PATH }}/app-releases/stable/${{ matrix.platform-name }}-manifests.json
-          gcloud storage cp ${{ env.DOWNLOAD_PATH }}/app-releases/stable/${{ matrix.platform-name }}-manifests.json ${{ env.DOWNLOAD_PATH }}/app-releases/stable
+          gcloud storage cp ${{ env.DOWNLOAD_PATH }}/app-releases/stable/${{ matrix.platform-name }}-manifests.json gs://files.jacktrip.org/app-releases/stable
           

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -710,27 +710,68 @@ jobs:
           draft: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  # deploy_jtl:
-  #   if:  startsWith(github.ref, 'refs/tags/') && needs.check-secrets.outputs.should_run == 'true'
-  #   needs: [build, sign]
-  #   runs-on: ubuntu-latest
-  #   name: 'deploy to updater'
-  #   permissions:
-  #     contents: "read"
-  #     id-token: "write"
-  #   env:
-  #     DOWNLOAD_PATH: ${{ github.workspace }}/Install
-  #   steps:
-  #     - name: download artifacts
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         path: ${{ env.DOWNLOAD_PATH }} # no "name" parameter - download all artifacts
-  #     - name: Authenticate to GCS
-  #       uses: google-github-actions/auth@v1
-  #       with:
-  #         workload_identity_provider: ${{ env.GCP_IDP }}
-  #         service_account: ${{ env.GCS_SVC_ACCT }}
-  #         create_credentials_file: true
-  #     - name: Upload file
-  #       run: |
-  #         gcloud storage cp ./somefile.txt gs://files.jacktrip.org/app-builds/somefile.txt
+  deploy_jtl:
+    # if:  startsWith(github.ref, 'refs/tags/') && github.event_name == 'release' && needs.check-secrets.outputs.should_run == 'true' # use this when done
+    if:  needs.check-secrets.outputs.should_run == 'true' # testing
+    needs: [build, sign]
+    runs-on: ubuntu-latest
+    name: 'deploy to updater'
+    permissions:
+      contents: "read"
+      id-token: "write"
+    env:
+      DOWNLOAD_PATH: ${{ github.workspace }}/Install
+    steps:
+      - name: download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: ${{ env.DOWNLOAD_PATH }} # no "name" parameter - download all artifacts
+      - name: Authenticate to GCS
+        uses: google-github-actions/auth@v1
+        with:
+          workload_identity_provider: ${{ env.GCP_IDP }}
+          service_account: ${{ env.GCS_SVC_ACCT }}
+          create_credentials_file: true
+      - name: Upload files
+        if: startsWith(github.ref, 'refs/tags/') && github.event_name == 'release' # don't run in testing. will remove line
+        run: |
+          gcloud storage cp ${{ env.DOWNLOAD_PATH }}/JackTrip*-Linux*-static-binary.zip gs://files.jacktrip.org/app-builds
+          gcloud storage cp ${{ env.DOWNLOAD_PATH }}/JackTrip*-Windows*-signed-installer.msi gs://files.jacktrip.org/app-builds
+          gcloud storage cp ${{ env.DOWNLOAD_PATH }}/JackTrip*-macOS*-signed-installer.pkg gs://files.jacktrip.org/app-builds
+      - name: Update edge manifests
+        run: |
+          gcloud storage cp --recursive gs://files.jacktrip.org/app-releases/* ${{ env.DOWNLOAD_PATH }}/app-releases
+
+          # Set the value of the variable
+          my_var="Some value"
+
+          # Define the JSON object to append
+          new_object=$(cat <<EOF
+          {
+            "version": "1.0.0",
+            "date": "$(date +%Y-%m-%d)",
+            "description": "Added new feature",
+            "my_var_value": "$my_var"
+          }
+          EOF
+          )
+
+          # Read the existing JSON array from the file
+          existing_mac_array=$(jq '.releases' ${{ env.DOWNLOAD_PATH }}/app-releases/edge/mac-manifests.json)
+          existing_win_array=$(jq '.releases' ${{ env.DOWNLOAD_PATH }}/app-releases/edge/win-manifests.json)
+
+          # Combine the new object and the existing array into a new array
+          new_mac_array=$(echo "$new_object $existing_mac_array" | jq -s .)
+          new_win_array=$(echo "$new_object $existing_win_array" | jq -s .)
+
+          # Update the "releases" key in the root object with the new array
+          jq '.releases = '"$new_mac_array" ${{ env.DOWNLOAD_PATH }}/app-releases/edge/mac-manifests.json > tmpfile && mv tmpfile ${{ env.DOWNLOAD_PATH }}/app-releases/edge/mac-manifests.json
+          jq '.releases = '"$new_win_array" ${{ env.DOWNLOAD_PATH }}/app-releases/edge/win-manifests.json > tmpfile && mv tmpfile ${{ env.DOWNLOAD_PATH }}/app-releases/edge/win-manifests.json
+
+          cat ${{ env.DOWNLOAD_PATH }}/app-releases/edge/mac-manifests.json
+          cat ${{ env.DOWNLOAD_PATH }}/app-releases/edge/win-manifests.json
+      - name: Update stable manifests
+        if: "!github.event.release.prerelease"
+        run: |
+          # do the full release work
+          

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -776,7 +776,7 @@ jobs:
       - name: download artifacts
         uses: actions/download-artifact@v2
         with:
-          path: ${{ env.DOWNLOAD_PATH }} # no "name" parameter - download all artifacts
+          path: ${{ env.DOWNLOAD_PATH }}
           name: JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-${{ steps.set-version.outputs.type }}
       - name: Authenticate to GCS
         uses: google-github-actions/auth@v1

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -654,8 +654,8 @@ jobs:
           else
             NAME="${{ matrix.build-job-name }}"
           fi
-          echo "::set-output name=version::$VERSION"
-          echo "::set-output name=name::$NAME"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "name=$NAME" >> $GITHUB_OUTPUT
       - name: Retrieve binary artifact
         uses: actions/download-artifact@v2
         if: matrix.binary-path && (!startsWith(github.ref, 'refs/tags/') || (startsWith(github.ref, 'refs/tags/') && matrix.release-name))
@@ -724,6 +724,16 @@ jobs:
       GCP_IDP: ${{ secrets.GCP_IDP }}
       GCS_SVC_ACCT: ${{ secrets.GCS_SVC_ACCT }}
     steps:
+      - name: set version string for manifests
+        shell: bash
+        id: set-version
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          else
+            VERSION=${GITHUB_SHA::7}
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
       - name: download artifacts
         uses: actions/download-artifact@v2
         with:
@@ -737,9 +747,9 @@ jobs:
       - name: Upload files
         if: startsWith(github.ref, 'refs/tags/') && github.event_name == 'release' # don't run in testing. will remove line
         run: |
-          gcloud storage cp ${{ env.DOWNLOAD_PATH }}/JackTrip*-Linux*-static-binary.zip gs://files.jacktrip.org/app-builds
-          gcloud storage cp ${{ env.DOWNLOAD_PATH }}/JackTrip*-Windows*-signed-installer.msi gs://files.jacktrip.org/app-builds
-          gcloud storage cp ${{ env.DOWNLOAD_PATH }}/JackTrip*-macOS*-signed-installer.pkg gs://files.jacktrip.org/app-builds
+          gcloud storage cp ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-Linux-x64-static-binary.zip gs://files.jacktrip.org/app-builds
+          gcloud storage cp ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-Windows-x64-signed-installer.msi gs://files.jacktrip.org/app-builds
+          gcloud storage cp ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-macOS-x64-signed-installer.pkg gs://files.jacktrip.org/app-builds
       - name: Update edge manifests
         run: |
           mkdir ${{ env.DOWNLOAD_PATH }}/app-releases
@@ -748,13 +758,40 @@ jobs:
           # Set the value of the variable
           my_var="Some value"
 
+          win_sha=$(shasum -a 256 ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-Windows-x64-signed-installer.msi | cut -d ' ' -f 1)
+          win_size=$(stat -f%z ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-Windows-x64-signed-installer.msi)
+          mac_sha=$(shasum -a 256 ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-macOS-x64-signed-installer.pkg | cut -d ' ' -f 1)
+          mac_size=$(stat -f%z ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-macOS-x64-signed-installer.pkg)
+          
+          version_number=${steps.set-version.outputs.version:1}
+
           # Define the JSON object to append
-          new_object=$(cat <<EOF
+          new_mac_object=$(cat <<EOF
           [{
-            "version": "1.0.0",
-            "date": "$(date +%Y-%m-%d)",
-            "description": "Added new feature",
-            "my_var_value": "$my_var"
+            "version":  "$version_number",
+            "changelog": "Full changelog at https://github.com/jacktrip/jacktrip/releases/tag/${{ steps.set-version.outputs.version }}",
+            "download": {
+                "date": "$(date "+%Y-%m-%dT00:00:00Z")",
+                "url": "https://files.jacktrip.org/app-builds/JackTrip-v1.7.1-macOS-x64-installer.pkg",
+                "downloadSize": "$mac_size",
+                "sha256": "$mac_sha"
+            }
+          }]
+          EOF
+          )
+
+          
+
+          new_win_object=$(cat <<EOF
+          [{
+            "version": "$version_number",
+            "changelog": "Full changelog at https://github.com/jacktrip/jacktrip/releases/tag/${{ steps.set-version.outputs.version }}",
+            "download": {
+                "date": "$(date "+%Y-%m-%dT00:00:00Z")",
+                "url": "https://files.jacktrip.org/app-builds/JackTrip-v1.7.1-Windows-x64-installer.pkg",
+                "downloadSize": "$win_size",
+                "sha256": "$win_sha"
+            }
           }]
           EOF
           )

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -785,11 +785,11 @@ jobs:
 
           file_sha=$(shasum -a 256 ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer${{ steps.set-version.outputs.extension}} | cut -d ' ' -f 1)
           file_size=$(stat -c%s ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer${{ steps.set-version.outputs.extension}})
-          echo "filesha=file_sha" >> $GITHUB_OUTPUT
-          echo "filesize=file_size" >> $GITHUB_OUTPUT
+          echo "filesha=$file_sha" >> $GITHUB_OUTPUT
+          echo "filesize=$file_size" >> $GITHUB_OUTPUT
           
           version_number=$(echo ${{ steps.set-version.outputs.version }} | cut -c 2- )
-          echo "versionnum=version_number" >> $GITHUB_OUTPUT
+          echo "versionnum=$version_number" >> $GITHUB_OUTPUT
 
           # Define the JSON object to append
           new_object=$(cat <<EOF
@@ -805,7 +805,7 @@ jobs:
           }]
           EOF
           )
-          echo "newobject=new_object" >> $GITHUB_OUTPUT
+          echo "newobject=$new_object" >> $GITHUB_OUTPUT
 
           # Read the existing JSON array from the file
           existing_array=$(jq '.releases' ${{ env.DOWNLOAD_PATH }}/app-releases/edge/${{ matrix.platform-name }}-manifests.json)

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -829,7 +829,7 @@ jobs:
             gcloud storage cp ${{ env.DOWNLOAD_PATH }}/app-releases/edge/${{ matrix.platform-name }}-manifests.json gs://files.jacktrip.org/app-releases/edge
           fi
       - name: Update stable manifests
-        if: "!github.event.release.prerelease"
+        if: github.event_name == 'release' && "!github.event.release.prerelease"
         run: |
           # do the full release work
           file_sha=${{ steps.update-edge.outputs.filesha }}

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -714,8 +714,23 @@ jobs:
     # if:  startsWith(github.ref, 'refs/tags/') && github.event_name == 'release' && needs.check-secrets.outputs.should_run == 'true' # use this when done
     if:  needs.check-secrets.outputs.should_run == 'true' # testing
     needs: [build, sign]
-    runs-on: ubuntu-latest
-    name: 'deploy to updater'
+    runs-on: ${{ matrix.runs-on }}
+    name: ${{ matrix.name }}
+    strategy:
+      matrix:
+        include:
+          - name: Update Windows manifests
+            if: needs.check-secrets.outputs.should_run == 'true'
+            platform-name: win
+            release-name: Windows-x64
+            build-job-name: Windows-x64-qmake-gcc-static-bundled_rtaudio
+            runs-on: ubuntu-latest
+          - name: Update Mac manifests
+            if: needs.check-secrets.outputs.should_run == 'true'
+            platform-name: mac
+            release-name: macOS-x64
+            build-job-name: macOS-x64-qmake-clang-static-bundled_rtaudio
+            runs-on: ubuntu-latest
     permissions:
       contents: "read"
       id-token: "write"
@@ -733,11 +748,24 @@ jobs:
           else
             VERSION=${GITHUB_SHA::7}
           fi
+          if [[ -n "${{ matrix.release-name }}" && "$GITHUB_REF" == refs/tags/* ]]; then
+            NAME="${{ matrix.release-name }}"
+          else
+            NAME="${{ matrix.build-job-name }}"
+          fi
+          if [[ "${{ matrix.platform-name }}" == "mac"]]; then
+            EXTENSION=".pkg"
+          else
+            EXTENSION=".msi"
+          fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "name=$NAME" >> $GITHUB_OUTPUT
+          echo "extension=$EXTENSION" >> $GITHUB_OUTPUT
       - name: download artifacts
         uses: actions/download-artifact@v2
         with:
           path: ${{ env.DOWNLOAD_PATH }} # no "name" parameter - download all artifacts
+          name: JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer
       - name: Authenticate to GCS
         uses: google-github-actions/auth@v1
         with:
@@ -747,69 +775,43 @@ jobs:
       - name: Upload files
         if: startsWith(github.ref, 'refs/tags/') && github.event_name == 'release' # don't run in testing. will remove line
         run: |
-          gcloud storage cp ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-Linux-x64-static-binary.zip gs://files.jacktrip.org/app-builds
-          gcloud storage cp ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-Windows-x64-signed-installer.msi gs://files.jacktrip.org/app-builds
-          gcloud storage cp ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-macOS-x64-signed-installer.pkg gs://files.jacktrip.org/app-builds
+          # gcloud storage cp ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-binary.zip gs://files.jacktrip.org/app-builds
+          gcloud storage cp ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer${{ steps.set-version.outputs.extension}} gs://files.jacktrip.org/app-builds
       - name: Update edge manifests
         run: |
           mkdir ${{ env.DOWNLOAD_PATH }}/app-releases
           gcloud storage cp --recursive gs://files.jacktrip.org/app-releases/* ${{ env.DOWNLOAD_PATH }}/app-releases
 
-          # Set the value of the variable
-          my_var="Some value"
-
-          win_sha=$(shasum -a 256 ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-Windows-x64-signed-installer.msi | cut -d ' ' -f 1)
-          win_size=$(stat -f%z ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-Windows-x64-signed-installer.msi)
-          mac_sha=$(shasum -a 256 ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-macOS-x64-signed-installer.pkg | cut -d ' ' -f 1)
-          mac_size=$(stat -f%z ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-macOS-x64-signed-installer.pkg)
+          file_sha=$(shasum -a 256 ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer${{ steps.set-version.outputs.extension}} | cut -d ' ' -f 1)
+          file_size=$(stat -f%z ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer${{ steps.set-version.outputs.extension}})
           
           version_number=${steps.set-version.outputs.version:1}
 
           # Define the JSON object to append
-          new_mac_object=$(cat <<EOF
+          new_object=$(cat <<EOF
           [{
             "version":  "$version_number",
             "changelog": "Full changelog at https://github.com/jacktrip/jacktrip/releases/tag/${{ steps.set-version.outputs.version }}",
             "download": {
                 "date": "$(date "+%Y-%m-%dT00:00:00Z")",
-                "url": "https://files.jacktrip.org/app-builds/JackTrip-v1.7.1-macOS-x64-installer.pkg",
-                "downloadSize": "$mac_size",
-                "sha256": "$mac_sha"
-            }
-          }]
-          EOF
-          )
-
-          
-
-          new_win_object=$(cat <<EOF
-          [{
-            "version": "$version_number",
-            "changelog": "Full changelog at https://github.com/jacktrip/jacktrip/releases/tag/${{ steps.set-version.outputs.version }}",
-            "download": {
-                "date": "$(date "+%Y-%m-%dT00:00:00Z")",
-                "url": "https://files.jacktrip.org/app-builds/JackTrip-v1.7.1-Windows-x64-installer.pkg",
-                "downloadSize": "$win_size",
-                "sha256": "$win_sha"
+                "url": "https://files.jacktrip.org/app-builds/JackTrip--${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer${{ steps.set-version.outputs.extension}}",
+                "downloadSize": "$file_size",
+                "sha256": "$file_sha"
             }
           }]
           EOF
           )
 
           # Read the existing JSON array from the file
-          existing_mac_array=$(jq '.releases' ${{ env.DOWNLOAD_PATH }}/app-releases/edge/mac-manifests.json)
-          existing_win_array=$(jq '.releases' ${{ env.DOWNLOAD_PATH }}/app-releases/edge/win-manifests.json)
+          existing_array=$(jq '.releases' ${{ env.DOWNLOAD_PATH }}/app-releases/edge/${{ matrix.platform-name }}-manifests.json)
 
           # Combine the new object and the existing array into a new array
-          new_mac_array=$(echo "$new_object $existing_mac_array" | jq -s 'add')
-          new_win_array=$(echo "$new_object $existing_win_array" | jq -s 'add')
+          new_array=$(echo "$new_object $existing_array" | jq -s 'add')
 
           # Update the "releases" key in the root object with the new array
-          jq '.releases = '"$new_mac_array" ${{ env.DOWNLOAD_PATH }}/app-releases/edge/mac-manifests.json > tmpfile && mv tmpfile ${{ env.DOWNLOAD_PATH }}/app-releases/edge/mac-manifests.json
-          jq '.releases = '"$new_win_array" ${{ env.DOWNLOAD_PATH }}/app-releases/edge/win-manifests.json > tmpfile && mv tmpfile ${{ env.DOWNLOAD_PATH }}/app-releases/edge/win-manifests.json
+          jq '.releases = '"$new_array" ${{ env.DOWNLOAD_PATH }}/app-releases/edge/${{ matrix.platform-name }}-manifests.json > tmpfile && mv tmpfile ${{ env.DOWNLOAD_PATH }}/app-releases/edge/${{ matrix.platform-name }}-manifests.json
 
-          cat ${{ env.DOWNLOAD_PATH }}/app-releases/edge/mac-manifests.json
-          cat ${{ env.DOWNLOAD_PATH }}/app-releases/edge/win-manifests.json
+          cat ${{ env.DOWNLOAD_PATH }}/app-releases/edge/${{ matrix.platform-name }}-manifests.json
       - name: Update stable manifests
         if: "!github.event.release.prerelease"
         run: |

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -829,7 +829,7 @@ jobs:
             gcloud storage cp ${{ env.DOWNLOAD_PATH }}/app-releases/edge/${{ matrix.platform-name }}-manifests.json gs://files.jacktrip.org/app-releases/edge
           fi
       - name: Update stable manifests
-        if: github.event_name == 'release' && "!github.event.release.prerelease"
+        if: github.event_name == 'release' && !github.event.release.prerelease
         run: |
           # do the full release work
           file_sha=${{ steps.update-edge.outputs.filesha }}

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -711,8 +711,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   deploy_jtl:
-    # if:  startsWith(github.ref, 'refs/tags/') && github.event_name == 'release' && needs.check-secrets.outputs.should_run == 'true' # use this when done
-    if:  needs.check-secrets.outputs.should_run == 'true' # testing
+    if:  startsWith(github.ref, 'refs/tags/') && github.event_name == 'release' && needs.check-secrets.outputs.should_run == 'true'
     needs: [build, sign]
     runs-on: ${{ matrix.runs-on }}
     name: ${{ matrix.name }}
@@ -785,7 +784,6 @@ jobs:
           service_account: ${{ env.GCS_SVC_ACCT }}
           create_credentials_file: true
       - name: Upload files
-        if: startsWith(github.ref, 'refs/tags/') && github.event_name == 'release' # don't run in testing. will remove line
         run: |
           gcloud storage cp ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-${{ steps.set-version.outputs.type }}${{ steps.set-version.outputs.extension }} gs://files.jacktrip.org/app-builds
       - name: Update edge manifests
@@ -828,7 +826,7 @@ jobs:
             jq '.releases = '"$new_array" ${{ env.DOWNLOAD_PATH }}/app-releases/edge/${{ matrix.platform-name }}-manifests.json > tmpfile && mv tmpfile ${{ env.DOWNLOAD_PATH }}/app-releases/edge/${{ matrix.platform-name }}-manifests.json
 
             cat ${{ env.DOWNLOAD_PATH }}/app-releases/edge/${{ matrix.platform-name }}-manifests.json
-            # gcloud storage cp ${{ env.DOWNLOAD_PATH }}/app-releases/edge/${{ matrix.platform-name }}-manifests.json ${{ env.DOWNLOAD_PATH }}/app-releases/edge
+            gcloud storage cp ${{ env.DOWNLOAD_PATH }}/app-releases/edge/${{ matrix.platform-name }}-manifests.json ${{ env.DOWNLOAD_PATH }}/app-releases/edge
           fi
       - name: Update stable manifests
         if: "!github.event.release.prerelease"
@@ -864,5 +862,5 @@ jobs:
           jq '.releases = '"$new_array" ${{ env.DOWNLOAD_PATH }}/app-releases/stable/${{ matrix.platform-name }}-manifests.json > tmpfile && mv tmpfile ${{ env.DOWNLOAD_PATH }}/app-releases/stable/${{ matrix.platform-name }}-manifests.json
 
           cat ${{ env.DOWNLOAD_PATH }}/app-releases/stable/${{ matrix.platform-name }}-manifests.json
-          # gcloud storage cp ${{ env.DOWNLOAD_PATH }}/app-releases/stable/${{ matrix.platform-name }}-manifests.json ${{ env.DOWNLOAD_PATH }}/app-releases/stable
+          gcloud storage cp ${{ env.DOWNLOAD_PATH }}/app-releases/stable/${{ matrix.platform-name }}-manifests.json ${{ env.DOWNLOAD_PATH }}/app-releases/stable
           

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -625,7 +625,6 @@ jobs:
       matrix:
         include:
           - name: Sign Windows artifacts
-            if: needs.check-secrets.outputs.should_run == 'true'
             release-name: Windows-x64
             build-job-name: Windows-x64-qmake-gcc-static-bundled_rtaudio
             runs-on: ubuntu-latest
@@ -637,10 +636,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        if: needs.check-secrets.outputs.should_run == 'true'
         with:
           fetch-depth: 0
           submodules: true
       - name: set version string for artifacts
+        if: needs.check-secrets.outputs.should_run == 'true'
         shell: bash
         id: set-version
         run: |
@@ -658,18 +659,18 @@ jobs:
           echo "name=$NAME" >> $GITHUB_OUTPUT
       - name: Retrieve binary artifact
         uses: actions/download-artifact@v2
-        if: matrix.binary-path && (!startsWith(github.ref, 'refs/tags/') || (startsWith(github.ref, 'refs/tags/') && matrix.release-name))
+        if: (matrix.binary-path && (!startsWith(github.ref, 'refs/tags/') || (startsWith(github.ref, 'refs/tags/') && matrix.release-name))) && needs.check-secrets.outputs.should_run == 'true'
         with:
           name: JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-binary
           path: ${{ env.BUILD_PATH }}/${{ matrix.binary-path }}
       - name: Retrieve Windows installer artifact
         uses: actions/download-artifact@v2
-        if: runner.os == 'Linux' && matrix.installer-path && (!startsWith(github.ref, 'refs/tags/') || (startsWith(github.ref, 'refs/tags/') && matrix.release-name))
+        if: (runner.os == 'Linux' && matrix.installer-path && (!startsWith(github.ref, 'refs/tags/') || (startsWith(github.ref, 'refs/tags/') && matrix.release-name))) && needs.check-secrets.outputs.should_run == 'true'
         with:
           name: JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer
           path: ${{ env.BUILD_PATH }}/${{ matrix.installer-path }}
       - name: sign artifacts for Windows
-        if: runner.os == 'Linux' && matrix.installer-path
+        if: runner.os == 'Linux' && matrix.installer-path && needs.check-secrets.outputs.should_run == 'true'
         env:
           TOTP: ${{ secrets.TOTP_SECRET }}
           CRED_ID: ${{ secrets.ESIGNER_CREDENTIAL_ID }}
@@ -685,7 +686,7 @@ jobs:
           rm $BUILD_PATH/${{ matrix.installer-path }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer.msi
       - name: upload installer
         uses: actions/upload-artifact@v3
-        if: matrix.installer-path && (!startsWith(github.ref, 'refs/tags/') || (startsWith(github.ref, 'refs/tags/') && matrix.release-name))
+        if: (matrix.installer-path && (!startsWith(github.ref, 'refs/tags/') || (startsWith(github.ref, 'refs/tags/') && matrix.release-name))) && needs.check-secrets.outputs.should_run == 'true'
         with:
           name: JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer
           path: ${{ env.BUILD_PATH }}/${{ matrix.installer-path }}

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -785,7 +785,7 @@ jobs:
           file_sha=$(shasum -a 256 ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer${{ steps.set-version.outputs.extension}} | cut -d ' ' -f 1)
           file_size=$(stat -c%s ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer${{ steps.set-version.outputs.extension}})
           
-          version_number=$(echo ${{ steps.set-version.outputs.version }} | cut -c 1- )
+          version_number=$(echo ${{ steps.set-version.outputs.version }} | cut -c 2- )
 
           # Define the JSON object to append
           new_object=$(cat <<EOF

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -635,11 +635,11 @@ jobs:
       BUILD_PATH: ${{ github.workspace }}/builddir
 
     steps:
-      - uses: actions/checkout@v2
-        if: needs.check-secrets.outputs.should_run == 'true'
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: true
+        if: needs.check-secrets.outputs.should_run == 'true'
       - name: set version string for artifacts
         if: needs.check-secrets.outputs.should_run == 'true'
         shell: bash

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -802,22 +802,22 @@ jobs:
           version_number=$(echo ${{ steps.set-version.outputs.version }} | cut -c 2- )
           echo "versionnum=$version_number" >> $GITHUB_OUTPUT
 
-          if [[ "${{ matrix.platform-name }}" != "linux"  ]]; then
-            # Define the JSON object to append
-            new_object=$(cat <<EOF
-            [{
-              "version":  "$version_number",
-              "changelog": "Full changelog at https://github.com/jacktrip/jacktrip/releases/tag/${{ steps.set-version.outputs.version }}",
-              "download": {
-                  "date": "$(date "+%Y-%m-%dT00:00:00Z")",
-                  "url": "https://files.jacktrip.org/app-builds/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-${{ steps.set-version.outputs.type }}${{ steps.set-version.outputs.extension }}",
-                  "downloadSize": "$file_size",
-                  "sha256": "$file_sha"
-              }
-            }]
-            EOF
-            )
+          # Define the JSON object to append
+          new_object=$(cat <<EOF
+          [{
+            "version":  "$version_number",
+            "changelog": "Full changelog at https://github.com/jacktrip/jacktrip/releases/tag/${{ steps.set-version.outputs.version }}",
+            "download": {
+                "date": "$(date "+%Y-%m-%dT00:00:00Z")",
+                "url": "https://files.jacktrip.org/app-builds/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-${{ steps.set-version.outputs.type }}${{ steps.set-version.outputs.extension }}",
+                "downloadSize": "$file_size",
+                "sha256": "$file_sha"
+            }
+          }]
+          EOF
+          )
 
+          if [[ "${{ matrix.platform-name }}" != "linux"  ]]; then
             # Read the existing JSON array from the file
             existing_array=$(jq '.releases' ${{ env.DOWNLOAD_PATH }}/app-releases/edge/${{ matrix.platform-name }}-manifests.json)
 

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -798,7 +798,7 @@ jobs:
             "changelog": "Full changelog at https://github.com/jacktrip/jacktrip/releases/tag/${{ steps.set-version.outputs.version }}",
             "download": {
                 "date": "$(date "+%Y-%m-%dT00:00:00Z")",
-                "url": "https://files.jacktrip.org/app-builds/JackTrip--${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer${{ steps.set-version.outputs.extension}}",
+                "url": "https://files.jacktrip.org/app-builds/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer${{ steps.set-version.outputs.extension}}",
                 "downloadSize": "$file_size",
                 "sha256": "$file_sha"
             }
@@ -833,7 +833,7 @@ jobs:
             "changelog": "Full changelog at https://github.com/jacktrip/jacktrip/releases/tag/${{ steps.set-version.outputs.version }}",
             "download": {
                 "date": "$(date "+%Y-%m-%dT00:00:00Z")",
-                "url": "https://files.jacktrip.org/app-builds/JackTrip--${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer${{ steps.set-version.outputs.extension}}",
+                "url": "https://files.jacktrip.org/app-builds/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer${{ steps.set-version.outputs.extension}}",
                 "downloadSize": "$file_size",
                 "sha256": "$file_sha"
             }

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -789,7 +789,6 @@ jobs:
         run: |
           gcloud storage cp ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-${{ steps.set-version.outputs.type }}${{ steps.set-version.outputs.extension }} gs://files.jacktrip.org/app-builds
       - name: Update edge manifests
-        if: ${{ matrix.platform-name }} != "linux" 
         id: update-edge
         run: |
           mkdir ${{ env.DOWNLOAD_PATH }}/app-releases
@@ -803,32 +802,34 @@ jobs:
           version_number=$(echo ${{ steps.set-version.outputs.version }} | cut -c 2- )
           echo "versionnum=$version_number" >> $GITHUB_OUTPUT
 
-          # Define the JSON object to append
-          new_object=$(cat <<EOF
-          [{
-            "version":  "$version_number",
-            "changelog": "Full changelog at https://github.com/jacktrip/jacktrip/releases/tag/${{ steps.set-version.outputs.version }}",
-            "download": {
-                "date": "$(date "+%Y-%m-%dT00:00:00Z")",
-                "url": "https://files.jacktrip.org/app-builds/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-${{ steps.set-version.outputs.type }}${{ steps.set-version.outputs.extension }}",
-                "downloadSize": "$file_size",
-                "sha256": "$file_sha"
-            }
-          }]
-          EOF
-          )
+          if [[ "${{ matrix.platform-name }}" != "linux"  ]]; then
+            # Define the JSON object to append
+            new_object=$(cat <<EOF
+            [{
+              "version":  "$version_number",
+              "changelog": "Full changelog at https://github.com/jacktrip/jacktrip/releases/tag/${{ steps.set-version.outputs.version }}",
+              "download": {
+                  "date": "$(date "+%Y-%m-%dT00:00:00Z")",
+                  "url": "https://files.jacktrip.org/app-builds/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-${{ steps.set-version.outputs.type }}${{ steps.set-version.outputs.extension }}",
+                  "downloadSize": "$file_size",
+                  "sha256": "$file_sha"
+              }
+            }]
+            EOF
+            )
 
-          # Read the existing JSON array from the file
-          existing_array=$(jq '.releases' ${{ env.DOWNLOAD_PATH }}/app-releases/edge/${{ matrix.platform-name }}-manifests.json)
+            # Read the existing JSON array from the file
+            existing_array=$(jq '.releases' ${{ env.DOWNLOAD_PATH }}/app-releases/edge/${{ matrix.platform-name }}-manifests.json)
 
-          # Combine the new object and the existing array into a new array
-          new_array=$(echo "$new_object $existing_array" | jq -s 'add')
+            # Combine the new object and the existing array into a new array
+            new_array=$(echo "$new_object $existing_array" | jq -s 'add')
 
-          # Update the "releases" key in the root object with the new array
-          jq '.releases = '"$new_array" ${{ env.DOWNLOAD_PATH }}/app-releases/edge/${{ matrix.platform-name }}-manifests.json > tmpfile && mv tmpfile ${{ env.DOWNLOAD_PATH }}/app-releases/edge/${{ matrix.platform-name }}-manifests.json
+            # Update the "releases" key in the root object with the new array
+            jq '.releases = '"$new_array" ${{ env.DOWNLOAD_PATH }}/app-releases/edge/${{ matrix.platform-name }}-manifests.json > tmpfile && mv tmpfile ${{ env.DOWNLOAD_PATH }}/app-releases/edge/${{ matrix.platform-name }}-manifests.json
 
-          cat ${{ env.DOWNLOAD_PATH }}/app-releases/edge/${{ matrix.platform-name }}-manifests.json
-          # gcloud storage cp ${{ env.DOWNLOAD_PATH }}/app-releases/edge/${{ matrix.platform-name }}-manifests.json ${{ env.DOWNLOAD_PATH }}/app-releases/edge
+            cat ${{ env.DOWNLOAD_PATH }}/app-releases/edge/${{ matrix.platform-name }}-manifests.json
+            # gcloud storage cp ${{ env.DOWNLOAD_PATH }}/app-releases/edge/${{ matrix.platform-name }}-manifests.json ${{ env.DOWNLOAD_PATH }}/app-releases/edge
+          fi
       - name: Update stable manifests
         if: "!github.event.release.prerelease"
         run: |

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -721,6 +721,8 @@ jobs:
       id-token: "write"
     env:
       DOWNLOAD_PATH: ${{ github.workspace }}/Install
+      GCP_IDP: ${{ secrets.GCP_IDP }}
+      GCS_SVC_ACCT: ${{ secrets.GCS_SVC_ACCT }}
     steps:
       - name: download artifacts
         uses: actions/download-artifact@v2

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -618,7 +618,6 @@ jobs:
           path: ${{ env.CLANG_TIDY_PATH }}/
   sign:
     needs: [build, check-secrets]
-    if: needs.check-secrets.outputs.should_run == 'true'
     runs-on: ${{ matrix.runs-on }}
     name: ${{ matrix.name }}
     strategy:
@@ -626,6 +625,7 @@ jobs:
       matrix:
         include:
           - name: Sign Windows artifacts
+            if: needs.check-secrets.outputs.should_run == 'true'
             release-name: Windows-x64
             build-job-name: Windows-x64-qmake-gcc-static-bundled_rtaudio
             runs-on: ubuntu-latest
@@ -691,7 +691,7 @@ jobs:
           path: ${{ env.BUILD_PATH }}/${{ matrix.installer-path }}
   # release - list of files uploaded to GH release is specified in the *upload* step
   deploy_test:
-    needs: build
+    needs: [build, sign]
     runs-on: ubuntu-latest
     name: 'deploy release'
     env:
@@ -707,7 +707,7 @@ jobs:
           ls ${{ env.DOWNLOAD_PATH }}/JackTrip*/*
   deploy_gh:
     if: startsWith(github.ref, 'refs/tags/') # run on tagged commits
-    needs: build
+    needs: [build, sign]
     runs-on: ubuntu-latest
     name: 'deploy release'
     env:

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -778,7 +778,6 @@ jobs:
           # gcloud storage cp ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-binary.zip gs://files.jacktrip.org/app-builds
           gcloud storage cp ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer${{ steps.set-version.outputs.extension}} gs://files.jacktrip.org/app-builds
       - name: Update edge manifests
-        shell: bash
         run: |
           mkdir ${{ env.DOWNLOAD_PATH }}/app-releases
           gcloud storage cp --recursive gs://files.jacktrip.org/app-releases/* ${{ env.DOWNLOAD_PATH }}/app-releases
@@ -786,7 +785,7 @@ jobs:
           file_sha=$(shasum -a 256 ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer${{ steps.set-version.outputs.extension}} | cut -d ' ' -f 1)
           file_size=$(stat -c%s ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer${{ steps.set-version.outputs.extension}})
           
-          version_number=${steps.set-version.outputs.version:1}
+          version_number=$(echo ${{ steps.set-version.outputs.version }} | cut -c 1- )
 
           # Define the JSON object to append
           new_object=$(cat <<EOF

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -711,7 +711,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   deploy_jtl:
-    if:  startsWith(github.ref, 'refs/tags/') && github.event_name == 'release' && needs.check-secrets.outputs.should_run == 'true'
+    # if:  startsWith(github.ref, 'refs/tags/') && github.event_name == 'release' && needs.check-secrets.outputs.should_run == 'true' # use this when done
+    if:  needs.check-secrets.outputs.should_run == 'true' # testing
     needs: [build, sign]
     runs-on: ${{ matrix.runs-on }}
     name: ${{ matrix.name }}

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -753,7 +753,7 @@ jobs:
           else
             NAME="${{ matrix.build-job-name }}"
           fi
-          if [[ "${{ matrix.platform-name }}" == "mac"]]; then
+          if [[ "${{ matrix.platform-name }}" == "mac" ]]; then
             EXTENSION=".pkg"
           else
             EXTENSION=".msi"

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -750,12 +750,12 @@ jobs:
 
           # Define the JSON object to append
           new_object=$(cat <<EOF
-          {
+          [{
             "version": "1.0.0",
             "date": "$(date +%Y-%m-%d)",
             "description": "Added new feature",
             "my_var_value": "$my_var"
-          }
+          }]
           EOF
           )
 
@@ -764,8 +764,8 @@ jobs:
           existing_win_array=$(jq '.releases' ${{ env.DOWNLOAD_PATH }}/app-releases/edge/win-manifests.json)
 
           # Combine the new object and the existing array into a new array
-          new_mac_array=$(echo "$new_object $existing_mac_array" | jq -s '.[0] + .[1:]')
-          new_win_array=$(echo "$new_object $existing_win_array" | jq -s '.[0] + .[1:]')
+          new_mac_array=$(echo "$new_object $existing_mac_array" | jq -s 'add')
+          new_win_array=$(echo "$new_object $existing_win_array" | jq -s 'add')
 
           # Update the "releases" key in the root object with the new array
           jq '.releases = '"$new_mac_array" ${{ env.DOWNLOAD_PATH }}/app-releases/edge/mac-manifests.json > tmpfile && mv tmpfile ${{ env.DOWNLOAD_PATH }}/app-releases/edge/mac-manifests.json

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -731,6 +731,12 @@ jobs:
             release-name: macOS-x64
             build-job-name: macOS-x64-qmake-clang-static-bundled_rtaudio
             runs-on: ubuntu-latest
+          - name: Update Linux manifests
+            if: needs.check-secrets.outputs.should_run == 'true'
+            platform-name: linux
+            release-name: Linux-x64
+            build-job-name: Linux-x64-qmake-gcc-static
+            runs-on: ubuntu-latest
     permissions:
       contents: "read"
       id-token: "write"
@@ -754,9 +760,11 @@ jobs:
             NAME="${{ matrix.build-job-name }}"
           fi
           if [[ "${{ matrix.platform-name }}" == "mac" ]]; then
-            EXTENSION=".pkg"
+            EXTENSION="signed-installer.pkg"
+          elif [[ "${{ matrix.platform-name }}" == "win" ]]; then
+            EXTENSION="signed-installer.msi"
           else
-            EXTENSION=".msi"
+            EXTENSION="binary.zip"
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "name=$NAME" >> $GITHUB_OUTPUT
@@ -765,7 +773,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           path: ${{ env.DOWNLOAD_PATH }} # no "name" parameter - download all artifacts
-          name: JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer
+          name: JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-${{ steps.set-version.outputs.extension }}
       - name: Authenticate to GCS
         uses: google-github-actions/auth@v1
         with:
@@ -775,16 +783,16 @@ jobs:
       - name: Upload files
         if: startsWith(github.ref, 'refs/tags/') && github.event_name == 'release' # don't run in testing. will remove line
         run: |
-          # gcloud storage cp ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-binary.zip gs://files.jacktrip.org/app-builds
-          gcloud storage cp ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer${{ steps.set-version.outputs.extension}} gs://files.jacktrip.org/app-builds
+          gcloud storage cp ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-${{ steps.set-version.outputs.extension }} gs://files.jacktrip.org/app-builds
       - name: Update edge manifests
+        if: ${{ matrix.platform-name }} != "linux" 
         id: update-edge
         run: |
           mkdir ${{ env.DOWNLOAD_PATH }}/app-releases
           gcloud storage cp --recursive gs://files.jacktrip.org/app-releases/* ${{ env.DOWNLOAD_PATH }}/app-releases
 
-          file_sha=$(shasum -a 256 ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer${{ steps.set-version.outputs.extension}} | cut -d ' ' -f 1)
-          file_size=$(stat -c%s ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer${{ steps.set-version.outputs.extension}})
+          file_sha=$(shasum -a 256 ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-${{ steps.set-version.outputs.extension }} | cut -d ' ' -f 1)
+          file_size=$(stat -c%s ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-${{ steps.set-version.outputs.extension }})
           echo "filesha=$file_sha" >> $GITHUB_OUTPUT
           echo "filesize=$file_size" >> $GITHUB_OUTPUT
           
@@ -798,7 +806,7 @@ jobs:
             "changelog": "Full changelog at https://github.com/jacktrip/jacktrip/releases/tag/${{ steps.set-version.outputs.version }}",
             "download": {
                 "date": "$(date "+%Y-%m-%dT00:00:00Z")",
-                "url": "https://files.jacktrip.org/app-builds/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer${{ steps.set-version.outputs.extension}}",
+                "url": "https://files.jacktrip.org/app-builds/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-${{ steps.set-version.outputs.extension}}",
                 "downloadSize": "$file_size",
                 "sha256": "$file_sha"
             }
@@ -833,7 +841,7 @@ jobs:
             "changelog": "Full changelog at https://github.com/jacktrip/jacktrip/releases/tag/${{ steps.set-version.outputs.version }}",
             "download": {
                 "date": "$(date "+%Y-%m-%dT00:00:00Z")",
-                "url": "https://files.jacktrip.org/app-builds/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer${{ steps.set-version.outputs.extension}}",
+                "url": "https://files.jacktrip.org/app-builds/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-${{ steps.set-version.outputs.extension}}",
                 "downloadSize": "$file_size",
                 "sha256": "$file_sha"
             }

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -805,7 +805,6 @@ jobs:
           }]
           EOF
           )
-          echo "newobject=$new_object" >> $GITHUB_OUTPUT
 
           # Read the existing JSON array from the file
           existing_array=$(jq '.releases' ${{ env.DOWNLOAD_PATH }}/app-releases/edge/${{ matrix.platform-name }}-manifests.json)
@@ -828,7 +827,19 @@ jobs:
           version_number=${{ steps.update-edge.outputs.versionnum }}
 
           # Define the JSON object to append
-          new_object=${{ steps.update-edge.outputs.newobject }}
+          new_object=$(cat <<EOF
+          [{
+            "version":  "$version_number",
+            "changelog": "Full changelog at https://github.com/jacktrip/jacktrip/releases/tag/${{ steps.set-version.outputs.version }}",
+            "download": {
+                "date": "$(date "+%Y-%m-%dT00:00:00Z")",
+                "url": "https://files.jacktrip.org/app-builds/JackTrip--${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-installer${{ steps.set-version.outputs.extension}}",
+                "downloadSize": "$file_size",
+                "sha256": "$file_sha"
+            }
+          }]
+          EOF
+          )
 
           # Read the existing JSON array from the file
           existing_array=$(jq '.releases' ${{ env.DOWNLOAD_PATH }}/app-releases/stable/${{ matrix.platform-name }}-manifests.json)

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -764,8 +764,8 @@ jobs:
           existing_win_array=$(jq '.releases' ${{ env.DOWNLOAD_PATH }}/app-releases/edge/win-manifests.json)
 
           # Combine the new object and the existing array into a new array
-          new_mac_array=$(echo "$new_object $existing_mac_array" | jq -s .)
-          new_win_array=$(echo "$new_object $existing_win_array" | jq -s .)
+          new_mac_array=$(echo "$new_object $existing_mac_array" | jq -s '.[0] + .[1:]')
+          new_win_array=$(echo "$new_object $existing_win_array" | jq -s '.[0] + .[1:]')
 
           # Update the "releases" key in the root object with the new array
           jq '.releases = '"$new_mac_array" ${{ env.DOWNLOAD_PATH }}/app-releases/edge/mac-manifests.json > tmpfile && mv tmpfile ${{ env.DOWNLOAD_PATH }}/app-releases/edge/mac-manifests.json

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -711,8 +711,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   deploy_jtl:
-    # if:  startsWith(github.ref, 'refs/tags/') && github.event_name == 'release' && needs.check-secrets.outputs.should_run == 'true' # use this when done
-    if:  needs.check-secrets.outputs.should_run == 'true' # testing
+    if:  startsWith(github.ref, 'refs/tags/') && github.event_name == 'release' && needs.check-secrets.outputs.should_run == 'true'
     needs: [build, sign]
     runs-on: ${{ matrix.runs-on }}
     name: ${{ matrix.name }}

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -778,14 +778,18 @@ jobs:
           # gcloud storage cp ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-binary.zip gs://files.jacktrip.org/app-builds
           gcloud storage cp ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer${{ steps.set-version.outputs.extension}} gs://files.jacktrip.org/app-builds
       - name: Update edge manifests
+        id: update-edge
         run: |
           mkdir ${{ env.DOWNLOAD_PATH }}/app-releases
           gcloud storage cp --recursive gs://files.jacktrip.org/app-releases/* ${{ env.DOWNLOAD_PATH }}/app-releases
 
           file_sha=$(shasum -a 256 ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer${{ steps.set-version.outputs.extension}} | cut -d ' ' -f 1)
           file_size=$(stat -c%s ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer${{ steps.set-version.outputs.extension}})
+          echo "filesha=file_sha" >> $GITHUB_OUTPUT
+          echo "filesize=file_size" >> $GITHUB_OUTPUT
           
           version_number=$(echo ${{ steps.set-version.outputs.version }} | cut -c 2- )
+          echo "versionnum=version_number" >> $GITHUB_OUTPUT
 
           # Define the JSON object to append
           new_object=$(cat <<EOF
@@ -801,6 +805,7 @@ jobs:
           }]
           EOF
           )
+          echo "newobject=new_object" >> $GITHUB_OUTPUT
 
           # Read the existing JSON array from the file
           existing_array=$(jq '.releases' ${{ env.DOWNLOAD_PATH }}/app-releases/edge/${{ matrix.platform-name }}-manifests.json)
@@ -812,8 +817,28 @@ jobs:
           jq '.releases = '"$new_array" ${{ env.DOWNLOAD_PATH }}/app-releases/edge/${{ matrix.platform-name }}-manifests.json > tmpfile && mv tmpfile ${{ env.DOWNLOAD_PATH }}/app-releases/edge/${{ matrix.platform-name }}-manifests.json
 
           cat ${{ env.DOWNLOAD_PATH }}/app-releases/edge/${{ matrix.platform-name }}-manifests.json
+          # gcloud storage cp ${{ env.DOWNLOAD_PATH }}/app-releases/edge/${{ matrix.platform-name }}-manifests.json ${{ env.DOWNLOAD_PATH }}/app-releases/edge
       - name: Update stable manifests
         if: "!github.event.release.prerelease"
         run: |
           # do the full release work
+          file_sha=${{ steps.update-edge.outputs.filesha }}
+          file_size=${{ steps.update-edge.outputs.filesize }}
+          
+          version_number=${{ steps.update-edge.outputs.versionnum }}
+
+          # Define the JSON object to append
+          new_object=${{ steps.update-edge.outputs.newobject }}
+
+          # Read the existing JSON array from the file
+          existing_array=$(jq '.releases' ${{ env.DOWNLOAD_PATH }}/app-releases/stable/${{ matrix.platform-name }}-manifests.json)
+
+          # Combine the new object and the existing array into a new array
+          new_array=$(echo "$new_object $existing_array" | jq -s 'add')
+
+          # Update the "releases" key in the root object with the new array
+          jq '.releases = '"$new_array" ${{ env.DOWNLOAD_PATH }}/app-releases/stable/${{ matrix.platform-name }}-manifests.json > tmpfile && mv tmpfile ${{ env.DOWNLOAD_PATH }}/app-releases/stable/${{ matrix.platform-name }}-manifests.json
+
+          cat ${{ env.DOWNLOAD_PATH }}/app-releases/stable/${{ matrix.platform-name }}-manifests.json
+          # gcloud storage cp ${{ env.DOWNLOAD_PATH }}/app-releases/stable/${{ matrix.platform-name }}-manifests.json ${{ env.DOWNLOAD_PATH }}/app-releases/stable
           

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -783,7 +783,7 @@ jobs:
           gcloud storage cp --recursive gs://files.jacktrip.org/app-releases/* ${{ env.DOWNLOAD_PATH }}/app-releases
 
           file_sha=$(shasum -a 256 ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer${{ steps.set-version.outputs.extension}} | cut -d ' ' -f 1)
-          file_size=$(stat -f%z ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer${{ steps.set-version.outputs.extension}})
+          file_size=$(stat -c%s ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-signed-installer${{ steps.set-version.outputs.extension}})
           
           version_number=${steps.set-version.outputs.version:1}
 

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -760,20 +760,24 @@ jobs:
             NAME="${{ matrix.build-job-name }}"
           fi
           if [[ "${{ matrix.platform-name }}" == "mac" ]]; then
-            EXTENSION="signed-installer.pkg"
+            EXTENSION=".pkg"
+            TYPE="signed-installer"
           elif [[ "${{ matrix.platform-name }}" == "win" ]]; then
-            EXTENSION="signed-installer.msi"
+            EXTENSION=".msi"
+            TYPE="signed-installer"
           else
-            EXTENSION="binary.zip"
+            EXTENSION=".zip"
+            TYPE="binary"
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "name=$NAME" >> $GITHUB_OUTPUT
           echo "extension=$EXTENSION" >> $GITHUB_OUTPUT
+          echo "type=$TYPE" >> $GITHUB_OUTPUT
       - name: download artifacts
         uses: actions/download-artifact@v2
         with:
           path: ${{ env.DOWNLOAD_PATH }} # no "name" parameter - download all artifacts
-          name: JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-${{ steps.set-version.outputs.extension }}
+          name: JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-${{ steps.set-version.outputs.type }}
       - name: Authenticate to GCS
         uses: google-github-actions/auth@v1
         with:
@@ -783,7 +787,7 @@ jobs:
       - name: Upload files
         if: startsWith(github.ref, 'refs/tags/') && github.event_name == 'release' # don't run in testing. will remove line
         run: |
-          gcloud storage cp ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-${{ steps.set-version.outputs.extension }} gs://files.jacktrip.org/app-builds
+          gcloud storage cp ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-${{ steps.set-version.outputs.type }}${{ steps.set-version.outputs.extension }} gs://files.jacktrip.org/app-builds
       - name: Update edge manifests
         if: ${{ matrix.platform-name }} != "linux" 
         id: update-edge
@@ -791,8 +795,8 @@ jobs:
           mkdir ${{ env.DOWNLOAD_PATH }}/app-releases
           gcloud storage cp --recursive gs://files.jacktrip.org/app-releases/* ${{ env.DOWNLOAD_PATH }}/app-releases
 
-          file_sha=$(shasum -a 256 ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-${{ steps.set-version.outputs.extension }} | cut -d ' ' -f 1)
-          file_size=$(stat -c%s ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-${{ steps.set-version.outputs.extension }})
+          file_sha=$(shasum -a 256 ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-${{ steps.set-version.outputs.type }}${{ steps.set-version.outputs.extension }} | cut -d ' ' -f 1)
+          file_size=$(stat -c%s ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-${{ steps.set-version.outputs.type }}${{ steps.set-version.outputs.extension }})
           echo "filesha=$file_sha" >> $GITHUB_OUTPUT
           echo "filesize=$file_size" >> $GITHUB_OUTPUT
           
@@ -806,7 +810,7 @@ jobs:
             "changelog": "Full changelog at https://github.com/jacktrip/jacktrip/releases/tag/${{ steps.set-version.outputs.version }}",
             "download": {
                 "date": "$(date "+%Y-%m-%dT00:00:00Z")",
-                "url": "https://files.jacktrip.org/app-builds/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-${{ steps.set-version.outputs.extension}}",
+                "url": "https://files.jacktrip.org/app-builds/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-${{ steps.set-version.outputs.type }}${{ steps.set-version.outputs.extension }}",
                 "downloadSize": "$file_size",
                 "sha256": "$file_sha"
             }
@@ -841,7 +845,7 @@ jobs:
             "changelog": "Full changelog at https://github.com/jacktrip/jacktrip/releases/tag/${{ steps.set-version.outputs.version }}",
             "download": {
                 "date": "$(date "+%Y-%m-%dT00:00:00Z")",
-                "url": "https://files.jacktrip.org/app-builds/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-${{ steps.set-version.outputs.extension}}",
+                "url": "https://files.jacktrip.org/app-builds/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-${{ steps.set-version.outputs.type }}${{ steps.set-version.outputs.extension }}",
                 "downloadSize": "$file_size",
                 "sha256": "$file_sha"
             }

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -742,6 +742,7 @@ jobs:
           gcloud storage cp ${{ env.DOWNLOAD_PATH }}/JackTrip*-macOS*-signed-installer.pkg gs://files.jacktrip.org/app-builds
       - name: Update edge manifests
         run: |
+          mkdir ${{ env.DOWNLOAD_PATH }}/app-releases
           gcloud storage cp --recursive gs://files.jacktrip.org/app-releases/* ${{ env.DOWNLOAD_PATH }}/app-releases
 
           # Set the value of the variable


### PR DESCRIPTION
**To start**:

We ran into an issue where Github was caching the manifest files for multiple days. So we're moving them to files.jacktrip.org.

**What this PR does**: 

On release, github actions will now take the newly created and signed release artifacts, upload them to files.jacktrip.org, download the manifest files, update them with a new release that points to those artifacts, and upload the updated manifest files. 

This takes a lot of the manual work out of releasing with the auto-updater.

The last part of the process that is still manual is moving the signed artifacts over the this repo to replace the unsigned ones.

Again, none of this happens on this repo, as the secrets are not available.

**Coming soon**:

A separate PR (then release) to update the url the desktop app points to when looking for updates. 