### PR TITLE
Temporarily get msys2 from choco

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -340,6 +340,7 @@ jobs:
         shell: bash
         run: |
           choco install jack --version=1.9.17 --no-progress
+          choco install msys2 --no-progress
           if [[ "${{ matrix.build-system }}" == "qmake" && -n "${{ matrix.static-qt-version }}" && -n "${{ matrix.vcpkg-triplet }}" ]]; then 
             vcpkg install openssl --triplet="${{ matrix.vcpkg-triplet }}"
           fi

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -340,8 +340,8 @@ jobs:
         shell: bash
         run: |
           choco install jack --version=1.9.17 --no-progress
-          choco install msys2 --no-progress
           if [[ "${{ matrix.build-system }}" == "qmake" && -n "${{ matrix.static-qt-version }}" && -n "${{ matrix.vcpkg-triplet }}" ]]; then 
+            choco install msys2 --no-progress
             vcpkg install openssl --triplet="${{ matrix.vcpkg-triplet }}"
           fi
           if [[ "${{ matrix.system-rtaudio }}" == true && -n "${{ matrix.vcpkg-triplet }}" ]]; then 


### PR DESCRIPTION
We have mostly moved our Windows package management to vcpkg, but currently the msys2 repo and mirrors no longer have the version of msys2 that vcpkg wants to pull as a dependency for openssl.

This temporarily gets msys2 from chocolatey until [this PR](https://github.com/microsoft/vcpkg/pull/30546) is merged.