### PR TITLE
Moving faust-generated code out of header files

### DIFF
--- a/src/Limiter.cpp
+++ b/src/Limiter.cpp
@@ -39,6 +39,78 @@
 #include "Limiter.h"
 
 #include "jacktrip_types.h"
+#include "limiterdsp.h"
+
+//*******************************************************************************
+Limiter::Limiter(int numchans, int numclients, bool verboseFlag)
+    : mNumChannels(numchans)
+    , mNumClients(numclients)
+    , warningAmp(0.0)
+    , warnCount(0)
+    , peakMagnitude(0.0)
+    , nextWarning(1)
+{
+    setVerbose(verboseFlag);
+    for (int i = 0; i < mNumChannels; i++) {
+        limiterdsp* dsp_ptr = new limiterdsp;
+        APIUI* ui_ptr       = new APIUI;
+        limiterP.push_back(dsp_ptr);
+        limiterUIP.push_back(ui_ptr);  // #included in limiterdsp.h
+        dsp_ptr->buildUserInterface(ui_ptr);
+#ifdef SINE_TEST
+        limitertest* test_ptr = new limitertest;
+        ui_ptr                = new APIUI;
+        limiterTestP.push_back(test_ptr);
+        limiterTestUIP.push_back(ui_ptr);  // #included in limitertest.h
+        test_ptr->buildUserInterface(ui_ptr);
+#endif
+    }
+    //    std::cout << "Limiter: constructed for "
+    // << mNumChannels << " channels and "
+    // << mNumClients << " assumed clients\n";
+}
+
+//*******************************************************************************
+Limiter::~Limiter()
+{
+    for (int i = 0; i < mNumChannels; i++) {
+        delete static_cast<limiterdsp*>(limiterP[i]);
+        delete static_cast<APIUI*>(limiterUIP[i]);
+    }
+    limiterP.clear();
+    limiterUIP.clear();
+}
+
+//*******************************************************************************
+void Limiter::init(int samplingRate)
+{
+    ProcessPlugin::init(samplingRate);
+    if (samplingRate != fSamplingFreq) {
+        std::cerr << "Sampling rate not set by superclass!\n";
+        std::exit(1);
+    }
+    fs = float(fSamplingFreq);
+    for (int i = 0; i < mNumChannels; i++) {
+        static_cast<limiterdsp*>(limiterP[i])
+            ->init(fs);  // compression filter parameters depend on sampling rate
+        APIUI* ui_ptr = static_cast<APIUI*>(limiterUIP[i]);
+        int ndx       = ui_ptr->getParamIndex("NumClientsAssumed");
+        ui_ptr->setParamValue(ndx, mNumClients);
+#ifdef SINE_TEST
+        static_cast<limitertest*>(limiterTestP[i])
+            ->init(fs);  // oscillator parameters depend on sampling rate
+        ui_ptr = static_cast<APIUI*>(limiterTestUIP[i]);
+        ndx    = ui_ptr->getParamIndex("Amp");
+        ui_ptr->setParamValue(ndx, 0.2);
+        ndx = ui_ptr->getParamIndex("Freq");
+        float sineFreq =
+            110.0 * pow(1.5, double(i))
+            * (mNumClients > 1 ? 1.25 : 1.0);  // Maj 7 chord for stereo in & out
+        ui_ptr->setParamValue(ndx, sineFreq);
+#endif
+    }
+    inited = true;
+}
 
 //*******************************************************************************
 void Limiter::compute(int nframes, float** inputs, float** outputs)
@@ -61,9 +133,10 @@ void Limiter::compute(int nframes, float** inputs, float** outputs)
             checkAmplitudes(nframes,
                             inputs[i]);  // we presently do one check across all channels
         }
-        limiterP[i]->compute(nframes, &inputs[i], &outputs[i]);
+        static_cast<limiterdsp*>(limiterP[i])->compute(nframes, &inputs[i], &outputs[i]);
 #ifdef SINE_TEST
-        limiterTestP[i]->compute(nframes, faustSigs, faustSigs);
+        static_cast<limitertest*>(limiterTestP[i])
+            ->compute(nframes, faustSigs, faustSigs);
         for (int n = 0; n < nframes; n++) {
             outputs[i][n] = outputs[i][n] + sineTestOut[n];
         }

--- a/src/Limiter.h
+++ b/src/Limiter.h
@@ -49,11 +49,11 @@
 #endif
 
 #include <cassert>
+#include <cmath>
 #include <iostream>
 #include <vector>
 
 #include "ProcessPlugin.h"
-#include "limiterdsp.h"
 
 /** \brief The Limiter class confines the output dynamic range to a
  *  "dynamic range lane" determined by the assumed number of clients.
@@ -62,67 +62,12 @@ class Limiter : public ProcessPlugin
 {
    public:
     /// \brief The class constructor sets the number of channels to limit
-    Limiter(int numchans, int numclients, bool verboseFlag = false)  // xtor
-        : mNumChannels(numchans)
-        , mNumClients(numclients)
-        , warningAmp(0.0)
-        , warnCount(0)
-        , peakMagnitude(0.0)
-        , nextWarning(1)
-    {
-        setVerbose(verboseFlag);
-        for (int i = 0; i < mNumChannels; i++) {
-            limiterP.push_back(new limiterdsp);
-            limiterUIP.push_back(new APIUI);  // #included in limiterdsp.h
-            limiterP[i]->buildUserInterface(limiterUIP[i]);
-#ifdef SINE_TEST
-            limiterTestP.push_back(new limitertest);
-            limiterTestUIP.push_back(new APIUI);  // #included in limitertest.h
-            limiterTestP[i]->buildUserInterface(limiterTestUIP[i]);
-#endif
-        }
-        //    std::cout << "Limiter: constructed for "
-        // << mNumChannels << " channels and "
-        // << mNumClients << " assumed clients\n";
-    }
+    Limiter(int numchans, int numclients, bool verboseFlag = false);
 
     /// \brief The class destructor
-    virtual ~Limiter()
-    {
-        for (int i = 0; i < mNumChannels; i++) {
-            delete limiterP[i];
-            delete limiterUIP[i];
-        }
-        limiterP.clear();
-        limiterUIP.clear();
-    }
+    virtual ~Limiter();
 
-    void init(int samplingRate) override
-    {
-        ProcessPlugin::init(samplingRate);
-        if (samplingRate != fSamplingFreq) {
-            std::cerr << "Sampling rate not set by superclass!\n";
-            std::exit(1);
-        }
-        fs = float(fSamplingFreq);
-        for (int i = 0; i < mNumChannels; i++) {
-            limiterP[i]->init(
-                fs);  // compression filter parameters depend on sampling rate
-            int ndx = limiterUIP[i]->getParamIndex("NumClientsAssumed");
-            limiterUIP[i]->setParamValue(ndx, mNumClients);
-#ifdef SINE_TEST
-            limiterTestP[i]->init(fs);  // oscillator parameters depend on sampling rate
-            ndx = limiterTestUIP[i]->getParamIndex("Amp");
-            limiterTestUIP[i]->setParamValue(ndx, 0.2);
-            ndx = limiterTestUIP[i]->getParamIndex("Freq");
-            float sineFreq =
-                110.0 * pow(1.5, double(i))
-                * (mNumClients > 1 ? 1.25 : 1.0);  // Maj 7 chord for stereo in & out
-            limiterTestUIP[i]->setParamValue(ndx, sineFreq);
-#endif
-        }
-        inited = true;
-    }
+    void init(int samplingRate) override;
     int getNumInputs() override { return (mNumChannels); }
     int getNumOutputs() override { return (mNumChannels); }
     void compute(int nframes, float** inputs, float** outputs) override;
@@ -190,11 +135,11 @@ class Limiter : public ProcessPlugin
     float fs;
     int mNumChannels;
     int mNumClients;
-    std::vector<limiterdsp*> limiterP;
-    std::vector<APIUI*> limiterUIP;
+    std::vector<void*> limiterP;
+    std::vector<void*> limiterUIP;
 #ifdef SINE_TEST
-    std::vector<limitertest*> limiterTestP;
-    std::vector<APIUI*> limiterTestUIP;
+    std::vector<void*> limiterTestP;
+    std::vector<void*> limiterTestUIP;
 #endif
     double warningAmp;
     uint32_t warnCount;

--- a/src/Reverb.cpp
+++ b/src/Reverb.cpp
@@ -37,7 +37,102 @@
 
 #include "Reverb.h"
 
+#include "freeverbdsp.h"  // stereo in and out
+#include "freeverbmonodsp.h"  // mono in and out (there is no mono to stereo case in jacktrip as yet)
 #include "jacktrip_types.h"
+#include "zitarevdsp.h"      // stereo in and out
+#include "zitarevmonodsp.h"  // mono in and out
+
+//*******************************************************************************
+Reverb::Reverb(int numInChans, int numOutChans, float reverbLevel, bool verboseFlag)
+    : mNumInChannels(numInChans), mNumOutChannels(numOutChans), mReverbLevel(reverbLevel)
+{
+    setVerbose(verboseFlag);
+    if (mNumInChannels < 1) {
+        std::cerr << "*** Reverb.h: must have at least one input audio channels\n";
+        mNumInChannels = 1;
+    }
+    if (mNumInChannels > 2) {
+        std::cerr << "*** Reverb.h: limiting number of audio output channels to 2\n";
+        mNumInChannels = 2;
+    }
+#if 0
+std::cout << "Reverb: constructed for "
+            << mNumInChannels << " input channels and "
+            << mNumOutChannels << " output channels with reverb level = "
+            << mReverbLevel << "\n";
+#endif
+
+    if (mReverbLevel <= 1.0) {                    // freeverb:
+        freeverbStereoP   = new freeverbdsp;      // stereo input and output
+        freeverbMonoP     = new freeverbmonodsp;  // mono input, stereo output
+        freeverbStereoUIP = new APIUI;            // #included in *dsp.h
+        freeverbMonoUIP   = new APIUI;
+        static_cast<freeverbdsp*>(freeverbStereoP)
+            ->buildUserInterface(static_cast<APIUI*>(freeverbStereoUIP));
+        static_cast<freeverbmonodsp*>(freeverbMonoP)
+            ->buildUserInterface(static_cast<APIUI*>(freeverbMonoUIP));
+        // std::cout << "Using freeverb\n";
+    } else {
+        zitarevStereoP   = new zitarevdsp;      // stereo input and output
+        zitarevMonoP     = new zitarevmonodsp;  // mono input, stereo output
+        zitarevStereoUIP = new APIUI;
+        zitarevMonoUIP   = new APIUI;
+        static_cast<zitarevdsp*>(zitarevStereoP)
+            ->buildUserInterface(static_cast<APIUI*>(zitarevStereoUIP));
+        static_cast<zitarevmonodsp*>(zitarevMonoP)
+            ->buildUserInterface(static_cast<APIUI*>(zitarevMonoUIP));
+        // std::cout << "Using zitarev\n";
+    }
+}
+
+//*******************************************************************************
+Reverb::~Reverb()
+{
+    if (mReverbLevel <= 1.0) {  // freeverb:
+        delete static_cast<freeverbdsp*>(freeverbStereoP);
+        delete static_cast<freeverbmonodsp*>(freeverbMonoP);
+        delete static_cast<APIUI*>(freeverbStereoUIP);
+        delete static_cast<APIUI*>(freeverbMonoUIP);
+    } else {
+        delete static_cast<zitarevdsp*>(zitarevStereoP);
+        delete static_cast<zitarevmonodsp*>(zitarevMonoP);
+        delete static_cast<APIUI*>(zitarevStereoUIP);
+        delete static_cast<APIUI*>(zitarevMonoUIP);
+    }
+}
+
+//*******************************************************************************
+void Reverb::init(int samplingRate)
+{
+    ProcessPlugin::init(samplingRate);
+    // std::cout << "Reverb: init(" << samplingRate << ")\n";
+    if (samplingRate != fSamplingFreq) {
+        std::cerr << "Sampling rate not set by superclass!\n";
+        std::exit(1);
+    }
+    fs = float(fSamplingFreq);
+    if (mReverbLevel <= 1.0) {  // freeverb:
+        static_cast<freeverbdsp*>(freeverbStereoP)
+            ->init(fs);  // compression filter parameters depend on sampling rate
+        static_cast<freeverbmonodsp*>(freeverbMonoP)
+            ->init(fs);  // compression filter parameters depend on sampling rate
+        int ndx = static_cast<APIUI*>(freeverbStereoUIP)->getParamIndex("Wet");
+        static_cast<APIUI*>(freeverbStereoUIP)->setParamValue(ndx, mReverbLevel);
+        static_cast<APIUI*>(freeverbMonoUIP)->setParamValue(ndx, mReverbLevel);
+    } else {  // zitarev:
+        static_cast<zitarevdsp*>(zitarevStereoP)
+            ->init(fs);  // compression filter parameters depend on sampling rate
+        static_cast<zitarevmonodsp*>(zitarevMonoP)
+            ->init(fs);  // compression filter parameters depend on sampling rate
+        int ndx = static_cast<APIUI*>(zitarevStereoUIP)->getParamIndex("Wet");
+        float zitaLevel =
+            mReverbLevel - 1.0f;  // range within zitarev is 0 to 1 (our version only)
+        static_cast<APIUI*>(zitarevStereoUIP)->setParamValue(ndx, zitaLevel);
+        static_cast<APIUI*>(zitarevMonoUIP)->setParamValue(ndx, zitaLevel);
+    }
+    inited = true;
+}
 
 //*******************************************************************************
 void Reverb::compute(int nframes, float** inputs, float** outputs)
@@ -53,17 +148,18 @@ void Reverb::compute(int nframes, float** inputs, float** outputs)
     }
     if (mReverbLevel <= 1.0) {
         if (mNumInChannels == 1) {
-            freeverbMonoP->compute(nframes, inputs, outputs);
+            static_cast<freeverbmonodsp*>(freeverbMonoP)
+                ->compute(nframes, inputs, outputs);
         } else {
             assert(mNumInChannels == 2);
-            freeverbStereoP->compute(nframes, inputs, outputs);
+            static_cast<freeverbdsp*>(freeverbStereoP)->compute(nframes, inputs, outputs);
         }
     } else {
         if (mNumInChannels == 1) {
-            zitarevMonoP->compute(nframes, inputs, outputs);
+            static_cast<zitarevmonodsp*>(zitarevMonoP)->compute(nframes, inputs, outputs);
         } else {
             assert(mNumInChannels == 2);
-            zitarevStereoP->compute(nframes, inputs, outputs);
+            static_cast<zitarevdsp*>(zitarevStereoP)->compute(nframes, inputs, outputs);
         }
     }
 }

--- a/src/StereoToMono.cpp
+++ b/src/StereoToMono.cpp
@@ -37,9 +37,23 @@
 
 #include "StereoToMono.h"
 
-#include <QVector>
+#include <iostream>
 
 #include "jacktrip_types.h"
+#include "stereotomonodsp.h"
+
+//*******************************************************************************
+StereoToMono::StereoToMono(bool verboseFlag)
+{
+    setVerbose(verboseFlag);
+    stereoToMonoP = new stereotomonodsp;
+}
+
+//*******************************************************************************
+StereoToMono::~StereoToMono()
+{
+    delete static_cast<stereotomonodsp*>(stereoToMonoP);
+}
 
 //*******************************************************************************
 void StereoToMono::init(int samplingRate)
@@ -51,7 +65,7 @@ void StereoToMono::init(int samplingRate)
     }
 
     fs = float(fSamplingFreq);
-    stereoToMonoP->init(fs);
+    static_cast<stereotomonodsp*>(stereoToMonoP)->init(fs);
 
     inited = true;
 }
@@ -69,5 +83,5 @@ void StereoToMono::compute(int nframes, float** inputs, float** outputs)
         }
         init(fSamplingFreq);
     }
-    stereoToMonoP->compute(nframes, inputs, outputs);
+    static_cast<stereotomonodsp*>(stereoToMonoP)->compute(nframes, inputs, outputs);
 }

--- a/src/StereoToMono.h
+++ b/src/StereoToMono.h
@@ -40,12 +40,8 @@
 #define __STEREOTOMONO_H__
 
 #include <QObject>
-#include <QVector>
-#include <iostream>
-#include <vector>
 
 #include "ProcessPlugin.h"
-#include "stereotomonodsp.h"
 
 /** \brief The Meter class measures the live audio loudness level
  */
@@ -55,14 +51,10 @@ class StereoToMono : public ProcessPlugin
 
    public:
     /// \brief The class constructor sets the number of channels to measure
-    StereoToMono(bool verboseFlag = false)
-    {
-        setVerbose(verboseFlag);
-        stereoToMonoP = new stereotomonodsp;
-    }
+    StereoToMono(bool verboseFlag = false);
 
     /// \brief The class destructor
-    virtual ~StereoToMono() { delete stereoToMonoP; }
+    virtual ~StereoToMono();
 
     void init(int samplingRate) override;
     int getNumInputs() override { return 2; }
@@ -72,9 +64,7 @@ class StereoToMono : public ProcessPlugin
 
    private:
     float fs;
-    // int mNumChannels;
-    stereotomonodsp* stereoToMonoP;
-    // bool hasProcessedAudio = false;
+    void* stereoToMonoP;
 };
 
 #endif


### PR DESCRIPTION
For remaining ProcessPlugins..

We recently discovered it is unsafe to includes these in headers because it can lead to symbol conflicts.

See https://github.com/jacktrip/jacktrip/pull/1010