### PR TITLE
Update version and changelog for beta 2

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -5,13 +5,17 @@
   - (added) GHA builds now include static preview docs
   - (added) when using the classic GUI, command line options are now parsed
   - (added) VS mode - Selecting and configuring device channels
+  - (added) Classic mode - Warning for machines without JACK installed
   - (updated) icons in VS mode 
   - (updated) Linux builds now use Qt 5.15.8
   - (updated) Replaced QVector in meter code
   - (updated) Removed set-output from GHA scripts for deprecation
   - (updated) Automated the auto-updater release process
+  - (updated) RtAudio is included in Linux binary releases
+  - (updated) text on audio setup confirm button when using deeplink
   - (fixed) ambiguous call to overloaded function in Qt6
   - (fixed) issue where selected devices were not the devices used for output
+  - (fixed) crash when using Classic mode and CLI w/ JACK
 - Version: "1.7.1"
   Date: 2023-02-03
   Description:

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -40,7 +40,7 @@
 
 #include "AudioInterface.h"
 
-constexpr const char* const gVersion = "1.8.0-beta1";  ///< JackTrip version
+constexpr const char* const gVersion = "1.8.0-beta2";  ///< JackTrip version
 
 //*******************************************************************************
 /// \name Default Values


### PR DESCRIPTION
Including the JACK crash fix, return of the "JACK not installed" warning, and updated audio confirm text in VS mode.