### PR TITLE
Clean up main

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,7 @@ if (NOT nogui)
   if (NOT novs)
     set (qjacktrip_SRC ${qjacktrip_SRC}
       src/gui/virtualstudio.cpp
+      src/gui/vsInit.cpp
       src/gui/vsQuickView.cpp
       src/gui/vsServerInfo.cpp
       src/gui/vsPing.cpp

--- a/jacktrip.pro
+++ b/jacktrip.pro
@@ -248,6 +248,7 @@ HEADERS += src/DataProtocol.h \
              src/gui/vuMeter.h
   !novs {
     HEADERS += src/gui/virtualstudio.h \
+               src/gui/vsInit.h \
                src/gui/vsDevice.h \
                src/gui/vsAudioInterface.h \
                src/gui/vsServerInfo.h \
@@ -312,6 +313,7 @@ SOURCES += src/DataProtocol.cpp \
              src/gui/vuMeter.cpp
   !novs {
     SOURCES += src/gui/virtualstudio.cpp \
+               src/gui/vsInit.cpp \
                src/gui/vsDevice.cpp \
                src/gui/vsAudioInterface.cpp \
                src/gui/vsServerInfo.cpp \

--- a/meson.build
+++ b/meson.build
@@ -144,6 +144,7 @@ else
 		]
 		moc_h += [
 			'src/gui/virtualstudio.h',
+			'src/gui/vsInit.h',
 			'src/gui/vsDevice.h',
 			'src/gui/vsAudioInterface.h',
 			'src/gui/vsServerInfo.h',

--- a/meson.build
+++ b/meson.build
@@ -131,6 +131,7 @@ else
 	else
 		src += [
 			'src/gui/virtualstudio.cpp',
+			'src/gui/vsInit.cpp',
 			'src/gui/vsDevice.cpp',
 			'src/gui/vsAudioInterface.cpp',
 			'src/gui/vsServerInfo.cpp',

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -327,6 +327,11 @@ void VirtualStudio::raiseToTop()
     m_view.requestActivate();  // Raise to top
 }
 
+bool VirtualStudio::vsModeActive()
+{
+    return m_vsModeActive;
+}
+
 bool VirtualStudio::showFirstRun()
 {
     return m_showFirstRun;
@@ -934,6 +939,7 @@ void VirtualStudio::toStandard()
     if (!m_standardWindow.isNull()) {
         m_view.hide();
         m_standardWindow->show();
+        m_vsModeActive = false;
     }
     QSettings settings;
     settings.setValue(QStringLiteral("UiMode"), QJackTrip::STANDARD);
@@ -1579,6 +1585,7 @@ void VirtualStudio::slotAuthSucceded()
     settings.beginGroup(QStringLiteral("VirtualStudio"));
     settings.setValue(QStringLiteral("RefreshToken"), m_refreshToken);
     settings.endGroup();
+    m_vsModeActive = true;
 
     m_device = new VsDevice(m_authenticator.data(), m_testMode);
     m_device->registerApp();

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -153,6 +153,7 @@ class VirtualStudio : public QObject
     void setStandardWindow(QSharedPointer<QJackTrip> window);
     void show();
     void raiseToTop();
+    bool vsModeActive();
 
     bool showFirstRun();
     void setShowFirstRun(bool show);
@@ -351,6 +352,7 @@ class VirtualStudio : public QObject
 
     bool m_showFirstRun = false;
     bool m_checkSsl     = true;
+    bool m_vsModeActive = false;
     QString m_updateChannel;
     QString m_refreshToken;
     QString m_userId;

--- a/src/gui/vsInit.cpp
+++ b/src/gui/vsInit.cpp
@@ -82,7 +82,7 @@ void VsInit::checkForInstance(QCoreApplication* app, QString& deeplink,
         Qt::QueuedConnection);
     // Create instanceServer to prevent new instances from being created
     void (QLocalSocket::*errorFunc)(QLocalSocket::LocalSocketError);
-#ifdef Q_OS_LINUX
+#if (QT_VERSION < QT_VERSION_CHECK(5, 15, 0))
     errorFunc = &QLocalSocket::error;
 #else
     errorFunc = &QLocalSocket::errorOccurred;

--- a/src/gui/vsInit.cpp
+++ b/src/gui/vsInit.cpp
@@ -100,7 +100,7 @@ void VsInit::checkForInstance(QString& deeplink)
                     [&]() {
                         // This is the first instance. Bring it to the
                         // top.
-                        if (!m_vs.isNull()) {
+                        if (!m_vs.isNull() && m_vs->vsModeActive()) {
                             m_vs->raiseToTop();
                         }
                         while (m_instanceServer->hasPendingConnections()) {
@@ -129,8 +129,8 @@ void VsInit::checkForInstance(QString& deeplink)
                             QUrl url(urlString);
 
                             // Join studio using received URL
-                            if (!m_vs.isNull() && url.scheme() == "jacktrip"
-                                && url.host() == "join") {
+                            if (!m_vs.isNull() && m_vs->vsModeActive()
+                                && url.scheme() == "jacktrip" && url.host() == "join") {
                                 m_vs->setStudioToJoin(url);
                             }
                         }

--- a/src/gui/vsInit.cpp
+++ b/src/gui/vsInit.cpp
@@ -31,11 +31,12 @@
 
 /**
  * \file vsInit.cpp
- * \author 
+ * \author
  * \date February 2023
  */
 
 #include "vsInit.h"
+
 #include <QCommandLineParser>
 #include <QDir>
 #include <QSettings>
@@ -55,7 +56,8 @@ QString VsInit::parseDeeplink(QCoreApplication* app)
     }
 }
 
-void VsInit::checkForInstance(QCoreApplication* app, QString& deeplink, QSharedPointer<VirtualStudio> vs)
+void VsInit::checkForInstance(QCoreApplication* app, QString& deeplink,
+                              QSharedPointer<VirtualStudio> vs)
 {
     m_vs = vs;
     // Create socket
@@ -156,7 +158,7 @@ void VsInit::setUrlScheme()
     set.setValue("DefaultIcon/Default", path);
     set.setValue("URL Protocol", "");
     set.setValue("shell/open/command/Default",
-                    QString("\"%1\"").arg(path) + " --gui --deeplink \"%1\"");
+                 QString("\"%1\"").arg(path) + " --gui --deeplink \"%1\"");
     set.endGroup();
 }
 #endif

--- a/src/gui/vsInit.cpp
+++ b/src/gui/vsInit.cpp
@@ -1,0 +1,162 @@
+//*****************************************************************
+/*
+  JackTrip: A System for High-Quality Audio Network Performance
+  over the Internet
+
+  Copyright (c) 2008-2023 Juan-Pablo Caceres, Chris Chafe.
+  SoundWIRE group at CCRMA, Stanford University.
+
+  Permission is hereby granted, free of charge, to any person
+  obtaining a copy of this software and associated documentation
+  files (the "Software"), to deal in the Software without
+  restriction, including without limitation the rights to use,
+  copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the
+  Software is furnished to do so, subject to the following
+  conditions:
+
+  The above copyright notice and this permission notice shall be
+  included in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+  OTHER DEALINGS IN THE SOFTWARE.
+*/
+//*****************************************************************
+
+/**
+ * \file vsInit.cpp
+ * \author 
+ * \date February 2023
+ */
+
+#include "vsInit.h"
+#include <QCommandLineParser>
+#include <QDir>
+#include <QSettings>
+
+QString VsInit::parseDeeplink(QCoreApplication* app)
+{
+    // Parse command line for deep link
+    QCommandLineParser parser;
+    QCommandLineOption deeplinkOption(QStringList() << QStringLiteral("deeplink"));
+    deeplinkOption.setValueName(QStringLiteral("deeplink"));
+    parser.addOption(deeplinkOption);
+    parser.parse(app->arguments());
+    if (parser.isSet(deeplinkOption)) {
+        return parser.value(deeplinkOption);
+    } else {
+        return QLatin1String("");
+    }
+}
+
+void VsInit::checkForInstance(QCoreApplication* app, QString& deeplink, QSharedPointer<VirtualStudio> vs)
+{
+    m_vs = vs;
+    // Create socket
+    m_instanceCheckSocket.reset(new QLocalSocket(app));
+    // End process if instance exists
+    QObject::connect(
+        m_instanceCheckSocket.data(), &QLocalSocket::connected, app,
+        [=]() {
+            // pass deeplink to existing instance before quitting
+            if (!deeplink.isEmpty()) {
+                QByteArray baDeeplink = deeplink.toLocal8Bit();
+                qint64 writeBytes     = m_instanceCheckSocket->write(baDeeplink);
+                m_instanceCheckSocket->flush();
+                m_instanceCheckSocket->disconnectFromServer();  // remove next
+
+                if (writeBytes < 0) {
+                    qDebug() << "sending deeplink failed";
+                }
+            }
+            emit QCoreApplication::quit();
+        },
+        Qt::QueuedConnection);
+    // Create instanceServer to prevent new instances from being created
+    void (QLocalSocket::*errorFunc)(QLocalSocket::LocalSocketError);
+#ifdef Q_OS_LINUX
+    errorFunc = &QLocalSocket::error;
+#else
+    errorFunc = &QLocalSocket::errorOccurred;
+#endif
+    QObject::connect(
+        m_instanceCheckSocket.data(), errorFunc, app,
+        [=](QLocalSocket::LocalSocketError socketError) {
+            switch (socketError) {
+            case QLocalSocket::ServerNotFoundError:
+            case QLocalSocket::SocketTimeoutError:
+            case QLocalSocket::ConnectionRefusedError:
+                m_instanceServer.reset(new QLocalServer(app));
+                m_instanceServer->setSocketOptions(QLocalServer::WorldAccessOption);
+                m_instanceServer->listen("jacktripExists");
+                QObject::connect(
+                    m_instanceServer.data(), &QLocalServer::newConnection, app,
+                    [&]() {
+                        // This is the first instance. Bring it to the
+                        // top.
+                        m_vs->raiseToTop();
+                        while (m_instanceServer->hasPendingConnections()) {
+                            // Receive URL from 2nd instance
+                            QLocalSocket* connectedSocket =
+                                m_instanceServer->nextPendingConnection();
+
+                            if (!connectedSocket->waitForConnected()) {
+                                qDebug() << "Never received connection";
+                                return;
+                            }
+
+                            if (!connectedSocket->waitForReadyRead()) {
+                                qDebug() << "Never ready to read";
+                                return;
+                            }
+
+                            if (connectedSocket->bytesAvailable()
+                                < (int)sizeof(quint16)) {
+                                qDebug() << "no bytes available";
+                                break;
+                            }
+
+                            QByteArray in(connectedSocket->readAll());
+                            QString urlString(in);
+                            QUrl url(urlString);
+
+                            // Join studio using received URL
+                            if (url.scheme() == "jacktrip" && url.host() == "join") {
+                                m_vs->setStudioToJoin(url);
+                            }
+                        }
+                    },
+                    Qt::QueuedConnection);
+                break;
+            case QLocalSocket::PeerClosedError:
+                break;
+            default:
+                qDebug() << m_instanceCheckSocket->errorString();
+            }
+        });
+    // Check for existing instance
+    m_instanceCheckSocket->connectToServer("jacktripExists");
+}
+
+#ifdef _WIN32
+void VsInit::setUrlScheme()
+{
+    // Set url scheme in registry
+    QString path = QDir::toNativeSeparators(qApp->applicationFilePath());
+
+    QSettings set("HKEY_CURRENT_USER\\Software\\Classes", QSettings::NativeFormat);
+    set.beginGroup("jacktrip");
+    set.setValue("Default", "URL:JackTrip Protocol");
+    set.setValue("DefaultIcon/Default", path);
+    set.setValue("URL Protocol", "");
+    set.setValue("shell/open/command/Default",
+                    QString("\"%1\"").arg(path) + " --gui --deeplink \"%1\"");
+    set.endGroup();
+}
+#endif

--- a/src/gui/vsInit.h
+++ b/src/gui/vsInit.h
@@ -31,7 +31,7 @@
 
 /**
  * \file vsInit.h
- * \author 
+ * \author
  * \date February 2023
  */
 
@@ -39,9 +39,9 @@
 #define __VSINIT_H__
 
 #include <QCoreApplication>
-#include <QScopedPointer>
 #include <QLocalServer>
 #include <QLocalSocket>
+#include <QScopedPointer>
 
 #include "virtualstudio.h"
 
@@ -49,13 +49,14 @@ class VsInit
 {
    public:
     VsInit() = default;
-    
+
     static QString parseDeeplink(QCoreApplication* app);
 #ifdef _WIN32
     static void setUrlScheme();
 #endif
-    void checkForInstance(QCoreApplication* app, QString& deeplink, QSharedPointer<VirtualStudio> vs);
-    
+    void checkForInstance(QCoreApplication* app, QString& deeplink,
+                          QSharedPointer<VirtualStudio> vs);
+
    private:
     QScopedPointer<QLocalServer> m_instanceServer;
     QScopedPointer<QLocalSocket> m_instanceCheckSocket;

--- a/src/gui/vsInit.h
+++ b/src/gui/vsInit.h
@@ -1,0 +1,65 @@
+//*****************************************************************
+/*
+  JackTrip: A System for High-Quality Audio Network Performance
+  over the Internet
+
+  Copyright (c) 2008-2023 Juan-Pablo Caceres, Chris Chafe.
+  SoundWIRE group at CCRMA, Stanford University.
+
+  Permission is hereby granted, free of charge, to any person
+  obtaining a copy of this software and associated documentation
+  files (the "Software"), to deal in the Software without
+  restriction, including without limitation the rights to use,
+  copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the
+  Software is furnished to do so, subject to the following
+  conditions:
+
+  The above copyright notice and this permission notice shall be
+  included in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+  OTHER DEALINGS IN THE SOFTWARE.
+*/
+//*****************************************************************
+
+/**
+ * \file vsInit.h
+ * \author 
+ * \date February 2023
+ */
+
+#ifndef __VSINIT_H__
+#define __VSINIT_H__
+
+#include <QCoreApplication>
+#include <QScopedPointer>
+#include <QLocalServer>
+#include <QLocalSocket>
+
+#include "virtualstudio.h"
+
+class VsInit
+{
+   public:
+    VsInit() = default;
+    
+    static QString parseDeeplink(QCoreApplication* app);
+#ifdef _WIN32
+    static void setUrlScheme();
+#endif
+    void checkForInstance(QCoreApplication* app, QString& deeplink, QSharedPointer<VirtualStudio> vs);
+    
+   private:
+    QScopedPointer<QLocalServer> m_instanceServer;
+    QScopedPointer<QLocalSocket> m_instanceCheckSocket;
+    QSharedPointer<VirtualStudio> m_vs;
+};
+
+#endif  // __VSINIT_H__

--- a/src/gui/vsInit.h
+++ b/src/gui/vsInit.h
@@ -45,8 +45,10 @@
 
 #include "virtualstudio.h"
 
-class VsInit
+class VsInit : QObject
 {
+    Q_OBJECT
+
    public:
     VsInit() = default;
 
@@ -54,8 +56,8 @@ class VsInit
 #ifdef _WIN32
     static void setUrlScheme();
 #endif
-    void checkForInstance(QCoreApplication* app, QString& deeplink,
-                          QSharedPointer<VirtualStudio> vs);
+    void checkForInstance(QString& deeplink);
+    void setVs(QSharedPointer<VirtualStudio> vs) { m_vs = vs; }
 
    private:
     QScopedPointer<QLocalServer> m_instanceServer;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -325,7 +325,7 @@ int main(int argc, char* argv[])
         // Set url scheme in registry
         VsInit::setUrlScheme();
         vsInit.reset(new VsInit());
-        vsInit->checkForInstance(app.data(), deeplink, vs);
+        vsInit->checkForInstance(deeplink);
 #endif  // _WIN32
         window.reset(new QJackTrip(&cliSettings, !deeplink.isEmpty()));
 #else
@@ -337,6 +337,7 @@ int main(int argc, char* argv[])
         vs.reset(new VirtualStudio(uiMode == QJackTrip::UNSET));
         QObject::connect(vs.data(), &VirtualStudio::signalExit, app.data(),
                          &QCoreApplication::quit, Qt::QueuedConnection);
+        vsInit->setVs(vs);
         vs->setStandardWindow(window);
         window->setVs(vs);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -325,7 +325,7 @@ int main(int argc, char* argv[])
         // Set url scheme in registry
         VsInit::setUrlScheme();
         vsInit.reset(new VsInit());
-        vsInit->checkForInstance(app.data(), deeplink, vs.data());
+        vsInit->checkForInstance(app.data(), deeplink, vs);
 #endif  // _WIN32
         window.reset(new QJackTrip(&cliSettings, !deeplink.isEmpty()));
 #else

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -337,7 +337,9 @@ int main(int argc, char* argv[])
         vs.reset(new VirtualStudio(uiMode == QJackTrip::UNSET));
         QObject::connect(vs.data(), &VirtualStudio::signalExit, app.data(),
                          &QCoreApplication::quit, Qt::QueuedConnection);
+#ifdef _WIN32
         vsInit->setVs(vs);
+#endif
         vs->setStandardWindow(window);
         window->setVs(vs);
 


### PR DESCRIPTION
Main has accumulated a lot of VirtualStudio specific code which, combined with all of the ifdefs being used, has made it a little hard to get a quick overview of what is happening at launch. This PR encapsulates a lot of the deeplink and instance checking code in its own class.

Couple of notes: I've left the author field in vsInit.h and vsInit.cpp blank because it's not really my code. If anyone knows who originally authored it, and could add their name there, that would be great. Also, is the code that checks for an existing instance of the program really only meant to be run under windows? And as always, if someone could test that deeplinks still work as expected, that would be great.