### PR TITLE
Reinstate backend warning in the classic GUI

### DIFF
--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -333,9 +333,7 @@ QJackTrip::QJackTrip(Settings* settings, bool suppressCommandlineWarning, QWidge
     // Check if Jack is actually available
     if (have_libjack() != 0) {
 #ifdef RT_AUDIO
-#ifdef PSI
         bool usingRtAudioAlready = m_ui->backendComboBox->currentIndex() == 1;
-#endif  // PSI
         m_ui->backendComboBox->setCurrentIndex(1);
         m_ui->backendComboBox->setEnabled(false);
         m_ui->backendLabel->setEnabled(false);
@@ -349,7 +347,6 @@ QJackTrip::QJackTrip(Settings* settings, bool suppressCommandlineWarning, QWidge
             "JACK was not found. This means that only the RtAudio backend is available "
             "and that JackTrip cannot be run in hub server mode.");
 
-#ifdef PSI
         QSettings settings;
         settings.beginGroup(QStringLiteral("Audio"));
         if (!settings.value(QStringLiteral("HideJackWarning"), false).toBool()) {
@@ -385,7 +382,6 @@ QJackTrip::QJackTrip(Settings* settings, bool suppressCommandlineWarning, QWidge
             settings.setValue(QStringLiteral("UsingFallback"), false);
         }
         settings.endGroup();
-#endif  // PSI
 #else   // RT_AUDIO
         QMessageBox msgBox;
         msgBox.setText(


### PR DESCRIPTION
While it's great that we have a choice of audio backends now, and users can run the program without JACK, our behaviour of silently falling back to the RtAudio backend when JACK isn't found is causing a lot of confusion amongst users outside the VirtualStudio community. (As I predicted when we first discussed this in #477.) It's gotten to the point that people are mistakenly under the impression that JackTrip installs JACK, and are having to rely on the cryptic WEAK-Jack messages the library generates to do any sort of trouble shooting, unaware that some of the output they're seeing means that JACK isn't properly installed. (See #941.) This pull request reinstates an error message that has remained in my builds.

When JACK isn't found, the user will be confronted with the following warning:

> An installation of JACK was not found. JackTrip will still run using a different audio backend (RtAudio) but some more advanced features, like the ability to run your own hub server, will not be available.
> 
> (If you install JACK at a later stage, these features will automatically be re-enabled.)

They're also given the option to silence this warning going forward.