### PR TITLE
Allow IP check to work with IPv6 only

### DIFF
--- a/src/gui/qjacktrip.h
+++ b/src/gui/qjacktrip.h
@@ -152,7 +152,8 @@ class QJackTrip : public QMainWindow
 
     QMutex m_requestMutex;
     QString m_IPv6Address;
-    bool m_hasIPv4Reply;
+    QString m_IPv4Address;
+    int m_replyCount = 0;
     QString m_lastPath;
 
     QLabel m_autoQueueIndicator;


### PR DESCRIPTION
Realised when looking over the IP check code that there's an assumption that an IPv4 address will always be available. This allows the code to report an address when on an IPv6 only network.