### PR TITLE
Point updater to files.jacktrip.org

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -1,17 +1,3 @@
-- Version: "1.8.0"
-  Date: 2023-03-01
-  Description:
-  - (added) Qt version option for Meson builds
-  - (added) GHA builds now include static preview docs
-  - (added) when using the classic GUI, command line options are now parsed
-  - (added) VS mode - Selecting and configuring device channels
-  - (updated) icons in VS mode 
-  - (updated) Linux builds now use Qt 5.15.8
-  - (updated) Replaced QVector in meter code
-  - (updated) Removed set-output from GHA scripts for deprecation
-  - (updated) Automated the auto-updater release process
-  - (fixed) ambiguous call to overloaded function in Qt6
-  - (fixed) issue where selected devices were not the devices used for output
 - Version: "1.7.1"
   Date: 2023-02-03
   Description:

--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -1,3 +1,17 @@
+- Version: "1.8.0"
+  Date: 2023-03-01
+  Description:
+  - (added) Qt version option for Meson builds
+  - (added) GHA builds now include static preview docs
+  - (added) when using the classic GUI, command line options are now parsed
+  - (added) VS mode - Selecting and configuring device channels
+  - (updated) icons in VS mode 
+  - (updated) Linux builds now use Qt 5.15.8
+  - (updated) Replaced QVector in meter code
+  - (updated) Removed set-output from GHA scripts for deprecation
+  - (updated) Automated the auto-updater release process
+  - (fixed) ambiguous call to overloaded function in Qt6
+  - (fixed) issue where selected devices were not the devices used for output
 - Version: "1.7.1"
   Date: 2023-02-03
   Description:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -496,7 +496,7 @@ int main(int argc, char* argv[])
                                     .toLower();
         QString baseUrl =
             QStringLiteral(
-                "https://raw.githubusercontent.com/jacktrip/jacktrip/dev/releases/%1")
+                "https://files.jacktrip.org/app-releases/%1")
                 .arg(updateChannel);
 #else
         QString baseUrl = QStringLiteral("https://nuages.psi-borg.org/jacktrip");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -494,10 +494,8 @@ int main(int argc, char* argv[])
         QString updateChannel = settings.value(QStringLiteral("UpdateChannel"), "stable")
                                     .toString()
                                     .toLower();
-        QString baseUrl =
-            QStringLiteral(
-                "https://files.jacktrip.org/app-releases/%1")
-                .arg(updateChannel);
+        QString baseUrl = QStringLiteral("https://files.jacktrip.org/app-releases/%1")
+                              .arg(updateChannel);
 #else
         QString baseUrl = QStringLiteral("https://nuages.psi-borg.org/jacktrip");
 #endif  // PSI


### PR DESCRIPTION
JackTrip will now look at files.jacktrip.org for manifest files since Github caches don't update as frequently as necessary.