### PR TITLE
Refresh devices when opening the popup

### DIFF
--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -159,6 +159,7 @@ JackTrip::JackTrip(jacktripModeT JacktripMode, dataProtocolT DataProtocolType,
 JackTrip::~JackTrip()
 {
     // wait();
+    stop();
     delete mDataProtocolSender;
     delete mDataProtocolReceiver;
     delete mAudioInterface;

--- a/src/UdpDataProtocol.cpp
+++ b/src/UdpDataProtocol.cpp
@@ -571,7 +571,6 @@ void UdpDataProtocol::run()
         }
         full_redundant_packet_size = 0x10000;  // max UDP datagram size
         full_redundant_packet      = new int8_t[full_redundant_packet_size];
-        qDebug() << "in receiver mode, pre receive packet";
         full_redundant_packet_size = receivePacket(
             reinterpret_cast<char*>(full_redundant_packet), full_redundant_packet_size);
         // Check that peer has the same audio settings
@@ -676,7 +675,6 @@ void UdpDataProtocol::run()
             //        timeout = cc unused!
 #if defined (MANUAL_POLL)
             waitForReady(60000); //60 seconds
-            qDebug() << "what is this";
             if (receivePacket(reinterpret_cast<char *>(full_redundant_packet), full_redundant_packet_size) > 0) {
                 receivePacketRedundancy(full_redundant_packet, full_redundant_packet_size,
                                         full_packet_size, current_seq_num, last_seq_num,
@@ -709,7 +707,6 @@ void UdpDataProtocol::run()
                 WSAResetEvent(eventArray[index - WSA_WAIT_EVENT_0]);
                 WSAGetOverlappedResult(mSocket, &socketOverlapped, &bytesTransferred, FALSE, &flags);
                 if (bytesTransferred == mControlPacketSize) {
-                    qDebug() << "maybe here?";
                     processControlPacket(reinterpret_cast<char *>(full_redundant_packet));
                 } else if (bytesTransferred > 0 ){
                     receivePacketRedundancy(full_redundant_packet, full_redundant_packet_size,
@@ -726,7 +723,6 @@ void UdpDataProtocol::run()
 #endif
             if (n > 0) {
                 waitTime = 0;
-                qDebug() << "somewhere here";
                 if (receivePacket(reinterpret_cast<char *>(full_redundant_packet), full_redundant_packet_size) > 0) {
                     receivePacketRedundancy(full_redundant_packet, full_redundant_packet_size,
                                             full_packet_size, current_seq_num, last_seq_num,

--- a/src/UdpDataProtocol.cpp
+++ b/src/UdpDataProtocol.cpp
@@ -571,6 +571,7 @@ void UdpDataProtocol::run()
         }
         full_redundant_packet_size = 0x10000;  // max UDP datagram size
         full_redundant_packet      = new int8_t[full_redundant_packet_size];
+        qDebug() << "in receiver mode, pre receive packet";
         full_redundant_packet_size = receivePacket(
             reinterpret_cast<char*>(full_redundant_packet), full_redundant_packet_size);
         // Check that peer has the same audio settings
@@ -675,6 +676,7 @@ void UdpDataProtocol::run()
             //        timeout = cc unused!
 #if defined (MANUAL_POLL)
             waitForReady(60000); //60 seconds
+            qDebug() << "what is this";
             if (receivePacket(reinterpret_cast<char *>(full_redundant_packet), full_redundant_packet_size) > 0) {
                 receivePacketRedundancy(full_redundant_packet, full_redundant_packet_size,
                                         full_packet_size, current_seq_num, last_seq_num,
@@ -707,6 +709,7 @@ void UdpDataProtocol::run()
                 WSAResetEvent(eventArray[index - WSA_WAIT_EVENT_0]);
                 WSAGetOverlappedResult(mSocket, &socketOverlapped, &bytesTransferred, FALSE, &flags);
                 if (bytesTransferred == mControlPacketSize) {
+                    qDebug() << "maybe here?";
                     processControlPacket(reinterpret_cast<char *>(full_redundant_packet));
                 } else if (bytesTransferred > 0 ){
                     receivePacketRedundancy(full_redundant_packet, full_redundant_packet_size,
@@ -723,6 +726,7 @@ void UdpDataProtocol::run()
 #endif
             if (n > 0) {
                 waitTime = 0;
+                qDebug() << "somewhere here";
                 if (receivePacket(reinterpret_cast<char *>(full_redundant_packet), full_redundant_packet_size) > 0) {
                     receivePacketRedundancy(full_redundant_packet, full_redundant_packet_size,
                                             full_packet_size, current_seq_num, last_seq_num,

--- a/src/gui/Connected.qml
+++ b/src/gui/Connected.qml
@@ -739,7 +739,8 @@ Item {
                         }
                         display: AbstractButton.TextBesideIcon
                         onClicked: {
-                            virtualstudio.refreshDevices();
+                            virtualstudio.updateDeviceList();
+                            virtualstudio.validateDevicesState();
                             inputCurrIndex = getCurrentInputDeviceIndex();
                             outputCurrIndex = getCurrentOutputDeviceIndex();
                         }

--- a/src/gui/Connected.qml
+++ b/src/gui/Connected.qml
@@ -61,9 +61,6 @@ Item {
     property string meterYellow: "#F5BF4F"
     property string meterRed: "#F21B1B"
 
-    property int inputCurrIndex: getCurrentInputDeviceIndex()
-    property int outputCurrIndex: getCurrentOutputDeviceIndex()
-
     property bool isUsingRtAudio: virtualstudio.audioBackend == "RtAudio"
 
     function getCurrentInputDeviceIndex () {
@@ -122,6 +119,16 @@ Item {
 
         texts[1] = "Your connection quality is <b>" + quality + "</b>."
         return texts;
+    }
+
+    Connections {
+        target: virtualstudio
+        function onInputDeviceChanged() {
+            inputCombo.currentIndex = getCurrentInputDeviceIndex();
+        }
+        function onOutputDeviceChanged() {
+            outputCombo.currentIndex = getCurrentOutputDeviceIndex();
+        }
     }
 
     Image {
@@ -317,7 +324,7 @@ Item {
                         width: parent.width - leftSpacer.width - rightMargin * virtualstudio.uiScale
                         enabled: virtualstudio.connectionState == "Connected"
                         model: outputComboModel
-                        currentIndex: outputCurrIndex
+                        currentIndex: getCurrentOutputDeviceIndex()
                         delegate: ItemDelegate {
                             required property var modelData
                             required property int index
@@ -496,7 +503,7 @@ Item {
                     ComboBox {
                         id: inputCombo
                         model: inputComboModel
-                        currentIndex: inputCurrIndex
+                        currentIndex: getCurrentInputDeviceIndex()
                         anchors.left: outputCombo.left
                         anchors.right: outputCombo.right
                         anchors.verticalCenter: inputLabel.verticalCenter
@@ -741,8 +748,6 @@ Item {
                         display: AbstractButton.TextBesideIcon
                         onClicked: {
                             virtualstudio.validateDevicesState();
-                            inputCurrIndex = getCurrentInputDeviceIndex();
-                            outputCurrIndex = getCurrentOutputDeviceIndex();
                         }
 
                         font {

--- a/src/gui/Connected.qml
+++ b/src/gui/Connected.qml
@@ -739,7 +739,6 @@ Item {
                         }
                         display: AbstractButton.TextBesideIcon
                         onClicked: {
-                            virtualstudio.refreshDevices();
                             virtualstudio.validateDevicesState();
                             inputCurrIndex = getCurrentInputDeviceIndex();
                             outputCurrIndex = getCurrentOutputDeviceIndex();

--- a/src/gui/Connected.qml
+++ b/src/gui/Connected.qml
@@ -161,7 +161,7 @@ Item {
         visible: showReadyScreen && isUsingRtAudio
         x: bodyMargin * virtualstudio.uiScale; y: 200 * virtualstudio.uiScale
         width: parent.width - (2 * x)
-        height: 360 * virtualstudio.uiScale
+        height: 372 * virtualstudio.uiScale
         clip: true
 
         Button {
@@ -191,9 +191,6 @@ Item {
             modal: true
             focus: true
             closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
-            onOpened: {
-                virtualstudio.refreshDevices()
-            }
             onClosed: {
                 virtualstudio.applySettings()
             }
@@ -290,6 +287,25 @@ Item {
                             background: Rectangle {
                                 color: "transparent"
                             }
+                        }
+                    }
+
+                    Image {
+                        id: headphonesIcon
+                        anchors.left: outputLabel.left
+                        anchors.top: outputLabel.bottom
+                        anchors.topMargin: bottomToolTipMargin * virtualstudio.uiScale
+                        source: "headphones.svg"
+                        sourceSize: Qt.size(28 * virtualstudio.uiScale, 28 * virtualstudio.uiScale)
+                        fillMode: Image.PreserveAspectFit
+                        smooth: true
+
+                        Colorize {
+                            anchors.fill: parent
+                            source: parent
+                            hue: 0
+                            saturation: 0
+                            lightness: virtualstudio.darkMode ? 1 : 0
                         }
                     }
 
@@ -455,6 +471,25 @@ Item {
                             background: Rectangle {
                                 color: "transparent"
                             }
+                        }
+                    }
+
+                    Image {
+                        id: microphoneIcon
+                        anchors.left: inputLabel.left
+                        anchors.top: inputLabel.bottom
+                        anchors.topMargin: bottomToolTipMargin * virtualstudio.uiScale
+                        source: "mic.svg"
+                        sourceSize: Qt.size(32 * virtualstudio.uiScale, 32 * virtualstudio.uiScale)
+                        fillMode: Image.PreserveAspectFit
+                        smooth: true
+
+                        Colorize {
+                            anchors.fill: parent
+                            source: parent
+                            hue: 0
+                            saturation: 0
+                            lightness: virtualstudio.darkMode ? 1 : 0
                         }
                     }
 
@@ -702,6 +737,40 @@ Item {
                             color: !Boolean(virtualstudio.devicesError) && virtualstudio.backendAvailable ? saveButtonText : disabledButtonText
                             anchors.horizontalCenter: parent.horizontalCenter
                             anchors.verticalCenter: parent.verticalCenter
+                        }
+                    }
+
+                    Button {
+                        id: refreshButton
+                        text: "Refresh Devices"
+                        anchors.right: closePopupButton.left
+                        anchors.rightMargin: rightMargin * virtualstudio.uiScale
+                        anchors.bottomMargin: rightMargin * virtualstudio.uiScale
+                        anchors.bottom: parent.bottom
+                        width: 150 * virtualstudio.uiScale; height: 30 * virtualstudio.uiScale
+
+                        palette.buttonText: textColour
+                        background: Rectangle {
+                            radius: 6 * virtualstudio.uiScale
+                            color: refreshButton.down ? buttonPressedColour : (refreshButton.hovered ? buttonHoverColour : buttonColour)
+                            border.width: 1
+                            border.color: refreshButton.down ? buttonPressedStroke : (refreshButton.hovered ? buttonHoverStroke : buttonStroke)
+                        }
+
+                        icon {
+                            source: "refresh.svg";
+                            color: textColour;
+                        }
+                        display: AbstractButton.TextBesideIcon
+                        onClicked: {
+                            virtualstudio.refreshDevices();
+                            inputCurrIndex = getCurrentInputDeviceIndex();
+                            outputCurrIndex = getCurrentOutputDeviceIndex();
+                        }
+
+                        font {
+                            family: "Poppins"
+                            pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale
                         }
                     }
                 }

--- a/src/gui/Connected.qml
+++ b/src/gui/Connected.qml
@@ -191,6 +191,9 @@ Item {
             modal: true
             focus: true
             closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
+            onOpened: {
+                virtualstudio.refreshDevices()
+            }
             onClosed: {
                 virtualstudio.applySettings()
             }

--- a/src/gui/Connected.qml
+++ b/src/gui/Connected.qml
@@ -739,7 +739,7 @@ Item {
                         }
                         display: AbstractButton.TextBesideIcon
                         onClicked: {
-                            virtualstudio.updateDeviceList();
+                            virtualstudio.refreshDevices();
                             virtualstudio.validateDevicesState();
                             inputCurrIndex = getCurrentInputDeviceIndex();
                             outputCurrIndex = getCurrentOutputDeviceIndex();

--- a/src/gui/Connected.qml
+++ b/src/gui/Connected.qml
@@ -724,6 +724,7 @@ Item {
                         anchors.bottomMargin: rightMargin * virtualstudio.uiScale
                         anchors.bottom: parent.bottom
                         width: 150 * virtualstudio.uiScale; height: 30 * virtualstudio.uiScale
+                        enabled: virtualstudio.connectionState == "Connected"
 
                         palette.buttonText: textColour
                         background: Rectangle {

--- a/src/gui/Connected.qml
+++ b/src/gui/Connected.qml
@@ -159,9 +159,9 @@ Item {
     Item {
         id: deviceSettings
         visible: showReadyScreen && isUsingRtAudio
-        x: bodyMargin * virtualstudio.uiScale; y: 200 * virtualstudio.uiScale
+        x: bodyMargin * virtualstudio.uiScale; y: 192 * virtualstudio.uiScale
         width: parent.width - (2 * x)
-        height: 372 * virtualstudio.uiScale
+        height: 384 * virtualstudio.uiScale
         clip: true
 
         Button {
@@ -689,30 +689,6 @@ Item {
                         color: textColour
                     }
 
-                    Text {
-                        id: warningOrErrorMessage
-                        anchors.left: inputLabel.left
-                        anchors.right: parent.right
-                        anchors.rightMargin: 16 * virtualstudio.uiScale
-                        anchors.top: inputMixModeHelpMessage.bottom
-                        anchors.topMargin: 8 * virtualstudio.uiScale
-                        anchors.bottomMargin: 8 * virtualstudio.uiScale
-                        textFormat: Text.RichText
-                        text: (virtualstudio.devicesError || virtualstudio.devicesWarning)
-                            + ((virtualstudio.devicesErrorHelpUrl || virtualstudio.devicesWarningHelpUrl)
-                                ? `&nbsp;<a style="color: ${linkText};" href=${virtualstudio.devicesErrorHelpUrl || virtualstudio.devicesWarningHelpUrl}>Learn More.</a>`
-                                : ""
-                            )
-                        onLinkActivated: link => {
-                            virtualstudio.openLink(link)
-                        }
-                        horizontalAlignment: Text.AlignHLeft
-                        wrapMode: Text.WordWrap
-                        color: warningTextColour
-                        font { family: "Poppins"; pixelSize: fontTiny * virtualstudio.fontScale * virtualstudio.uiScale }
-                        visible: Boolean(virtualstudio.devicesError) || Boolean(virtualstudio.devicesWarning);
-                    }
-
                     Button {
                         id: closePopupButton
                         anchors.right: parent.right
@@ -744,7 +720,7 @@ Item {
                         id: refreshButton
                         text: "Refresh Devices"
                         anchors.right: closePopupButton.left
-                        anchors.rightMargin: rightMargin * virtualstudio.uiScale
+                        anchors.rightMargin: 8 * virtualstudio.uiScale
                         anchors.bottomMargin: rightMargin * virtualstudio.uiScale
                         anchors.bottom: parent.bottom
                         width: 150 * virtualstudio.uiScale; height: 30 * virtualstudio.uiScale
@@ -752,9 +728,9 @@ Item {
                         palette.buttonText: textColour
                         background: Rectangle {
                             radius: 6 * virtualstudio.uiScale
-                            color: refreshButton.down ? buttonPressedColour : (refreshButton.hovered ? buttonHoverColour : buttonColour)
+                            color: refreshButton.down ? browserButtonPressedColour : (refreshButton.hovered ? browserButtonHoverColour : browserButtonColour)
                             border.width: 1
-                            border.color: refreshButton.down ? buttonPressedStroke : (refreshButton.hovered ? buttonHoverStroke : buttonStroke)
+                            border.color: refreshButton.down ? browserButtonPressedStroke : (refreshButton.hovered ? browserButtonHoverStroke : browserButtonStroke)
                         }
 
                         icon {

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1855,22 +1855,18 @@ void VirtualStudio::slotAuthFailed()
 
 void VirtualStudio::processFinished()
 {
-    qDebug() << "in processFinished";
     if (m_device != nullptr && m_device->reconnect()) {
-        qDebug() << "should reconnect";
         if (m_device != nullptr && m_device->hasTerminated()) {
             if (m_useRtAudio) {
                 refreshRtAudioDevices();
                 validateInputDevicesState();
                 validateOutputDevicesState();
             }
-            qDebug() << "hasTerminated";
             connectToStudio(m_currentStudio);
         }
         return;
     }
     // use disconnect function to handle reset of all internal flags and timers
-    qDebug() << "will disconnect";
     disconnect();
 
     // reset network statistics

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1100,6 +1100,17 @@ void VirtualStudio::refreshDevices()
         setAudioReady(false);
     }
 
+    updateDeviceList();
+    validateDevicesState();
+    if (!m_vsAudioInterface.isNull()) {
+        restartAudio();
+    }
+#endif
+}
+
+void VirtualStudio::updateDeviceList()
+{
+#ifdef RT_AUDIO
     RtAudioInterface::getDeviceList(&m_inputDeviceList, &m_inputDeviceCategories,
                                     &m_inputDeviceChannels, true);
     RtAudioInterface::getDeviceList(&m_outputDeviceList, &m_outputDeviceCategories,
@@ -1113,10 +1124,6 @@ void VirtualStudio::refreshDevices()
                                                        inputComboModel);
     m_view.engine()->rootContext()->setContextProperty(QStringLiteral("outputComboModel"),
                                                        outputComboModel);
-    validateDevicesState();
-    if (!m_vsAudioInterface.isNull()) {
-        restartAudio();
-    }
 #endif
 }
 

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1100,6 +1100,20 @@ void VirtualStudio::refreshDevices()
         setAudioReady(false);
     }
 
+    refreshRtAudioDevices();
+    validateDevicesState();
+    if (!m_vsAudioInterface.isNull()) {
+        restartAudio();
+    }
+#endif
+}
+
+void VirtualStudio::refreshRtAudioDevices()
+{
+    if (!m_useRtAudio) {
+        return;
+    }
+#ifdef RT_AUDIO
     RtAudioInterface::getDeviceList(&m_inputDeviceList, &m_inputDeviceCategories,
                                     &m_inputDeviceChannels, true);
     RtAudioInterface::getDeviceList(&m_outputDeviceList, &m_outputDeviceCategories,
@@ -1113,10 +1127,6 @@ void VirtualStudio::refreshDevices()
                                                        inputComboModel);
     m_view.engine()->rootContext()->setContextProperty(QStringLiteral("outputComboModel"),
                                                        outputComboModel);
-    validateDevicesState();
-    if (!m_vsAudioInterface.isNull()) {
-        restartAudio();
-    }
 #endif
 }
 
@@ -1849,6 +1859,9 @@ void VirtualStudio::processFinished()
     if (m_device->reconnect()) {
         qDebug() << "should reconnect";
         if (m_device->hasTerminated()) {
+            if (m_useRtAudio) {
+                refreshRtAudioDevices();
+            }
             qDebug() << "hasTerminated";
             connectToStudio(m_currentStudio);
         }

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1100,6 +1100,20 @@ void VirtualStudio::refreshDevices()
         setAudioReady(false);
     }
 
+    refreshRtAudioDevices();
+    validateDevicesState();
+    if (!m_vsAudioInterface.isNull()) {
+        restartAudio();
+    }
+#endif
+}
+
+void VirtualStudio::refreshRtAudioDevices()
+{
+    if (!m_useRtAudio) {
+        return;
+    }
+#ifdef RT_AUDIO
     RtAudioInterface::getDeviceList(&m_inputDeviceList, &m_inputDeviceCategories,
                                     &m_inputDeviceChannels, true);
     RtAudioInterface::getDeviceList(&m_outputDeviceList, &m_outputDeviceCategories,
@@ -1113,10 +1127,6 @@ void VirtualStudio::refreshDevices()
                                                        inputComboModel);
     m_view.engine()->rootContext()->setContextProperty(QStringLiteral("outputComboModel"),
                                                        outputComboModel);
-    validateDevicesState();
-    if (!m_vsAudioInterface.isNull()) {
-        restartAudio();
-    }
 #endif
 }
 
@@ -1846,18 +1856,18 @@ void VirtualStudio::slotAuthFailed()
 void VirtualStudio::processFinished()
 {
     qDebug() << "in processFinished";
-    if (m_device != nullptr) {
-        if (m_device->reconnect()) {
-            qDebug() << "should reconnect";
-            if (m_device->hasTerminated()) {
-                if (m_useRtAudio) {
-                    refreshDevices();
-                }
-                qDebug() << "hasTerminated";
-                connectToStudio(m_currentStudio);
+    if (m_device != nullptr && m_device->reconnect()) {
+        qDebug() << "should reconnect";
+        if (m_device != nullptr && m_device->hasTerminated()) {
+            if (m_useRtAudio) {
+                refreshRtAudioDevices();
+                validateInputDevicesState();
+                validateOutputDevicesState();
             }
-            return;
+            qDebug() << "hasTerminated";
+            connectToStudio(m_currentStudio);
         }
+        return;
     }
     // use disconnect function to handle reset of all internal flags and timers
     qDebug() << "will disconnect";

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1188,8 +1188,8 @@ void VirtualStudio::validateInputDevicesState()
     if (m_inputDevice == QStringLiteral("")
         || m_inputDeviceList.indexOf(m_inputDevice) == -1) {
         m_inputDevice = m_inputDeviceList[0];
-        emit inputDeviceChanged(m_inputDevice, false);
     }
+    emit inputDeviceChanged(m_inputDevice, false);
 
     // Given the currently selected input device, reset the available input channel
     // options
@@ -1339,8 +1339,8 @@ void VirtualStudio::validateOutputDevicesState()
     if (m_outputDevice == QStringLiteral("")
         || m_outputDeviceList.indexOf(m_outputDevice) == -1) {
         m_outputDevice = m_outputDeviceList[0];
-        emit outputDeviceChanged(m_outputDevice, false);
     }
+    emit outputDeviceChanged(m_outputDevice, false);
 
     // Given the currently selected output device, reset the available output channel
     // options

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1845,13 +1845,17 @@ void VirtualStudio::slotAuthFailed()
 
 void VirtualStudio::processFinished()
 {
+    qDebug() << "in processFinished";
     if (m_device->reconnect()) {
+        qDebug() << "should reconnect";
         if (m_device->hasTerminated()) {
+            qDebug() << "hasTerminated";
             connectToStudio(m_currentStudio);
         }
         return;
     }
     // use disconnect function to handle reset of all internal flags and timers
+    qDebug() << "will disconnect";
     disconnect();
 
     // reset network statistics

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1100,17 +1100,6 @@ void VirtualStudio::refreshDevices()
         setAudioReady(false);
     }
 
-    updateDeviceList();
-    validateDevicesState();
-    if (!m_vsAudioInterface.isNull()) {
-        restartAudio();
-    }
-#endif
-}
-
-void VirtualStudio::updateDeviceList()
-{
-#ifdef RT_AUDIO
     RtAudioInterface::getDeviceList(&m_inputDeviceList, &m_inputDeviceCategories,
                                     &m_inputDeviceChannels, true);
     RtAudioInterface::getDeviceList(&m_outputDeviceList, &m_outputDeviceCategories,
@@ -1124,6 +1113,10 @@ void VirtualStudio::updateDeviceList()
                                                        inputComboModel);
     m_view.engine()->rootContext()->setContextProperty(QStringLiteral("outputComboModel"),
                                                        outputComboModel);
+    validateDevicesState();
+    if (!m_vsAudioInterface.isNull()) {
+        restartAudio();
+    }
 #endif
 }
 

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -252,7 +252,6 @@ class VirtualStudio : public QObject
     void logout();
     void refreshStudios(int index, bool signalRefresh = false);
     void refreshDevices();
-    void refreshRtAudioDevices();
     void validateDevicesState();
     void validateInputDevicesState();
     void validateOutputDevicesState();

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -252,6 +252,7 @@ class VirtualStudio : public QObject
     void logout();
     void refreshStudios(int index, bool signalRefresh = false);
     void refreshDevices();
+    void updateDeviceList();
     void validateDevicesState();
     void validateInputDevicesState();
     void validateOutputDevicesState();

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -252,6 +252,7 @@ class VirtualStudio : public QObject
     void logout();
     void refreshStudios(int index, bool signalRefresh = false);
     void refreshDevices();
+    void refreshRtAudioDevices();
     void validateDevicesState();
     void validateInputDevicesState();
     void validateOutputDevicesState();

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -252,7 +252,6 @@ class VirtualStudio : public QObject
     void logout();
     void refreshStudios(int index, bool signalRefresh = false);
     void refreshDevices();
-    void updateDeviceList();
     void validateDevicesState();
     void validateInputDevicesState();
     void validateOutputDevicesState();

--- a/src/gui/vsDevice.cpp
+++ b/src/gui/vsDevice.cpp
@@ -306,7 +306,6 @@ void VsDevice::setReconnect(bool reconnect)
 {
     m_reconnect = reconnect;
     if (reconnect) {
-        qDebug() << "perform reconnect things";
         stopPinger();
         if (m_webSocket != nullptr && m_webSocket->isValid()) {
             m_webSocket->closeSocket();


### PR DESCRIPTION
There's a small downside here which is calling "refreshDevices" disconnects you from audio briefly. I guess this is because it's unsafe to reload the device list when it's wired up to meters + other things?