### PR TITLE
make buffer size and sample rate settable for Pipewire

### DIFF
--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -1115,11 +1115,13 @@ JackTrip* Settings::getConfiguredJackTrip()
         jackTrip->setSampleRate(mSampleRate);
     }
 
+#if defined(__unix__)
     if (mChangeDefaultBS and mChangeDefaultSR) {
         char latency_env[40];
         sprintf(latency_env, "%d/%d", mAudioBufferSize, mSampleRate);
         setenv("PIPEWIRE_LATENCY", latency_env, 1);
     }
+#endif
 
     // Set RtAudio
 #ifdef RT_AUDIO

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -1108,15 +1108,23 @@ JackTrip* Settings::getConfiguredJackTrip()
     // Change default Buffer Size
     if (mChangeDefaultBS) {
         jackTrip->setAudioBufferSizeInSamples(mAudioBufferSize);
+        if (!mChangeDefaultSR) {
+            jackTrip->setSampleRate(48000);
+            mSampleRate = 48000;
+        }
     }
 
     // Change default Sampling Rate
     if (mChangeDefaultSR) {
         jackTrip->setSampleRate(mSampleRate);
+        if (!mChangeDefaultBS) {
+            jackTrip->setAudioBufferSizeInSamples(128);
+            mAudioBufferSize = 128;
+        }
     }
 
 #if defined(__unix__)
-    if (mChangeDefaultBS and mChangeDefaultSR) {
+    if (mChangeDefaultBS or mChangeDefaultSR) {
         char latency_env[40];
         sprintf(latency_env, "%d/%d", mAudioBufferSize, mSampleRate);
         setenv("PIPEWIRE_LATENCY", latency_env, 1);

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -162,10 +162,12 @@ class Settings : public QObject
     bool mChangeDefaultSR    = false;  ///< Change Default Sampling Rate
     bool mChangeDefaultID    = 0;      ///< Change Default device ID
     bool mChangeDefaultBS    = false;  ///< Change Default Buffer Size
-#ifdef RT_AUDIO
+
     unsigned int mSampleRate;
-    unsigned int mDeviceID;
     unsigned int mAudioBufferSize;
+
+#ifdef RT_AUDIO
+    unsigned int mDeviceID;
     std::string mInputDeviceName, mOutputDeviceName;
 #endif
     unsigned int mHubConnectionMode = JackTrip::SERVERTOCLIENT;


### PR DESCRIPTION
The command line flags for setting the buffer size and sample rate were only available to the RtAudio backend. Making these flags available to all backends, let's us set the PIPEWIRE_LATENCY environment variable before the JACK client gets setup.

PIPEWIRE_LATENCY needs buffer size and sample rate. Getting the default values for these from JACK requires a JACK client. Instead of opening an ephemeral JACK client, ~~we require setting both buffer size (-F) and sample rate (-T) for setting PIPEWIRE_LATENCY instead.~~ we set the undefined value to the JackTrip's own default value.

PS: This also fixes -T segfaulting.