### PR TITLE
Fix updater release scripts

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -694,7 +694,7 @@ jobs:
           path: ${{ env.BUILD_PATH }}/${{ matrix.installer-path }}
   # release - list of files uploaded to GH release is specified in the *upload* step
   deploy_gh:
-    if: startsWith(github.ref, 'refs/tags/') # run on tagged commits
+    if: startsWith(github.ref, 'refs/tags/') && github.event_name == 'release' # run on releases only
     needs: [build, sign]
     runs-on: ubuntu-latest
     name: 'deploy release'

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -713,27 +713,6 @@ jobs:
           draft: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  release_test:
-    if:  github.event_name == 'release'
-    runs-on: ubuntu-latest
-    name: 'test release if statement'
-    steps:
-      - name: print
-        run: echo "release if passed"
-  tag_test:
-    if:  startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
-    name: 'test tag if statement'
-    steps:
-      - name: print
-        run: echo "tag if passed"
-  secrets_test:
-    if:  needs.check-secrets.outputs.should_run == 'true'
-    runs-on: ubuntu-latest
-    name: 'test secrets if statement'
-    steps:
-      - name: print
-        run: echo "secrets if passed"
   deploy_jtl:
     if:  startsWith(github.ref, 'refs/tags/') && github.event_name == 'release' && needs.check-secrets.outputs.should_run == 'true'
     needs: [build, sign]

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -19,6 +19,8 @@ on:
       - 'documentation/**'
       - 'scripts/**'
       - 'README**'
+  release:
+    types: [published]
   workflow_dispatch:
   schedule:
     - cron:  '0 0 * * 0' # run weekly to refresh static Qt cache

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -711,6 +711,27 @@ jobs:
           draft: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  release_test:
+    if:  github.event_name == 'release'
+    runs-on: ubuntu-latest
+    name: 'test release if statement'
+    steps:
+      - name: print
+        run: echo "release if passed"
+  tag_test:
+    if:  startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    name: 'test tag if statement'
+    steps:
+      - name: print
+        run: echo "tag if passed"
+  secrets_test:
+    if:  needs.check-secrets.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    name: 'test secrets if statement'
+    steps:
+      - name: print
+        run: echo "secrets if passed"
   deploy_jtl:
     if:  startsWith(github.ref, 'refs/tags/') && github.event_name == 'release' && needs.check-secrets.outputs.should_run == 'true'
     needs: [build, sign]


### PR DESCRIPTION
The `github.event_name = 'release'` check was failing because we never actually run our actions in response to a release being published. This fixes that problem. 

We _may_ reconsider enabling the `deploy_gh` job on tagged commits and instead run it only on releases, but I don't have enough perspective as to what that would break.