### PR TITLE
bufstrategy 4, runs PLC directly in audio callback (the original way)…

### DIFF
--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -165,8 +165,10 @@ JackTrip::~JackTrip()
     delete mDataProtocolReceiver;
     delete mAudioInterface;
     delete mPacketHeader;
-    delete mRegulatorWorkerPtr;
-    delete mRegulatorThreadPtr;
+    if (mRegulatorWorkerPtr != NULL)
+        delete mRegulatorWorkerPtr;
+    if (mRegulatorThreadPtr != NULL)
+        delete mRegulatorThreadPtr;
     delete mSendRingBuffer;
     delete mReceiveRingBuffer;
 }
@@ -429,14 +431,14 @@ void JackTrip::setupRingBuffers()
             mReceiveRingBuffer =
                 new RingBuffer(audio_output_slot_size, mBufferQueueLength);
             mPacketHeader->setBufferRequiresSameSettings(true);
-        } else if (mBufferStrategy == 3) {
+        } else if ((mBufferStrategy == 3) || (mBufferStrategy == 4)) {
             cout << "Using experimental buffer strategy " << mBufferStrategy
                  << "-- Regulator with PLC" << endl;
 
             mReceiveRingBuffer =
                 new Regulator(mNumAudioChansOut, mAudioBitResolution, mAudioBufferSize,
-                              mBufferQueueLength, mBroadcastQueueLength);
-            // bufStrategy 3, mBufferQueueLength is in integer msec not packets
+                              mBufferQueueLength, mBufferStrategy, mBroadcastQueueLength);
+            // bufStrategy 3 or 4, mBufferQueueLength is in integer msec not packets
 
             mPacketHeader->setBufferRequiresSameSettings(false);  // = asym is default
 

--- a/src/JackTrip.h
+++ b/src/JackTrip.h
@@ -38,7 +38,7 @@
 #ifndef __JACKTRIP_H__
 #define __JACKTRIP_H__
 
-//#include <tr1/memory> //for shared_ptr
+// #include <tr1/memory> //for shared_ptr
 #include <QObject>
 #include <QSharedPointer>
 #include <QSslSocket>
@@ -58,7 +58,7 @@
 #include "PacketHeader.h"
 #include "RingBuffer.h"
 
-//#include <signal.h>
+// #include <signal.h>
 /** \brief Main class to creates a SERVER (to listen) or a CLIENT (to connect
  * to a listening server) to send audio streams in the network.
  *
@@ -392,7 +392,7 @@ class JackTrip : public QObject
     virtual void receiveNetworkPacket(int8_t* ptrToReadSlot)
     {
         mReceiveRingBuffer->readSlotNonBlocking(ptrToReadSlot);
-        if (mBufferStrategy == 3) {
+        if (mBufferStrategy == 3) {  // PLC workerThread
             // trigger next packet using RegulatorThread
             emit signalReceivedNetworkPacket();
         }

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -105,13 +105,15 @@ constexpr double AutoInitValFactor =
 constexpr int WindowDivisor = 8;     // for faster auto tracking
 constexpr int MaxFPP        = 1024;  // tested up to this FPP
 //*******************************************************************************
-Regulator::Regulator(int rcvChannels, int bit_res, int FPP, int qLen, int bqLen)
+Regulator::Regulator(int rcvChannels, int bit_res, int FPP, int qLen, int bufStrategy,
+                     int bqLen)
     : RingBuffer(0, 0)
     , mNumChannels(rcvChannels)
     , mAudioBitRes(bit_res)
     , mFPP(FPP)
     , mMsecTolerance((double)qLen)  // handle non-auto mode, expects positive qLen
     , mAuto(false)
+    , mBufStrategy(bufStrategy)
     , m_b_BroadcastQueueLength(bqLen)
 {
     // catch settings that are compute bound using long HIST
@@ -359,6 +361,13 @@ void Regulator::pushPacket(const int8_t* buf, int seq_num)
     if (mLastSeqNumIn != -1)
         memcpy(mSlots[mLastSeqNumIn % mNumSlots], buf, mBytes);
 };
+
+//*******************************************************************************
+void Regulator::pullPacket(int8_t* buf)
+{  // only for mBufferStrategy == 4, not using workerThread
+    pullPacket();
+    memcpy(buf, mXfrBuffer, mBytes);
+}
 
 //*******************************************************************************
 void Regulator::pullPacket()

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -536,7 +536,7 @@ void Settings::parseInput(int argc, char** argv)
             break;
         case OPT_BUFSTRATEGY:  // Buf strategy
             mBufferStrategy = atoi(optarg);
-            if (-1 > mBufferStrategy || 3 < mBufferStrategy) {
+            if (-1 > mBufferStrategy || 4 < mBufferStrategy) {
                 std::cerr << "Unsupported buffer strategy " << optarg << endl;
                 printUsage();
                 std::exit(1);
@@ -862,7 +862,7 @@ void Settings::printUsage()
     cout << " -D, --nojackportsconnect                 Don't connect default audio ports "
             "in jack"
          << endl;
-    cout << " --bufstrategy # (0, 1, 2)                Use alternative jitter buffer"
+    cout << " --bufstrategy # (0, 1, 2, 3, 4)          Use alternative jitter buffer"
          << endl;
     cout << " --broadcast <broadcast_queue>            Duplicate receive ports with the specified broadcast_queue length. "
                                                        "Broadcast outputs have higher latency but less packet loss.\n";

--- a/src/gui/qjacktrip.ui
+++ b/src/gui/qjacktrip.ui
@@ -1906,7 +1906,7 @@ To connect to a hub server you need to run as a hub client.</string>
      <x>0</x>
      <y>0</y>
      <width>409</width>
-     <height>27</height>
+     <height>30</height>
     </rect>
    </property>
   </widget>
@@ -1986,7 +1986,7 @@ To connect to a hub server you need to run as a hub client.</string>
   <tabstop>disconnectScriptBrowse</tabstop>
  </tabstops>
  <resources>
-  <include location="qjacktrip_novs.qrc"/>
+  <include location="qjacktrip.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/src/gui/qjacktrip.ui
+++ b/src/gui/qjacktrip.ui
@@ -7,14 +7,14 @@
     <x>0</x>
     <y>0</y>
     <width>409</width>
-    <height>997</height>
+    <height>961</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>JackTrip</string>
   </property>
   <property name="windowIcon">
-   <iconset resource="qjacktrip_novs.qrc">
+   <iconset resource="qjacktrip.qrc">
     <normaloff>:/qjacktrip/icon.png</normaloff>:/qjacktrip/icon.png</iconset>
   </property>
   <widget class="QWidget" name="centralWidget">
@@ -109,7 +109,7 @@
        </size>
       </property>
       <property name="currentIndex">
-       <number>3</number>
+       <number>0</number>
       </property>
       <property name="tabsClosable">
        <bool>false</bool>

--- a/src/gui/qjacktrip.ui
+++ b/src/gui/qjacktrip.ui
@@ -7,14 +7,14 @@
     <x>0</x>
     <y>0</y>
     <width>409</width>
-    <height>961</height>
+    <height>997</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>JackTrip</string>
   </property>
   <property name="windowIcon">
-   <iconset resource="qjacktrip.qrc">
+   <iconset resource="qjacktrip_novs.qrc">
     <normaloff>:/qjacktrip/icon.png</normaloff>:/qjacktrip/icon.png</iconset>
   </property>
   <widget class="QWidget" name="centralWidget">
@@ -109,7 +109,7 @@
        </size>
       </property>
       <property name="currentIndex">
-       <number>0</number>
+       <number>3</number>
       </property>
       <property name="tabsClosable">
        <bool>false</bool>
@@ -1408,7 +1408,12 @@ for better quality at the expense of latency.</string>
           </item>
           <item>
            <property name="text">
-            <string>3 (experimental)</string>
+            <string>3 (experimental - in own thread) </string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>4 (experimental - in callback)</string>
            </property>
           </item>
          </widget>
@@ -1901,7 +1906,7 @@ To connect to a hub server you need to run as a hub client.</string>
      <x>0</x>
      <y>0</y>
      <width>409</width>
-     <height>30</height>
+     <height>27</height>
     </rect>
    </property>
   </widget>
@@ -1981,7 +1986,7 @@ To connect to a hub server you need to run as a hub client.</string>
   <tabstop>disconnectScriptBrowse</tabstop>
  </tabstops>
  <resources>
-  <include location="qjacktrip.qrc"/>
+  <include location="qjacktrip_novs.qrc"/>
  </resources>
  <connections/>
 </ui>


### PR DESCRIPTION
bufstrategy 4, runs PLC directly in audio callback (the original way) rather bufstrategy 3 where it runs in a workerThread (the current way)

The problem is windows does not play nice with our new separate workerThread computation of PLC. 
The symptom is continuous distortion when using bufStrategy 3.
A new bufStrategy 4 reverts to the earlier, original, non-workerThread methods.
This fixes PLC in windows, and might fix similar problems encountered with macos, or some other.
So... don't use --bufstrategy 3 in a windows hub client, use --bufstrategy 4
(everything else about the CLI and GUI arguments works the same)

The fix involves overloading Regulator::pullPacket to have it both ways.

Regulator::pullPacket() does the PLC heavy work.
For bufStrategy 3 it is called from the workerThread slot RegulatorWorker::pullPacket()
For bufStrategy 4 it is called from the overloaded Regulator::pullPacket(int8_t* buf) 

Total explanation:

The audio callback calls **receiveNetworkPacket** which then calls
**readSlotNonBlocking(ptrToReadSlot)**
    if bufStrategy 3
      returns the result from workerThread
    if bufStrategy 4
      calls pullPacket(ptrToReadSlot)
        which calls pullPacket() and then returns the result directly      

**receiveNetworkPacket** then, if in bufStrategy 3 mode, emits 
  signalReceivedNetworkPacket which calls pullPacket() in workerThread

Interface changes are in 
Settings and qjacktrip.ui which has two items now instead of just the first one
**3 (experimental - in own thread) 
4 (experimental - in callback)**

or CLI:

jacktrip -C jackloop128.stanford.edu **--bufstrategy 3** -q auto3 --udprt
jacktrip -C jackloop128.stanford.edu **--bufstrategy 4** -q auto3 --udprt
