### PR TITLE
Fix crash when using JACK

### DIFF
--- a/src/AudioInterface.cpp
+++ b/src/AudioInterface.cpp
@@ -55,10 +55,8 @@ AudioInterface::AudioInterface(JackTrip* jacktrip, QVarLengthArray<int> InputCha
 #endif  // endwhere
                                audioBitResolutionT AudioBitResolution,
                                bool processWithNetwork)
-    : mJackTrip(jacktrip)
-    , mInputChans(InputChans)
+    : mInputChans(InputChans)
     , mOutputChans(OutputChans)
-    , mInputMixMode(InputMixMode)
     ,
 #ifdef WAIR  // WAIR
     mNumNetRevChans(NumNetRevChans)
@@ -72,6 +70,8 @@ AudioInterface::AudioInterface(JackTrip* jacktrip, QVarLengthArray<int> InputCha
     , mAudioOutputPacket(NULL)
     , mLoopBack(false)
     , mProcessWithNetwork(processWithNetwork)
+    , mJackTrip(jacktrip)
+    , mInputMixMode(InputMixMode)
     , mProcessingAudio(false)
 {
 #ifndef WAIR
@@ -108,6 +108,9 @@ AudioInterface::AudioInterface(JackTrip* jacktrip, QVarLengthArray<int> InputCha
         mInBufCopy[i] =
             new sample_t[MAX_AUDIO_BUFFER_SIZE];  // required for processing audio input
     }
+
+    mNumInChans  = mInputChans.size();
+    mNumOutChans = mOutputChans.size();
 }
 
 //*******************************************************************************

--- a/src/AudioInterface.cpp
+++ b/src/AudioInterface.cpp
@@ -47,14 +47,14 @@ using std::cout;
 using std::endl;
 
 //*******************************************************************************
-AudioInterface::AudioInterface(JackTrip* jacktrip, QVarLengthArray<int> InputChans,
+AudioInterface::AudioInterface(QVarLengthArray<int> InputChans,
                                QVarLengthArray<int> OutputChans,
                                inputMixModeT InputMixMode,
 #ifdef WAIR  // wair
                                int NumNetRevChans,
 #endif  // endwhere
                                audioBitResolutionT AudioBitResolution,
-                               bool processWithNetwork)
+                               bool processWithNetwork, JackTrip* jacktrip)
     : mInputChans(InputChans)
     , mOutputChans(OutputChans)
     ,

--- a/src/AudioInterface.h
+++ b/src/AudioInterface.h
@@ -258,13 +258,9 @@ class AudioInterface
     void computeProcessToNetwork(QVarLengthArray<sample_t*>& in_buffer,
                                  unsigned int n_frames);
 
-    JackTrip* mJackTrip;  ///< JackTrip Mediator Class pointer
-    int mNumInChans;      ///< Number of Input Channels
-    int mNumOutChans;     ///<  Number of Output Channels
     QVarLengthArray<int> mInputChans;
     QVarLengthArray<int> mOutputChans;
-    inputMixModeT mInputMixMode;  ///< Input mixing mode
-#ifdef WAIR                       // wair
+#ifdef WAIR               // wair
     int mNumNetRevChans;  ///<  Number of Network Audio Channels (net comb filters)
     QVarLengthArray<sample_t*>
         mNetInBuffer;  ///< Vector of Input buffers/channel read from net
@@ -298,6 +294,11 @@ class AudioInterface
     AudioTester* mAudioTesterP{nullptr};
 
    protected:
+    JackTrip* mJackTrip;          ///< JackTrip Mediator Class pointer
+    int mNumInChans;              ///< Number of Input Channels
+    int mNumOutChans;             ///<  Number of Output Channels
+    inputMixModeT mInputMixMode;  ///< Input mixing mode
+
     void setDevicesWarningMsg(warningMessageT msg);
     void setDevicesErrorMsg(errorMessageT msg);
 

--- a/src/AudioInterface.h
+++ b/src/AudioInterface.h
@@ -98,6 +98,8 @@ class AudioInterface
      * \param NumInChans Number of Input Channels
      * \param NumOutChans Number of Output Channels
      * \param AudioBitResolution Audio Sample Resolutions in bits
+     * \param processWithNetwork Send audio to and from the network
+     * \param jacktrip Pointer to the JackTrip class that connects all classes (mediator)
      */
     AudioInterface(
         QVarLengthArray<int> InputChans, QVarLengthArray<int> OutputChans,
@@ -106,7 +108,7 @@ class AudioInterface
         int NumNetRevChans,
 #endif  // endwhere
         AudioInterface::audioBitResolutionT AudioBitResolution = AudioInterface::BIT16,
-        bool processWithNetwork = true, JackTrip* jacktrip = nullptr);
+        bool processWithNetwork = false, JackTrip* jacktrip = nullptr);
     /// \brief The class destructor
     virtual ~AudioInterface();
 

--- a/src/AudioInterface.h
+++ b/src/AudioInterface.h
@@ -100,13 +100,13 @@ class AudioInterface
      * \param AudioBitResolution Audio Sample Resolutions in bits
      */
     AudioInterface(
-        JackTrip* jacktrip, QVarLengthArray<int> InputChans,
-        QVarLengthArray<int> OutputChans, inputMixModeT InputMixMode,
+        QVarLengthArray<int> InputChans, QVarLengthArray<int> OutputChans,
+        inputMixModeT InputMixMode,
 #ifdef WAIR  // wair
         int NumNetRevChans,
 #endif  // endwhere
         AudioInterface::audioBitResolutionT AudioBitResolution = AudioInterface::BIT16,
-        bool processWithNetwork                                = true);
+        bool processWithNetwork = true, JackTrip* jacktrip = nullptr);
     /// \brief The class destructor
     virtual ~AudioInterface();
 

--- a/src/AudioInterface.h
+++ b/src/AudioInterface.h
@@ -94,7 +94,6 @@ class AudioInterface
     };
 
     /** \brief The class constructor
-     * \param jacktrip Pointer to the JackTrip class that connects all classes (mediator)
      * \param NumInChans Number of Input Channels
      * \param NumOutChans Number of Output Channels
      * \param AudioBitResolution Audio Sample Resolutions in bits

--- a/src/AudioInterface.h
+++ b/src/AudioInterface.h
@@ -184,10 +184,12 @@ class AudioInterface
     virtual void setInputChannels(QVarLengthArray<int> inputChans)
     {
         mInputChans = inputChans;
+        mNumInChans = inputChans.size();
     }
     virtual void setOutputChannels(QVarLengthArray<int> outputChans)
     {
         mOutputChans = outputChans;
+        mNumOutChans = outputChans.size();
     }
     virtual void setInputMixMode(inputMixModeT mode) { mInputMixMode = mode; }
     virtual void setSampleRate(uint32_t sample_rate) { mSampleRate = sample_rate; }
@@ -257,6 +259,8 @@ class AudioInterface
                                  unsigned int n_frames);
 
     JackTrip* mJackTrip;  ///< JackTrip Mediator Class pointer
+    int mNumInChans;      ///< Number of Input Channels
+    int mNumOutChans;     ///<  Number of Output Channels
     QVarLengthArray<int> mInputChans;
     QVarLengthArray<int> mOutputChans;
     inputMixModeT mInputMixMode;  ///< Input mixing mode

--- a/src/JackAudioInterface.cpp
+++ b/src/JackAudioInterface.cpp
@@ -66,13 +66,13 @@ JackAudioInterface::JackAudioInterface(
 #ifdef WAIR  // wair
     int NumNetRevChans,
 #endif  // endwhere
-    AudioInterface::audioBitResolutionT AudioBitResolution, JackTrip* jacktrip,
-    const QString& ClientName)
+    AudioInterface::audioBitResolutionT AudioBitResolution, bool processWithNetwork,
+    JackTrip* jacktrip, const QString& ClientName)
     : AudioInterface(InputChans, OutputChans, MIX_UNSET,
 #ifdef WAIR  // wair
                      NumNetRevChans,
 #endif  // endwhere
-                     AudioBitResolution, jacktrip)
+                     AudioBitResolution, processWithNetwork, jacktrip)
     , mClient(NULL)
     , mClientName(ClientName)
     , mBroadcast(false)

--- a/src/JackAudioInterface.cpp
+++ b/src/JackAudioInterface.cpp
@@ -73,47 +73,10 @@ JackAudioInterface::JackAudioInterface(
                      NumNetRevChans,
 #endif  // endwhere
                      AudioBitResolution)
-// , mNumInChans(NumInChans)
-// , mNumOutChans(NumOutChans)
-#ifdef WAIR  // WAIR
-    , mNumNetRevChans(NumNetRevChans)
-#endif  // endwhere
     , mClient(NULL)
     , mClientName(ClientName)
     , mBroadcast(false)
-    , mJackTrip(jacktrip)
 {
-    mNumInChans  = InputChans.size();
-    mNumOutChans = OutputChans.size();
-}
-
-//*******************************************************************************
-JackAudioInterface::JackAudioInterface(
-    QVarLengthArray<int> InputChans, QVarLengthArray<int> OutputChans,
-#ifdef WAIR  // wair
-    int NumNetRevChans,
-#endif  // endwhere
-    AudioInterface::audioBitResolutionT AudioBitResolution, const QString& ClientName)
-    : AudioInterface(nullptr, InputChans, OutputChans, AudioInterface::MIX_UNSET,
-#ifdef WAIR  // wair
-                     NumNetRevChans,
-#endif  // endwhere
-                     AudioBitResolution, false)
-// , mNumInChans(NumInChans)
-// , mNumOutChans(NumOutChans)
-#ifdef WAIR  // WAIR
-    , mNumNetRevChans(NumNetRevChans)
-#endif  // endwhere
-    , mClient(NULL)
-    , mClientName(ClientName)
-    , mBroadcast(false)
-    , mJackTrip(nullptr)
-{
-    JackAudioInterface(nullptr, InputChans, OutputChans, AudioInterface::MIX_UNSET,
-#ifdef WAIR  // wair
-                       NumNetRevChans,
-#endif  // endwhere
-                       AudioBitResolution, ClientName);
 }
 
 //*******************************************************************************

--- a/src/JackAudioInterface.cpp
+++ b/src/JackAudioInterface.cpp
@@ -83,6 +83,8 @@ JackAudioInterface::JackAudioInterface(
     , mBroadcast(false)
     , mJackTrip(jacktrip)
 {
+    mNumInChans = InputChans.size();
+    mNumOutChans = OutputChans.size();
 }
 
 //*******************************************************************************

--- a/src/JackAudioInterface.cpp
+++ b/src/JackAudioInterface.cpp
@@ -63,13 +63,12 @@ QMutex JackAudioInterface::sJackMutex;
 //*******************************************************************************
 JackAudioInterface::JackAudioInterface(
     QVarLengthArray<int> InputChans, QVarLengthArray<int> OutputChans,
-    inputMixModeT InputMixMode,
 #ifdef WAIR  // wair
     int NumNetRevChans,
 #endif  // endwhere
     AudioInterface::audioBitResolutionT AudioBitResolution, JackTrip* jacktrip,
     const QString& ClientName)
-    : AudioInterface(InputChans, OutputChans, InputMixMode,
+    : AudioInterface(InputChans, OutputChans, MIX_UNSET,
 #ifdef WAIR  // wair
                      NumNetRevChans,
 #endif  // endwhere

--- a/src/JackAudioInterface.cpp
+++ b/src/JackAudioInterface.cpp
@@ -62,17 +62,18 @@ QMutex JackAudioInterface::sJackMutex;
 
 //*******************************************************************************
 JackAudioInterface::JackAudioInterface(
-    JackTrip* jacktrip, QVarLengthArray<int> InputChans, QVarLengthArray<int> OutputChans,
+    QVarLengthArray<int> InputChans, QVarLengthArray<int> OutputChans,
     inputMixModeT InputMixMode,
 #ifdef WAIR  // wair
     int NumNetRevChans,
 #endif  // endwhere
-    AudioInterface::audioBitResolutionT AudioBitResolution, const QString& ClientName)
-    : AudioInterface(jacktrip, InputChans, OutputChans, InputMixMode,
+    AudioInterface::audioBitResolutionT AudioBitResolution, JackTrip* jacktrip,
+    const QString& ClientName)
+    : AudioInterface(InputChans, OutputChans, InputMixMode,
 #ifdef WAIR  // wair
                      NumNetRevChans,
 #endif  // endwhere
-                     AudioBitResolution)
+                     AudioBitResolution, jacktrip)
     , mClient(NULL)
     , mClientName(ClientName)
     , mBroadcast(false)

--- a/src/JackAudioInterface.cpp
+++ b/src/JackAudioInterface.cpp
@@ -83,7 +83,7 @@ JackAudioInterface::JackAudioInterface(
     , mBroadcast(false)
     , mJackTrip(jacktrip)
 {
-    mNumInChans = InputChans.size();
+    mNumInChans  = InputChans.size();
     mNumOutChans = OutputChans.size();
 }
 

--- a/src/JackAudioInterface.h
+++ b/src/JackAudioInterface.h
@@ -74,12 +74,13 @@ class JackAudioInterface : public AudioInterface
      * \param ClientName Client name in Jack
      */
     JackAudioInterface(
-        JackTrip* jacktrip, QVarLengthArray<int> InputChans,
-        QVarLengthArray<int> OutputChans, inputMixModeT InputMixMode,
+        QVarLengthArray<int> InputChans, QVarLengthArray<int> OutputChans,
+        inputMixModeT InputMixMode,
 #ifdef WAIR  // wair
         int NumNetRevChans,
 #endif  // endwhere
         AudioInterface::audioBitResolutionT AudioBitResolution = AudioInterface::BIT16,
+        JackTrip* jacktrip                                     = nullptr,
         const QString& ClientName = QStringLiteral("JackTrip"));
     /// \brief The class destructor
     virtual ~JackAudioInterface();

--- a/src/JackAudioInterface.h
+++ b/src/JackAudioInterface.h
@@ -75,7 +75,6 @@ class JackAudioInterface : public AudioInterface
      */
     JackAudioInterface(
         QVarLengthArray<int> InputChans, QVarLengthArray<int> OutputChans,
-        inputMixModeT InputMixMode,
 #ifdef WAIR  // wair
         int NumNetRevChans,
 #endif  // endwhere

--- a/src/JackAudioInterface.h
+++ b/src/JackAudioInterface.h
@@ -81,61 +81,61 @@ class JackAudioInterface : public AudioInterface
 #endif  // endwhere
         AudioInterface::audioBitResolutionT AudioBitResolution = AudioInterface::BIT16,
         const QString& ClientName = QStringLiteral("JackTrip"));
-    /// \brief Overloaded class constructor with null JackTrip pointer
-    JackAudioInterface(
-        QVarLengthArray<int> InputChans, QVarLengthArray<int> OutputChans,
-#ifdef WAIR  // wair
-        int NumNetRevChans,
-#endif  // endwhere
-        AudioInterface::audioBitResolutionT AudioBitResolution = AudioInterface::BIT16,
-        const QString& ClientName = QStringLiteral("JackTrip"));
     /// \brief The class destructor
     virtual ~JackAudioInterface();
 
     /// \brief Setup the client
-    virtual void setup(bool verbose = true);
+    virtual void setup(bool verbose = true) override;
     /** \brief Tell the JACK server that we are ready to roll. The
      * process-callback will start running. This runs on its own thread.
      * \return 0 on success, otherwise a non-zero error code
      */
-    virtual int startProcess();
+    virtual int startProcess() override;
     /** \brief Stops the process-callback thread
      * \return 0 on success, otherwise a non-zero error code
      */
-    virtual int stopProcess();
+    virtual int stopProcess() override;
     /// \brief Connect the default ports, capture to sends, and receives to playback
-    void connectDefaultPorts();
+    void connectDefaultPorts() override;
+
+    /// \brief Get Number of Input Channels
+    virtual int getNumInputChannels() const override { return mNumInChans; }
+    /// \brief Get Number of Output Channels
+    virtual int getNumOutputChannels() const override { return mNumOutChans; }
 
     //--------------SETTERS---------------------------------------------
     /// \brief Set Client Name to something different that the default (JackTrip)
-    virtual void setClientName(const QString& ClientName) { mClientName = ClientName; }
-    virtual void setSampleRate(uint32_t /*sample_rate*/)
+    virtual void setClientName(const QString& ClientName) override
+    {
+        mClientName = ClientName;
+    }
+    virtual void setSampleRate(uint32_t /*sample_rate*/) override
     {
         std::cout << "WARNING: Setting the Sample Rate in Jack mode has no effect."
                   << std::endl;
     }
-    virtual void setBufferSizeInSamples(uint32_t /*buf_size*/)
+    virtual void setBufferSizeInSamples(uint32_t /*buf_size*/) override
     {
         std::cout << "WARNING: Setting the Sample Rate in Jack mode has no effect."
                   << std::endl;
     }
-    virtual void enableBroadcastOutput() { mBroadcast = true; }
+    virtual void enableBroadcastOutput() override { mBroadcast = true; }
     //------------------------------------------------------------------
 
     //--------------GETTERS---------------------------------------------
     /// \brief Get the actual client name assigned by the Jack server
     virtual QString getAssignedClientName() final { return mAssignedClientName; }
     /// \brief Get the Jack Server Sampling Rate, in samples/second
-    virtual uint32_t getSampleRate() const;
+    virtual uint32_t getSampleRate() const override;
     /// \brief Get the Jack Server Buffer Size, in samples
-    virtual uint32_t getBufferSizeInSamples() const;
+    virtual uint32_t getBufferSizeInSamples() const override;
     /// \brief Get the Jack Server Buffer Size, in bytes
     virtual uint32_t getBufferSizeInBytes() const
     {
         return (getBufferSizeInSamples() * getAudioBitResolution() / 8);
     }
     /// \brief Get size of each audio per channel, in bytes
-    virtual size_t getSizeInBytesPerChannel() const;
+    virtual size_t getSizeInBytesPerChannel() const override;
     //------------------------------------------------------------------
 
    private:
@@ -182,12 +182,7 @@ class JackAudioInterface : public AudioInterface
     // reference : http://article.gmane.org/gmane.comp.audio.jackit/12873
     static int wrapperProcessCallback(jack_nframes_t nframes, void* arg);
 
-    int mNumInChans;      ///< Number of Input Channels
-    int mNumOutChans;     ///<  Number of Output Channels
-#ifdef WAIR               // WAIR
-    int mNumNetRevChans;  ///<  Number of Network Audio Channels (network comb filters
-#endif                    // endwhere
-    int mNumFrames;       ///< Buffer block size, in samples
+    int mNumFrames;  ///< Buffer block size, in samples
 
     jack_client_t* mClient;  ///< Jack Client
     QString mClientName;     ///< Jack Client Name
@@ -202,9 +197,7 @@ class JackAudioInterface : public AudioInterface
     QVarLengthArray<sample_t*>
         mBroadcastBuffer;  ///< Vector of Output buffer/channel to write to JACK
     bool mBroadcast;
-    QVector<ProcessPlugin*> mProcessPlugins;  ///< Vector of ProcesPlugin<EM>s</EM>
     static QMutex sJackMutex;  ///< Mutex to make thread safe jack functions that are not
-    JackTrip* mJackTrip;       ///< JackTrip Mediator Class pointer
 };
 
 #endif

--- a/src/JackAudioInterface.h
+++ b/src/JackAudioInterface.h
@@ -39,7 +39,7 @@
 #define __JACKAUDIOINTERFACE_H__
 
 #include <iostream>
-//#include <tr1/memory> //for shared_ptr
+// #include <tr1/memory> //for shared_ptr
 #ifdef USE_WEAK_JACK
 #include "weak_libjack.h"
 #else
@@ -67,10 +67,11 @@ class JackAudioInterface : public AudioInterface
 {
    public:
     /** \brief The class constructor
-     * \param jacktrip Pointer to the JackTrip class that connects all classes (mediator)
      * \param NumInChans Number of Input Channels
      * \param NumOutChans Number of Output Channels
      * \param AudioBitResolution Audio Sample Resolutions in bits
+     * \param processWithNetwork Send audio to and from the network
+     * \param jacktrip Pointer to the JackTrip class that connects all classes (mediator)
      * \param ClientName Client name in Jack
      */
     JackAudioInterface(
@@ -79,7 +80,7 @@ class JackAudioInterface : public AudioInterface
         int NumNetRevChans,
 #endif  // endwhere
         AudioInterface::audioBitResolutionT AudioBitResolution = AudioInterface::BIT16,
-        JackTrip* jacktrip                                     = nullptr,
+        bool processWithNetwork = false, JackTrip* jacktrip = nullptr,
         const QString& ClientName = QStringLiteral("JackTrip"));
     /// \brief The class destructor
     virtual ~JackAudioInterface();

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -260,7 +260,7 @@ void JackTrip::setupAudio(
             outputChannels[i] = 1 + i;
         }
         mAudioInterface = new RtAudioInterface(
-            inputChannels, outputChannels, mInputMixMode, mAudioBitResolution true, this);
+            inputChannels, outputChannels, mInputMixMode, mAudioBitResolution, true, this);
         mAudioInterface->setSampleRate(mSampleRate);
         mAudioInterface->setDeviceID(mDeviceID);
         mAudioInterface->setInputDevice(mInputDeviceName);

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -203,7 +203,6 @@ void JackTrip::setupAudio(
             outputChannels[i] = 1 + i;
         }
         mAudioInterface = new JackAudioInterface(inputChannels, outputChannels,
-                                                 AudioInterface::MIX_UNSET,
 #ifdef WAIR  // wair
                                                  mNumNetRevChans,
 #endif  // endwhere

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -202,12 +202,12 @@ void JackTrip::setupAudio(
         for (int i = 0; i < mNumAudioChansOut; i++) {
             outputChannels[i] = 1 + i;
         }
-        mAudioInterface = new JackAudioInterface(this, inputChannels, outputChannels,
+        mAudioInterface = new JackAudioInterface(inputChannels, outputChannels,
                                                  AudioInterface::MIX_UNSET,
 #ifdef WAIR  // wair
                                                  mNumNetRevChans,
 #endif  // endwhere
-                                                 mAudioBitResolution);
+                                                 mAudioBitResolution, this);
 
 #ifdef WAIRTOHUB  // WAIR
 
@@ -292,8 +292,8 @@ void JackTrip::setupAudio(
         for (int i = 0; i < mNumAudioChansOut; i++) {
             outputChannels[i] = 1 + i;
         }
-        mAudioInterface = new RtAudioInterface(this, inputChannels, outputChannels,
-                                               mInputMixMode, mAudioBitResolution);
+        mAudioInterface = new RtAudioInterface(inputChannels, outputChannels,
+                                               mInputMixMode, mAudioBitResolution, this);
         mAudioInterface->setSampleRate(mSampleRate);
         mAudioInterface->setDeviceID(mDeviceID);
         mAudioInterface->setInputDevice(mInputDeviceName);

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -259,8 +259,9 @@ void JackTrip::setupAudio(
         for (int i = 0; i < mNumAudioChansOut; i++) {
             outputChannels[i] = 1 + i;
         }
-        mAudioInterface = new RtAudioInterface(
-            inputChannels, outputChannels, mInputMixMode, mAudioBitResolution, true, this);
+        mAudioInterface =
+            new RtAudioInterface(inputChannels, outputChannels, mInputMixMode,
+                                 mAudioBitResolution, true, this);
         mAudioInterface->setSampleRate(mSampleRate);
         mAudioInterface->setDeviceID(mDeviceID);
         mAudioInterface->setInputDevice(mInputDeviceName);

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -206,7 +206,7 @@ void JackTrip::setupAudio(
 #ifdef WAIR  // wair
                                                  mNumNetRevChans,
 #endif  // endwhere
-                                                 mAudioBitResolution, this);
+                                                 mAudioBitResolution, true, this);
 
 #ifdef WAIRTOHUB  // WAIR
 
@@ -259,8 +259,8 @@ void JackTrip::setupAudio(
         for (int i = 0; i < mNumAudioChansOut; i++) {
             outputChannels[i] = 1 + i;
         }
-        mAudioInterface = new RtAudioInterface(this, inputChannels, outputChannels,
-                                               mInputMixMode, mAudioBitResolution);
+        mAudioInterface = new RtAudioInterface(
+            inputChannels, outputChannels, mInputMixMode, mAudioBitResolution true, this);
         mAudioInterface->setSampleRate(mSampleRate);
         mAudioInterface->setDeviceID(mDeviceID);
         mAudioInterface->setInputDevice(mInputDeviceName);
@@ -291,8 +291,9 @@ void JackTrip::setupAudio(
         for (int i = 0; i < mNumAudioChansOut; i++) {
             outputChannels[i] = 1 + i;
         }
-        mAudioInterface = new RtAudioInterface(inputChannels, outputChannels,
-                                               mInputMixMode, mAudioBitResolution, this);
+        mAudioInterface =
+            new RtAudioInterface(inputChannels, outputChannels, mInputMixMode,
+                                 mAudioBitResolution, true, this);
         mAudioInterface->setSampleRate(mSampleRate);
         mAudioInterface->setDeviceID(mDeviceID);
         mAudioInterface->setInputDevice(mInputDeviceName);

--- a/src/RtAudioInterface.cpp
+++ b/src/RtAudioInterface.cpp
@@ -58,18 +58,6 @@ RtAudioInterface::RtAudioInterface(JackTrip* jacktrip, QVarLengthArray<int> Inpu
 }
 
 //*******************************************************************************
-RtAudioInterface::RtAudioInterface(QVarLengthArray<int> InputChans,
-                                   QVarLengthArray<int> OutputChans,
-                                   inputMixModeT InputMixMode,
-                                   audioBitResolutionT AudioBitResolution)
-    : AudioInterface(nullptr, InputChans, OutputChans, InputMixMode, AudioBitResolution,
-                     false)
-    , mRtAudio(NULL)
-{
-    RtAudioInterface(nullptr, InputChans, OutputChans, InputMixMode, AudioBitResolution);
-}
-
-//*******************************************************************************
 RtAudioInterface::~RtAudioInterface()
 {
     if (mRtAudio != NULL) {
@@ -392,8 +380,7 @@ int RtAudioInterface::RtAudioCallback(void* outputBuffer, void* inputBuffer,
     inputBuffer_sample  = (sample_t*)inputBuffer;
     outputBuffer_sample = (sample_t*)outputBuffer;
 
-    int chansIn           = getNumInputChannels();
-    inputMixModeT mixMode = getInputMixMode();
+    int chansIn = getNumInputChannels();
     if (inputBuffer_sample != NULL && outputBuffer_sample != NULL) {
         // Get input and output buffers
         //-------------------------------------------------------------------
@@ -407,7 +394,7 @@ int RtAudioInterface::RtAudioCallback(void* outputBuffer, void* inputBuffer,
             mOutBuffer[i] = outputBuffer_sample + (nFrames * i);
         }
         if (chansIn == 2 && mInBuffer.size() == chansIn
-            && mixMode == AudioInterface::MIXTOMONO) {
+            && mInputMixMode == AudioInterface::MIXTOMONO) {
             mStereoToMonoMixer->compute(nFrames, mInBuffer.data(), mInBuffer.data());
         }
         AudioInterface::callback(mInBuffer, mOutBuffer, nFrames);

--- a/src/RtAudioInterface.cpp
+++ b/src/RtAudioInterface.cpp
@@ -48,11 +48,12 @@ using std::cout;
 using std::endl;
 
 //*******************************************************************************
-RtAudioInterface::RtAudioInterface(JackTrip* jacktrip, QVarLengthArray<int> InputChans,
+RtAudioInterface::RtAudioInterface(QVarLengthArray<int> InputChans,
                                    QVarLengthArray<int> OutputChans,
                                    inputMixModeT InputMixMode,
-                                   audioBitResolutionT AudioBitResolution)
-    : AudioInterface(jacktrip, InputChans, OutputChans, InputMixMode, AudioBitResolution)
+                                   audioBitResolutionT AudioBitResolution,
+                                   JackTrip* jacktrip)
+    : AudioInterface(InputChans, OutputChans, InputMixMode, AudioBitResolution, jacktrip)
     , mRtAudio(NULL)
 {
 }

--- a/src/RtAudioInterface.cpp
+++ b/src/RtAudioInterface.cpp
@@ -52,8 +52,9 @@ RtAudioInterface::RtAudioInterface(QVarLengthArray<int> InputChans,
                                    QVarLengthArray<int> OutputChans,
                                    inputMixModeT InputMixMode,
                                    audioBitResolutionT AudioBitResolution,
-                                   JackTrip* jacktrip)
-    : AudioInterface(InputChans, OutputChans, InputMixMode, AudioBitResolution, jacktrip)
+                                   bool processWithNetwork, JackTrip* jacktrip)
+    : AudioInterface(InputChans, OutputChans, InputMixMode, AudioBitResolution,
+                     processWithNetwork, jacktrip)
     , mRtAudio(NULL)
 {
 }

--- a/src/RtAudioInterface.h
+++ b/src/RtAudioInterface.h
@@ -52,15 +52,16 @@ class RtAudioInterface : public AudioInterface
 {
    public:
     /** \brief The class constructor
-     * \param jacktrip Pointer to the JackTrip class that connects all classes (mediator)
      * \param NumInChans Number of Input Channels
      * \param NumOutChans Number of Output Channels
      * \param AudioBitResolution Audio Sample Resolutions in bits
+     * \param processWithNetwork Send audio to and from the network
+     * \param jacktrip Pointer to the JackTrip class that connects all classes (mediator)
      */
     RtAudioInterface(QVarLengthArray<int> InputChans, QVarLengthArray<int> OutputChans,
                      inputMixModeT InputMixMode             = AudioInterface::MIX_UNSET,
                      audioBitResolutionT AudioBitResolution = BIT16,
-                     JackTrip* jacktrip                     = nullptr);
+                     bool processWithNetwork = false, JackTrip* jacktrip = nullptr);
     /// \brief The class destructor
     virtual ~RtAudioInterface();
 

--- a/src/RtAudioInterface.h
+++ b/src/RtAudioInterface.h
@@ -61,10 +61,6 @@ class RtAudioInterface : public AudioInterface
                      QVarLengthArray<int> OutputChans,
                      inputMixModeT InputMixMode             = AudioInterface::MIX_UNSET,
                      audioBitResolutionT AudioBitResolution = BIT16);
-    /// \brief Overloaded class constructor with null JackTrip pointer
-    RtAudioInterface(QVarLengthArray<int> InputChans, QVarLengthArray<int> OutputChans,
-                     inputMixModeT InputMixMode             = AudioInterface::MIX_UNSET,
-                     audioBitResolutionT AudioBitResolution = BIT16);
     /// \brief The class destructor
     virtual ~RtAudioInterface();
 

--- a/src/RtAudioInterface.h
+++ b/src/RtAudioInterface.h
@@ -57,10 +57,10 @@ class RtAudioInterface : public AudioInterface
      * \param NumOutChans Number of Output Channels
      * \param AudioBitResolution Audio Sample Resolutions in bits
      */
-    RtAudioInterface(JackTrip* jacktrip, QVarLengthArray<int> InputChans,
-                     QVarLengthArray<int> OutputChans,
+    RtAudioInterface(QVarLengthArray<int> InputChans, QVarLengthArray<int> OutputChans,
                      inputMixModeT InputMixMode             = AudioInterface::MIX_UNSET,
-                     audioBitResolutionT AudioBitResolution = BIT16);
+                     audioBitResolutionT AudioBitResolution = BIT16,
+                     JackTrip* jacktrip                     = nullptr);
     /// \brief The class destructor
     virtual ~RtAudioInterface();
 

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -130,7 +130,7 @@ class Settings : public QObject
     JackTrip::dataProtocolT mDataProtocol = JackTrip::UDP;  ///< Data Protocol
     int mNumAudioInputChans               = 2;              ///< Number of Input Channels
     int mNumAudioOutputChans              = 2;              ///< Number of Output Channels
-    int mBaseAudioInputChanNum            = 1;              ///< Base Input Channel Number
+    int mBaseAudioInputChanNum            = 0;              ///< Base Input Channel Number
     int mBufferQueueLength =
         gDefaultQueueLength;  ///< Audio Buffer from network queue length
     AudioInterface::audioBitResolutionT mAudioBitResolution = AudioInterface::BIT16;

--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -882,7 +882,7 @@ void QJackTrip::start()
             }
 
             m_jackTrip.reset(new JackTrip(
-                jackTripMode, JackTrip::UDP, 1, m_ui->channelSendSpinBox->value(),
+                jackTripMode, JackTrip::UDP, 0, m_ui->channelSendSpinBox->value(),
                 m_ui->channelRecvSpinBox->value(), AudioInterface::MIX_UNSET,
 #ifdef WAIR  // wair
                 0,


### PR DESCRIPTION
I've taken the path of least resistance to fix this, but I think we need to rethink the constructor for the base AudioInterface class. Channel selection has no meaning when using JACK and passing QVarLengthArrays doesn't make a lot of sense here. I'd suggest it would probably be worth either having an overloaded constructor, or (possibly better) having the channel lists as member variables of the derived RtAudioInterface class instead. (And having the getter and setter functions defined as part of this class rather than the base class.)