### PR TITLE
Fix Compiler Warnings When Building Without RtAudio

### DIFF
--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -471,7 +471,6 @@ int VirtualStudio::inputMixMode()
 }
 #endif
 
-
 QString VirtualStudio::outputDevice()
 {
 #ifdef RT_AUDIO

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -418,13 +418,12 @@ void VirtualStudio::setInputDevice([[maybe_unused]] const QString& device)
 #endif
 }
 
+#ifdef RT_AUDIO
 int VirtualStudio::baseInputChannel()
 {
-#ifdef RT_AUDIO
     if (m_useRtAudio) {
         return m_baseInputChannel;
     }
-#endif
     return 0;
 }
 
@@ -433,19 +432,15 @@ void VirtualStudio::setBaseInputChannel([[maybe_unused]] int baseChannel)
     if (!m_useRtAudio) {
         return;
     }
-#ifdef RT_AUDIO
     m_baseInputChannel = baseChannel;
     emit baseInputChannelChanged(m_baseInputChannel, true);
-#endif
 }
 
 int VirtualStudio::numInputChannels()
 {
-#ifdef RT_AUDIO
     if (m_useRtAudio) {
         return m_numInputChannels;
     }
-#endif
     return 0;
 }
 
@@ -454,10 +449,8 @@ void VirtualStudio::setNumInputChannels([[maybe_unused]] int numChannels)
     if (!m_useRtAudio) {
         return;
     }
-#ifdef RT_AUDIO
     m_numInputChannels = numChannels;
     emit numInputChannelsChanged(m_numInputChannels, true);
-#endif
 }
 
 void VirtualStudio::setInputMixMode(int mode)
@@ -465,11 +458,8 @@ void VirtualStudio::setInputMixMode(int mode)
     if (!m_useRtAudio) {
         return;
     }
-#ifdef RT_AUDIO
     m_inputMixMode = mode;
     emit inputMixModeChanged(m_inputMixMode, true);
-#endif
-    return;
 }
 
 int VirtualStudio::inputMixMode()
@@ -477,10 +467,10 @@ int VirtualStudio::inputMixMode()
     if (!m_useRtAudio) {
         return -1;
     }
-#ifdef RT_AUDIO
     return m_inputMixMode;
-#endif
 }
+#endif
+
 
 QString VirtualStudio::outputDevice()
 {
@@ -502,13 +492,12 @@ void VirtualStudio::setOutputDevice([[maybe_unused]] const QString& device)
 #endif
 }
 
+#ifdef RT_AUDIO
 int VirtualStudio::baseOutputChannel()
 {
-#ifdef RT_AUDIO
     if (m_useRtAudio) {
         return m_baseOutputChannel;
     }
-#endif
     return 0;
 }
 
@@ -517,19 +506,15 @@ void VirtualStudio::setBaseOutputChannel([[maybe_unused]] int baseChannel)
     if (!m_useRtAudio) {
         return;
     }
-#ifdef RT_AUDIO
     m_baseOutputChannel = baseChannel;
     emit baseOutputChannelChanged(m_baseOutputChannel, true);
-#endif
 }
 
 int VirtualStudio::numOutputChannels()
 {
-#ifdef RT_AUDIO
     if (m_useRtAudio) {
         return m_numOutputChannels;
     }
-#endif
     return 0;
 }
 
@@ -538,11 +523,10 @@ void VirtualStudio::setNumOutputChannels([[maybe_unused]] int numChannels)
     if (!m_useRtAudio) {
         return;
     }
-#ifdef RT_AUDIO
     m_numOutputChannels = numChannels;
     emit numOutputChannelsChanged(m_numOutputChannels, true);
-#endif
 }
+#endif
 
 int VirtualStudio::previousInput()
 {

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -2416,16 +2416,18 @@ void VirtualStudio::startAudio()
             &VsAudioInterface::setOutputDevice);
     connect(this, &VirtualStudio::outputDeviceSelected, m_vsAudioInterface.data(),
             &VsAudioInterface::setOutputDevice);
-    connect(this, &VirtualStudio::numInputChannelsChanged, m_vsAudioInterface.data(),
-            &VsAudioInterface::setNumInputChannels);
+#ifdef RT_AUDIO
     connect(this, &VirtualStudio::baseInputChannelChanged, m_vsAudioInterface.data(),
             &VsAudioInterface::setBaseInputChannel);
+    connect(this, &VirtualStudio::numInputChannelsChanged, m_vsAudioInterface.data(),
+            &VsAudioInterface::setNumInputChannels);
     connect(this, &VirtualStudio::inputMixModeChanged, m_vsAudioInterface.data(),
             &VsAudioInterface::setInputMixMode);
-    connect(this, &VirtualStudio::numOutputChannelsChanged, m_vsAudioInterface.data(),
-            &VsAudioInterface::setNumOutputChannels);
     connect(this, &VirtualStudio::baseOutputChannelChanged, m_vsAudioInterface.data(),
             &VsAudioInterface::setBaseOutputChannel);
+    connect(this, &VirtualStudio::numOutputChannelsChanged, m_vsAudioInterface.data(),
+            &VsAudioInterface::setNumOutputChannels);
+#endif
     connect(this, &VirtualStudio::audioBackendChanged, m_vsAudioInterface.data(),
             &VsAudioInterface::setAudioInterfaceMode);
     connect(this, &VirtualStudio::triggerPlayOutputAudio, m_vsAudioInterface.data(),

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -86,6 +86,7 @@ class VirtualStudio : public QObject
                    previousInputChanged)
     Q_PROPERTY(int previousOutput READ previousOutput WRITE setPreviousOutput NOTIFY
                    previousOutputChanged)
+#ifdef RT_AUDIO
     Q_PROPERTY(int baseInputChannel READ baseInputChannel WRITE setBaseInputChannel NOTIFY
                    baseInputChannelChanged)
     Q_PROPERTY(int numInputChannels READ numInputChannels WRITE setNumInputChannels NOTIFY
@@ -96,7 +97,7 @@ class VirtualStudio : public QObject
                    NOTIFY baseOutputChannelChanged)
     Q_PROPERTY(int numOutputChannels READ numOutputChannels WRITE setNumOutputChannels
                    NOTIFY numOutputChannelsChanged)
-
+#endif
     Q_PROPERTY(QString devicesWarning READ devicesWarning NOTIFY devicesWarningChanged)
     Q_PROPERTY(QString devicesError READ devicesError NOTIFY devicesErrorChanged)
     Q_PROPERTY(QString devicesWarningHelpUrl READ devicesWarningHelpUrl NOTIFY
@@ -169,18 +170,22 @@ class VirtualStudio : public QObject
     void setAudioBackend(const QString& backend);
     QString inputDevice();
     void setInputDevice(const QString& device);
+#ifdef RT_AUDIO
     int baseInputChannel();
     void setBaseInputChannel(int baseChannel);
     int numInputChannels();
     void setNumInputChannels(int numChannels);
     void setInputMixMode(int mode);
     int inputMixMode();
+#endif
     QString outputDevice();
     void setOutputDevice(const QString& device);
+#ifdef RT_AUDIO
     int baseOutputChannel();
     void setBaseOutputChannel(int baseChannel);
     int numOutputChannels();
     void setNumOutputChannels(int numChannels);
+#endif
     int previousInput();
     void setPreviousInput(int device);
     int previousOutput();

--- a/src/gui/vsAudioInterface.cpp
+++ b/src/gui/vsAudioInterface.cpp
@@ -337,19 +337,18 @@ void VsAudioInterface::setInputDevice(QString deviceName, bool shouldRestart)
     }
 }
 
+#ifdef RT_AUDIO
 void VsAudioInterface::setBaseInputChannel(int baseChannel, bool shouldRestart)
 {
     if (m_audioInterfaceMode != VsAudioInterface::RTAUDIO) {
         return;
     }
-#ifdef RT_AUDIO
     m_baseInputChannel = baseChannel;
     if (!m_audioInterface.isNull()) {
         if (m_audioActive && shouldRestart) {
             emit settingsUpdated();
         }
     }
-#endif
     return;
 }
 
@@ -358,14 +357,12 @@ void VsAudioInterface::setNumInputChannels(int numChannels, bool shouldRestart)
     if (m_audioInterfaceMode != VsAudioInterface::RTAUDIO) {
         return;
     }
-#ifdef RT_AUDIO
     m_numAudioChansIn = numChannels;
     if (!m_audioInterface.isNull()) {
         if (m_audioActive && shouldRestart) {
             emit settingsUpdated();
         }
     }
-#endif
 }
 
 void VsAudioInterface::setInputMixMode(const int mode, bool shouldRestart)
@@ -373,7 +370,6 @@ void VsAudioInterface::setInputMixMode(const int mode, bool shouldRestart)
     if (m_audioInterfaceMode != VsAudioInterface::RTAUDIO) {
         return;
     }
-#ifdef RT_AUDIO
     m_inputMixMode = mode;
     if (!m_audioInterface.isNull()) {
         if (m_audioActive && shouldRestart) {
@@ -381,9 +377,8 @@ void VsAudioInterface::setInputMixMode(const int mode, bool shouldRestart)
         }
     }
     return;
-#endif
 }
-
+#endif
 void VsAudioInterface::setOutputDevice(QString deviceName, bool shouldRestart)
 {
     m_outputDeviceName = deviceName.toStdString();
@@ -394,19 +389,18 @@ void VsAudioInterface::setOutputDevice(QString deviceName, bool shouldRestart)
     }
 }
 
+#ifdef RT_AUDIO
 void VsAudioInterface::setBaseOutputChannel(int baseChannel, bool shouldRestart)
 {
     if (m_audioInterfaceMode != VsAudioInterface::RTAUDIO) {
         return;
     }
-#ifdef RT_AUDIO
     m_baseOutputChannel = baseChannel;
     if (!m_audioInterface.isNull()) {
         if (m_audioActive && shouldRestart) {
             emit settingsUpdated();
         }
     }
-#endif
     return;
 }
 
@@ -415,15 +409,14 @@ void VsAudioInterface::setNumOutputChannels(int numChannels, bool shouldRestart)
     if (m_audioInterfaceMode != VsAudioInterface::RTAUDIO) {
         return;
     }
-#ifdef RT_AUDIO
     m_numAudioChansOut = numChannels;
     if (!m_audioInterface.isNull()) {
         if (m_audioActive && shouldRestart) {
             emit settingsUpdated();
         }
     }
-#endif
 }
+#endif
 
 void VsAudioInterface::setAudioInterfaceMode(bool useRtAudio, bool shouldRestart)
 {

--- a/src/gui/vsAudioInterface.h
+++ b/src/gui/vsAudioInterface.h
@@ -93,12 +93,16 @@ class VsAudioInterface : public QObject
 
    public slots:
     void setInputDevice(QString deviceName, bool shouldRestart = true);
+#ifdef RT_AUDIO
     void setBaseInputChannel(int baseChannel, bool shouldRestart = true);
     void setNumInputChannels(int numChannels, bool shouldRestart = true);
     void setInputMixMode(const int mode, bool shouldRestart = true);
+#endif
     void setOutputDevice(QString deviceName, bool shouldRestart = true);
+#ifdef RT_AUDIO
     void setBaseOutputChannel(int baseChannel, bool shouldRestart = true);
     void setNumOutputChannels(int numChannels, bool shouldRestart = true);
+#endif
     void setAudioInterfaceMode(bool useRtAudio, bool shouldRestart = true);
     void setInputVolume(float multiplier);
     void setOutputVolume(float multiplier);


### PR DESCRIPTION
Fixes some compiler warnings in builds not using RtAudio. To test and change flags with meson build system:

`meson configure -Drtaudio=disabled` or ``meson configure -Drtaudio=enabled` (in your build directory)