### PR TITLE
Bugfix Refresh Button & Device Combo State

### DIFF
--- a/src/gui/Settings.qml
+++ b/src/gui/Settings.qml
@@ -536,7 +536,7 @@ Item {
             ComboBox {
                 id: inputCombo
                 model: inputComboModel
-                currentIndex: getCurrentOutputDeviceIndex()
+                currentIndex: getCurrentInputDeviceIndex()
                 anchors.left: outputCombo.left
                 anchors.right: outputCombo.right
                 anchors.verticalCenter: inputLabel.verticalCenter

--- a/src/gui/Settings.qml
+++ b/src/gui/Settings.qml
@@ -41,6 +41,30 @@ Item {
 
     property string settingsGroupView: "Audio"
 
+    function getCurrentInputDeviceIndex () {
+        if (virtualstudio.inputDevice === "") {
+            return inputComboModel.findIndex(elem => elem.type === "element");
+        }
+
+        let idx = inputComboModel.findIndex(elem => elem.type === "element" && elem.text === virtualstudio.inputDevice);
+        if (idx < 0) {
+            idx = inputComboModel.findIndex(elem => elem.type === "element");
+        }
+        return idx;
+    }
+
+    function getCurrentOutputDeviceIndex() {
+        if (virtualstudio.outputDevice === "") {
+            return outputComboModel.findIndex(elem => elem.type === "element");
+        }
+
+        let idx = outputComboModel.findIndex(elem => elem.type === "element" && elem.text === virtualstudio.outputDevice);
+        if (idx < 0) {
+            idx = outputComboModel.findIndex(elem => elem.type === "element");
+        }
+        return idx;
+    }
+
     ToolBar {
         id: header
         width: parent.width
@@ -95,7 +119,11 @@ Item {
                     color: textColour;
                 }
                 display: AbstractButton.TextBesideIcon
-                onClicked: { virtualstudio.refreshDevices() }
+                onClicked: {
+                    virtualstudio.refreshDevices();
+                    inputCombo.currentIndex = getCurrentInputDeviceIndex();
+                    outputCombo.currentIndex = getCurrentOutputDeviceIndex();
+                }
                 width: 144 * virtualstudio.uiScale; height: 30 * virtualstudio.uiScale
                 font {
                     family: "Poppins"
@@ -319,18 +347,7 @@ Item {
                 anchors.rightMargin: rightMargin * virtualstudio.uiScale
                 width: parent.width - outputLabel.width - rightMargin * virtualstudio.uiScale
                 model: outputComboModel
-                currentIndex: (() => {
-                    if (virtualstudio.outputDevice === "") {
-                        return outputComboModel.findIndex(elem => elem.type === "element");
-                    }
-
-                    let idx = outputComboModel.findIndex(elem => elem.type === "element" && elem.text === virtualstudio.outputDevice);
-                    if (idx < 0) {
-                        idx = outputComboModel.findIndex(elem => elem.type === "element");
-                    }
-
-                    return idx;
-                })()
+                currentIndex: getCurrentOutputDeviceIndex()
                 delegate: ItemDelegate {
                     required property var modelData
                     required property int index
@@ -519,18 +536,7 @@ Item {
             ComboBox {
                 id: inputCombo
                 model: inputComboModel
-                currentIndex: (() => {
-                    if (virtualstudio.inputDevice === "") {
-                        return inputComboModel.findIndex(elem => elem.type === "element");
-                    }
-
-                    let idx = inputComboModel.findIndex(elem => elem.type === "element" && elem.text === virtualstudio.inputDevice);
-                    if (idx < 0) {
-                        idx = inputComboModel.findIndex(elem => elem.type === "element");
-                    }
-
-                    return idx;
-                })()
+                currentIndex: getCurrentOutputDeviceIndex()
                 anchors.left: outputCombo.left
                 anchors.right: outputCombo.right
                 anchors.verticalCenter: inputLabel.verticalCenter

--- a/src/gui/Setup.qml
+++ b/src/gui/Setup.qml
@@ -44,7 +44,31 @@ Item {
 
     property bool currShowWarnings: virtualstudio.showWarnings
     property string warningScreen: virtualstudio.showWarnings ? "ethernet" : ( permissions.micPermission == "unknown" ? "microphone" : "acknowledged")
- 
+
+    function getCurrentInputDeviceIndex () {
+        if (virtualstudio.inputDevice === "") {
+            return inputComboModel.findIndex(elem => elem.type === "element");
+        }
+
+        let idx = inputComboModel.findIndex(elem => elem.type === "element" && elem.text === virtualstudio.inputDevice);
+        if (idx < 0) {
+            idx = inputComboModel.findIndex(elem => elem.type === "element");
+        }
+        return idx;
+    }
+
+    function getCurrentOutputDeviceIndex() {
+        if (virtualstudio.outputDevice === "") {
+            return outputComboModel.findIndex(elem => elem.type === "element");
+        }
+
+        let idx = outputComboModel.findIndex(elem => elem.type === "element" && elem.text === virtualstudio.outputDevice);
+        if (idx < 0) {
+            idx = outputComboModel.findIndex(elem => elem.type === "element");
+        }
+        return idx;
+    }
+
     Item {
         id: ethernetWarningItem
         width: parent.width; height: parent.height
@@ -539,7 +563,11 @@ Item {
                 color: textColour;
             }
             display: AbstractButton.TextBesideIcon
-            onClicked: { virtualstudio.refreshDevices() }
+            onClicked: {
+                virtualstudio.refreshDevices();
+                inputCombo.currentIndex = getCurrentInputDeviceIndex();
+                outputCombo.currentIndex = getCurrentOutputDeviceIndex();
+            }
             anchors.right: parent.right
             anchors.rightMargin: rightMargin * virtualstudio.uiScale
             anchors.verticalCenter: pageTitle.verticalCenter
@@ -905,18 +933,7 @@ Item {
                 anchors.rightMargin: rightMargin * virtualstudio.uiScale
                 width: parent.width - outputLabel.width - rightMargin * virtualstudio.uiScale
                 model: outputComboModel
-                currentIndex: (() => {
-                    if (virtualstudio.outputDevice === "") {
-                        return outputComboModel.findIndex(elem => elem.type === "element");
-                    }
-
-                    let idx = outputComboModel.findIndex(elem => elem.type === "element" && elem.text === virtualstudio.outputDevice);
-                    if (idx < 0) {
-                        idx = outputComboModel.findIndex(elem => elem.type === "element");
-                    }
-
-                    return idx;
-                })()
+                currentIndex: getCurrentOutputDeviceIndex()
                 delegate: ItemDelegate {
                     required property var modelData
                     required property int index
@@ -1105,18 +1122,7 @@ Item {
             ComboBox {
                 id: inputCombo
                 model: inputComboModel
-                currentIndex: (() => {
-                    if (virtualstudio.inputDevice === "") {
-                        return inputComboModel.findIndex(elem => elem.type === "element");
-                    }
-
-                    let idx = inputComboModel.findIndex(elem => elem.type === "element" && elem.text === virtualstudio.inputDevice);
-                    if (idx < 0) {
-                        idx = inputComboModel.findIndex(elem => elem.type === "element");
-                    }
-
-                    return idx;
-                })()
+                currentIndex: getCurrentInputDeviceIndex()
                 anchors.left: outputCombo.left
                 anchors.right: outputCombo.right
                 anchors.verticalCenter: inputLabel.verticalCenter


### PR DESCRIPTION
Fixes a minor issue with the refresh devices button that causes the audio device in-use to get out of sync with the display on the device combo box. This happens because the underlying data model changes, though the selected index of the combo box stays the same.

To reproduce on MacOS MacBook Pro (with headphones):
1. Make sure headphones are plugged in
2. Open app, select `Apple Inc.: MacBook Pro Speakers`, then press save
3. Close app and restart app
4. Select `Apple Inc.: External Headphones`. When testing output, audio should go through headphones
5. Unplug headphones
6. Refresh Devices. Combo box should switch to `Apple Inc.: MacBook Pro Speakers` and testing output audio should go through computer speakers
7. Plug in headphones
8. Refresh Devices. Combo box should switch to `Apple Inc.: External Headphones` but audio still goes through computer speakers. 

This bug occurs because the `inputComboModel` and `outputComboModel` values get updated but `currentIndex` doesn't change. With this fix, the audio output stays on the external speakers and doesn't switch back to external headphones, keeping the combo boxes in sync with the underlying data model

(Fix for https://app.asana.com/0/1200778084029081/1203931384588553/f)
