### PR TITLE
Adding build-aux directory for better integration in Gnome Builder

### DIFF
--- a/build-aux/flatpak/org.jacktrip.JackTrip.json
+++ b/build-aux/flatpak/org.jacktrip.JackTrip.json
@@ -1,0 +1,36 @@
+{
+    "app-id": "org.jacktrip.JackTrip",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "5.15-22.08",
+    "sdk": "org.kde.Sdk",
+    "command": "jacktrip",
+    "finish-args": [
+        "--share=ipc",
+        "--socket=x11",
+        "--device=dri",
+        "--share=network",
+        "--filesystem=xdg-run/pipewire-0",
+        "--env=PIPEWIRE_LATENCY=256/48000"
+    ],
+    "cleanup": [
+        "/lib/python3.10",
+        "/share/man"
+    ],
+    "modules": [
+        "pypi-dependencies.json",
+        {
+            "name": "jacktrip",
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dbuildtype=debugoptimized"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "disable-submodules": true,
+                    "url": "https://github.com/jacktrip/jacktrip/"
+                }
+            ]
+        }
+    ]
+}

--- a/build-aux/flatpak/pypi-dependencies.json
+++ b/build-aux/flatpak/pypi-dependencies.json
@@ -1,0 +1,40 @@
+{
+    "name": "pypi-dependencies",
+    "buildsystem": "simple",
+    "build-commands": [],
+    "modules": [
+        {
+            "name": "python3-pyyaml",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pyyaml\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/36/2b/61d51a2c4f25ef062ae3f74576b01638bebad5e045f747ff12643df63844/PyYAML-6.0.tar.gz",
+                    "sha256": "68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"
+                }
+            ]
+        },
+        {
+            "name": "python3-jinja2",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"jinja2\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/bc/c3/f068337a370801f372f2f8f6bad74a5c140f6fda3d9de154052708dd3c65/Jinja2-3.1.2-py3-none-any.whl",
+                    "sha256": "6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/95/7e/68018b70268fb4a2a605e2be44ab7b4dd7ce7808adae6c5ef32e34f4b55a/MarkupSafe-2.1.2.tar.gz",
+                    "sha256": "abcabc8c2b26036d62d4c746381a6f7cf60aafcc653198ad678306986b09450d"
+                }
+            ]
+        }
+    ]
+}

--- a/build-aux/flatpak/requirements.txt
+++ b/build-aux/flatpak/requirements.txt
@@ -1,0 +1,2 @@
+pyyaml
+jinja2

--- a/build-aux/flatpak/update_pip_deps.sh
+++ b/build-aux/flatpak/update_pip_deps.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# https://github.com/flatpak/flatpak-builder-tools/tree/master/pip
+flatpak-pip-generator --runtime='org.freedesktop.Sdk//22.08' --requirements-file='requirements.txt' --output pypi-dependencies


### PR DESCRIPTION
Having the flatpak manifest in the build-aux directory let's Gnome Builder setup flatpak directly as a project configuration. This change makes it much easier to check and debug the flatpak build.