### PR TITLE
Improve Sign In For First Time Users

### DIFF
--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1013,7 +1013,6 @@ void VirtualStudio::toVirtualStudio()
                 (*parameters)[QStringLiteral("code")] = QUrl::fromPercentEncoding(code);
             } else if (stage == QAbstractOAuth2::Stage::RequestingAuthorization) {
                 parameters->insert(QStringLiteral("audience"), AUTH_AUDIENCE);
-                parameters->insert(QStringLiteral("prompt"), QStringLiteral("login"));
             }
             if (!parameters->contains("client_id")) {
                 parameters->insert("client_id", AUTH_CLIENT_ID);
@@ -2040,7 +2039,6 @@ void VirtualStudio::setupAuthenticator()
             } else if (stage == QAbstractOAuth2::Stage::RequestingAuthorization) {
                 parameters->insert(QStringLiteral("audience"),
                                    QStringLiteral("https://api.jacktrip.org"));
-                parameters->insert(QStringLiteral("prompt"), QStringLiteral("login"));
             }
         });
 

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1036,6 +1036,20 @@ void VirtualStudio::logout()
         m_device->removeApp();
     }
 
+    QUrl logoutURL = QUrl("https://auth.jacktrip.org/v2/logout");
+    QUrlQuery query;
+    query.addQueryItem(QStringLiteral("client_id"), AUTH_CLIENT_ID);
+    if (m_testMode) {
+        query.addQueryItem(QStringLiteral("returnTo"),
+                           QStringLiteral("https://test.jacktrip.org/"));
+    } else {
+        query.addQueryItem(QStringLiteral("returnTo"),
+                           QStringLiteral("https://app.jacktrip.org/"));
+    }
+
+    logoutURL.setQuery(query);
+    launchBrowser(logoutURL);
+
     m_authenticator->setToken(QLatin1String(""));
     m_authenticator->setRefreshToken(QLatin1String(""));
 


### PR DESCRIPTION
Follows up to and undoes #866. As a consequence of that pull request, first time users would need to log in again (for example, by re-entering their username and password) on the desktop app even though they had just done it through the web app by signing up for an account.

This PR undoes that requirement (46a35551ee02f2ba1fda87fa2deebce9115366eb) and redoes logout (01fb969608475bc6d5300ec6ad8c5fa14e74827b) by navigating to the user logout URL as explained [here](https://github.com/jacktrip/jacktrip/pull/866#issuecomment-1379713455). After pressing the logout button, the user is redirected to the app homepage. That may be good enough, or we might want to design a better dedicated logout landing page specifically for the desktop app.