### PR TITLE
AudioSettings should show the currently selected device

### DIFF
--- a/src/gui/AudioSettings.qml
+++ b/src/gui/AudioSettings.qml
@@ -43,8 +43,32 @@ Rectangle {
     property bool isUsingRtAudio: virtualstudio.audioBackend == "RtAudio"
     property bool hasNoBackend: !isUsingJack && !isUsingRtAudio && !virtualstudio.backendAvailable;
 
-    required property int inputCurrIndex
-    required property int outputCurrIndex
+    property int inputCurrIndex: getCurrentInputDeviceIndex()
+    property int outputCurrIndex: getCurrentOutputDeviceIndex()
+
+    function getCurrentInputDeviceIndex () {
+        if (virtualstudio.inputDevice === "") {
+            return inputComboModel.findIndex(elem => elem.type === "element");
+        }
+
+        let idx = inputComboModel.findIndex(elem => elem.type === "element" && elem.text === virtualstudio.inputDevice);
+        if (idx < 0) {
+            idx = inputComboModel.findIndex(elem => elem.type === "element");
+        }
+        return idx;
+    }
+
+    function getCurrentOutputDeviceIndex() {
+        if (virtualstudio.outputDevice === "") {
+            return outputComboModel.findIndex(elem => elem.type === "element");
+        }
+
+        let idx = outputComboModel.findIndex(elem => elem.type === "element" && elem.text === virtualstudio.outputDevice);
+        if (idx < 0) {
+            idx = outputComboModel.findIndex(elem => elem.type === "element");
+        }
+        return idx;
+    }
 
     Item {
         id: usingRtAudio
@@ -1070,7 +1094,7 @@ Rectangle {
         anchors.left: parent.left
         anchors.leftMargin: leftMargin * virtualstudio.uiScale
         anchors.right: parent.right
-        
+
         visible: parent.hasNoBackend
 
         Text {

--- a/src/gui/Settings.qml
+++ b/src/gui/Settings.qml
@@ -80,8 +80,6 @@ Item {
 
         AudioSettings{
             id: audioSettings
-            inputCurrIndex: inputCurrIndex
-            outputCurrIndex: outputCurrIndex
         }
     }
 
@@ -201,8 +199,8 @@ Item {
                         anchors.left: audioButtonText.right
                         anchors.verticalCenter: audioButtonText.verticalCenter
                         anchors.rightMargin: 16 * virtualstudio.uiScale
-                        width: 8 * virtualstudio.uiScale 
-                        height: 8 * virtualstudio.uiScale 
+                        width: 8 * virtualstudio.uiScale
+                        height: 8 * virtualstudio.uiScale
                         color: errorFlagColour
                         radius: 4 * virtualstudio.uiScale
                         visible: Boolean(virtualstudio.devicesError)
@@ -231,7 +229,7 @@ Item {
                         color: textColour
                     }
                 }
-                
+
 
                 background: Rectangle {
                     width: parent.width

--- a/src/gui/Setup.qml
+++ b/src/gui/Setup.qml
@@ -45,33 +45,6 @@ Item {
     property bool currShowWarnings: virtualstudio.showWarnings
     property string warningScreen: virtualstudio.showWarnings ? "ethernet" : ( permissions.micPermission == "unknown" ? "microphone" : "acknowledged")
 
-    property int inputCurrIndex: getCurrentInputDeviceIndex()
-    property int outputCurrIndex: getCurrentOutputDeviceIndex()
-
-    function getCurrentInputDeviceIndex () {
-        if (virtualstudio.inputDevice === "") {
-            return inputComboModel.findIndex(elem => elem.type === "element");
-        }
-
-        let idx = inputComboModel.findIndex(elem => elem.type === "element" && elem.text === virtualstudio.inputDevice);
-        if (idx < 0) {
-            idx = inputComboModel.findIndex(elem => elem.type === "element");
-        }
-        return idx;
-    }
-
-    function getCurrentOutputDeviceIndex() {
-        if (virtualstudio.outputDevice === "") {
-            return outputComboModel.findIndex(elem => elem.type === "element");
-        }
-
-        let idx = outputComboModel.findIndex(elem => elem.type === "element" && elem.text === virtualstudio.outputDevice);
-        if (idx < 0) {
-            idx = outputComboModel.findIndex(elem => elem.type === "element");
-        }
-        return idx;
-    }
-
     Item {
         id: ethernetWarningItem
         width: parent.width; height: parent.height
@@ -566,8 +539,6 @@ Item {
             display: AbstractButton.TextBesideIcon
             onClicked: {
                 virtualstudio.refreshDevices();
-                inputCurrIndex = getCurrentInputDeviceIndex();
-                outputCurrIndex = getCurrentOutputDeviceIndex();
             }
             anchors.right: parent.right
             anchors.rightMargin: rightMargin * virtualstudio.uiScale
@@ -585,9 +556,6 @@ Item {
             width: parent.width
             anchors.top: pageTitle.bottom
             anchors.topMargin: 24 * virtualstudio.uiScale
-
-            inputCurrIndex: inputCurrIndex
-            outputCurrIndex: outputCurrIndex
         }
 
         Button {


### PR DESCRIPTION
I'm seeing that virtualstudio.cpp is reporting the correct device names and indices, but they are somehow not making it into the QML.

Moving these funcs into AudioSettings.qml seem to fix it. 