### PR TITLE
Fixing Play Test Tone button on Linux

### DIFF
--- a/src/Meter.cpp
+++ b/src/Meter.cpp
@@ -38,7 +38,37 @@
 
 #include "Meter.h"
 
+#include <iostream>
+
 #include "jacktrip_types.h"
+#include "meterdsp.h"
+
+//*******************************************************************************
+Meter::Meter(int numchans, bool verboseFlag) : mNumChannels(numchans)
+{
+    setVerbose(verboseFlag);
+    for (int i = 0; i < mNumChannels; i++) {
+        meterP.push_back(new meterdsp);
+    }
+}
+
+//*******************************************************************************
+Meter::~Meter()
+{
+    for (int i = 0; i < mNumChannels; i++) {
+        delete static_cast<meterdsp*>(meterP[i]);
+    }
+    meterP.clear();
+    if (mValues) {
+        delete mValues;
+    }
+    if (mOutValues) {
+        delete mOutValues;
+    }
+    if (mBuffer) {
+        delete mBuffer;
+    }
+}
 
 //*******************************************************************************
 void Meter::init(int samplingRate)
@@ -51,7 +81,7 @@ void Meter::init(int samplingRate)
 
     fs = float(fSamplingFreq);
     for (int i = 0; i < mNumChannels; i++) {
-        meterP[i]->init(fs);
+        static_cast<meterdsp*>(meterP[i])->init(fs);
     }
 
     /* Set meter values to the default floor */
@@ -97,7 +127,7 @@ void Meter::compute(int nframes, float** inputs, float** /*_*/)
 
     for (int i = 0; i < mNumChannels; i++) {
         /* Run the signal through Faust  */
-        meterP[i]->compute(nframes, &inputs[i], &mBuffer);
+        static_cast<meterdsp*>(meterP[i])->compute(nframes, &inputs[i], &mBuffer);
 
         /* Use the existing value of mValues[i] as
            the threshold - this will be reset to the default floor of -80dB

--- a/src/Meter.h
+++ b/src/Meter.h
@@ -41,11 +41,9 @@
 
 #include <QObject>
 #include <QTimer>
-#include <iostream>
 #include <vector>
 
 #include "ProcessPlugin.h"
-#include "meterdsp.h"
 
 /** \brief The Meter class measures the live audio loudness level
  */
@@ -55,33 +53,10 @@ class Meter : public ProcessPlugin
 
    public:
     /// \brief The class constructor sets the number of channels to measure
-    Meter(int numchans, bool verboseFlag = false) : mNumChannels(numchans)
-    {
-        setVerbose(verboseFlag);
-        for (int i = 0; i < mNumChannels; i++) {
-            meterP.push_back(new meterdsp);
-            // meterUIP.push_back(new APIUI);
-            // meterP[i]->buildUserInterface(meterUIP[i]);
-        }
-    }
+    Meter(int numchans, bool verboseFlag = false);
 
     /// \brief The class destructor
-    virtual ~Meter()
-    {
-        for (int i = 0; i < mNumChannels; i++) {
-            delete meterP[i];
-        }
-        meterP.clear();
-        if (mValues) {
-            delete mValues;
-        }
-        if (mOutValues) {
-            delete mOutValues;
-        }
-        if (mBuffer) {
-            delete mBuffer;
-        }
-    }
+    virtual ~Meter();
 
     void init(int samplingRate) override;
     int getNumInputs() override { return (mNumChannels); }
@@ -97,7 +72,7 @@ class Meter : public ProcessPlugin
     float fs;
     int mNumChannels;
     float threshold = -80.0;
-    std::vector<meterdsp*> meterP;
+    std::vector<void*> meterP;
     bool hasProcessedAudio = false;
 
     QTimer mTimer;

--- a/src/Tone.h
+++ b/src/Tone.h
@@ -40,11 +40,9 @@
 #define __TONE_H__
 
 #include <QObject>
-#include <iostream>
 #include <vector>
 
 #include "ProcessPlugin.h"
-#include "tonedsp.h"
 
 /** \brief The Tone plugin plays some arbitrary sample audio
  */
@@ -54,26 +52,10 @@ class Tone : public ProcessPlugin
 
    public:
     /// \brief The class constructor sets the number of channels to measure
-    Tone(int numchans, bool verboseFlag = false) : mNumChannels(numchans)
-    {
-        setVerbose(verboseFlag);
-        for (int i = 0; i < mNumChannels; i++) {
-            toneP.push_back(new tonedsp);
-            toneUIP.push_back(new APIUI);  // #included in tonedsp.h
-            toneP[i]->buildUserInterface(toneUIP[i]);
-        }
-    }
+    Tone(int numchans, bool verboseFlag = false);
 
     /// \brief The class destructor
-    virtual ~Tone()
-    {
-        for (int i = 0; i < mNumChannels; i++) {
-            delete toneP[i];
-            delete toneUIP[i];
-        }
-        toneP.clear();
-        toneUIP.clear();
-    }
+    virtual ~Tone();
 
     void init(int samplingRate) override;
     int getNumInputs() override { return (mNumChannels); }
@@ -87,8 +69,8 @@ class Tone : public ProcessPlugin
     void triggerPlayback();
 
    private:
-    std::vector<tonedsp*> toneP;
-    std::vector<APIUI*> toneUIP;
+    std::vector<void*> toneP;
+    std::vector<void*> toneUIP;
     float fs;
     int mNumChannels;
 };

--- a/src/Volume.h
+++ b/src/Volume.h
@@ -40,13 +40,9 @@
 #define __VOLUME_H__
 
 #include <QObject>
-#include <QTimer>
-#include <QVector>
-#include <iostream>
 #include <vector>
 
 #include "ProcessPlugin.h"
-#include "volumedsp.h"
 
 /** \brief The Volume plugin adjusts the level of the signal via multiplication
  */
@@ -56,26 +52,10 @@ class Volume : public ProcessPlugin
 
    public:
     /// \brief The class constructor sets the number of channels to measure
-    Volume(int numchans, bool verboseFlag = false) : mNumChannels(numchans)
-    {
-        setVerbose(verboseFlag);
-        for (int i = 0; i < mNumChannels; i++) {
-            volumeP.push_back(new volumedsp);
-            volumeUIP.push_back(new APIUI);  // #included in volumedsp.h
-            volumeP[i]->buildUserInterface(volumeUIP[i]);
-        }
-    }
+    Volume(int numchans, bool verboseFlag = false);
 
     /// \brief The class destructor
-    virtual ~Volume()
-    {
-        for (int i = 0; i < mNumChannels; i++) {
-            delete volumeP[i];
-            delete volumeUIP[i];
-        }
-        volumeP.clear();
-        volumeUIP.clear();
-    }
+    virtual ~Volume();
 
     void init(int samplingRate) override;
     int getNumInputs() override { return (mNumChannels); }
@@ -90,8 +70,8 @@ class Volume : public ProcessPlugin
     void muteUpdated(bool muted);
 
    private:
-    std::vector<volumedsp*> volumeP;
-    std::vector<APIUI*> volumeUIP;
+    std::vector<void*> volumeP;
+    std::vector<void*> volumeUIP;
     float fs;
     int mNumChannels;
     float mVolMultiplier = 0.0;


### PR DESCRIPTION
It turns out that it is unsafe to include multiple faust-generated C++ files in the same object. They contain multiple symbols which use the same name, including APIUI and #ifdef statements. Mixing these together leads to very unpredictable behaviour, including crashes.

In particular, I discovered the the vsAudioInterface class was including Tone.h, Meter.h and Volume.h, and each of those was including their own faust-generated c++ files. This was causing symbol conflicts in the generated object code. It's actually quite suprising that it only seemed to have a side-effect on Linux, and only in it "not working." I think we were just getting lucky.

I've reworked the Tone, Meter and Volume classes so that the faust generated c++ code is only used in their .cpp files. This ensures that each of them uses the correct symbols, and the duplicate names do not cause conflicts.