### PR TITLE
Select Output Channels

### DIFF
--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -82,7 +82,7 @@ bool JackTrip::sJackStopped = false;
 
 //*******************************************************************************
 JackTrip::JackTrip(jacktripModeT JacktripMode, dataProtocolT DataProtocolType,
-                   int BaseChanIn, int NumChansIn, int NumChansOut,
+                   int BaseChanIn, int NumChansIn, int BaseChanOut, int NumChansOut,
                    AudioInterface::inputMixModeT InputMixMode,
 #ifdef WAIR  // WAIR
                    int NumNetRevChans,
@@ -100,6 +100,7 @@ JackTrip::JackTrip(jacktripModeT JacktripMode, dataProtocolT DataProtocolType,
     , mAudiointerfaceMode(JackTrip::JACK)
     , mBaseAudioChanIn(BaseChanIn)
     , mNumAudioChansIn(NumChansIn)
+    , mBaseAudioChanOut(BaseChanOut)
     , mNumAudioChansOut(NumChansOut)
     , mInputMixMode(InputMixMode)
 #ifdef WAIR  // WAIR
@@ -257,7 +258,7 @@ void JackTrip::setupAudio(
             inputChannels[i] = mBaseAudioChanIn + i;
         }
         for (int i = 0; i < mNumAudioChansOut; i++) {
-            outputChannels[i] = 1 + i;
+            outputChannels[i] = mBaseAudioChanOut + i;
         }
         mAudioInterface =
             new RtAudioInterface(inputChannels, outputChannels, mInputMixMode,
@@ -290,7 +291,7 @@ void JackTrip::setupAudio(
             inputChannels[i] = mBaseAudioChanIn + i;
         }
         for (int i = 0; i < mNumAudioChansOut; i++) {
-            outputChannels[i] = 1 + i;
+            outputChannels[i] = mBaseAudioChanOut + i;
         }
         mAudioInterface =
             new RtAudioInterface(inputChannels, outputChannels, mInputMixMode,

--- a/src/JackTrip.h
+++ b/src/JackTrip.h
@@ -134,7 +134,7 @@ class JackTrip : public QObject
      */
     JackTrip(
         jacktripModeT JacktripMode = CLIENT, dataProtocolT DataProtocolType = UDP,
-        int NumChansIn = gDefaultNumInChannels, int BaseChanIn = 0,
+        int BaseChanIn = 0, int NumChansIn = gDefaultNumInChannels, int BaseChanOut = 0,
         int NumChansOut                            = gDefaultNumInChannels,
         AudioInterface::inputMixModeT InputMixMode = AudioInterface::MIX_UNSET,
 #ifdef WAIR  // wair
@@ -628,6 +628,7 @@ class JackTrip : public QObject
 
     int mBaseAudioChanIn;                         ///< Base Audio Input Channel
     int mNumAudioChansIn;                         ///< Number of Audio Input Channels
+    int mBaseAudioChanOut;                        ///< Base Audio Output Channel
     int mNumAudioChansOut;                        ///< Number of Audio Output Channels
     AudioInterface::inputMixModeT mInputMixMode;  ///< Input mix mode
 

--- a/src/JackTripWorker.cpp
+++ b/src/JackTripWorker.cpp
@@ -125,7 +125,7 @@ void JackTripWorker::setJackTrip(int id, const QString& client_address,
     //        qDebug() << "is WAIR?" <<  tmp ;
     qDebug() << "mNumNetRevChans" << mNumNetRevChans;
 
-    mJackTrip.reset(new JackTrip(JackTrip::SERVERPINGSERVER, JackTrip::UDP, 1, 1, 1,
+    mJackTrip.reset(new JackTrip(JackTrip::SERVERPINGSERVER, JackTrip::UDP, 0, 1, 0, 1,
                                  AudioInterface::MIX_UNSET, mNumNetRevChans,
                                  FORCEBUFFERQ));
     // Add Plugins
@@ -147,7 +147,7 @@ void JackTripWorker::setJackTrip(int id, const QString& client_address,
         }
     }
 #else   // endwhere
-    mJackTrip.reset(new JackTrip(JackTrip::SERVERPINGSERVER, JackTrip::UDP, 1, 1, 1,
+    mJackTrip.reset(new JackTrip(JackTrip::SERVERPINGSERVER, JackTrip::UDP, 0, 1, 0, 1,
                                  AudioInterface::MIX_UNSET, mBufferQueueLength));
 #endif  // not wair
 #endif  // ifndef __JAMTEST__

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -1054,7 +1054,7 @@ JackTrip* Settings::getConfiguredJackTrip()
         std::cout << "Settings:startJackTrip before new JackTrip" << std::endl;
     JackTrip* jackTrip = new JackTrip(
         mJackTripMode, mDataProtocol, mBaseAudioInputChanNum, mNumAudioInputChans,
-        mNumAudioOutputChans, AudioInterface::MIX_UNSET,
+        mBaseAudioOutputChanNum, mNumAudioOutputChans, AudioInterface::MIX_UNSET,
 #ifdef WAIR  // wair
         mNumNetRevChans,
 #endif  // endwhere

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -131,6 +131,7 @@ class Settings : public QObject
     int mNumAudioInputChans               = 2;              ///< Number of Input Channels
     int mNumAudioOutputChans              = 2;              ///< Number of Output Channels
     int mBaseAudioInputChanNum            = 0;              ///< Base Input Channel Number
+    int mBaseAudioOutputChanNum           = 0;  ///< Base Output Channel Number
     int mBufferQueueLength =
         gDefaultQueueLength;  ///< Audio Buffer from network queue length
     AudioInterface::audioBitResolutionT mAudioBitResolution = AudioInterface::BIT16;

--- a/src/gui/Settings.qml
+++ b/src/gui/Settings.qml
@@ -305,7 +305,7 @@ Item {
         Item {
             id: usingRtAudio
             anchors.top: parent.top
-            anchors.topMargin: 32 * virtualstudio.uiScale
+            anchors.topMargin: 24 * virtualstudio.uiScale
             anchors.bottom: parent.bottom
             anchors.left: parent.left
             anchors.leftMargin: 24 * virtualstudio.uiScale
@@ -480,10 +480,10 @@ Item {
                 anchors.left: outputCombo.left
                 anchors.right: outputCombo.horizontalCenter
                 anchors.top: outputSlider.bottom
-                anchors.topMargin: 24 * virtualstudio.uiScale
+                anchors.topMargin: 12 * virtualstudio.uiScale
                 textFormat: Text.RichText
                 text: "Output Channel(s)"
-                font { family: "Poppins"; pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale }
+                font { family: "Poppins"; pixelSize: fontExtraSmall * virtualstudio.fontScale * virtualstudio.uiScale }
                 color: textColour
             }
 
@@ -493,7 +493,7 @@ Item {
                 anchors.right: outputCombo.horizontalCenter
                 anchors.rightMargin: 8 * virtualstudio.uiScale
                 anchors.top: outputChannelsLabel.bottom
-                anchors.topMargin: 16 * virtualstudio.uiScale
+                anchors.topMargin: 12 * virtualstudio.uiScale
                 model: outputChannelsComboModel
                 currentIndex: (() => {
                     let idx = outputChannelsComboModel.findIndex(elem => elem.baseChannel === virtualstudio.baseOutputChannel
@@ -738,10 +738,10 @@ Item {
                 anchors.left: inputCombo.left
                 anchors.right: inputCombo.horizontalCenter
                 anchors.top: inputSlider.bottom
-                anchors.topMargin: 24 * virtualstudio.uiScale
+                anchors.topMargin: 12 * virtualstudio.uiScale
                 textFormat: Text.RichText
                 text: "Input Channel(s)"
-                font { family: "Poppins"; pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale }
+                font { family: "Poppins"; pixelSize: fontExtraSmall * virtualstudio.fontScale * virtualstudio.uiScale }
                 color: textColour
             }
 
@@ -751,7 +751,7 @@ Item {
                 anchors.right: inputCombo.horizontalCenter
                 anchors.rightMargin: 8 * virtualstudio.uiScale
                 anchors.top: inputChannelsLabel.bottom
-                anchors.topMargin: 16 * virtualstudio.uiScale
+                anchors.topMargin: 12 * virtualstudio.uiScale
                 model: inputChannelsComboModel
                 currentIndex: (() => {
                     let idx = inputChannelsComboModel.findIndex(elem => elem.baseChannel === virtualstudio.baseInputChannel
@@ -796,10 +796,10 @@ Item {
                 anchors.right: inputCombo.right
                 anchors.rightMargin: 8 * virtualstudio.uiScale
                 anchors.top: inputSlider.bottom
-                anchors.topMargin: 24 * virtualstudio.uiScale
+                anchors.topMargin: 12 * virtualstudio.uiScale
                 textFormat: Text.RichText
                 text: "Mono / Stereo"
-                font { family: "Poppins"; pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale }
+                font { family: "Poppins"; pixelSize: fontExtraSmall * virtualstudio.fontScale * virtualstudio.uiScale }
                 color: textColour
             }
 
@@ -809,7 +809,7 @@ Item {
                 anchors.right: inputCombo.right
                 anchors.rightMargin: 8 * virtualstudio.uiScale
                 anchors.top: inputMixModeLabel.bottom
-                anchors.topMargin: 16 * virtualstudio.uiScale
+                anchors.topMargin: 12 * virtualstudio.uiScale
                 model: inputMixModeComboModel
                 currentIndex: (() => {
                     let idx = inputMixModeComboModel.findIndex(elem => elem.value === virtualstudio.inputMixMode);
@@ -912,7 +912,7 @@ Item {
         Item {
             id: usingJACK
             anchors.top: parent.top
-            anchors.topMargin: 32 * virtualstudio.uiScale
+            anchors.topMargin: 24 * virtualstudio.uiScale
             anchors.bottom: parent.bottom
             anchors.left: parent.left
             anchors.leftMargin: leftMargin * virtualstudio.uiScale
@@ -1209,7 +1209,7 @@ Item {
         Item {
             id: noBackend
             anchors.top: parent.top
-            anchors.topMargin: 32 * virtualstudio.uiScale
+            anchors.topMargin: 24 * virtualstudio.uiScale
             anchors.bottom: parent.bottom
             anchors.left: parent.left
             anchors.leftMargin: leftMargin * virtualstudio.uiScale

--- a/src/gui/Settings.qml
+++ b/src/gui/Settings.qml
@@ -458,8 +458,8 @@ Item {
 
             Image {
                 id: outputLouderIcon
-                anchors.right: testOutputAudioButton.left
-                anchors.rightMargin: 16 * virtualstudio.uiScale
+                anchors.right: parent.right
+                anchors.rightMargin: rightMargin * virtualstudio.uiScale
                 anchors.verticalCenter: outputSlider.verticalCenter
                 source: "loud.svg"
                 sourceSize: Qt.size(16 * virtualstudio.uiScale, 16 * virtualstudio.uiScale)
@@ -475,6 +475,63 @@ Item {
                 }
             }
 
+            Text {
+                id: outputChannelsLabel
+                anchors.left: outputCombo.left
+                anchors.right: outputCombo.horizontalCenter
+                anchors.top: outputSlider.bottom
+                anchors.topMargin: 24 * virtualstudio.uiScale
+                textFormat: Text.RichText
+                text: "Output Channel(s)"
+                font { family: "Poppins"; pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale }
+                color: textColour
+            }
+
+            ComboBox {
+                id: outputChannelsCombo
+                anchors.left: outputCombo.left
+                anchors.right: outputCombo.horizontalCenter
+                anchors.rightMargin: 8 * virtualstudio.uiScale
+                anchors.top: outputChannelsLabel.bottom
+                anchors.topMargin: 16 * virtualstudio.uiScale
+                model: outputChannelsComboModel
+                currentIndex: (() => {
+                    let idx = outputChannelsComboModel.findIndex(elem => elem.baseChannel === virtualstudio.baseOutputChannel
+                        && elem.numChannels === virtualstudio.numOutputChannels);
+                    if (idx < 0) {
+                        idx = 0;
+                    }
+                    return idx;
+                })()
+                delegate: ItemDelegate {
+                    required property var modelData
+                    required property int index
+                    width: parent.width
+                    contentItem: Text {
+                        text: modelData.label
+                    }
+                    highlighted: outputChannelsCombo.highlightedIndex === index
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: {
+                            outputChannelsCombo.currentIndex = index
+                            outputChannelsCombo.popup.close()
+                            virtualstudio.baseOutputChannel = modelData.baseChannel
+                            virtualstudio.numOutputChannels = modelData.numChannels
+                            virtualstudio.validateDevicesState()
+                        }
+                    }
+                }
+                contentItem: Text {
+                    leftPadding: 12
+                    font: inputCombo.font
+                    horizontalAlignment: Text.AlignHLeft
+                    verticalAlignment: Text.AlignVCenter
+                    elide: Text.ElideRight
+                    text: outputChannelsCombo.model[outputChannelsCombo.currentIndex].label || ""
+                }
+            }
+
             Button {
                 id: testOutputAudioButton
                 background: Rectangle {
@@ -486,7 +543,7 @@ Item {
                 onClicked: { virtualstudio.playOutputAudio() }
                 anchors.right: parent.right
                 anchors.rightMargin: rightMargin * virtualstudio.uiScale
-                anchors.verticalCenter: outputSlider.verticalCenter
+                anchors.verticalCenter: outputChannelsCombo.verticalCenter
                 width: 144 * virtualstudio.uiScale; height: 30 * virtualstudio.uiScale
                 Text {
                     text: "Play Test Tone"

--- a/src/gui/Setup.qml
+++ b/src/gui/Setup.qml
@@ -1044,8 +1044,8 @@ Item {
 
             Image {
                 id: outputLouderIcon
-                anchors.right: testOutputAudioButton.left
-                anchors.rightMargin: 16 * virtualstudio.uiScale
+                anchors.right: parent.right
+                anchors.rightMargin: rightMargin * virtualstudio.uiScale
                 anchors.verticalCenter: outputSlider.verticalCenter
                 source: "loud.svg"
                 sourceSize: Qt.size(16 * virtualstudio.uiScale, 16 * virtualstudio.uiScale)
@@ -1061,6 +1061,63 @@ Item {
                 }
             }
 
+            Text {
+                id: outputChannelsLabel
+                anchors.left: outputCombo.left
+                anchors.right: outputCombo.horizontalCenter
+                anchors.top: outputSlider.bottom
+                anchors.topMargin: 24 * virtualstudio.uiScale
+                textFormat: Text.RichText
+                text: "Output Channel(s)"
+                font { family: "Poppins"; pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale }
+                color: textColour
+            }
+
+            ComboBox {
+                id: outputChannelsCombo
+                anchors.left: outputCombo.left
+                anchors.right: outputCombo.horizontalCenter
+                anchors.rightMargin: 8 * virtualstudio.uiScale
+                anchors.top: outputChannelsLabel.bottom
+                anchors.topMargin: 16 * virtualstudio.uiScale
+                model: outputChannelsComboModel
+                currentIndex: (() => {
+                    let idx = outputChannelsComboModel.findIndex(elem => elem.baseChannel === virtualstudio.baseOutputChannel
+                        && elem.numChannels === virtualstudio.numOutputChannels);
+                    if (idx < 0) {
+                        idx = 0;
+                    }
+                    return idx;
+                })()
+                delegate: ItemDelegate {
+                    required property var modelData
+                    required property int index
+                    width: parent.width
+                    contentItem: Text {
+                        text: modelData.label
+                    }
+                    highlighted: outputChannelsCombo.highlightedIndex === index
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: {
+                            outputChannelsCombo.currentIndex = index
+                            outputChannelsCombo.popup.close()
+                            virtualstudio.baseOutputChannel = modelData.baseChannel
+                            virtualstudio.numOutputChannels = modelData.numChannels
+                            virtualstudio.validateDevicesState()
+                        }
+                    }
+                }
+                contentItem: Text {
+                    leftPadding: 12
+                    font: inputCombo.font
+                    horizontalAlignment: Text.AlignHLeft
+                    verticalAlignment: Text.AlignVCenter
+                    elide: Text.ElideRight
+                    text: outputChannelsCombo.model[outputChannelsCombo.currentIndex].label || ""
+                }
+            }
+
             Button {
                 id: testOutputAudioButton
                 background: Rectangle {
@@ -1072,7 +1129,7 @@ Item {
                 onClicked: { virtualstudio.playOutputAudio() }
                 anchors.right: parent.right
                 anchors.rightMargin: rightMargin * virtualstudio.uiScale
-                anchors.verticalCenter: outputSlider.verticalCenter
+                anchors.verticalCenter: outputChannelsCombo.verticalCenter
                 width: 144 * virtualstudio.uiScale; height: 30 * virtualstudio.uiScale
                 Text {
                     text: "Play Test Tone"
@@ -1236,7 +1293,7 @@ Item {
 
             Image {
                 id: inputLouderIcon
-                anchors.right: hiddenInputButton.left
+                anchors.right: parent.right
                 anchors.rightMargin: rightMargin * virtualstudio.uiScale
                 anchors.verticalCenter: inputSlider.verticalCenter
                 source: "loud.svg"
@@ -1251,15 +1308,6 @@ Item {
                     saturation: 0
                     lightness: virtualstudio.darkMode ? 1 : 0
                 }
-            }
-
-            Button {
-                id: hiddenInputButton
-                anchors.right: parent.right
-                anchors.rightMargin: rightMargin * virtualstudio.uiScale
-                anchors.verticalCenter: inputSlider.verticalCenter
-                width: 144 * virtualstudio.uiScale; height: 30 * virtualstudio.uiScale
-                visible: false
             }
 
             Text {

--- a/src/gui/Setup.qml
+++ b/src/gui/Setup.qml
@@ -584,7 +584,7 @@ Item {
             x: leftMargin * virtualstudio.uiScale
             width: parent.width - leftMargin * virtualstudio.uiScale
             anchors.top: pageTitle.bottom
-            anchors.topMargin: 32 * virtualstudio.uiScale
+            anchors.topMargin: 24 * virtualstudio.uiScale
             visible: parent.hasNoBackend
 
             Text {
@@ -603,7 +603,7 @@ Item {
             x: leftMargin * virtualstudio.uiScale
             width: parent.width - leftMargin * virtualstudio.uiScale
             anchors.top: pageTitle.bottom
-            anchors.topMargin: 32 * virtualstudio.uiScale
+            anchors.topMargin: 24 * virtualstudio.uiScale
             visible: parent.isUsingJack
 
             Text {
@@ -896,7 +896,7 @@ Item {
             x: leftMargin * virtualstudio.uiScale
             width: parent.width - leftMargin * virtualstudio.uiScale
             anchors.top: pageTitle.bottom
-            anchors.topMargin: 32 * virtualstudio.uiScale
+            anchors.topMargin: 24 * virtualstudio.uiScale
             visible: parent.isUsingRtAudio
 
             Text {
@@ -1066,10 +1066,10 @@ Item {
                 anchors.left: outputCombo.left
                 anchors.right: outputCombo.horizontalCenter
                 anchors.top: outputSlider.bottom
-                anchors.topMargin: 24 * virtualstudio.uiScale
+                anchors.topMargin: 12 * virtualstudio.uiScale
                 textFormat: Text.RichText
                 text: "Output Channel(s)"
-                font { family: "Poppins"; pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale }
+                font { family: "Poppins"; pixelSize: fontExtraSmall * virtualstudio.fontScale * virtualstudio.uiScale }
                 color: textColour
             }
 
@@ -1079,7 +1079,7 @@ Item {
                 anchors.right: outputCombo.horizontalCenter
                 anchors.rightMargin: 8 * virtualstudio.uiScale
                 anchors.top: outputChannelsLabel.bottom
-                anchors.topMargin: 16 * virtualstudio.uiScale
+                anchors.topMargin: 12 * virtualstudio.uiScale
                 model: outputChannelsComboModel
                 currentIndex: (() => {
                     let idx = outputChannelsComboModel.findIndex(elem => elem.baseChannel === virtualstudio.baseOutputChannel
@@ -1315,10 +1315,10 @@ Item {
                 anchors.left: inputCombo.left
                 anchors.right: inputCombo.horizontalCenter
                 anchors.top: inputSlider.bottom
-                anchors.topMargin: 24 * virtualstudio.uiScale
+                anchors.topMargin: 12 * virtualstudio.uiScale
                 textFormat: Text.RichText
                 text: "Input Channel(s)"
-                font { family: "Poppins"; pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale }
+                font { family: "Poppins"; pixelSize: fontExtraSmall * virtualstudio.fontScale * virtualstudio.uiScale }
                 color: textColour
             }
 
@@ -1328,7 +1328,7 @@ Item {
                 anchors.right: inputCombo.horizontalCenter
                 anchors.rightMargin: 8 * virtualstudio.uiScale
                 anchors.top: inputChannelsLabel.bottom
-                anchors.topMargin: 16 * virtualstudio.uiScale
+                anchors.topMargin: 12 * virtualstudio.uiScale
                 model: inputChannelsComboModel
                 currentIndex: (() => {
                     let idx = inputChannelsComboModel.findIndex(elem => elem.baseChannel === virtualstudio.baseInputChannel
@@ -1373,10 +1373,10 @@ Item {
                 anchors.right: inputCombo.right
                 anchors.rightMargin: 8 * virtualstudio.uiScale
                 anchors.top: inputSlider.bottom
-                anchors.topMargin: 24 * virtualstudio.uiScale
+                anchors.topMargin: 12 * virtualstudio.uiScale
                 textFormat: Text.RichText
                 text: "Mono / Stereo"
-                font { family: "Poppins"; pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale }
+                font { family: "Poppins"; pixelSize: fontExtraSmall * virtualstudio.fontScale * virtualstudio.uiScale }
                 color: textColour
             }
 
@@ -1386,7 +1386,7 @@ Item {
                 anchors.right: inputCombo.right
                 anchors.rightMargin: 8 * virtualstudio.uiScale
                 anchors.top: inputMixModeLabel.bottom
-                anchors.topMargin: 16 * virtualstudio.uiScale
+                anchors.topMargin: 12 * virtualstudio.uiScale
                 model: inputMixModeComboModel
                 currentIndex: (() => {
                     let idx = inputMixModeComboModel.findIndex(elem => elem.value === virtualstudio.inputMixMode);

--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -882,7 +882,7 @@ void QJackTrip::start()
             }
 
             m_jackTrip.reset(new JackTrip(
-                jackTripMode, JackTrip::UDP, 0, m_ui->channelSendSpinBox->value(),
+                jackTripMode, JackTrip::UDP, 0, m_ui->channelSendSpinBox->value(), 0,
                 m_ui->channelRecvSpinBox->value(), AudioInterface::MIX_UNSET,
 #ifdef WAIR  // wair
                 0,

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -2033,7 +2033,11 @@ void VirtualStudio::updatedOutputVuMeasurements(const float* valuesInDecibels,
             detectedClip = true;
         }
     }
-
+#ifdef RT_AUDIO
+    if (m_numOutputChannels == 1) {
+        uiValues[1] = uiValues[0];
+    }
+#endif
     m_view.engine()->rootContext()->setContextProperty(QStringLiteral("outputMeterModel"),
                                                        QVariant::fromValue(uiValues));
 }

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1503,10 +1503,11 @@ void VirtualStudio::completeConnection()
         JackTrip* jackTrip = m_device->initJackTrip(
             m_useRtAudio, input, output,
 #ifdef RT_AUDIO
-            m_numInputChannels, m_numOutputChannels, m_baseInputChannel,
+            m_baseInputChannel, m_numInputChannels, m_baseOutputChannel,
+            m_numOutputChannels,
 #else
-            2, 2,  // default to 2 channels for input and 2 channels for output
-            1,     // start at channel 1 by default
+            0, 2, 0, 2,  // default to 2 channels for input and 2 channels for output
+                         // starting at channel 0
 #endif
             inputMixMode, buffer_size, m_bufferStrategy, studioInfo);
         if (jackTrip == 0) {

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1290,17 +1290,6 @@ void VirtualStudio::validateOutputDevicesState()
                   << std::endl;
         return;
     } else if (numDevicesChannelsAvailable == 1) {
-        // Set the output mix mode to just have "Mono" as the option
-        QJsonObject outputMixModeComboElement = QJsonObject();
-        outputMixModeComboElement.insert(QString::fromStdString("label"),
-                                         QString::fromStdString("Mono"));
-        outputMixModeComboElement.insert(QString::fromStdString("value"),
-                                         static_cast<int>(AudioInterface::MONO));
-        m_view.engine()->rootContext()->setContextProperty(
-            QStringLiteral("outputMixModeComboModel"),
-            QVariant::fromValue(QVariant(
-                QVariantList() << QVariant(QJsonValue(outputMixModeComboElement)))));
-
         // Set the output channels combo to only have channel 1 as an option
         QJsonObject outputChannelsComboElement = QJsonObject();
         outputChannelsComboElement.insert(QString::fromStdString("label"),
@@ -1324,13 +1313,6 @@ void VirtualStudio::validateOutputDevicesState()
         // set the output channels selector to have the options based on the currently
         // selected device
         QVariantList items = QVariantList();
-        for (int i = 0; i < numDevicesChannelsAvailable; i++) {
-            QJsonObject element = QJsonObject();
-            element.insert(QString::fromStdString("label"), QVariant(i + 1).toString());
-            element.insert(QString::fromStdString("baseChannel"), QVariant(i).toInt());
-            element.insert(QString::fromStdString("numChannels"), QVariant(1).toInt());
-            items.push_back(QVariant(QJsonValue(element)));
-        }
         for (int i = 0; i < numDevicesChannelsAvailable; i++) {
             if (i % 2 == 0) {
                 QJsonObject element = QJsonObject();

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -279,7 +279,7 @@ VirtualStudio::VirtualStudio(bool firstRun, QObject* parent)
     m_view.setMinimumSize(QSize(594, 519));
     // m_view.setMaximumSize(QSize(696, 577));
     m_view.setResizeMode(QQuickView::SizeRootObjectToView);
-    m_view.resize(696 * m_uiScale, 656 * m_uiScale);
+    m_view.resize(696 * m_uiScale, 676 * m_uiScale);
 
     // Connect our timers
     connect(&m_retryPeriodTimer, &QTimer::timeout, this, &VirtualStudio::endRetryPeriod);

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -2418,6 +2418,8 @@ void VirtualStudio::startAudio()
     m_vsAudioInterface->setBaseInputChannel(m_baseInputChannel, true);
     m_vsAudioInterface->setNumInputChannels(m_numInputChannels, true);
     m_vsAudioInterface->setInputMixMode(m_inputMixMode, true);
+    m_vsAudioInterface->setBaseOutputChannel(m_baseOutputChannel, true);
+    m_vsAudioInterface->setNumOutputChannels(m_numOutputChannels, true);
 #endif
     connect(m_vsAudioInterface.data(), &VsAudioInterface::devicesErrorMsgChanged, this,
             &VirtualStudio::updatedDevicesErrorMsg);
@@ -2443,6 +2445,10 @@ void VirtualStudio::startAudio()
             &VsAudioInterface::setBaseInputChannel);
     connect(this, &VirtualStudio::inputMixModeChanged, m_vsAudioInterface.data(),
             &VsAudioInterface::setInputMixMode);
+    connect(this, &VirtualStudio::numOutputChannelsChanged, m_vsAudioInterface.data(),
+            &VsAudioInterface::setNumOutputChannels);
+    connect(this, &VirtualStudio::baseOutputChannelChanged, m_vsAudioInterface.data(),
+            &VsAudioInterface::setBaseOutputChannel);
     connect(this, &VirtualStudio::audioBackendChanged, m_vsAudioInterface.data(),
             &VsAudioInterface::setAudioInterfaceMode);
     connect(this, &VirtualStudio::triggerPlayOutputAudio, m_vsAudioInterface.data(),

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -125,7 +125,8 @@ VirtualStudio::VirtualStudio(bool firstRun, QObject* parent)
     }
 
     // use default base channel 0, if the setting does not exist
-    m_baseInputChannel = settings.value(QStringLiteral("BaseInputChannel"), 0).toInt();
+    m_baseInputChannel  = settings.value(QStringLiteral("BaseInputChannel"), 0).toInt();
+    m_baseOutputChannel = settings.value(QStringLiteral("BaseOutputChannel"), 0).toInt();
 
     // Handle migration scenarios. Assume this is a new user
     // if we have m_inputDevice == "" and m_outputDevice == ""
@@ -137,6 +138,10 @@ VirtualStudio::VirtualStudio(bool firstRun, QObject* parent)
                              .value(QStringLiteral("InputMixMode"),
                                     static_cast<int>(AudioInterface::MONO))
                              .toInt();
+
+        // use 2 channels for output
+        m_numOutputChannels =
+            settings.value(QStringLiteral("NumOutputChannels"), 2).toInt();
     } else {
         // existing installs - keep using stereo
         m_numInputChannels =
@@ -145,6 +150,10 @@ VirtualStudio::VirtualStudio(bool firstRun, QObject* parent)
                              .value(QStringLiteral("InputMixMode"),
                                     static_cast<int>(AudioInterface::STEREO))
                              .toInt();
+
+        // use 2 channels for output
+        m_numOutputChannels =
+            settings.value(QStringLiteral("NumOutputChannels"), 2).toInt();
     }
 
     m_bufferSize     = settings.value(QStringLiteral("BufferSize"), 128).toInt();
@@ -189,6 +198,18 @@ VirtualStudio::VirtualStudio(bool firstRun, QObject* parent)
         QStringLiteral("inputChannelsComboModel"),
         QVariant::fromValue(
             QVariant(QVariantList() << QVariant(QJsonValue(inputChannelsComboElement)))));
+
+    QJsonObject outputChannelsComboElement = QJsonObject();
+    outputChannelsComboElement.insert(QString::fromStdString("label"),
+                                      QString::fromStdString("1 & 2"));
+    outputChannelsComboElement.insert(QString::fromStdString("baseChannel"),
+                                      QVariant(0).toInt());
+    outputChannelsComboElement.insert(QString::fromStdString("numChannels"),
+                                      QVariant(2).toInt());
+    m_view.engine()->rootContext()->setContextProperty(
+        QStringLiteral("outputChannelsComboModel"),
+        QVariant::fromValue(QVariant(
+            QVariantList() << QVariant(QJsonValue(outputChannelsComboElement)))));
 
 #endif
     m_bufferStrategy = settings.value(QStringLiteral("BufferStrategy"), 0).toInt();
@@ -473,6 +494,48 @@ void VirtualStudio::setOutputDevice([[maybe_unused]] const QString& device)
     m_outputDevice = device;
     emit outputDeviceChanged(m_outputDevice, false);
     emit outputDeviceSelected(m_outputDevice);
+#endif
+}
+
+int VirtualStudio::baseOutputChannel()
+{
+#ifdef RT_AUDIO
+    if (m_useRtAudio) {
+        return m_baseOutputChannel;
+    }
+#endif
+    return 0;
+}
+
+void VirtualStudio::setBaseOutputChannel([[maybe_unused]] int baseChannel)
+{
+    if (!m_useRtAudio) {
+        return;
+    }
+#ifdef RT_AUDIO
+    m_baseOutputChannel = baseChannel;
+    emit baseOutputChannelChanged(m_baseOutputChannel, true);
+#endif
+}
+
+int VirtualStudio::numOutputChannels()
+{
+#ifdef RT_AUDIO
+    if (m_useRtAudio) {
+        return m_numOutputChannels;
+    }
+#endif
+    return 0;
+}
+
+void VirtualStudio::setNumOutputChannels([[maybe_unused]] int numChannels)
+{
+    if (!m_useRtAudio) {
+        return;
+    }
+#ifdef RT_AUDIO
+    m_numOutputChannels = numChannels;
+    emit numOutputChannelsChanged(m_numOutputChannels, true);
 #endif
 }
 
@@ -1040,6 +1103,12 @@ void VirtualStudio::refreshDevices()
 
 void VirtualStudio::validateDevicesState()
 {
+    validateInputDevicesState();
+    validateOutputDevicesState();
+}
+
+void VirtualStudio::validateInputDevicesState()
+{
     if (!m_useRtAudio) {
         return;
     }
@@ -1048,17 +1117,12 @@ void VirtualStudio::validateDevicesState()
         return;
     }
 
-    // Given input device list and output device list, check that the currently set device
+    // Given input device list, check that the currently set device
     // actually exists
     if (m_inputDevice == QStringLiteral("")
         || m_inputDeviceList.indexOf(m_inputDevice) == -1) {
         m_inputDevice = m_inputDeviceList[0];
         emit inputDeviceChanged(m_inputDevice, false);
-    }
-    if (m_outputDevice == QStringLiteral("")
-        || m_outputDeviceList.indexOf(m_outputDevice) == -1) {
-        m_outputDevice = m_outputDeviceList[0];
-        emit outputDeviceChanged(m_outputDevice, false);
     }
 
     // Given the currently selected input device, reset the available input channel
@@ -1189,6 +1253,109 @@ void VirtualStudio::validateDevicesState()
                 m_inputMixMode = static_cast<int>(AudioInterface::MONO);
                 emit inputMixModeChanged(m_inputMixMode);
             }
+        }
+    }
+#endif  // RT_AUDIO
+}
+
+void VirtualStudio::validateOutputDevicesState()
+{
+    if (!m_useRtAudio) {
+        return;
+    }
+#ifdef RT_AUDIO
+    if (m_outputDeviceList.size() == 0 || m_outputDeviceList.size() == 0) {
+        return;
+    }
+
+    // Given output device list, check that the currently set device
+    // actually exists
+    if (m_outputDevice == QStringLiteral("")
+        || m_outputDeviceList.indexOf(m_outputDevice) == -1) {
+        m_outputDevice = m_outputDeviceList[0];
+        emit outputDeviceChanged(m_outputDevice, false);
+    }
+
+    // Given the currently selected output device, reset the available output channel
+    // options
+    int indexOfOutput = m_outputDeviceList.indexOf(m_outputDevice);
+    if (indexOfOutput == -1) {
+        std::cerr << "Invalid state. Output device index should never be -1" << std::endl;
+        return;
+    }
+
+    int numDevicesChannelsAvailable = m_outputDeviceChannels.at(indexOfOutput);
+    if (numDevicesChannelsAvailable < 1) {
+        std::cerr << "Invalid state. Number of channels should never be less than 1"
+                  << std::endl;
+        return;
+    } else if (numDevicesChannelsAvailable == 1) {
+        // Set the output mix mode to just have "Mono" as the option
+        QJsonObject outputMixModeComboElement = QJsonObject();
+        outputMixModeComboElement.insert(QString::fromStdString("label"),
+                                         QString::fromStdString("Mono"));
+        outputMixModeComboElement.insert(QString::fromStdString("value"),
+                                         static_cast<int>(AudioInterface::MONO));
+        m_view.engine()->rootContext()->setContextProperty(
+            QStringLiteral("outputMixModeComboModel"),
+            QVariant::fromValue(QVariant(
+                QVariantList() << QVariant(QJsonValue(outputMixModeComboElement)))));
+
+        // Set the output channels combo to only have channel 1 as an option
+        QJsonObject outputChannelsComboElement = QJsonObject();
+        outputChannelsComboElement.insert(QString::fromStdString("label"),
+                                          QString::fromStdString("1"));
+        outputChannelsComboElement.insert(QString::fromStdString("baseChannel"),
+                                          QVariant(0).toInt());
+        outputChannelsComboElement.insert(QString::fromStdString("numChannels"),
+                                          QVariant(1).toInt());
+        m_view.engine()->rootContext()->setContextProperty(
+            QStringLiteral("outputChannelsComboModel"),
+            QVariant::fromValue(QVariant(
+                QVariantList() << QVariant(QJsonValue(outputChannelsComboElement)))));
+
+        // Set the only allowed options for these variables automatically
+        m_baseOutputChannel = 0;
+        m_numOutputChannels = 1;
+
+        emit baseOutputChannelChanged(m_baseOutputChannel);
+        emit numOutputChannelsChanged(m_numOutputChannels);
+    } else {
+        // set the output channels selector to have the options based on the currently
+        // selected device
+        QVariantList items = QVariantList();
+        for (int i = 0; i < numDevicesChannelsAvailable; i++) {
+            QJsonObject element = QJsonObject();
+            element.insert(QString::fromStdString("label"), QVariant(i + 1).toString());
+            element.insert(QString::fromStdString("baseChannel"), QVariant(i).toInt());
+            element.insert(QString::fromStdString("numChannels"), QVariant(1).toInt());
+            items.push_back(QVariant(QJsonValue(element)));
+        }
+        for (int i = 0; i < numDevicesChannelsAvailable; i++) {
+            if (i % 2 == 0) {
+                QJsonObject element = QJsonObject();
+                element.insert(
+                    QString::fromStdString("label"),
+                    QVariant(i + 1).toString() + " & " + QVariant(i + 2).toString());
+                element.insert(QString::fromStdString("baseChannel"),
+                               QVariant(i).toInt());
+                element.insert(QString::fromStdString("numChannels"),
+                               QVariant(2).toInt());
+                items.push_back(QVariant(QJsonValue(element)));
+            }
+        }
+        m_view.engine()->rootContext()->setContextProperty(
+            QStringLiteral("outputChannelsComboModel"), QVariant(items));
+
+        // if the current m_baseOutputChannel or m_numOutputChannels is invalid based on
+        // this device's option, use the first two channels by default
+        if (m_baseOutputChannel + m_numOutputChannels > numDevicesChannelsAvailable) {
+            // we're in the case where numDevicesChannelsAvailable >= 2, so always have
+            // the ability to use the first 2 channels
+            m_baseOutputChannel = 0;
+            m_numOutputChannels = 2;
+            emit baseOutputChannelChanged(m_baseOutputChannel);
+            emit numOutputChannelsChanged(m_numOutputChannels);
         }
     }
 #endif  // RT_AUDIO

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -92,6 +92,10 @@ class VirtualStudio : public QObject
                    numInputChannelsChanged)
     Q_PROPERTY(int inputMixMode READ inputMixMode WRITE setInputMixMode NOTIFY
                    inputMixModeChanged)
+    Q_PROPERTY(int baseOutputChannel READ baseOutputChannel WRITE setBaseOutputChannel
+                   NOTIFY baseOutputChannelChanged)
+    Q_PROPERTY(int numOutputChannels READ numOutputChannels WRITE setNumOutputChannels
+                   NOTIFY numOutputChannelsChanged)
 
     Q_PROPERTY(QString devicesWarning READ devicesWarning NOTIFY devicesWarningChanged)
     Q_PROPERTY(QString devicesError READ devicesError NOTIFY devicesErrorChanged)
@@ -170,6 +174,10 @@ class VirtualStudio : public QObject
     int inputMixMode();
     QString outputDevice();
     void setOutputDevice(const QString& device);
+    int baseOutputChannel();
+    void setBaseOutputChannel(int baseChannel);
+    int numOutputChannels();
+    void setNumOutputChannels(int numChannels);
     int previousInput();
     void setPreviousInput(int device);
     int previousOutput();
@@ -233,6 +241,8 @@ class VirtualStudio : public QObject
     void refreshStudios(int index, bool signalRefresh = false);
     void refreshDevices();
     void validateDevicesState();
+    void validateInputDevicesState();
+    void validateOutputDevicesState();
     void playOutputAudio();
     void revertSettings();
     void applySettings();
@@ -274,6 +284,8 @@ class VirtualStudio : public QObject
     void outputDeviceChanged(QString device, bool shouldRestart = true);
     void inputDeviceSelected(QString device, bool shouldRestart = true);
     void outputDeviceSelected(QString device, bool shouldRestart = true);
+    void baseOutputChannelChanged(int baseChannel, bool shouldRestart = true);
+    void numOutputChannelsChanged(int numChannels, bool shouldRestart = true);
     void previousInputChanged();
     void previousOutputChanged();
     void devicesWarningChanged();
@@ -445,7 +457,8 @@ class VirtualStudio : public QObject
     int m_numInputChannels;
     int m_inputMixMode;
 
-    int m_numOutputChannels = 2;
+    int m_baseOutputChannel;
+    int m_numOutputChannels;
 
     bool m_previousUseRtAudio = false;
     inline void delay(int millisecondsWait)

--- a/src/gui/vsAudioInterface.cpp
+++ b/src/gui/vsAudioInterface.cpp
@@ -233,7 +233,7 @@ void VsAudioInterface::setupRtAudio()
             inputChans[i] = m_baseInputChannel + i;
         }
         for (int i = 0; i < m_numAudioChansOut; i++) {
-            outputChans[i] = 1 + i;
+            outputChans[i] = m_baseOutputChannel + i;
         }
 
         m_audioInterface.reset(new RtAudioInterface(
@@ -392,6 +392,37 @@ void VsAudioInterface::setOutputDevice(QString deviceName, bool shouldRestart)
             emit settingsUpdated();
         }
     }
+}
+
+void VsAudioInterface::setBaseOutputChannel(int baseChannel, bool shouldRestart)
+{
+    if (m_audioInterfaceMode != VsAudioInterface::RTAUDIO) {
+        return;
+    }
+#ifdef RT_AUDIO
+    m_baseOutputChannel = baseChannel;
+    if (!m_audioInterface.isNull()) {
+        if (m_audioActive && shouldRestart) {
+            emit settingsUpdated();
+        }
+    }
+#endif
+    return;
+}
+
+void VsAudioInterface::setNumOutputChannels(int numChannels, bool shouldRestart)
+{
+    if (m_audioInterfaceMode != VsAudioInterface::RTAUDIO) {
+        return;
+    }
+#ifdef RT_AUDIO
+    m_numAudioChansOut = numChannels;
+    if (!m_audioInterface.isNull()) {
+        if (m_audioActive && shouldRestart) {
+            emit settingsUpdated();
+        }
+    }
+#endif
 }
 
 void VsAudioInterface::setAudioInterfaceMode(bool useRtAudio, bool shouldRestart)

--- a/src/gui/vsAudioInterface.h
+++ b/src/gui/vsAudioInterface.h
@@ -97,6 +97,8 @@ class VsAudioInterface : public QObject
     void setNumInputChannels(int numChannels, bool shouldRestart = true);
     void setInputMixMode(const int mode, bool shouldRestart = true);
     void setOutputDevice(QString deviceName, bool shouldRestart = true);
+    void setBaseOutputChannel(int baseChannel, bool shouldRestart = true);
+    void setNumOutputChannels(int numChannels, bool shouldRestart = true);
     void setAudioInterfaceMode(bool useRtAudio, bool shouldRestart = true);
     void setInputVolume(float multiplier);
     void setOutputVolume(float multiplier);
@@ -136,8 +138,9 @@ class VsAudioInterface : public QObject
     bool m_audioActive    = false;
     bool m_hasBeenActive  = false;
 
-    int m_baseInputChannel = 0;
-    int m_inputMixMode     = 0;
+    int m_baseInputChannel  = 0;
+    int m_baseOutputChannel = 0;
+    int m_inputMixMode      = 0;
 
     // Needed in constructor
     int m_numAudioChansIn;   ///< Number of Audio Input Channels

--- a/src/gui/vsDevice.cpp
+++ b/src/gui/vsDevice.cpp
@@ -343,18 +343,20 @@ void VsDevice::sendLevels()
 // initJackTrip spawns a new jacktrip process with the desired settings
 JackTrip* VsDevice::initJackTrip(
     [[maybe_unused]] bool useRtAudio, [[maybe_unused]] std::string input,
-    [[maybe_unused]] std::string output, [[maybe_unused]] int numChannelsIn,
-    [[maybe_unused]] int numChannelsOut, [[maybe_unused]] int baseInputChannel,
-    [[maybe_unused]] int inputMixMode, [[maybe_unused]] int bufferSize,
-    [[maybe_unused]] int bufferStrategy, VsServerInfo* studioInfo)
+    [[maybe_unused]] std::string output, [[maybe_unused]] int baseInputChannel,
+    [[maybe_unused]] int numChannelsIn, [[maybe_unused]] int baseOutputChannel,
+    [[maybe_unused]] int numChannelsOut, [[maybe_unused]] int inputMixMode,
+    [[maybe_unused]] int bufferSize, [[maybe_unused]] int bufferStrategy,
+    VsServerInfo* studioInfo)
 {
-    m_jackTrip.reset(new JackTrip(
-        JackTrip::CLIENTTOPINGSERVER, JackTrip::UDP, baseInputChannel, numChannelsIn,
-        numChannelsOut, static_cast<AudioInterface::inputMixModeT>(inputMixMode),
+    m_jackTrip.reset(
+        new JackTrip(JackTrip::CLIENTTOPINGSERVER, JackTrip::UDP, baseInputChannel,
+                     numChannelsIn, baseOutputChannel, numChannelsOut,
+                     static_cast<AudioInterface::inputMixModeT>(inputMixMode),
 #ifdef WAIR  // wair
-        0,
+                     0,
 #endif  // endwhere
-        4, 1));
+                     4, 1));
     m_jackTrip->setConnectDefaultAudioPorts(true);
 #ifdef RT_AUDIO
     if (useRtAudio) {

--- a/src/gui/vsDevice.h
+++ b/src/gui/vsDevice.h
@@ -67,9 +67,9 @@ class VsDevice : public QObject
     void sendHeartbeat();
     void setServerId(QString studioID);
     JackTrip* initJackTrip(bool useRtAudio, std::string input, std::string output,
-                           int numChannelsIn, int numChannelsOut, int baseInputChannel,
-                           int inputMixMode, int bufferSize, int bufferStrategy,
-                           VsServerInfo* studioInfo);
+                           int baseInputChannel, int numChannelsIn, int baseOutputChannel,
+                           int numChannelsOut, int inputMixMode, int bufferSize,
+                           int bufferStrategy, VsServerInfo* studioInfo);
     void startJackTrip();
     void stopJackTrip();
     void reconcileAgentConfig(QJsonDocument newState);


### PR DESCRIPTION
Follow up to #904. We'd also like the ability of users to select which output channels they want to use. It includes channel selection but not channel configuration options like with input channels (e.g. mix-to-mono, etc.).

- If the device has one channel  in VS mode, only a "1" is available
- If the device has more than one channel in VS mode, only stereo pairs are included "1 & 2", "3 & 4", and so on. There is no "1" or "2" (or so on), options.

[6dc5de2](https://github.com/jacktrip/jacktrip/pull/953/commits/6dc5de2c35a11d25fdc7e4a508bf1af5871d80d6) also fixes some bugs pertaining to the order and default values of `JackTrip()` constructor parameters.

This PR represents the minimal functionality we would like at this time on the JackTrip Labs side of the project. Any future work on output channel configuration should probably happen in a new PR, to limit the scope of this one