### PR TITLE
Fix Windows deeplink when open

### DIFF
--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -324,7 +324,7 @@ void VirtualStudio::show()
     if (m_checkSsl) {
         // Check our available SSL version
         QString sslVersion = QSslSocket::sslLibraryVersionString();
-        std::cout << "SSL Library: " << sslVersion.toStdString() << std::endl;
+        qDebug() << "SSL Library: " << sslVersion.toStdString();
         if (sslVersion.isEmpty()) {
             QMessageBox msgBox;
             msgBox.setText(

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -324,7 +324,7 @@ void VirtualStudio::show()
     if (m_checkSsl) {
         // Check our available SSL version
         QString sslVersion = QSslSocket::sslLibraryVersionString();
-        qDebug() << "SSL Library: " << sslVersion.toStdString();
+        qDebug() << "SSL Library: " << sslVersion;
         if (sslVersion.isEmpty()) {
             QMessageBox msgBox;
             msgBox.setText(

--- a/src/gui/vsInit.cpp
+++ b/src/gui/vsInit.cpp
@@ -65,6 +65,7 @@ void VsInit::checkForInstance(QString& deeplink)
         m_instanceCheckSocket.data(), &QLocalSocket::connected, this,
         [=]() {
             // pass deeplink to existing instance before quitting
+            qDebug() << deeplink;
             if (!deeplink.isEmpty()) {
                 QByteArray baDeeplink = deeplink.toLocal8Bit();
                 qint64 writeBytes     = m_instanceCheckSocket->write(baDeeplink);
@@ -112,20 +113,26 @@ void VsInit::checkForInstance(QString& deeplink)
                                 qDebug() << "Never received connection";
                                 return;
                             }
+                            qDebug() << "Connected";
 
                             if (!connectedSocket->waitForReadyRead()) {
                                 qDebug() << "Never ready to read";
-                                return;
+                                if (!(connectedSocket->bytesAvailable() > 0)) {
+                                    qDebug() << "Ready but no bytes available";
+                                    return;
+                                }
                             }
-
+                            qDebug() << "Ready to read";
                             if (connectedSocket->bytesAvailable()
                                 < (int)sizeof(quint16)) {
                                 qDebug() << "no bytes available";
                                 break;
                             }
+                            qDebug() << "bytes available";
 
                             QByteArray in(connectedSocket->readAll());
                             QString urlString(in);
+                            qDebug() << urlString;
                             QUrl url(urlString);
 
                             // Join studio using received URL

--- a/src/gui/vsInit.cpp
+++ b/src/gui/vsInit.cpp
@@ -65,7 +65,6 @@ void VsInit::checkForInstance(QString& deeplink)
         m_instanceCheckSocket.data(), &QLocalSocket::connected, this,
         [=]() {
             // pass deeplink to existing instance before quitting
-            qDebug() << "Deeplink:" << deeplink;
             if (!deeplink.isEmpty()) {
                 QByteArray baDeeplink = deeplink.toLocal8Bit();
                 qint64 writeBytes     = m_instanceCheckSocket->write(baDeeplink);
@@ -113,7 +112,6 @@ void VsInit::checkForInstance(QString& deeplink)
                                 qDebug() << "Never received connection";
                                 return;
                             }
-                            qDebug() << "Connected";
 
                             if (!connectedSocket->waitForReadyRead()) {
                                 qDebug() << "Never ready to read";
@@ -122,17 +120,15 @@ void VsInit::checkForInstance(QString& deeplink)
                                     return;
                                 }
                             }
-                            qDebug() << "Ready to read";
+
                             if (connectedSocket->bytesAvailable()
                                 < (int)sizeof(quint16)) {
                                 qDebug() << "no bytes available";
                                 break;
                             }
-                            qDebug() << "bytes available";
 
                             QByteArray in(connectedSocket->readAll());
                             QString urlString(in);
-                            qDebug() << urlString;
                             QUrl url(urlString);
 
                             // Join studio using received URL

--- a/src/gui/vsInit.cpp
+++ b/src/gui/vsInit.cpp
@@ -65,7 +65,7 @@ void VsInit::checkForInstance(QString& deeplink)
         m_instanceCheckSocket.data(), &QLocalSocket::connected, this,
         [=]() {
             // pass deeplink to existing instance before quitting
-            qDebug() << "Deeplink: " + deeplink;
+            qDebug() << "Deeplink:" << deeplink;
             if (!deeplink.isEmpty()) {
                 QByteArray baDeeplink = deeplink.toLocal8Bit();
                 qint64 writeBytes     = m_instanceCheckSocket->write(baDeeplink);

--- a/src/gui/vsInit.cpp
+++ b/src/gui/vsInit.cpp
@@ -65,7 +65,7 @@ void VsInit::checkForInstance(QString& deeplink)
         m_instanceCheckSocket.data(), &QLocalSocket::connected, this,
         [=]() {
             // pass deeplink to existing instance before quitting
-            qDebug() << deeplink;
+            qDebug() << "Deeplink: " + deeplink;
             if (!deeplink.isEmpty()) {
                 QByteArray baDeeplink = deeplink.toLocal8Bit();
                 qint64 writeBytes     = m_instanceCheckSocket->write(baDeeplink);
@@ -118,7 +118,7 @@ void VsInit::checkForInstance(QString& deeplink)
                             if (!connectedSocket->waitForReadyRead()) {
                                 qDebug() << "Never ready to read";
                                 if (!(connectedSocket->bytesAvailable() > 0)) {
-                                    qDebug() << "Ready but no bytes available";
+                                    qDebug() << "Not ready and no bytes available";
                                     return;
                                 }
                             }


### PR DESCRIPTION
So the std::cout `VirtualStudio::show()` was somehow colliding with the socket and instead of the deeplink URL, the characters "SSL Lib" or "SSL L" were going across the local socket that checks for the existing instance of the app.

I switched it to qDebug since it's already in `virtualstudio.cpp`. Solved the problem.