### PR TITLE
Replace QVector in meter code 

### DIFF
--- a/src/Auth.h
+++ b/src/Auth.h
@@ -54,17 +54,28 @@ class Auth : public QObject
         WRONGTIME   = 5 << 16
     };
 
-    Auth(const QString& fileName, QObject* parent = nullptr);
+    Auth(const QString& fileName = "", bool monitorChanges = false,
+         QObject* parent = nullptr);
     ~Auth();
 
     AuthResponseT checkCredentials(const QString& username, const QString& password);
+    bool setFileName(const QString& fileName, bool readFile = true);
+    QStringList getUsers();
+    QString getTimes(const QString& username);
+    void deleteUser(const QString& username);
+    void editUser(const QString& username, const QString& times,
+                  const QString& password = "");
+    bool writeFile();
+
+    QString generateSalt();
 
    private slots:
     void reloadAuthFile();
 
    private:
-    void loadAuthFile(const QString& filename);
+    bool loadAuthFile(const QString& filename);
     bool checkTime(const QString& username);
+    bool verifyTimeFormat(const QString& times);
 
     char char64(int value);
     QByteArray charGroup(unsigned char byte3, unsigned char byte2, unsigned char byte1,
@@ -77,6 +88,7 @@ class Auth : public QObject
     QHash<QString, QString> m_timesTable;
 
     QString m_authFileName;
+    bool m_monitorChanges;
     QFileSystemWatcher m_authFileWatcher;
 };
 

--- a/src/Meter.cpp
+++ b/src/Meter.cpp
@@ -38,8 +38,6 @@
 
 #include "Meter.h"
 
-#include <QVector>
-
 #include "jacktrip_types.h"
 
 //*******************************************************************************

--- a/src/Meter.h
+++ b/src/Meter.h
@@ -41,7 +41,6 @@
 
 #include <QObject>
 #include <QTimer>
-#include <QVector>
 #include <iostream>
 #include <vector>
 

--- a/src/Meter.h
+++ b/src/Meter.h
@@ -73,6 +73,15 @@ class Meter : public ProcessPlugin
             delete meterP[i];
         }
         meterP.clear();
+        if (mValues) {
+            delete mValues;
+        }
+        if (mOutValues) {
+            delete mOutValues;
+        }
+        if (mBuffer) {
+            delete mBuffer;
+        }
     }
 
     void init(int samplingRate) override;
@@ -84,6 +93,8 @@ class Meter : public ProcessPlugin
     void updateNumChannels(int nChansIn, int nChansOut) override;
 
    private:
+    void setupValues();
+
     float fs;
     int mNumChannels;
     float threshold = -80.0;
@@ -91,13 +102,16 @@ class Meter : public ProcessPlugin
     bool hasProcessedAudio = false;
 
     QTimer mTimer;
-    QVector<float> mValues;
+    float* mValues    = nullptr;
+    float* mOutValues = nullptr;
+    float* mBuffer    = nullptr;
+    int mBufSize      = 0;
 
    private slots:
     void onTick();
 
    signals:
-    void onComputedVolumeMeasurements(QVector<float> values);
+    void onComputedVolumeMeasurements(float* values, int n);
 };
 
 #endif

--- a/src/UdpHubListener.cpp
+++ b/src/UdpHubListener.cpp
@@ -218,7 +218,7 @@ void UdpHubListener::start()
             emit signalError(error_message);
             return;
         }
-        mAuth.reset(new Auth(mCredsFile));
+        mAuth.reset(new Auth(mCredsFile, true));
     }
 
     cout << "JackTrip HUB SERVER: Waiting for client connections..." << endl;

--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -28,6 +28,7 @@
 #include <QFileDialog>
 #include <QHostAddress>
 #include <QMessageBox>
+#include <QProcess>
 #include <QSettings>
 #include <QVector>
 #include <cstdlib>
@@ -220,6 +221,21 @@ QJackTrip::QJackTrip(Settings* settings, bool suppressCommandlineWarning, QWidge
         m_ui->outLimiterLabel->setEnabled(m_ui->outLimiterCheckBox->isChecked());
         m_ui->outClientsSpinBox->setEnabled(m_ui->outLimiterCheckBox->isChecked());
     });
+
+    connect(m_ui->connectScriptCheckBox, &QCheckBox::stateChanged, this, [=]() {
+        m_ui->connectScriptEdit->setEnabled(m_ui->connectScriptCheckBox->isChecked());
+        m_ui->connectScriptBrowse->setEnabled(m_ui->connectScriptCheckBox->isChecked());
+    });
+    connect(m_ui->disconnectScriptCheckBox, &QCheckBox::stateChanged, this, [=]() {
+        m_ui->disconnectScriptEdit->setEnabled(
+            m_ui->disconnectScriptCheckBox->isChecked());
+        m_ui->disconnectScriptBrowse->setEnabled(
+            m_ui->disconnectScriptCheckBox->isChecked());
+    });
+    connect(m_ui->connectScriptBrowse, &QPushButton::clicked, this,
+            &QJackTrip::browseForFile);
+    connect(m_ui->disconnectScriptBrowse, &QPushButton::clicked, this,
+            &QJackTrip::browseForFile);
 
     connect(m_netManager.data(), &QNetworkAccessManager::finished, this,
             &QJackTrip::receivedIP);
@@ -482,6 +498,21 @@ void QJackTrip::processFinished()
     } else {
         m_jackTrip.reset();
     }
+
+    if (m_ui->disconnectScriptCheckBox->isChecked()) {
+        QStringList arguments = m_ui->disconnectScriptEdit->text().split(
+            QStringLiteral(" "), Qt::SkipEmptyParts);
+        if (!arguments.isEmpty()) {
+            QProcess disconnectScript;
+            disconnectScript.setProgram(arguments.takeFirst());
+            disconnectScript.setWorkingDirectory(QDir::homePath());
+            disconnectScript.setArguments(arguments);
+            disconnectScript.setStandardOutputFile(QProcess::nullDevice());
+            disconnectScript.setStandardErrorFile(QProcess::nullDevice());
+            disconnectScript.startDetached();
+        }
+    }
+
     if (m_isExiting) {
         m_exitSent = true;
         emit signalExit();
@@ -510,6 +541,19 @@ void QJackTrip::processError(const QString& errorMessage)
 void QJackTrip::receivedConnectionFromPeer()
 {
     m_ui->statusBar->showMessage(QStringLiteral("Received Connection from Peer!"));
+    if (m_ui->connectScriptCheckBox->isChecked()) {
+        QStringList arguments = m_ui->connectScriptEdit->text().split(QStringLiteral(" "),
+                                                                      Qt::SkipEmptyParts);
+        if (!arguments.isEmpty()) {
+            QProcess connectScript;
+            connectScript.setProgram(arguments.takeFirst());
+            connectScript.setWorkingDirectory(QDir::homePath());
+            connectScript.setArguments(arguments);
+            connectScript.setStandardOutputFile(QProcess::nullDevice());
+            connectScript.setStandardErrorFile(QProcess::nullDevice());
+            connectScript.startDetached();
+        }
+    }
 }
 
 void QJackTrip::queueLengthChanged(int queueLength)
@@ -559,6 +603,10 @@ void QJackTrip::chooseRunType(int index)
         if (index != -1) {
             m_ui->optionsTabWidget->removeTab(index);
         }
+        index = findTab(QStringLiteral("Scripting"));
+        if (index != -1) {
+            m_ui->optionsTabWidget->removeTab(index);
+        }
         authFilesChanged();
 #ifdef RT_AUDIO
         index = findTab(QStringLiteral("Audio Backend"));
@@ -574,6 +622,10 @@ void QJackTrip::chooseRunType(int index)
         advancedOptionsForHubServer(false);
         if (findTab(QStringLiteral("Plugins")) == -1) {
             m_ui->optionsTabWidget->addTab(m_ui->pluginsTab, QStringLiteral("Plugins"));
+        }
+        if (findTab(QStringLiteral("Scripting")) == -1) {
+            m_ui->optionsTabWidget->addTab(m_ui->scriptingTab,
+                                           QStringLiteral("Scripting"));
         }
 #ifdef RT_AUDIO
         if (findTab(QStringLiteral("Audio Backend")) == -1) {
@@ -652,7 +704,13 @@ void QJackTrip::browseForFile()
         fileEdit = m_ui->keyEdit;
     } else {
         fileType = QLatin1String("");
-        fileEdit = m_ui->credsEdit;
+        if (sender == m_ui->connectScriptBrowse) {
+            fileEdit = m_ui->connectScriptEdit;
+        } else if (sender == m_ui->disconnectScriptBrowse) {
+            fileEdit = m_ui->disconnectScriptEdit;
+        } else {
+            fileEdit = m_ui->credsEdit;
+        }
     }
     QString fileName = QFileDialog::getOpenFileName(this, QStringLiteral("Open File"),
                                                     m_lastPath, fileType);
@@ -999,13 +1057,13 @@ void QJackTrip::exit()
     }
 }
 
-void QJackTrip::updatedInputMeasurements(const QVector<float> valuesInDb)
+void QJackTrip::updatedInputMeasurements(const float* valuesInDb, int numChannels)
 {
     for (int i = 0; i < m_inputMeters.count(); i++) {
         // Determine decibel reading
         qreal dB = m_meterMin;
-        if (i < valuesInDb.size()) {
-            dB = std::max(m_meterMin, valuesInDb.at(i));
+        if (i < numChannels) {
+            dB = std::max(m_meterMin, valuesInDb[i]);
         }
 
         // Produce a normalized value from 0 to 1
@@ -1014,13 +1072,13 @@ void QJackTrip::updatedInputMeasurements(const QVector<float> valuesInDb)
     }
 }
 
-void QJackTrip::updatedOutputMeasurements(const QVector<float> valuesInDb)
+void QJackTrip::updatedOutputMeasurements(const float* valuesInDb, int numChannels)
 {
     for (int i = 0; i < m_outputMeters.count(); i++) {
         // Determine decibel reading
         qreal dB = m_meterMin;
-        if (i < valuesInDb.size()) {
-            dB = std::max(m_meterMin, valuesInDb.at(i));
+        if (i < numChannels) {
+            dB = std::max(m_meterMin, valuesInDb[i]);
         }
 
         // Produce a normalized value from 0 to 1
@@ -1415,6 +1473,17 @@ void QJackTrip::loadSettings(Settings* cliSettings)
     m_ui->outClientsSpinBox->setValue(
         settings.value(QStringLiteral("Clients"), 1).toInt());
     settings.endGroup();
+
+    settings.beginGroup(QStringLiteral("Scripting"));
+    m_ui->connectScriptCheckBox->setChecked(
+        settings.value(QStringLiteral("ConnectEnabled"), false).toBool());
+    m_ui->connectScriptEdit->setText(
+        settings.value(QStringLiteral("ConnectScript"), "").toString());
+    m_ui->disconnectScriptCheckBox->setChecked(
+        settings.value(QStringLiteral("DisconnectEnabled"), false).toBool());
+    m_ui->disconnectScriptEdit->setText(
+        settings.value(QStringLiteral("DisconnectScript"), "").toString());
+    settings.endGroup();
 }
 
 void QJackTrip::saveSettings()
@@ -1517,6 +1586,16 @@ void QJackTrip::saveSettings()
                       m_ui->outCompressorCheckBox->isChecked());
     settings.setValue(QStringLiteral("Limiter"), m_ui->outLimiterCheckBox->isChecked());
     settings.setValue(QStringLiteral("Clients"), m_ui->outClientsSpinBox->value());
+    settings.endGroup();
+
+    settings.beginGroup(QStringLiteral("Scripting"));
+    settings.setValue(QStringLiteral("ConnectEnabled"),
+                      m_ui->connectScriptCheckBox->isChecked());
+    settings.setValue(QStringLiteral("ConnectScript"), m_ui->connectScriptEdit->text());
+    settings.setValue(QStringLiteral("DisconnectEnabled"),
+                      m_ui->disconnectScriptCheckBox->isChecked());
+    settings.setValue(QStringLiteral("DisconnectScript"),
+                      m_ui->disconnectScriptEdit->text());
     settings.endGroup();
 
     settings.beginGroup(QStringLiteral("Window"));

--- a/src/gui/qjacktrip.h
+++ b/src/gui/qjacktrip.h
@@ -98,8 +98,8 @@ class QJackTrip : public QMainWindow
     void start();
     void stop();
     void exit();
-    void updatedInputMeasurements(const QVector<float> valuesInDb);
-    void updatedOutputMeasurements(const QVector<float> valuesInDb);
+    void updatedInputMeasurements(const float* valuesInDb, int numChannels);
+    void updatedOutputMeasurements(const float* valuesInDb, int numChannels);
 #ifndef NO_VS
     void virtualStudioMode();
 #endif

--- a/src/gui/qjacktrip.ui
+++ b/src/gui/qjacktrip.ui
@@ -1763,6 +1763,74 @@ and wetness is the essence of beauty.</string>
         </item>
        </layout>
       </widget>
+      <widget class="QWidget" name="scriptingTab">
+       <attribute name="title">
+        <string>Scripting</string>
+       </attribute>
+       <layout class="QGridLayout" name="gridLayout_12">
+        <item row="1" column="0">
+         <widget class="QLineEdit" name="connectScriptEdit">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLineEdit" name="disconnectScriptEdit">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <spacer name="scriptingVerticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="1" column="1">
+         <widget class="QPushButton" name="connectScriptBrowse">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>Browse</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0" colspan="2">
+         <widget class="QCheckBox" name="connectScriptCheckBox">
+          <property name="text">
+           <string>Execute script on &amp;connection</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0" colspan="2">
+         <widget class="QCheckBox" name="disconnectScriptCheckBox">
+          <property name="text">
+           <string>Execute script on &amp;disconnection</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QPushButton" name="disconnectScriptBrowse">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>Browse</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
      </widget>
     </item>
     <item row="0" column="1">
@@ -1905,6 +1973,12 @@ To connect to a hub server you need to run as a hub client.</string>
   <tabstop>outCompressorCheckBox</tabstop>
   <tabstop>outLimiterCheckBox</tabstop>
   <tabstop>outClientsSpinBox</tabstop>
+  <tabstop>connectScriptCheckBox</tabstop>
+  <tabstop>connectScriptEdit</tabstop>
+  <tabstop>connectScriptBrowse</tabstop>
+  <tabstop>disconnectScriptCheckBox</tabstop>
+  <tabstop>disconnectScriptEdit</tabstop>
+  <tabstop>disconnectScriptBrowse</tabstop>
  </tabstops>
  <resources>
   <include location="qjacktrip.qrc"/>

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1265,7 +1265,7 @@ void VirtualStudio::manageStudio(int studioIndex, bool start)
         QString expiration =
             QDateTime::currentDateTimeUtc().addSecs(60 * 30).toString(Qt::ISODate);
         QJsonObject json      = {{QLatin1String("enabled"), true},
-                            {QLatin1String("expiresAt"), expiration}};
+                                 {QLatin1String("expiresAt"), expiration}};
         QJsonDocument request = QJsonDocument(json);
 
         QNetworkReply* reply = m_authenticator->put(
@@ -1574,7 +1574,8 @@ void VirtualStudio::updatedDevicesWarningHelpUrl(const QString& url)
     return;
 }
 
-void VirtualStudio::updatedInputVuMeasurements(const QVector<float>& valuesInDecibels)
+void VirtualStudio::updatedInputVuMeasurements(const float* valuesInDecibels,
+                                               int numChannels)
 {
     QJsonArray uiValues;
     bool detectedClip = false;
@@ -1583,7 +1584,7 @@ void VirtualStudio::updatedInputVuMeasurements(const QVector<float>& valuesInDec
     for (int i = 0; i < 2; i++) {
         // Determine decibel reading
         float dB = m_meterMin;
-        if (i < valuesInDecibels.size()) {
+        if (i < numChannels) {
             dB = std::max(m_meterMin, valuesInDecibels[i]);
         }
 
@@ -1606,7 +1607,8 @@ void VirtualStudio::updatedInputVuMeasurements(const QVector<float>& valuesInDec
                                                        QVariant::fromValue(uiValues));
 }
 
-void VirtualStudio::updatedOutputVuMeasurements(const QVector<float>& valuesInDecibels)
+void VirtualStudio::updatedOutputVuMeasurements(const float* valuesInDecibels,
+                                                int numChannels)
 {
     QJsonArray uiValues;
     bool detectedClip = false;
@@ -1615,7 +1617,7 @@ void VirtualStudio::updatedOutputVuMeasurements(const QVector<float>& valuesInDe
     for (int i = 0; i < 2; i++) {
         // Determine decibel reading
         float dB = m_meterMin;
-        if (i < valuesInDecibels.size()) {
+        if (i < numChannels) {
             dB = std::max(m_meterMin, valuesInDecibels[i]);
         }
 

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1265,7 +1265,7 @@ void VirtualStudio::manageStudio(int studioIndex, bool start)
         QString expiration =
             QDateTime::currentDateTimeUtc().addSecs(60 * 30).toString(Qt::ISODate);
         QJsonObject json      = {{QLatin1String("enabled"), true},
-                                 {QLatin1String("expiresAt"), expiration}};
+                            {QLatin1String("expiresAt"), expiration}};
         QJsonDocument request = QJsonDocument(json);
 
         QNetworkReply* reply = m_authenticator->put(

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -232,8 +232,8 @@ class VirtualStudio : public QObject
     void editProfile();
     void showAbout();
     void openLink(const QString& url);
-    void updatedInputVuMeasurements(const QVector<float>& valuesInDecibels);
-    void updatedOutputVuMeasurements(const QVector<float>& valuesInDecibels);
+    void updatedInputVuMeasurements(const float* valuesInDecibels, int numChannels);
+    void updatedOutputVuMeasurements(const float* valuesInDecibels, int numChannels);
     void setInputVolume(float multiplier);
     void setOutputVolume(float multiplier);
     void setInputMuted(bool muted);

--- a/src/gui/vsAudioInterface.cpp
+++ b/src/gui/vsAudioInterface.cpp
@@ -286,14 +286,14 @@ void VsAudioInterface::replaceProcess()
     }
 }
 
-void VsAudioInterface::processInputMeterMeasurements(QVector<float> values)
+void VsAudioInterface::processInputMeterMeasurements(float* values, int numChannels)
 {
-    emit newInputMeterMeasurements(values);
+    emit newInputMeterMeasurements(values, numChannels);
 }
 
-void VsAudioInterface::processOutputMeterMeasurements(QVector<float> values)
+void VsAudioInterface::processOutputMeterMeasurements(float* values, int numChannels)
 {
-    emit newOutputMeterMeasurements(values);
+    emit newOutputMeterMeasurements(values, numChannels);
 }
 
 void VsAudioInterface::addInputPlugin(ProcessPlugin* plugin)

--- a/src/gui/vsAudioInterface.h
+++ b/src/gui/vsAudioInterface.h
@@ -108,8 +108,8 @@ class VsAudioInterface : public QObject
     void triggerPlayback();
     void settingsUpdated();
     void modeUpdated();
-    void newInputMeterMeasurements(QVector<float> values);
-    void newOutputMeterMeasurements(QVector<float> values);
+    void newInputMeterMeasurements(float* values, int numChannels);
+    void newOutputMeterMeasurements(float* values, int numChannels);
     void errorToProcess(const QString& errorMessage);
     void devicesErrorMsgChanged(const QString& msg);
     void devicesWarningMsgChanged(const QString& msg);
@@ -119,8 +119,8 @@ class VsAudioInterface : public QObject
    private slots:
     // void refreshAudioStream();
     void replaceProcess();
-    void processInputMeterMeasurements(QVector<float> values);
-    void processOutputMeterMeasurements(QVector<float> values);
+    void processInputMeterMeasurements(float* values, int numChannels);
+    void processOutputMeterMeasurements(float* values, int numChannels);
 
    private:
     void setupJackAudio();

--- a/src/gui/vuMeter.cpp
+++ b/src/gui/vuMeter.cpp
@@ -35,6 +35,9 @@ VuMeter::VuMeter(QWidget* parent) : QWidget(parent), m_level(0)
     m_yellowOff.setRgb(85, 65, 22);
     m_redOn.setRgb(242, 27, 27);
     m_redOff.setRgb(84, 4, 4);
+
+    m_threshhold1 = std::round(m_bins * 0.6);
+    m_threshhold2 = std::round(m_bins * 0.8);
 }
 
 void VuMeter::setLevel(qreal level)
@@ -53,17 +56,17 @@ void VuMeter::paintEvent([[maybe_unused]] QPaintEvent* event)
     for (quint32 i = 0; i < m_bins; i++) {
         bool on = level > i;
         if (on) {
-            if (i < 9) {
+            if (i < m_threshhold1) {
                 painter.setBrush(m_greenOn);
-            } else if (i < 12) {
+            } else if (i < m_threshhold2) {
                 painter.setBrush(m_yellowOn);
             } else {
                 painter.setBrush(m_redOn);
             }
         } else {
-            if (i < 9) {
+            if (i < m_threshhold1) {
                 painter.setBrush(m_greenOff);
-            } else if (i < 12) {
+            } else if (i < m_threshhold2) {
                 painter.setBrush(m_yellowOff);
             } else {
                 painter.setBrush(m_redOff);

--- a/src/gui/vuMeter.h
+++ b/src/gui/vuMeter.h
@@ -51,8 +51,10 @@ class VuMeter : public QWidget
     QColor m_redOn;
     QColor m_redOff;
 
-    quint32 m_bins    = 15;
+    quint32 m_bins    = 30;
     quint32 m_margins = 2;
+    quint32 m_threshhold1;
+    quint32 m_threshhold2;
 };
 
 #endif  // VUMETER_H


### PR DESCRIPTION
Use a couple of float arrays that only get reallocated if the number of channels changes. (And have a working buffer that is only reallocated if it needs to grow.) This should stop the meter code from churning through memory.

As an added bonus, there's now an option in the classic GUI to execute an external script on connection or disconnection.