### PR TITLE
Fixes for Special Characters in Device Names

### DIFF
--- a/src/RtAudioInterface.cpp
+++ b/src/RtAudioInterface.cpp
@@ -629,7 +629,8 @@ void RtAudioInterface::getDeviceInfoFromName(std::string deviceName, int* index,
         unsigned int devices = rtaudio.getDeviceCount();
         for (unsigned int j = 0; j < devices; j++) {
             RtAudio::DeviceInfo info = rtaudio.getDeviceInfo(j);
-            if (info.probed == true && deviceName == info.name) {
+            if (info.probed == true
+                && deviceName == QString::fromStdString(info.name).toStdString()) {
                 if ((isInput && info.inputChannels > 0)
                     || (!isInput && info.outputChannels > 0)) {
                     *index = j;


### PR DESCRIPTION
As it turns out, `QString::fromStdString(str).toStdString() != str` in the case of some special characters. We had some support tickets from people who had a `RØDE Microphone` and weren't able to use them. I don't fully understand why, since `Ø` is a utf-8 character which is the encoding that `fromStdString` and `toStdString` use. But this appears to fix the issue.

Tested by creating a virtual device with the "Audio MIDI Setup" with the name `RØDE Microphone`. I also tried it with other special characters (symbols, accented vowels, the `n` with tilde, etc). So maybe this won't fully fix the issue, but it does seem like it will support a wider range of devices.

https://user-images.githubusercontent.com/26987971/226728516-6f8981ea-2eb9-44e2-a421-5e8642c9abcf.mov

