### PR TITLE
Save Output Channels Settings

### DIFF
--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1399,6 +1399,8 @@ void VirtualStudio::applySettings()
     settings.setValue(QStringLiteral("BaseInputChannel"), m_baseInputChannel);
     settings.setValue(QStringLiteral("NumInputChannels"), m_numInputChannels);
     settings.setValue(QStringLiteral("InputMixMode"), m_inputMixMode);
+    settings.setValue(QStringLiteral("BaseOutputChannel"), m_baseOutputChannel);
+    settings.setValue(QStringLiteral("NumOutputChannels"), m_baseInputChannel);
     settings.endGroup();
 
     m_previousUseRtAudio = m_useRtAudio;

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1400,7 +1400,7 @@ void VirtualStudio::applySettings()
     settings.setValue(QStringLiteral("NumInputChannels"), m_numInputChannels);
     settings.setValue(QStringLiteral("InputMixMode"), m_inputMixMode);
     settings.setValue(QStringLiteral("BaseOutputChannel"), m_baseOutputChannel);
-    settings.setValue(QStringLiteral("NumOutputChannels"), m_baseInputChannel);
+    settings.setValue(QStringLiteral("NumOutputChannels"), m_numOutputChannels);
     settings.endGroup();
 
     m_previousUseRtAudio = m_useRtAudio;


### PR DESCRIPTION
Must have forgotten to add these lines when working on output channels. This fixes the bug where channels other than 1 and 2 won't get saved - it'll always revert back - for output devices.