### PR TITLE
Fix Output Device Selection Bug

### DIFF
--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1325,8 +1325,8 @@ void VirtualStudio::completeConnection()
         int buffer_size    = 0;
 #ifdef RT_AUDIO
         if (m_useRtAudio) {
-            input = m_inputDevice.toStdString();
-            output = m_outputDevice.toStdString();
+            input       = m_inputDevice.toStdString();
+            output      = m_outputDevice.toStdString();
             buffer_size = m_bufferSize;
         }
         int inputMixMode = m_inputMixMode;

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1326,13 +1326,7 @@ void VirtualStudio::completeConnection()
 #ifdef RT_AUDIO
         if (m_useRtAudio) {
             input = m_inputDevice.toStdString();
-            // if (m_inputDevice == QLatin1String("(default)")) {
-            //     input = "";
-            // }
-            // output = m_outputDevice.toStdString();
-            // if (m_outputDevice == QLatin1String("(default)")) {
-            //     output = "";
-            // }
+            output = m_outputDevice.toStdString();
             buffer_size = m_bufferSize;
         }
         int inputMixMode = m_inputMixMode;


### PR DESCRIPTION
When working on the input channels feature, I mistakenly commented out one more line than I intended to, resulting in the user's selection of output device not being respected.