### PR TITLE
vsInit cleanup

### DIFF
--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -31,7 +31,7 @@
 
 /**
  * \file virtualstudio.cpp
- * \author Aaron Wyatt
+ * \author Matt Horton, based on code by Aaron Wyatt
  * \date March 2022
  */
 
@@ -324,6 +324,9 @@ void VirtualStudio::show()
     if (m_checkSsl) {
         // Check our available SSL version
         QString sslVersion = QSslSocket::sslLibraryVersionString();
+        // Important: this needs to be output with qDebug rather than to std::cout
+        // otherwise it may get passed to an existing JackTrip instance in place of our
+        // deeplink. (Need to find the root cause of this.)
         qDebug() << "SSL Library: " << sslVersion;
         if (sslVersion.isEmpty()) {
             QMessageBox msgBox;
@@ -1637,7 +1640,7 @@ void VirtualStudio::manageStudio(int studioIndex, bool start)
         QString expiration =
             QDateTime::currentDateTimeUtc().addSecs(60 * 30).toString(Qt::ISODate);
         QJsonObject json      = {{QLatin1String("enabled"), true},
-                            {QLatin1String("expiresAt"), expiration}};
+                                 {QLatin1String("expiresAt"), expiration}};
         QJsonDocument request = QJsonDocument(json);
 
         QNetworkReply* reply = m_authenticator->put(

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1640,7 +1640,7 @@ void VirtualStudio::manageStudio(int studioIndex, bool start)
         QString expiration =
             QDateTime::currentDateTimeUtc().addSecs(60 * 30).toString(Qt::ISODate);
         QJsonObject json      = {{QLatin1String("enabled"), true},
-                                 {QLatin1String("expiresAt"), expiration}};
+                            {QLatin1String("expiresAt"), expiration}};
         QJsonDocument request = QJsonDocument(json);
 
         QNetworkReply* reply = m_authenticator->put(

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -31,7 +31,7 @@
 
 /**
  * \file virtualstudio.h
- * \author Aaron Wyatt
+ * \author Matt Horton, based on code by Aaron Wyatt
  * \date March 2022
  */
 

--- a/src/gui/vsInit.cpp
+++ b/src/gui/vsInit.cpp
@@ -31,7 +31,7 @@
 
 /**
  * \file vsInit.cpp
- * \author
+ * \author Aaron Wyatt, based on code by Matt Horton
  * \date February 2023
  */
 
@@ -58,26 +58,11 @@ QString VsInit::parseDeeplink(QCoreApplication* app)
 
 void VsInit::checkForInstance(QString& deeplink)
 {
+    m_deeplink = deeplink;
     // Create socket
     m_instanceCheckSocket.reset(new QLocalSocket(this));
-    // End process if instance exists
-    QObject::connect(
-        m_instanceCheckSocket.data(), &QLocalSocket::connected, this,
-        [=]() {
-            // pass deeplink to existing instance before quitting
-            if (!deeplink.isEmpty()) {
-                QByteArray baDeeplink = deeplink.toLocal8Bit();
-                qint64 writeBytes     = m_instanceCheckSocket->write(baDeeplink);
-                m_instanceCheckSocket->flush();
-                m_instanceCheckSocket->disconnectFromServer();  // remove next
-
-                if (writeBytes < 0) {
-                    qDebug() << "sending deeplink failed";
-                }
-            }
-            emit QCoreApplication::quit();
-        },
-        Qt::QueuedConnection);
+    QObject::connect(m_instanceCheckSocket.data(), &QLocalSocket::connected, this,
+                     &VsInit::connectionReceived, Qt::QueuedConnection);
     // Create instanceServer to prevent new instances from being created
     void (QLocalSocket::*errorFunc)(QLocalSocket::LocalSocketError);
 #if (QT_VERSION < QT_VERSION_CHECK(5, 15, 0))
@@ -85,67 +70,8 @@ void VsInit::checkForInstance(QString& deeplink)
 #else
     errorFunc = &QLocalSocket::errorOccurred;
 #endif
-    QObject::connect(
-        m_instanceCheckSocket.data(), errorFunc, this,
-        [&](QLocalSocket::LocalSocketError socketError) {
-            switch (socketError) {
-            case QLocalSocket::ServerNotFoundError:
-            case QLocalSocket::SocketTimeoutError:
-            case QLocalSocket::ConnectionRefusedError:
-                m_instanceServer.reset(new QLocalServer(this));
-                m_instanceServer->setSocketOptions(QLocalServer::WorldAccessOption);
-                m_instanceServer->listen("jacktripExists");
-                QObject::connect(
-                    m_instanceServer.data(), &QLocalServer::newConnection, this,
-                    [&]() {
-                        // This is the first instance. Bring it to the
-                        // top.
-                        if (!m_vs.isNull() && m_vs->vsModeActive()) {
-                            m_vs->raiseToTop();
-                        }
-                        while (m_instanceServer->hasPendingConnections()) {
-                            // Receive URL from 2nd instance
-                            QLocalSocket* connectedSocket =
-                                m_instanceServer->nextPendingConnection();
-
-                            if (!connectedSocket->waitForConnected()) {
-                                qDebug() << "Never received connection";
-                                return;
-                            }
-
-                            if (!connectedSocket->waitForReadyRead()) {
-                                qDebug() << "Never ready to read";
-                                if (!(connectedSocket->bytesAvailable() > 0)) {
-                                    qDebug() << "Not ready and no bytes available";
-                                    return;
-                                }
-                            }
-
-                            if (connectedSocket->bytesAvailable()
-                                < (int)sizeof(quint16)) {
-                                qDebug() << "no bytes available";
-                                break;
-                            }
-
-                            QByteArray in(connectedSocket->readAll());
-                            QString urlString(in);
-                            QUrl url(urlString);
-
-                            // Join studio using received URL
-                            if (!m_vs.isNull() && m_vs->vsModeActive()
-                                && url.scheme() == "jacktrip" && url.host() == "join") {
-                                m_vs->setStudioToJoin(url);
-                            }
-                        }
-                    },
-                    Qt::QueuedConnection);
-                break;
-            case QLocalSocket::PeerClosedError:
-                break;
-            default:
-                qDebug() << m_instanceCheckSocket->errorString();
-            }
-        });
+    QObject::connect(m_instanceCheckSocket.data(), errorFunc, this,
+                     &VsInit::connectionFailed);
     // Check for existing instance
     m_instanceCheckSocket->connectToServer("jacktripExists");
 }
@@ -166,3 +92,79 @@ void VsInit::setUrlScheme()
     set.endGroup();
 }
 #endif
+
+void VsInit::connectionReceived()
+{
+    // pass deeplink to existing instance before quitting
+    if (!m_deeplink.isEmpty()) {
+        QByteArray baDeeplink = m_deeplink.toLocal8Bit();
+        qint64 writeBytes     = m_instanceCheckSocket->write(baDeeplink);
+        m_instanceCheckSocket->flush();
+        m_instanceCheckSocket->disconnectFromServer();  // remove next
+
+        if (writeBytes < 0) {
+            qDebug() << "sending deeplink failed";
+        }
+    }
+    // End process if instance exists
+    emit QCoreApplication::quit();
+}
+
+void VsInit::connectionFailed(QLocalSocket::LocalSocketError socketError)
+{
+    switch (socketError) {
+    case QLocalSocket::ServerNotFoundError:
+    case QLocalSocket::SocketTimeoutError:
+    case QLocalSocket::ConnectionRefusedError:
+        m_instanceServer.reset(new QLocalServer(this));
+        m_instanceServer->setSocketOptions(QLocalServer::WorldAccessOption);
+        m_instanceServer->listen("jacktripExists");
+        QObject::connect(m_instanceServer.data(), &QLocalServer::newConnection, this,
+                         &VsInit::responseReceived, Qt::QueuedConnection);
+        break;
+    case QLocalSocket::PeerClosedError:
+        break;
+    default:
+        qDebug() << m_instanceCheckSocket->errorString();
+    }
+}
+
+void VsInit::responseReceived()
+{
+    // This is the first instance. Bring it to the top.
+    if (!m_vs.isNull() && m_vs->vsModeActive()) {
+        m_vs->raiseToTop();
+    }
+    while (m_instanceServer->hasPendingConnections()) {
+        // Receive URL from 2nd instance
+        QLocalSocket* connectedSocket = m_instanceServer->nextPendingConnection();
+
+        if (!connectedSocket->waitForConnected()) {
+            qDebug() << "Never received connection";
+            return;
+        }
+
+        if (!connectedSocket->waitForReadyRead()) {
+            qDebug() << "Never ready to read";
+            if (!(connectedSocket->bytesAvailable() > 0)) {
+                qDebug() << "Not ready and no bytes available";
+                return;
+            }
+        }
+
+        if (connectedSocket->bytesAvailable() < (int)sizeof(quint16)) {
+            qDebug() << "no bytes available";
+            break;
+        }
+
+        QByteArray in(connectedSocket->readAll());
+        QString urlString(in);
+        QUrl url(urlString);
+
+        // Join studio using received URL
+        if (!m_vs.isNull() && m_vs->vsModeActive() && url.scheme() == "jacktrip"
+            && url.host() == "join") {
+            m_vs->setStudioToJoin(url);
+        }
+    }
+}

--- a/src/gui/vsInit.h
+++ b/src/gui/vsInit.h
@@ -31,7 +31,7 @@
 
 /**
  * \file vsInit.h
- * \author
+ * \author Aaron Wyatt, based on code by Matt Horton
  * \date February 2023
  */
 
@@ -45,7 +45,7 @@
 
 #include "virtualstudio.h"
 
-class VsInit : QObject
+class VsInit : public QObject
 {
     Q_OBJECT
 
@@ -53,16 +53,22 @@ class VsInit : QObject
     VsInit() = default;
 
     static QString parseDeeplink(QCoreApplication* app);
+    void checkForInstance(QString& deeplink);
+    void setVs(QSharedPointer<VirtualStudio> vs) { m_vs = vs; }
 #ifdef _WIN32
     static void setUrlScheme();
 #endif
-    void checkForInstance(QString& deeplink);
-    void setVs(QSharedPointer<VirtualStudio> vs) { m_vs = vs; }
+
+   private slots:
+    void connectionReceived();
+    void connectionFailed(QLocalSocket::LocalSocketError socketError);
+    void responseReceived();
 
    private:
     QScopedPointer<QLocalServer> m_instanceServer;
     QScopedPointer<QLocalSocket> m_instanceCheckSocket;
     QSharedPointer<VirtualStudio> m_vs;
+    QString m_deeplink;
 };
 
 #endif  // __VSINIT_H__


### PR DESCRIPTION
Get rid of complex nested lambdas so that the code is easier to read. Also adds a warning related to #979 and updates authorship of some files.

@mattahorton, I'm going to need your help testing this. (Deeplink functionality/instance checking on windows.) Cleaning up this code will hopefully help us to find and fix the root cause of #979.