### PR TITLE
replacing ipify url with jacktrip api endpoint

### DIFF
--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -259,6 +259,9 @@ Regulator::~Regulator()
 
 void Regulator::setFPPratio()
 {
+    qDebug() << "myFPP = " << mFPP << " / "
+        << "peerFPP = " << mPeerFPP;
+
     if (mPeerFPP != mFPP) {
         if (mPeerFPP > mFPP)
             mFPPratioDenominator = mPeerFPP / mFPP;

--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -240,8 +240,9 @@ QJackTrip::QJackTrip(Settings* settings, bool suppressCommandlineWarning, QWidge
     connect(m_netManager.data(), &QNetworkAccessManager::finished, this,
             &QJackTrip::receivedIP);
     // Use the ipify API to find our external IP address.
-    m_netManager->get(QNetworkRequest(QUrl(QStringLiteral("https://api.ipify.org"))));
-    m_netManager->get(QNetworkRequest(QUrl(QStringLiteral("https://api6.ipify.org"))));
+    // m_netManager->get(QNetworkRequest(QUrl(QStringLiteral("https://api.ipify.org"))));
+    m_netManager->get(
+        QNetworkRequest(QUrl(QStringLiteral("https://app.jacktrip.org/api/getmyip"))));
     m_ui->statusBar->showMessage(QStringLiteral("JackTrip version ").append(gVersion));
 
     // Set up our interface for the default Client run mode.

--- a/src/gui/qjacktrip.h
+++ b/src/gui/qjacktrip.h
@@ -151,8 +151,6 @@ class QJackTrip : public QMainWindow
     QList<QLabel*> m_outputLabels;
 
     QMutex m_requestMutex;
-    QString m_IPv6Address;
-    bool m_hasIPv4Reply;
     QString m_lastPath;
 
     QLabel m_autoQueueIndicator;


### PR DESCRIPTION
ipify is triggering firewall warnings (norton). i suspect this is due to it using a wildcard certificate.

➜  jacktrip git:(dev) ✗ curl https://api.ipify.org
76.226.67.212%

➜  jacktrip git:(dev) ✗ curl https://api6.ipify.org
curl: (6) Could not resolve host: api6.ipify.org

➜  jacktrip git:(dev) ✗ curl https://app.jacktrip.org/api/getmyip
76.226.67.212%
