### PR TITLE
Improvements and Fixes for Device Flow Code

### DIFF
--- a/src/gui/Login.qml
+++ b/src/gui/Login.qml
@@ -53,8 +53,8 @@ Item {
     property string disabledButtonText: "#D3D4D4"
     property string errorTextColour: "#DB0A0A"
 
-    property bool showCodeFlow: loginScreen.state === "polling" || loginScreen.state === "failed" || (loginScreen.state === "success" && auth.authenticationMethod === "code flow")
-    property bool showLoading: loginScreen.state === "refreshing" || (loginScreen.state === "success" && auth.authenticationMethod === "refresh token")
+    property bool showCodeFlow: (loginScreen.state === "unauthenticated" && !auth.attemptingRefreshToken) || (loginScreen.state === "polling" || loginScreen.state === "failed" || (loginScreen.state === "success" && auth.authenticationMethod === "code flow"))
+    property bool showLoading: (loginScreen.state === "unauthenticated" ** auth.attemptingRefreshToken) || loginScreen.state === "refreshing" || (loginScreen.state === "success" && auth.authenticationMethod === "refresh token")
 
     Clipboard {
         id: clipboard

--- a/src/gui/Login.qml
+++ b/src/gui/Login.qml
@@ -13,6 +13,9 @@ Item {
             name: "unauthenticated"
         },
         State {
+            name: "refreshing"
+        },
+        State {
             name: "polling"
         },
         State {
@@ -50,278 +53,316 @@ Item {
     property string disabledButtonText: "#D3D4D4"
     property string errorTextColour: "#DB0A0A"
 
+    property bool showCodeFlow: loginScreen.state === "polling" || loginScreen.state === "failed" || (loginScreen.state === "success" && auth.authenticationMethod === "code flow")
+    property bool showLoading: loginScreen.state === "refreshing" || (loginScreen.state === "success" && auth.authenticationMethod === "refresh token")
+
     Clipboard {
         id: clipboard
     }
 
-    Image {
-        id: loginLogo
-        source: "logo.svg"
-        x: parent.width / 2 - (150 * virtualstudio.uiScale); y: 88 * virtualstudio.uiScale
-        width: 42 * virtualstudio.uiScale; height: 76 * virtualstudio.uiScale
-        sourceSize: Qt.size(loginLogo.width,loginLogo.height)
-        fillMode: Image.PreserveAspectFit
-        smooth: true
-        visible: true
-    }
-
-    Image {
-        source: virtualstudio.darkMode ? "jacktrip white.png" : "jacktrip.png"
-        anchors.bottom: loginLogo.bottom
-        x: parent.width / 2 - (88 * virtualstudio.uiScale)
-        width: 238 * virtualstudio.uiScale; height: 56 * virtualstudio.uiScale
-        visible: true
-    }
-
-    Text {
-        text: "Virtual Studio"
-        font.family: "Poppins"
-        font.pixelSize: 28 * virtualstudio.fontScale * virtualstudio.uiScale
+    Item {
+        id: loginScreenHeader
         anchors.horizontalCenter: parent.horizontalCenter
-        y: 166 * virtualstudio.uiScale
-        color: textColour
-        visible: true
-    }
+        y: showCodeFlow ? 88 * virtualstudio.uiScale : 144 * virtualstudio.uiScale
 
-    Text {
-        id: authFailedText
-        text: "There was an error trying to sign in. Please try again."
-        font.family: "Poppins"
-        font.pixelSize: 10 * virtualstudio.fontScale * virtualstudio.uiScale
-        anchors.horizontalCenter: parent.horizontalCenter
-        y: backButton.visible ? 600 * virtualstudio.uiScale : 560 * virtualstudio.uiScale
-        visible: (loginScreen.state === "failed" || hasFailedAtLeastOnce) && loginScreen.state !== "success"
-        color: errorTextColour
-    }
-
-    Image {
-        id: successIcon
-        source: "check.svg"
-        y: 344 * virtualstudio.uiScale
-        anchors.horizontalCenter: parent.horizontalCenter
-        visible: loginScreen.state === "success"
-        sourceSize: Qt.size(96 * virtualstudio.uiScale, 96 * virtualstudio.uiScale)
-        fillMode: Image.PreserveAspectFit
-        smooth: true
-    }
-
-    Colorize {
-        anchors.fill: successIcon
-        source: successIcon
-        hue: .44
-        saturation: .55
-        lightness: .49
-        visible: loginScreen.state === "success"
-    }
-
-    Text {
-        id: deviceVerificationExplanation
-        text: `Please sign in and confirm the following code using your web browser.`
-        font.family: "Poppins"
-        font.pixelSize: 11 * virtualstudio.fontScale * virtualstudio.uiScale
-        anchors.horizontalCenter: parent.horizontalCenter
-        y: 248 * virtualstudio.uiScale
-        width: 500 * virtualstudio.uiScale;
-        visible: true
-        color: textColour
-        wrapMode: Text.WordWrap
-        horizontalAlignment: Text.AlignHCenter
-        textFormat: Text.RichText
-        onLinkActivated: link => {
-            if (!Boolean(auth.verificationCode)) {
-                return;
-            }
-            virtualstudio.openLink(link)
-        }
-    }
-
-    Text {
-        id: deviceVerificationCode
-        text: auth.verificationCode || "Loading...";
-        font.family: "Poppins"
-        font.pixelSize: 20 * virtualstudio.fontScale * virtualstudio.uiScale
-        font.letterSpacing: Boolean(auth.verificationCode) ? 8 : 1
-        anchors.horizontalCenter: parent.horizontalCenter
-        y: 320 * virtualstudio.uiScale
-        width: 360 * virtualstudio.uiScale;
-        visible: !auth.isAuthenticated
-        color: Boolean(auth.verificationCode) ? textColour : disabledButtonText
-        wrapMode: Text.WordWrap
-        horizontalAlignment: Text.AlignHCenter
-
-        Timer {
-            id: copiedResetTimer
-            interval: 2000; running: false; repeat: false
-            onTriggered: codeCopied = false;
+        Image {
+            id: loginLogo
+            source: "logo.svg"
+            x: parent.width / 2 - (150 * virtualstudio.uiScale);
+            width: 42 * virtualstudio.uiScale; height: 76 * virtualstudio.uiScale
+            sourceSize: Qt.size(loginLogo.width,loginLogo.height)
+            fillMode: Image.PreserveAspectFit
+            smooth: true
         }
 
-        MouseArea {
-            id: deviceVerificationCodeMouseArea
-            anchors.fill: parent
-            cursorShape: Qt.PointingHandCursor
-            enabled: Boolean(auth.verificationCode)
-            hoverEnabled: true
-            onClicked: () => {
-                codeCopied = true;
-                clipboard.setText(auth.verificationCode);
-                copiedResetTimer.restart()
-            }
+        Image {
+            source: virtualstudio.darkMode ? "jacktrip white.png" : "jacktrip.png"
+            anchors.bottom: loginLogo.bottom
+            x: parent.width / 2 - (88 * virtualstudio.uiScale)
+            width: 238 * virtualstudio.uiScale; height: 56 * virtualstudio.uiScale
         }
 
-        ToolTip {
-            parent: deviceVerificationCode
-            visible: loginScreen.state === "polling" && deviceVerificationCodeMouseArea.containsMouse
-            delay: 100
-            contentItem: Rectangle {
-                color: toolTipBackgroundColour
-                radius: 3
-                anchors.fill: parent
-                layer.enabled: true
-                border.width: 1
-                border.color: tooltipStroke
-
-                Text {
-                    anchors.centerIn: parent
-                    font { family: "Poppins"; pixelSize: 8 * virtualstudio.fontScale * virtualstudio.uiScale}
-                    text: codeCopied ? qsTr("📋 Copied code to clipboard") : qsTr("📋 Copy code to Clipboard")
-                    color: toolTipTextColour
-                }
-            }
-            background: Rectangle {
-                color: "transparent"
-            }
-        }
-    }
-
-    Text {
-        id: deviceVerificationFollowUp
-        text: "Return here when you are done."
-        font.family: "Poppins"
-        font.pixelSize: 11 * virtualstudio.fontScale * virtualstudio.uiScale
-        anchors.horizontalCenter: parent.horizontalCenter
-        y: 512 * virtualstudio.uiScale
-        width: 500 * virtualstudio.uiScale;
-        visible: true
-        color: textColour
-        wrapMode: Text.WordWrap
-        horizontalAlignment: Text.AlignHCenter
-    }
-
-    Button {
-        id: loginButton
-        background: Rectangle {
-            radius: 6 * virtualstudio.uiScale
-            color: loginButton.down ? buttonPressedColour : (loginButton.hovered ? buttonHoverColour : buttonColour)
-            border.width: 1
-            border.color: loginButton.down ? buttonPressedStroke : (loginButton.hovered ? buttonHoverStroke : buttonStroke)
-            layer.enabled: !loginButton.down
-        }
-        onClicked: {
-            if (auth.verificationCode && auth.verificationUrl) {
-                virtualstudio.showFirstRun = false;
-                virtualstudio.openLink(auth.verificationUrl);
-            }
-        }
-        anchors.horizontalCenter: parent.horizontalCenter
-        y: 400 * virtualstudio.uiScale
-        width: 263 * virtualstudio.uiScale; height: 64 * virtualstudio.uiScale
         Text {
-            text: "Sign In"
+            text: "Virtual Studio"
             font.family: "Poppins"
-            font.pixelSize: 18 * virtualstudio.fontScale * virtualstudio.uiScale
-            font.weight: Font.Bold
+            font.pixelSize: 24 * virtualstudio.fontScale * virtualstudio.uiScale
             anchors.horizontalCenter: parent.horizontalCenter
-            anchors.verticalCenter: parent.verticalCenter
-            color: loginButton.down ? buttonTextPressed : (loginButton.hovered ? buttonTextHover : buttonTextColour)
+            y: 80 * virtualstudio.uiScale
+            color: textColour
         }
-        visible: !auth.isAuthenticated
     }
 
     Item {
-        id: loginScreenFooter
+        id: codeFlow
         anchors.horizontalCenter: parent.horizontalCenter
-        y: 560 * virtualstudio.uiScale
-        height: 100 * virtualstudio.uiScale
+        y: 108 * virtualstudio.uiScale
+        visible: showCodeFlow
+        width: parent.width
 
-        Button {
-            id: backButton
-            visible: !virtualstudio.vsFtux
-            background: Rectangle {
-                radius: 6 * virtualstudio.uiScale
-                color: backButton.down ? buttonPressedColour : (backButton.hovered ? buttonHoverColour : buttonColour)
-                border.color: backButton.down ? buttonPressedStroke : (backButton.hovered ? buttonHoverStroke : buttonStroke)
-                border.width: 1
-                layer.enabled: !backButton.down
-            }
-            onClicked: () => { if (!auth.isAuthenticated) { virtualstudio.windowState = "start"; } }
-            anchors.verticalCenter: parent.verticalCenter
-            anchors.right: parent.horizontalCenter
-            anchors.rightMargin: 8 * virtualstudio.uiScale
-            width: 144 * virtualstudio.uiScale; height: 32 * virtualstudio.uiScale
-            Text {
-                text: "Back"
-                font.family: "Poppins"
-                font.pixelSize: 9 * virtualstudio.fontScale * virtualstudio.uiScale
-                anchors.horizontalCenter: parent.horizontalCenter
-                anchors.verticalCenter: parent.verticalCenter
-                color: backButton.down ? buttonTextPressed : (backButton.hovered ? buttonTextHover : textColour)
-            }
-        }
-
-        Button {
-            id: classicModeButton
-            visible: virtualstudio.showFirstRun && virtualstudio.vsFtux
-            background: Rectangle {
-                radius: 6 * virtualstudio.uiScale
-                color: classicModeButton.down ? buttonPressedColour : (classicModeButton.hovered ? buttonHoverColour : buttonColour)
-                border.color: classicModeButton.down ? buttonPressedStroke : (classicModeButton.hovered ? buttonHoverStroke : buttonStroke)
-                border.width: 1
-                layer.enabled: !classicModeButton.down
-            }
-            onClicked: { virtualstudio.windowState = "login"; virtualstudio.toStandard(); }
-            anchors.verticalCenter: parent.verticalCenter
-            anchors.right: parent.horizontalCenter
-            anchors.rightMargin: 8 * virtualstudio.uiScale
-            width: 160 * virtualstudio.uiScale; height: 32 * virtualstudio.uiScale
-            Text {
-                text: "Use Classic Mode"
-                font.family: "Poppins"
-                font.pixelSize: 9 * virtualstudio.fontScale * virtualstudio.uiScale
-                anchors.horizontalCenter: parent.horizontalCenter
-                anchors.verticalCenter: parent.verticalCenter
-                color: classicModeButton.down ? buttonTextPressed : (classicModeButton.hovered ? buttonTextHover : textColour)
-            }
-        }
-
-        Button {
-            id: resetCodeButton
+        Text {
+            id: deviceVerificationExplanation
+            text: `Please sign in and confirm the following code using your web browser.`
+            font.family: "Poppins"
+            font.pixelSize: 11 * virtualstudio.fontScale * virtualstudio.uiScale
+            anchors.horizontalCenter: parent.horizontalCenter
+            y: 128 * virtualstudio.uiScale
+            width: 500 * virtualstudio.uiScale;
             visible: true
-            background: Rectangle {
-                radius: 6 * virtualstudio.uiScale
-                color: resetCodeButton.down ? buttonPressedColour : (resetCodeButton.hovered ? buttonHoverColour : buttonColour)
-                border.color: resetCodeButton.down ? buttonPressedStroke : (resetCodeButton.hovered ? buttonHoverStroke : buttonStroke)
-                border.width: 1
-                layer.enabled: !resetCodeButton.down
+            color: textColour
+            wrapMode: Text.WordWrap
+            horizontalAlignment: Text.AlignHCenter
+            textFormat: Text.RichText
+            onLinkActivated: link => {
+                if (!Boolean(auth.verificationCode)) {
+                    return;
+                }
+                virtualstudio.openLink(link)
             }
-            onClicked: () => { 
-                if (auth.verificationCode && auth.verificationUrl) {
-                    auth.resetCode();
+        }
+
+        // TODO: handle this case!
+        // Text {
+        //     id: authFailedText
+        //     text: "There was an error trying to sign in. Please try again."
+        //     font.family: "Poppins"
+        //     font.pixelSize: 10 * virtualstudio.fontScale * virtualstudio.uiScale
+        //     anchors.horizontalCenter: parent.horizontalCenter
+        //     y: backButton.visible ? 600 * virtualstudio.uiScale : 560 * virtualstudio.uiScale
+        //     visible: (loginScreen.state === "failed" || hasFailedAtLeastOnce) && loginScreen.state !== "success"
+        //     color: errorTextColour
+        // }
+
+        Image {
+            id: successIcon
+            source: "check.svg"
+            y: 224 * virtualstudio.uiScale
+            anchors.horizontalCenter: parent.horizontalCenter
+            visible: loginScreen.state === "success"
+            sourceSize: Qt.size(96 * virtualstudio.uiScale, 96 * virtualstudio.uiScale)
+            fillMode: Image.PreserveAspectFit
+            smooth: true
+        }
+
+        Colorize {
+            anchors.fill: successIcon
+            source: successIcon
+            hue: .44
+            saturation: .55
+            lightness: .49
+            visible: loginScreen.state === "success"
+        }
+
+        Text {
+            id: deviceVerificationCode
+            text: auth.verificationCode || "Loading...";
+            font.family: "Poppins"
+            font.pixelSize: 20 * virtualstudio.fontScale * virtualstudio.uiScale
+            font.letterSpacing: Boolean(auth.verificationCode) ? 8 : 1
+            anchors.horizontalCenter: parent.horizontalCenter
+            y: 208 * virtualstudio.uiScale
+            width: 360 * virtualstudio.uiScale;
+            visible: !auth.isAuthenticated
+            color: Boolean(auth.verificationCode) ? textColour : disabledButtonText
+            wrapMode: Text.WordWrap
+            horizontalAlignment: Text.AlignHCenter
+
+            Timer {
+                id: copiedResetTimer
+                interval: 2000; running: false; repeat: false
+                onTriggered: codeCopied = false;
+            }
+
+            MouseArea {
+                id: deviceVerificationCodeMouseArea
+                anchors.fill: parent
+                cursorShape: Qt.PointingHandCursor
+                enabled: Boolean(auth.verificationCode)
+                hoverEnabled: true
+                onClicked: () => {
+                    codeCopied = true;
+                    clipboard.setText(auth.verificationCode);
+                    copiedResetTimer.restart()
                 }
             }
-            
-            anchors.left: (backButton.visible || classicModeButton.visible) ? parent.horizontalCenter : undefined
-            anchors.leftMargin: (backButton.visible || classicModeButton.visible) ? 8 * virtualstudio.uiScale : undefined
-            anchors.horizontalCenter: (!backButton.visible && !classicModeButton.visible) ? parent.horizontalCenter : undefined
-            anchors.verticalCenter: parent.verticalCenter
-            width: 144 * virtualstudio.uiScale; height: 32 * virtualstudio.uiScale
+
+            ToolTip {
+                parent: deviceVerificationCode
+                visible: loginScreen.state === "polling" && deviceVerificationCodeMouseArea.containsMouse
+                delay: 100
+                contentItem: Rectangle {
+                    color: toolTipBackgroundColour
+                    radius: 3
+                    anchors.fill: parent
+                    layer.enabled: true
+                    border.width: 1
+                    border.color: tooltipStroke
+
+                    Text {
+                        anchors.centerIn: parent
+                        font { family: "Poppins"; pixelSize: 8 * virtualstudio.fontScale * virtualstudio.uiScale}
+                        text: codeCopied ? qsTr("📋 Copied code to clipboard") : qsTr("📋 Copy code to Clipboard")
+                        color: toolTipTextColour
+                    }
+                }
+                background: Rectangle {
+                    color: "transparent"
+                }
+            }
+        }
+
+        Button {
+            id: loginButton
+            background: Rectangle {
+                radius: 6 * virtualstudio.uiScale
+                color: loginButton.down ? buttonPressedColour : (loginButton.hovered ? buttonHoverColour : buttonColour)
+                border.width: 1
+                border.color: loginButton.down ? buttonPressedStroke : (loginButton.hovered ? buttonHoverStroke : buttonStroke)
+                layer.enabled: !loginButton.down
+            }
+            onClicked: {
+                if (auth.verificationCode && auth.verificationUrl) {
+                    // virtualstudio.showFirstRun = false;
+                    virtualstudio.openLink(auth.verificationUrl);
+                }
+            }
+            anchors.horizontalCenter: parent.horizontalCenter
+            y: 284 * virtualstudio.uiScale
+            width: 263 * virtualstudio.uiScale; height: 64 * virtualstudio.uiScale
             Text {
-                text: "Reset Code"
+                text: "Sign In"
                 font.family: "Poppins"
-                font.pixelSize: 9 * virtualstudio.fontScale * virtualstudio.uiScale
+                font.pixelSize: 18 * virtualstudio.fontScale * virtualstudio.uiScale
+                font.weight: Font.Bold
                 anchors.horizontalCenter: parent.horizontalCenter
                 anchors.verticalCenter: parent.verticalCenter
-                color: resetCodeButton.down ? buttonTextPressed : (resetCodeButton.hovered ? buttonTextHover : textColour)
+                color: loginButton.down ? buttonTextPressed : (loginButton.hovered ? buttonTextHover : buttonTextColour)
             }
+            visible: !auth.isAuthenticated
+        }
+
+        Text {
+            id: deviceVerificationFollowUp
+            text: "Return here when you are done."
+            font.family: "Poppins"
+            font.pixelSize: 11 * virtualstudio.fontScale * virtualstudio.uiScale
+            anchors.horizontalCenter: parent.horizontalCenter
+            y: 384 * virtualstudio.uiScale
+            width: 500 * virtualstudio.uiScale;
+            visible: true
+            color: textColour
+            wrapMode: Text.WordWrap
+            horizontalAlignment: Text.AlignHCenter
+        }
+
+        Item {
+            id: loginScreenFooter
+            anchors.horizontalCenter: parent.horizontalCenter
+            y: 420 * virtualstudio.uiScale
+            width: parent.width
+            height: 100 * virtualstudio.uiScale
+
+            Button {
+                id: backButton
+                visible: !virtualstudio.vsFtux
+                background: Rectangle {
+                    radius: 6 * virtualstudio.uiScale
+                    color: backButton.down ? buttonPressedColour : (backButton.hovered ? buttonHoverColour : buttonColour)
+                    border.color: backButton.down ? buttonPressedStroke : (backButton.hovered ? buttonHoverStroke : buttonStroke)
+                    border.width: 1
+                    layer.enabled: !backButton.down
+                }
+                onClicked: () => { if (!auth.isAuthenticated) { virtualstudio.windowState = "start"; } }
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.right: parent.horizontalCenter
+                anchors.rightMargin: 8 * virtualstudio.uiScale
+                width: 144 * virtualstudio.uiScale; height: 32 * virtualstudio.uiScale
+                Text {
+                    text: "Back"
+                    font.family: "Poppins"
+                    font.pixelSize: 9 * virtualstudio.fontScale * virtualstudio.uiScale
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    anchors.verticalCenter: parent.verticalCenter
+                    color: backButton.down ? buttonTextPressed : (backButton.hovered ? buttonTextHover : textColour)
+                }
+            }
+
+            Button {
+                id: classicModeButton
+                visible: virtualstudio.showFirstRun && virtualstudio.vsFtux
+                background: Rectangle {
+                    radius: 6 * virtualstudio.uiScale
+                    color: classicModeButton.down ? buttonPressedColour : (classicModeButton.hovered ? buttonHoverColour : buttonColour)
+                    border.color: classicModeButton.down ? buttonPressedStroke : (classicModeButton.hovered ? buttonHoverStroke : buttonStroke)
+                    border.width: 1
+                    layer.enabled: !classicModeButton.down
+                }
+                onClicked: { virtualstudio.windowState = "login"; virtualstudio.toStandard(); }
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.right: parent.horizontalCenter
+                anchors.rightMargin: 8 * virtualstudio.uiScale
+                width: 160 * virtualstudio.uiScale; height: 32 * virtualstudio.uiScale
+                Text {
+                    text: "Use Classic Mode"
+                    font.family: "Poppins"
+                    font.pixelSize: 9 * virtualstudio.fontScale * virtualstudio.uiScale
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    anchors.verticalCenter: parent.verticalCenter
+                    color: classicModeButton.down ? buttonTextPressed : (classicModeButton.hovered ? buttonTextHover : textColour)
+                }
+            }
+
+            Button {
+                id: resetCodeButton
+                visible: true
+                background: Rectangle {
+                    radius: 6 * virtualstudio.uiScale
+                    color: resetCodeButton.down ? buttonPressedColour : (resetCodeButton.hovered ? buttonHoverColour : buttonColour)
+                    border.color: resetCodeButton.down ? buttonPressedStroke : (resetCodeButton.hovered ? buttonHoverStroke : buttonStroke)
+                    border.width: 1
+                    layer.enabled: !resetCodeButton.down
+                }
+                onClicked: () => { 
+                    if (auth.verificationCode && auth.verificationUrl) {
+                        auth.resetCode();
+                    }
+                }
+
+                anchors.horizontalCenter: (!backButton.visible && !classicModeButton.visible) ? parent.horizontalCenter : undefined
+                anchors.left: (backButton.visible || classicModeButton.visible) ? parent.horizontalCenter : undefined
+                anchors.leftMargin: (backButton.visible || classicModeButton.visible) ? 8 * virtualstudio.uiScale : undefined
+                anchors.verticalCenter: parent.verticalCenter
+                width: 144 * virtualstudio.uiScale; height: 32 * virtualstudio.uiScale
+                Text {
+                    text: "Reset Code"
+                    font.family: "Poppins"
+                    font.pixelSize: 9 * virtualstudio.fontScale * virtualstudio.uiScale
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    anchors.verticalCenter: parent.verticalCenter
+                    color: resetCodeButton.down ? buttonTextPressed : (resetCodeButton.hovered ? buttonTextHover : textColour)
+                }
+            }
+        }
+
+
+    }
+
+    Item {
+        id: refreshToken
+        anchors.horizontalCenter: parent.horizontalCenter
+        y: 108 * virtualstudio.uiScale
+        visible: showLoading
+        
+        Text {
+            id: loadingViaRefreshToken
+            text: "Loading...";
+            font.family: "Poppins"
+            font.pixelSize: 20 * virtualstudio.fontScale * virtualstudio.uiScale
+            anchors.horizontalCenter: parent.horizontalCenter
+            y: 208 * virtualstudio.uiScale
+            width: 360 * virtualstudio.uiScale;
+            color: textColour
+            wrapMode: Text.WordWrap
+            horizontalAlignment: Text.AlignHCenter
         }
     }
 

--- a/src/gui/Login.qml
+++ b/src/gui/Login.qml
@@ -63,7 +63,7 @@ Item {
     Item {
         id: loginScreenHeader
         anchors.horizontalCenter: parent.horizontalCenter
-        y: showCodeFlow ? 36 * virtualstudio.uiScale : 144 * virtualstudio.uiScale
+        y: showCodeFlow ? 48 * virtualstudio.uiScale : 144 * virtualstudio.uiScale
 
         Image {
             id: loginLogo
@@ -95,7 +95,7 @@ Item {
     Item {
         id: codeFlow
         anchors.horizontalCenter: parent.horizontalCenter
-        y: 55 * virtualstudio.uiScale
+        y: 68 * virtualstudio.uiScale
         height: parent.height - codeFlow.y
         visible: showCodeFlow
         width: parent.width
@@ -235,7 +235,8 @@ Item {
             font.family: "Poppins"
             font.pixelSize: 10 * virtualstudio.fontScale * virtualstudio.uiScale
             anchors.horizontalCenter: parent.horizontalCenter
-            y: 360 * virtualstudio.uiScale
+            anchors.bottom: loginScreenFooter.top
+            anchors.bottomMargin: 16 * virtualstudio.uiScale
             visible: (loginScreen.state === "failed" || hasFailedAtLeastOnce) && loginScreen.state !== "success"
             color: errorTextColour
         }
@@ -244,10 +245,9 @@ Item {
             id: loginScreenFooter
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.bottom: parent.bottom
-            anchors.bottomMargin: 16 * virtualstudio.uiScale
-            y: 420 * virtualstudio.uiScale
+            anchors.bottomMargin: 24 * virtualstudio.uiScale
             width: parent.width
-            height: 80 * virtualstudio.uiScale
+            height: 48 * virtualstudio.uiScale
 
             Button {
                 id: backButton

--- a/src/gui/Login.qml
+++ b/src/gui/Login.qml
@@ -56,12 +56,12 @@ Item {
     Image {
         id: loginLogo
         source: "logo.svg"
-        x: parent.width / 2 - (150 * virtualstudio.uiScale); y: 110 * virtualstudio.uiScale
+        x: parent.width / 2 - (150 * virtualstudio.uiScale); y: 88 * virtualstudio.uiScale
         width: 42 * virtualstudio.uiScale; height: 76 * virtualstudio.uiScale
         sourceSize: Qt.size(loginLogo.width,loginLogo.height)
         fillMode: Image.PreserveAspectFit
         smooth: true
-        visible: loginScreen.state === "unauthenticated"
+        visible: true
     }
 
     Image {
@@ -69,7 +69,7 @@ Item {
         anchors.bottom: loginLogo.bottom
         x: parent.width / 2 - (88 * virtualstudio.uiScale)
         width: 238 * virtualstudio.uiScale; height: 56 * virtualstudio.uiScale
-        visible: loginScreen.state === "unauthenticated" || loginScreen.state === "failed"
+        visible: true
     }
 
     Text {
@@ -77,31 +77,9 @@ Item {
         font.family: "Poppins"
         font.pixelSize: 28 * virtualstudio.fontScale * virtualstudio.uiScale
         anchors.horizontalCenter: parent.horizontalCenter
-        y: 208 * virtualstudio.uiScale
+        y: 166 * virtualstudio.uiScale
         color: textColour
-        visible: loginScreen.state === "unauthenticated" || loginScreen.state === "failed"
-    }
-
-    Text {
-        id: loggingInText
-        text: "Logging in..."
-        font.family: "Poppins"
-        font.pixelSize: 18 * virtualstudio.fontScale * virtualstudio.uiScale
-        anchors.horizontalCenter: parent.horizontalCenter
-        y: 282 * virtualstudio.uiScale
-        visible: loginScreen.state === "unauthenticated" && virtualstudio.hasRefreshToken
-        color: textColour
-    }
-
-    Text {
-        id: authSucceededText
-        text: "Success!"
-        font.family: "Poppins"
-        font.pixelSize: 18 * virtualstudio.fontScale * virtualstudio.uiScale
-        anchors.horizontalCenter: parent.horizontalCenter
-        y: 348 * virtualstudio.uiScale
-        visible: loginScreen.state === "success"
-        color: textColour
+        visible: true
     }
 
     Text {
@@ -118,7 +96,7 @@ Item {
     Image {
         id: successIcon
         source: "check.svg"
-        y: 240 * virtualstudio.uiScale
+        y: 344 * virtualstudio.uiScale
         anchors.horizontalCenter: parent.horizontalCenter
         visible: loginScreen.state === "success"
         sourceSize: Qt.size(96 * virtualstudio.uiScale, 96 * virtualstudio.uiScale)
@@ -136,35 +114,14 @@ Item {
     }
 
     Text {
-        id: deviceVerificationHeader
-        text: "Authorize Application"
-        font.family: "Poppins"
-        font.pixelSize: 20 * virtualstudio.fontScale * virtualstudio.uiScale
-        anchors.horizontalCenter: parent.horizontalCenter
-        y: 88 * virtualstudio.uiScale
-        visible: loginScreen.state === "polling"
-        color: textColour
-        horizontalAlignment: Text.AlignHCenter
-    }
-
-    Text {
         id: deviceVerificationExplanation
-        text: `To log in to your Virtual Studio account, please enter the following one-time code at `
-            + `<a style="color: ${linkTextColour}" href='${auth.verificationUrl}'><u><b>${
-                    ((completeUrl) => {
-                        if (completeUrl.indexOf("?") === -1) {
-                            return completeUrl;
-                        }
-                        return completeUrl.substring(0, auth.verificationUrl.indexOf("?"))
-                    })(auth.verificationUrl)
-                }</b></u></a>`
-            + ` and sign in through your browser.`
+        text: `Please sign in and confirm the following code using your web browser.`
         font.family: "Poppins"
         font.pixelSize: 11 * virtualstudio.fontScale * virtualstudio.uiScale
         anchors.horizontalCenter: parent.horizontalCenter
-        y: 160 * virtualstudio.uiScale
+        y: 248 * virtualstudio.uiScale
         width: 500 * virtualstudio.uiScale;
-        visible: loginScreen.state === "polling"
+        visible: true
         color: textColour
         wrapMode: Text.WordWrap
         horizontalAlignment: Text.AlignHCenter
@@ -184,9 +141,9 @@ Item {
         font.pixelSize: 20 * virtualstudio.fontScale * virtualstudio.uiScale
         font.letterSpacing: Boolean(auth.verificationCode) ? 8 : 1
         anchors.horizontalCenter: parent.horizontalCenter
-        y: 280 * virtualstudio.uiScale
+        y: 320 * virtualstudio.uiScale
         width: 360 * virtualstudio.uiScale;
-        visible: loginScreen.state === "polling"
+        visible: !auth.isAuthenticated
         color: Boolean(auth.verificationCode) ? textColour : disabledButtonText
         wrapMode: Text.WordWrap
         horizontalAlignment: Text.AlignHCenter
@@ -201,6 +158,7 @@ Item {
             id: deviceVerificationCodeMouseArea
             anchors.fill: parent
             cursorShape: Qt.PointingHandCursor
+            enabled: Boolean(auth.verificationCode)
             hoverEnabled: true
             onClicked: () => {
                 codeCopied = true;
@@ -236,38 +194,16 @@ Item {
 
     Text {
         id: deviceVerificationFollowUp
-        text: "Once you've authorized this application, you'll automatically be moved to the next screen."
+        text: "Return here when you are done."
         font.family: "Poppins"
         font.pixelSize: 11 * virtualstudio.fontScale * virtualstudio.uiScale
         anchors.horizontalCenter: parent.horizontalCenter
-        y: 475 * virtualstudio.uiScale
+        y: 512 * virtualstudio.uiScale
         width: 500 * virtualstudio.uiScale;
-        visible: loginScreen.state === "polling"
+        visible: true
         color: textColour
         wrapMode: Text.WordWrap
         horizontalAlignment: Text.AlignHCenter
-    }
-
-    Text {
-        id: cancelDeviceVerification
-        text: "Cancel"
-        font.family: "Poppins"
-        font.pixelSize: 11 * virtualstudio.fontScale * virtualstudio.uiScale
-        font.underline: true;
-        anchors.horizontalCenter: parent.horizontalCenter
-        y: 535 * virtualstudio.uiScale
-        visible: loginScreen.state === "polling"
-        color: textColour
-        wrapMode: Text.WordWrap
-        horizontalAlignment: Text.AlignHCenter
-        
-        MouseArea {
-            anchors.fill: parent
-            onClicked: () => {
-                auth.cancelAuthenticationFlow();
-            }
-            cursorShape: Qt.PointingHandCursor
-        }
     }
 
     Button {
@@ -280,12 +216,11 @@ Item {
             layer.enabled: !loginButton.down
         }
         onClicked: {
-            loginScreen.state = "polling"; // Hack - transition to 'polling' before auth state actually changes for improved UX
             virtualstudio.showFirstRun = false;
-            virtualstudio.login()
+            virtualstudio.openLink(auth.verificationUrl);
         }
         anchors.horizontalCenter: parent.horizontalCenter
-        y: showBackButton ? 321 * virtualstudio.uiScale : 371 * virtualstudio.uiScale
+        y: 400 * virtualstudio.uiScale
         width: 263 * virtualstudio.uiScale; height: 64 * virtualstudio.uiScale
         Text {
             text: "Sign In"
@@ -296,7 +231,7 @@ Item {
             anchors.verticalCenter: parent.verticalCenter
             color: loginButton.down ? buttonTextPressed : (loginButton.hovered ? buttonTextHover : buttonTextColour)
         }
-        visible: (!virtualstudio.hasRefreshToken && loginScreen.state === "unauthenticated") || loginScreen.state === "failed"
+        visible: !auth.isAuthenticated
     }
 
     Text {
@@ -306,8 +241,8 @@ Item {
         font.pixelSize: 11 * virtualstudio.fontScale * virtualstudio.uiScale
         font.underline: true;
         anchors.horizontalCenter: parent.horizontalCenter
-        y: 520 * virtualstudio.uiScale
-        visible: showBackButton && (!virtualstudio.hasRefreshToken && loginScreen.state === "unauthenticated") || loginScreen.state === "failed"
+        y: 560 * virtualstudio.uiScale
+        visible: showBackButton && (!virtualstudio.hasRefreshToken) || loginScreen.state === "failed"
         color: textColour
         wrapMode: Text.WordWrap
         horizontalAlignment: Text.AlignHCenter
@@ -316,33 +251,6 @@ Item {
             anchors.fill: parent
             onClicked: () => { virtualstudio.windowState = "start" }
             cursorShape: Qt.PointingHandCursor
-        }
-    }
-
-    Button {
-        id: openVerificationUrlButton
-        visible: loginScreen.state === "polling"
-        enabled: Boolean(auth.verificationCode)
-        background: Rectangle {
-            radius: 6 * virtualstudio.uiScale
-            color: openVerificationUrlButton.down ? buttonPressedColour : (openVerificationUrlButton.hovered ? buttonHoverColour : buttonColour)
-            border.width: 1
-            border.color: openVerificationUrlButton.down ? buttonPressedStroke : (openVerificationUrlButton.hovered ? buttonHoverStroke : buttonStroke)
-            layer.enabled: !openVerificationUrlButton.down
-        }
-        onClicked: { virtualstudio.openLink(auth.verificationUrl); }
-        anchors.horizontalCenter: parent.horizontalCenter
-        y: 370 * virtualstudio.uiScale
-        width: 216 * virtualstudio.uiScale; height: 48 * virtualstudio.uiScale
-        Text {
-            text: "Open Browser"
-            font.family: "Poppins"
-            font.pixelSize: 12 * virtualstudio.fontScale * virtualstudio.uiScale
-            anchors.horizontalCenter: parent.horizontalCenter
-            anchors.verticalCenter: parent.verticalCenter
-            color: !Boolean(auth.verificationCode)
-                ? disabledButtonText
-                : openVerificationUrlButton.down ? buttonTextPressed : (openVerificationUrlButton.hovered ? buttonTextHover : buttonTextColour)
         }
     }
 

--- a/src/gui/Login.qml
+++ b/src/gui/Login.qml
@@ -30,6 +30,7 @@ Item {
 
     property bool showBackButton: true
     property bool codeCopied: false
+    property bool hasFailedAtLeastOnce: false
 
     property string backgroundColour: virtualstudio.darkMode ? "#272525" : "#FAFBFB"
     property string textColour: virtualstudio.darkMode ? "#FAFBFB" : "#0F0D0D"
@@ -48,6 +49,7 @@ Item {
     property string toolTipBackgroundColour: codeCopied ? "#57B147" : (virtualstudio.darkMode ? "#323232" : "#F3F3F3")
     property string tooltipStroke: virtualstudio.darkMode ? "#80827D7D" : "#34979797"
     property string disabledButtonText: "#D3D4D4"
+    property string errorTextColour: "#DB0A0A"
 
     Clipboard {
         id: clipboard
@@ -84,13 +86,13 @@ Item {
 
     Text {
         id: authFailedText
-        text: "Log in failed. Please try again."
+        text: "There was an error trying to sign in. Please try again."
         font.family: "Poppins"
-        font.pixelSize: 18 * virtualstudio.fontScale * virtualstudio.uiScale
+        font.pixelSize: 10 * virtualstudio.fontScale * virtualstudio.uiScale
         anchors.horizontalCenter: parent.horizontalCenter
-        y: 282 * virtualstudio.uiScale
-        visible: loginScreen.state === "failed"
-        color: textColour
+        y: backButton.visible ? 600 * virtualstudio.uiScale : 560 * virtualstudio.uiScale
+        visible: (loginScreen.state === "failed" || hasFailedAtLeastOnce) && loginScreen.state !== "success"
+        color: errorTextColour
     }
 
     Image {
@@ -242,14 +244,14 @@ Item {
         font.underline: true;
         anchors.horizontalCenter: parent.horizontalCenter
         y: 560 * virtualstudio.uiScale
-        visible: showBackButton && (!virtualstudio.hasRefreshToken) || loginScreen.state === "failed"
+        visible: showBackButton
         color: textColour
         wrapMode: Text.WordWrap
         horizontalAlignment: Text.AlignHCenter
         
         MouseArea {
             anchors.fill: parent
-            onClicked: () => { virtualstudio.windowState = "start" }
+            onClicked: () => { if (!auth.isAuthenticated) { virtualstudio.windowState = "start"; } }
             cursorShape: Qt.PointingHandCursor
         }
     }
@@ -281,6 +283,9 @@ Item {
         target: auth
         function onUpdatedAuthenticationStage (stage) {
             loginScreen.state = stage;
+            if (stage === "failed") {
+                hasFailedAtLeastOnce = true;
+            }
         }
     }
 }

--- a/src/gui/Login.qml
+++ b/src/gui/Login.qml
@@ -299,27 +299,23 @@ Item {
         visible: (!virtualstudio.hasRefreshToken && loginScreen.state === "unauthenticated") || loginScreen.state === "failed"
     }
 
-    Button {
+    Text {
         id: backButton
-        visible: (!virtualstudio.hasRefreshToken && loginScreen.state === "unauthenticated") || loginScreen.state === "failed"
-        background: Rectangle {
-            radius: 6 * virtualstudio.uiScale
-            color: backButton.down ? buttonPressedColour : (backButton.hovered ? buttonHoverColour : buttonColour)
-            border.width: 1
-            border.color: backButton.down ? buttonPressedStroke : (backButton.hovered ? buttonHoverStroke : buttonStroke)
-            layer.enabled: !backButton.down
-        }
-        onClicked: { virtualstudio.windowState = "start" }
+        text: "Back"
+        font.family: "Poppins"
+        font.pixelSize: 11 * virtualstudio.fontScale * virtualstudio.uiScale
+        font.underline: true;
         anchors.horizontalCenter: parent.horizontalCenter
-        y: 401 * virtualstudio.uiScale
-        width: 263 * virtualstudio.uiScale; height: 64 * virtualstudio.uiScale
-        Text {
-            text: "Back"
-            font.family: "Poppins"
-            font.pixelSize: 18 * virtualstudio.fontScale * virtualstudio.uiScale
-            anchors.horizontalCenter: parent.horizontalCenter
-            anchors.verticalCenter: parent.verticalCenter
-            color: backButton.down ? buttonTextPressed : (backButton.hovered ? buttonTextHover : buttonTextColour)
+        y: 520 * virtualstudio.uiScale
+        visible: showBackButton && (!virtualstudio.hasRefreshToken && loginScreen.state === "unauthenticated") || loginScreen.state === "failed"
+        color: textColour
+        wrapMode: Text.WordWrap
+        horizontalAlignment: Text.AlignHCenter
+        
+        MouseArea {
+            anchors.fill: parent
+            onClicked: () => { virtualstudio.windowState = "start" }
+            cursorShape: Qt.PointingHandCursor
         }
     }
 

--- a/src/gui/Login.qml
+++ b/src/gui/Login.qml
@@ -286,6 +286,9 @@ Item {
             if (stage === "failed") {
                 hasFailedAtLeastOnce = true;
             }
+            if (stage === "success") {
+                hasFailedAtLeastOnce = false; // reset
+            }
         }
     }
 }

--- a/src/gui/Login.qml
+++ b/src/gui/Login.qml
@@ -309,9 +309,9 @@ Item {
                 }
             }
             
-            anchors.left: (backButton.visible || classicModeButton.visible) ? parent.horizontalCenter : null
-            anchors.leftMargin: (backButton.visible || classicModeButton.visible) ? 8 * virtualstudio.uiScale : null
-            anchors.horizontalCenter: (!backButton.visible && !classicModeButton.visible) ? parent.horizontalCenter : null
+            anchors.left: (backButton.visible || classicModeButton.visible) ? parent.horizontalCenter : undefined
+            anchors.leftMargin: (backButton.visible || classicModeButton.visible) ? 8 * virtualstudio.uiScale : undefined
+            anchors.horizontalCenter: (!backButton.visible && !classicModeButton.visible) ? parent.horizontalCenter : undefined
             anchors.verticalCenter: parent.verticalCenter
             width: 144 * virtualstudio.uiScale; height: 32 * virtualstudio.uiScale
             Text {

--- a/src/gui/Login.qml
+++ b/src/gui/Login.qml
@@ -63,7 +63,7 @@ Item {
     Item {
         id: loginScreenHeader
         anchors.horizontalCenter: parent.horizontalCenter
-        y: showCodeFlow ? 88 * virtualstudio.uiScale : 144 * virtualstudio.uiScale
+        y: showCodeFlow ? 36 * virtualstudio.uiScale : 144 * virtualstudio.uiScale
 
         Image {
             id: loginLogo
@@ -95,13 +95,14 @@ Item {
     Item {
         id: codeFlow
         anchors.horizontalCenter: parent.horizontalCenter
-        y: 108 * virtualstudio.uiScale
+        y: 55 * virtualstudio.uiScale
+        height: parent.height - codeFlow.y
         visible: showCodeFlow
         width: parent.width
 
         Text {
             id: deviceVerificationExplanation
-            text: `Please sign in and confirm the following code using your web browser.`
+            text: `Please sign in and confirm the following code using your web browser. Return here when you are done.`
             font.family: "Poppins"
             font.pixelSize: 11 * virtualstudio.fontScale * virtualstudio.uiScale
             anchors.horizontalCenter: parent.horizontalCenter
@@ -119,18 +120,6 @@ Item {
                 virtualstudio.openLink(link)
             }
         }
-
-        // TODO: handle this case!
-        // Text {
-        //     id: authFailedText
-        //     text: "There was an error trying to sign in. Please try again."
-        //     font.family: "Poppins"
-        //     font.pixelSize: 10 * virtualstudio.fontScale * virtualstudio.uiScale
-        //     anchors.horizontalCenter: parent.horizontalCenter
-        //     y: backButton.visible ? 600 * virtualstudio.uiScale : 560 * virtualstudio.uiScale
-        //     visible: (loginScreen.state === "failed" || hasFailedAtLeastOnce) && loginScreen.state !== "success"
-        //     color: errorTextColour
-        // }
 
         Image {
             id: successIcon
@@ -159,7 +148,7 @@ Item {
             font.pixelSize: 20 * virtualstudio.fontScale * virtualstudio.uiScale
             font.letterSpacing: Boolean(auth.verificationCode) ? 8 : 1
             anchors.horizontalCenter: parent.horizontalCenter
-            y: 208 * virtualstudio.uiScale
+            y: 196 * virtualstudio.uiScale
             width: 360 * virtualstudio.uiScale;
             visible: !auth.isAuthenticated
             color: Boolean(auth.verificationCode) ? textColour : disabledButtonText
@@ -226,7 +215,7 @@ Item {
                 }
             }
             anchors.horizontalCenter: parent.horizontalCenter
-            y: 284 * virtualstudio.uiScale
+            y: 260 * virtualstudio.uiScale
             width: 263 * virtualstudio.uiScale; height: 64 * virtualstudio.uiScale
             Text {
                 text: "Sign In"
@@ -241,25 +230,24 @@ Item {
         }
 
         Text {
-            id: deviceVerificationFollowUp
-            text: "Return here when you are done."
+            id: authFailedText
+            text: "There was an error trying to sign in. Please try again."
             font.family: "Poppins"
-            font.pixelSize: 11 * virtualstudio.fontScale * virtualstudio.uiScale
+            font.pixelSize: 10 * virtualstudio.fontScale * virtualstudio.uiScale
             anchors.horizontalCenter: parent.horizontalCenter
-            y: 384 * virtualstudio.uiScale
-            width: 500 * virtualstudio.uiScale;
-            visible: true
-            color: textColour
-            wrapMode: Text.WordWrap
-            horizontalAlignment: Text.AlignHCenter
+            y: 360 * virtualstudio.uiScale
+            visible: (loginScreen.state === "failed" || hasFailedAtLeastOnce) && loginScreen.state !== "success"
+            color: errorTextColour
         }
 
         Item {
             id: loginScreenFooter
             anchors.horizontalCenter: parent.horizontalCenter
+            anchors.bottom: parent.bottom
+            anchors.bottomMargin: 16 * virtualstudio.uiScale
             y: 420 * virtualstudio.uiScale
             width: parent.width
-            height: 100 * virtualstudio.uiScale
+            height: 80 * virtualstudio.uiScale
 
             Button {
                 id: backButton

--- a/src/gui/Login.qml
+++ b/src/gui/Login.qml
@@ -28,7 +28,6 @@ Item {
         color: backgroundColour
     }
 
-    property bool showBackButton: true
     property bool codeCopied: false
     property bool hasFailedAtLeastOnce: false
 
@@ -218,8 +217,10 @@ Item {
             layer.enabled: !loginButton.down
         }
         onClicked: {
-            virtualstudio.showFirstRun = false;
-            virtualstudio.openLink(auth.verificationUrl);
+            if (auth.verificationCode && auth.verificationUrl) {
+                virtualstudio.showFirstRun = false;
+                virtualstudio.openLink(auth.verificationUrl);
+            }
         }
         anchors.horizontalCenter: parent.horizontalCenter
         y: 400 * virtualstudio.uiScale
@@ -236,46 +237,91 @@ Item {
         visible: !auth.isAuthenticated
     }
 
-    Text {
-        id: backButton
-        text: "Back"
-        font.family: "Poppins"
-        font.pixelSize: 11 * virtualstudio.fontScale * virtualstudio.uiScale
-        font.underline: true;
+    Item {
+        id: loginScreenFooter
         anchors.horizontalCenter: parent.horizontalCenter
         y: 560 * virtualstudio.uiScale
-        visible: showBackButton
-        color: textColour
-        wrapMode: Text.WordWrap
-        horizontalAlignment: Text.AlignHCenter
-        
-        MouseArea {
-            anchors.fill: parent
-            onClicked: () => { if (!auth.isAuthenticated) { virtualstudio.windowState = "start"; } }
-            cursorShape: Qt.PointingHandCursor
-        }
-    }
+        height: 100 * virtualstudio.uiScale
 
-    Button {
-        id: classicModeButton
-        visible: !showBackButton && virtualstudio.showFirstRun && virtualstudio.vsFtux
-        background: Rectangle {
-            radius: 6 * virtualstudio.uiScale
-            color: classicModeButton.down ? buttonPressedColour : (classicModeButton.hovered ? buttonHoverColour : backgroundColour)
-            border.width: 0
-            layer.enabled: !classicModeButton.down
-        }
-        onClicked: { virtualstudio.windowState = "login"; virtualstudio.toStandard(); }
-        anchors.horizontalCenter: parent.horizontalCenter
-        y: 600 * virtualstudio.uiScale
-        width: 160 * virtualstudio.uiScale; height: 32 * virtualstudio.uiScale
-        Text {
-            text: "Use Classic Mode"
-            font.family: "Poppins"
-            font.pixelSize: 9 * virtualstudio.fontScale * virtualstudio.uiScale
-            anchors.horizontalCenter: parent.horizontalCenter
+        Button {
+            id: backButton
+            visible: !virtualstudio.vsFtux
+            background: Rectangle {
+                radius: 6 * virtualstudio.uiScale
+                color: backButton.down ? buttonPressedColour : (backButton.hovered ? buttonHoverColour : buttonColour)
+                border.color: backButton.down ? buttonPressedStroke : (backButton.hovered ? buttonHoverStroke : buttonStroke)
+                border.width: 1
+                layer.enabled: !backButton.down
+            }
+            onClicked: () => { if (!auth.isAuthenticated) { virtualstudio.windowState = "start"; } }
             anchors.verticalCenter: parent.verticalCenter
-            color: classicModeButton.down ? buttonTextPressed : (classicModeButton.hovered ? buttonTextHover : textColour)
+            anchors.right: parent.horizontalCenter
+            anchors.rightMargin: 8 * virtualstudio.uiScale
+            width: 144 * virtualstudio.uiScale; height: 32 * virtualstudio.uiScale
+            Text {
+                text: "Back"
+                font.family: "Poppins"
+                font.pixelSize: 9 * virtualstudio.fontScale * virtualstudio.uiScale
+                anchors.horizontalCenter: parent.horizontalCenter
+                anchors.verticalCenter: parent.verticalCenter
+                color: backButton.down ? buttonTextPressed : (backButton.hovered ? buttonTextHover : textColour)
+            }
+        }
+
+        Button {
+            id: classicModeButton
+            visible: virtualstudio.showFirstRun && virtualstudio.vsFtux
+            background: Rectangle {
+                radius: 6 * virtualstudio.uiScale
+                color: classicModeButton.down ? buttonPressedColour : (classicModeButton.hovered ? buttonHoverColour : buttonColour)
+                border.color: classicModeButton.down ? buttonPressedStroke : (classicModeButton.hovered ? buttonHoverStroke : buttonStroke)
+                border.width: 1
+                layer.enabled: !classicModeButton.down
+            }
+            onClicked: { virtualstudio.windowState = "login"; virtualstudio.toStandard(); }
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.right: parent.horizontalCenter
+            anchors.rightMargin: 8 * virtualstudio.uiScale
+            width: 160 * virtualstudio.uiScale; height: 32 * virtualstudio.uiScale
+            Text {
+                text: "Use Classic Mode"
+                font.family: "Poppins"
+                font.pixelSize: 9 * virtualstudio.fontScale * virtualstudio.uiScale
+                anchors.horizontalCenter: parent.horizontalCenter
+                anchors.verticalCenter: parent.verticalCenter
+                color: classicModeButton.down ? buttonTextPressed : (classicModeButton.hovered ? buttonTextHover : textColour)
+            }
+        }
+
+        Button {
+            id: resetCodeButton
+            visible: true
+            background: Rectangle {
+                radius: 6 * virtualstudio.uiScale
+                color: resetCodeButton.down ? buttonPressedColour : (resetCodeButton.hovered ? buttonHoverColour : buttonColour)
+                border.color: resetCodeButton.down ? buttonPressedStroke : (resetCodeButton.hovered ? buttonHoverStroke : buttonStroke)
+                border.width: 1
+                layer.enabled: !resetCodeButton.down
+            }
+            onClicked: () => { 
+                if (auth.verificationCode && auth.verificationUrl) {
+                    auth.resetCode();
+                }
+            }
+            
+            anchors.left: (backButton.visible || classicModeButton.visible) ? parent.horizontalCenter : null
+            anchors.leftMargin: (backButton.visible || classicModeButton.visible) ? 8 * virtualstudio.uiScale : null
+            anchors.horizontalCenter: (!backButton.visible && !classicModeButton.visible) ? parent.horizontalCenter : null
+            anchors.verticalCenter: parent.verticalCenter
+            width: 144 * virtualstudio.uiScale; height: 32 * virtualstudio.uiScale
+            Text {
+                text: "Reset Code"
+                font.family: "Poppins"
+                font.pixelSize: 9 * virtualstudio.fontScale * virtualstudio.uiScale
+                anchors.horizontalCenter: parent.horizontalCenter
+                anchors.verticalCenter: parent.verticalCenter
+                color: resetCodeButton.down ? buttonTextPressed : (resetCodeButton.hovered ? buttonTextHover : textColour)
+            }
         }
     }
 

--- a/src/gui/Login.qml
+++ b/src/gui/Login.qml
@@ -210,7 +210,6 @@ Item {
             }
             onClicked: {
                 if (auth.verificationCode && auth.verificationUrl) {
-                    // virtualstudio.showFirstRun = false;
                     virtualstudio.openLink(auth.verificationUrl);
                 }
             }
@@ -311,16 +310,10 @@ Item {
                     layer.enabled: !resetCodeButton.down
                 }
                 onClicked: () => {
-                    console.log("BackButton: ", backButton.visible);
-                    console.log("ClassicModeButton: ", classicModeButton.visible);
                     if (auth.verificationCode && auth.verificationUrl) {
                         auth.resetCode();
                     }
                 }
-
-                // anchors.horizontalCenter: (!backButton.visible && !classicModeButton.visible) ? parent.horizontalCenter : undefined
-                // anchors.left: (backButton.visible || classicModeButton.visible) ? parent.horizontalCenter : undefined
-                // anchors.leftMargin: (backButton.visible || classicModeButton.visible) ? 8 * virtualstudio.uiScale : undefined
                 x: (parent.showBackButton || parent.showClassicModeButton) ? (parent.x + parent.width / 2) + 8 * virtualstudio.uiScale : (parent.x + parent.width / 2) - resetCodeButton.width / 2
                 anchors.verticalCenter: parent.verticalCenter
                 width: 144 * virtualstudio.uiScale; height: 32 * virtualstudio.uiScale

--- a/src/gui/Login.qml
+++ b/src/gui/Login.qml
@@ -354,11 +354,6 @@ Item {
     Connections {
         target: auth
         function onUpdatedAuthenticationStage (stage) {
-            // Edge case: went from refreshing token, but failed and switched to device code flow automatically
-            if (loginScreen.state === "refreshing" && stage === "polling") {
-                numFailures = numFailures + 1;
-            }
-
             loginScreen.state = stage;
             if (stage === "failed") {
                 numFailures = numFailures + 1;

--- a/src/gui/Login.qml
+++ b/src/gui/Login.qml
@@ -249,9 +249,12 @@ Item {
             width: parent.width
             height: 48 * virtualstudio.uiScale
 
+            property bool showBackButton: !virtualstudio.vsFtux
+            property bool showClassicModeButton: virtualstudio.showFirstRun && virtualstudio.vsFtux
+
             Button {
                 id: backButton
-                visible: !virtualstudio.vsFtux
+                visible: parent.showBackButton
                 background: Rectangle {
                     radius: 6 * virtualstudio.uiScale
                     color: backButton.down ? buttonPressedColour : (backButton.hovered ? buttonHoverColour : buttonColour)
@@ -261,8 +264,7 @@ Item {
                 }
                 onClicked: () => { if (!auth.isAuthenticated) { virtualstudio.windowState = "start"; } }
                 anchors.verticalCenter: parent.verticalCenter
-                anchors.right: parent.horizontalCenter
-                anchors.rightMargin: 8 * virtualstudio.uiScale
+                x: (parent.x + parent.width / 2) - backButton.width - 8 * virtualstudio.uiScale
                 width: 144 * virtualstudio.uiScale; height: 32 * virtualstudio.uiScale
                 Text {
                     text: "Back"
@@ -276,7 +278,7 @@ Item {
 
             Button {
                 id: classicModeButton
-                visible: virtualstudio.showFirstRun && virtualstudio.vsFtux
+                visible: parent.showClassicModeButton
                 background: Rectangle {
                     radius: 6 * virtualstudio.uiScale
                     color: classicModeButton.down ? buttonPressedColour : (classicModeButton.hovered ? buttonHoverColour : buttonColour)
@@ -286,8 +288,7 @@ Item {
                 }
                 onClicked: { virtualstudio.windowState = "login"; virtualstudio.toStandard(); }
                 anchors.verticalCenter: parent.verticalCenter
-                anchors.right: parent.horizontalCenter
-                anchors.rightMargin: 8 * virtualstudio.uiScale
+                x: (parent.x + parent.width / 2) - classicModeButton.width - 8 * virtualstudio.uiScale
                 width: 160 * virtualstudio.uiScale; height: 32 * virtualstudio.uiScale
                 Text {
                     text: "Use Classic Mode"
@@ -309,15 +310,18 @@ Item {
                     border.width: 1
                     layer.enabled: !resetCodeButton.down
                 }
-                onClicked: () => { 
+                onClicked: () => {
+                    console.log("BackButton: ", backButton.visible);
+                    console.log("ClassicModeButton: ", classicModeButton.visible);
                     if (auth.verificationCode && auth.verificationUrl) {
                         auth.resetCode();
                     }
                 }
 
-                anchors.horizontalCenter: (!backButton.visible && !classicModeButton.visible) ? parent.horizontalCenter : undefined
-                anchors.left: (backButton.visible || classicModeButton.visible) ? parent.horizontalCenter : undefined
-                anchors.leftMargin: (backButton.visible || classicModeButton.visible) ? 8 * virtualstudio.uiScale : undefined
+                // anchors.horizontalCenter: (!backButton.visible && !classicModeButton.visible) ? parent.horizontalCenter : undefined
+                // anchors.left: (backButton.visible || classicModeButton.visible) ? parent.horizontalCenter : undefined
+                // anchors.leftMargin: (backButton.visible || classicModeButton.visible) ? 8 * virtualstudio.uiScale : undefined
+                x: (parent.showBackButton || parent.showClassicModeButton) ? (parent.x + parent.width / 2) + 8 * virtualstudio.uiScale : (parent.x + parent.width / 2) - resetCodeButton.width / 2
                 anchors.verticalCenter: parent.verticalCenter
                 width: 144 * virtualstudio.uiScale; height: 32 * virtualstudio.uiScale
                 Text {

--- a/src/gui/Settings.qml
+++ b/src/gui/Settings.qml
@@ -566,7 +566,7 @@ Item {
                 border.width: 1
                 border.color: logoutButton.down ? buttonPressedStroke : (logoutButton.hovered ? buttonHoverStroke : buttonStroke)
             }
-            onClicked: { virtualstudio.windowState = "login"; virtualstudio.logout() }
+            onClicked: { virtualstudio.logout(); }
             anchors.horizontalCenter: parent.horizontalCenter
             y: editButton.y + (48 * virtualstudio.uiScale)
             width: 260 * virtualstudio.uiScale; height: 30 * virtualstudio.uiScale

--- a/src/gui/Settings.qml
+++ b/src/gui/Settings.qml
@@ -566,7 +566,7 @@ Item {
                 border.width: 1
                 border.color: logoutButton.down ? buttonPressedStroke : (logoutButton.hovered ? buttonHoverStroke : buttonStroke)
             }
-            onClicked: { virtualstudio.logout(); }
+            onClicked: { virtualstudio.showFirstRun = false; virtualstudio.logout(); }
             anchors.horizontalCenter: parent.horizontalCenter
             y: editButton.y + (48 * virtualstudio.uiScale)
             width: 260 * virtualstudio.uiScale; height: 30 * virtualstudio.uiScale

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -99,10 +99,10 @@ VirtualStudio::VirtualStudio(bool firstRun, QObject* parent)
         m_auth->authenticate(QStringLiteral(""));  // retry without using refresh token
     });
     connect(m_auth.data(), &VsAuth::fetchUserInfoFailed, this, [=]() {
-        login();  // retry
+        m_auth->authenticate(QStringLiteral(""));  // retry without using refresh token
     });
     connect(m_auth.data(), &VsAuth::deviceCodeExpired, this, [=]() {
-        login();  // retry
+        m_auth->authenticate(QStringLiteral(""));  // retry without using refresh token
     });
 
     // Load our font for our qml interface

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1096,16 +1096,12 @@ void VirtualStudio::toStandard()
 
 void VirtualStudio::toVirtualStudio()
 {
-    if (!m_refreshToken.isEmpty()) {
-        // Attempt to refresh our virtual studio auth token
-        m_auth->authenticate(m_refreshToken);
-    }
+    m_auth->authenticate(m_refreshToken);
 }
 
 void VirtualStudio::login()
 {
-    // Important! When the user presses "log in", always use a fresh device flow
-    m_auth->authenticate(QString(""));
+    m_auth->authenticate(QString(m_refreshToken));
 }
 
 void VirtualStudio::logout()
@@ -1147,6 +1143,9 @@ void VirtualStudio::logout()
     m_userMetadata = QJsonObject();
     m_userId.clear();
     emit hasRefreshTokenChanged();
+
+    // reset window state
+    setWindowState(QStringLiteral("login"));
 }
 
 void VirtualStudio::refreshStudios(int index, bool signalRefresh)
@@ -2375,9 +2374,6 @@ void VirtualStudio::getServerList(bool firstLoad, bool signalRefresh, int index)
                 }
             }
             if (firstLoad) {
-#ifndef _WIN32  // Hack - purely for UX
-                QThread::msleep(400);
-#endif
                 emit authSucceeded();
                 m_refreshTimer.setInterval(10000);
                 m_refreshTimer.start();

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -368,9 +368,7 @@ void VirtualStudio::show()
         m_checkSsl = false;
     }
 
-    if (!m_showFirstRun) {
-        toVirtualStudio();
-    }
+    login();
     m_view.show();
 }
 

--- a/src/gui/vs.qml
+++ b/src/gui/vs.qml
@@ -145,5 +145,10 @@ Rectangle {
         function onDisconnected() {
             virtualstudio.windowState = "browse";
         }
+        function onWindowStateUpdated() {
+            if (virtualstudio.windowState === "login") {
+                virtualstudio.login();
+            }
+        }
     }
 }

--- a/src/gui/vsAuth.cpp
+++ b/src/gui/vsAuth.cpp
@@ -152,6 +152,14 @@ void VsAuth::refreshAccessToken(QString refreshToken)
     });
 }
 
+void VsAuth::resetCode()
+{
+    if (!m_verificationCode.isEmpty()) {
+        m_deviceCodeFlow->cancelCodeFlow();
+        m_deviceCodeFlow->grant();
+    }
+}
+
 void VsAuth::codeFlowCompleted(QString accessToken, QString refreshToken)
 {
     m_refreshToken = refreshToken;

--- a/src/gui/vsAuth.cpp
+++ b/src/gui/vsAuth.cpp
@@ -191,12 +191,12 @@ void VsAuth::handleAuthSucceeded(QString userId, QString accessToken)
         m_authenticationMethod = QStringLiteral("refresh token");
     }
 
-    m_userId              = userId;
-    m_verificationCode    = QStringLiteral("");
-    m_accessToken         = accessToken;
-    m_authenticationStage = QStringLiteral("success");
+    m_userId                 = userId;
+    m_verificationCode       = QStringLiteral("");
+    m_accessToken            = accessToken;
+    m_authenticationStage    = QStringLiteral("success");
     m_attemptingRefreshToken = false;
-    m_isAuthenticated     = true;
+    m_isAuthenticated        = true;
 
     emit updatedUserId(m_userId);
     emit updatedAuthenticationStage(m_authenticationStage);
@@ -216,13 +216,13 @@ void VsAuth::handleAuthFailed()
     // that authentication succeeded
     std::cout << "Failed to authenticate user" << std::endl;
 
-    m_userId              = QStringLiteral("");
-    m_verificationCode    = QStringLiteral("");
-    m_accessToken         = QStringLiteral("");
-    m_authenticationStage = QStringLiteral("failed");
-    m_authenticationMethod = QStringLiteral("");
+    m_userId                 = QStringLiteral("");
+    m_verificationCode       = QStringLiteral("");
+    m_accessToken            = QStringLiteral("");
+    m_authenticationStage    = QStringLiteral("failed");
+    m_authenticationMethod   = QStringLiteral("");
     m_attemptingRefreshToken = false;
-    m_isAuthenticated     = false;
+    m_isAuthenticated        = false;
 
     emit updatedUserId(m_userId);
     emit updatedAuthenticationStage(m_authenticationStage);

--- a/src/gui/vsAuth.cpp
+++ b/src/gui/vsAuth.cpp
@@ -67,6 +67,9 @@ void VsAuth::authenticate(QString currentRefreshToken)
         // if no refresh token, initialize device flow
         m_deviceCodeFlow->grant();
     } else {
+        m_attemptingRefreshToken = true;
+        emit updatedAttemptingRefreshToken(m_attemptingRefreshToken);
+
         // otherwise, use refresh token to gain a new access token
         m_refreshToken = currentRefreshToken;
         refreshAccessToken(m_refreshToken);
@@ -192,12 +195,14 @@ void VsAuth::handleAuthSucceeded(QString userId, QString accessToken)
     m_verificationCode    = QStringLiteral("");
     m_accessToken         = accessToken;
     m_authenticationStage = QStringLiteral("success");
+    m_attemptingRefreshToken = false;
     m_isAuthenticated     = true;
 
     emit updatedUserId(m_userId);
     emit updatedAuthenticationStage(m_authenticationStage);
     emit updatedVerificationCode(m_verificationCode);
     emit updatedIsAuthenticated(m_isAuthenticated);
+    emit updatedAttemptingRefreshToken(m_attemptingRefreshToken);
     emit updatedAuthenticationMethod(m_authenticationMethod);
 
     // notify UI and virtual studio class of success
@@ -216,12 +221,14 @@ void VsAuth::handleAuthFailed()
     m_accessToken         = QStringLiteral("");
     m_authenticationStage = QStringLiteral("failed");
     m_authenticationMethod = QStringLiteral("");
+    m_attemptingRefreshToken = false;
     m_isAuthenticated     = false;
 
     emit updatedUserId(m_userId);
     emit updatedAuthenticationStage(m_authenticationStage);
     emit updatedVerificationCode(m_verificationCode);
     emit updatedIsAuthenticated(m_isAuthenticated);
+    emit updatedAttemptingRefreshToken(m_attemptingRefreshToken);
     emit updatedAuthenticationMethod(m_authenticationMethod);
 
     // notify UI and virtual studio class of failure

--- a/src/gui/vsAuth.h
+++ b/src/gui/vsAuth.h
@@ -87,12 +87,16 @@ class VsAuth : public QObject
     void updatedUserId(QString userId);
     void authSucceeded();
     void authFailed();
+    void refreshTokenFailed();
+    void fetchUserInfoFailed();
+    void deviceCodeExpired();
 
    private slots:
     void handleAuthSucceeded(QString userId, QString accessToken);
     void handleAuthFailed();
     void initializedCodeFlow(QString code, QString verificationUrl);
     void codeFlowCompleted(QString accessToken, QString refreshToken);
+    void codeExpired();
 
    private:
     void fetchUserInfo(QString accessToken);

--- a/src/gui/vsAuth.h
+++ b/src/gui/vsAuth.h
@@ -58,6 +58,7 @@ class VsAuth : public QObject
     Q_PROPERTY(
         QString verificationUrl READ deviceVerificationUrl NOTIFY updatedVerificationUrl);
     Q_PROPERTY(bool isAuthenticated READ isAuthenticated NOTIFY updatedIsAuthenticated);
+    Q_PROPERTY(QString authenticationMethod READ authenticationMethod NOTIFY updatedAuthenticationMethod);
     Q_PROPERTY(QString userId READ userId NOTIFY updatedUserId);
 
    public:
@@ -79,6 +80,7 @@ class VsAuth : public QObject
     QString userId() { return m_userId; };
     QString accessToken() { return m_accessToken; };
     QString refreshToken() { return m_refreshToken; };
+    QString authenticationMethod() { return m_authenticationMethod; }
 
    signals:
     void updatedAuthenticationStage(QString authenticationStage);
@@ -86,6 +88,7 @@ class VsAuth : public QObject
     void updatedVerificationUrl(QUrl verificationUrl);
     void updatedIsAuthenticated(bool isAuthenticated);
     void updatedUserId(QString userId);
+    void updatedAuthenticationMethod(QString grant);
     void authSucceeded();
     void authFailed();
     void refreshTokenFailed();
@@ -106,8 +109,9 @@ class VsAuth : public QObject
     QString m_authorizationServerHost;
 
     QString m_authenticationStage = QStringLiteral("unauthenticated");
-    QString m_verificationCode    = QString("");
+    QString m_verificationCode    = QStringLiteral("");
     QString m_verificationUrl;
+    QString m_authenticationMethod = QStringLiteral("");
 
     bool m_isAuthenticated = false;
     QString m_userId;

--- a/src/gui/vsAuth.h
+++ b/src/gui/vsAuth.h
@@ -58,8 +58,10 @@ class VsAuth : public QObject
     Q_PROPERTY(
         QString verificationUrl READ deviceVerificationUrl NOTIFY updatedVerificationUrl);
     Q_PROPERTY(bool isAuthenticated READ isAuthenticated NOTIFY updatedIsAuthenticated);
-    Q_PROPERTY(QString authenticationMethod READ authenticationMethod NOTIFY updatedAuthenticationMethod);
-    Q_PROPERTY(bool attemptingRefreshToken READ attemptingRefreshToken NOTIFY updatedAttemptingRefreshToken);
+    Q_PROPERTY(QString authenticationMethod READ authenticationMethod NOTIFY
+                   updatedAuthenticationMethod);
+    Q_PROPERTY(bool attemptingRefreshToken READ attemptingRefreshToken NOTIFY
+                   updatedAttemptingRefreshToken);
     Q_PROPERTY(QString userId READ userId NOTIFY updatedUserId);
 
    public:
@@ -117,7 +119,7 @@ class VsAuth : public QObject
     QString m_authenticationMethod = QStringLiteral("");
 
     bool m_attemptingRefreshToken = false;
-    bool m_isAuthenticated = false;
+    bool m_isAuthenticated        = false;
     QString m_userId;
     QString m_accessToken;
     QString m_refreshToken;

--- a/src/gui/vsAuth.h
+++ b/src/gui/vsAuth.h
@@ -59,6 +59,7 @@ class VsAuth : public QObject
         QString verificationUrl READ deviceVerificationUrl NOTIFY updatedVerificationUrl);
     Q_PROPERTY(bool isAuthenticated READ isAuthenticated NOTIFY updatedIsAuthenticated);
     Q_PROPERTY(QString authenticationMethod READ authenticationMethod NOTIFY updatedAuthenticationMethod);
+    Q_PROPERTY(bool attemptingRefreshToken READ attemptingRefreshToken NOTIFY updatedAttemptingRefreshToken);
     Q_PROPERTY(QString userId READ userId NOTIFY updatedUserId);
 
    public:
@@ -81,6 +82,7 @@ class VsAuth : public QObject
     QString accessToken() { return m_accessToken; };
     QString refreshToken() { return m_refreshToken; };
     QString authenticationMethod() { return m_authenticationMethod; }
+    bool attemptingRefreshToken() { return m_attemptingRefreshToken; }
 
    signals:
     void updatedAuthenticationStage(QString authenticationStage);
@@ -89,6 +91,7 @@ class VsAuth : public QObject
     void updatedIsAuthenticated(bool isAuthenticated);
     void updatedUserId(QString userId);
     void updatedAuthenticationMethod(QString grant);
+    void updatedAttemptingRefreshToken(bool attemptingRefreshToken);
     void authSucceeded();
     void authFailed();
     void refreshTokenFailed();
@@ -113,6 +116,7 @@ class VsAuth : public QObject
     QString m_verificationUrl;
     QString m_authenticationMethod = QStringLiteral("");
 
+    bool m_attemptingRefreshToken = false;
     bool m_isAuthenticated = false;
     QString m_userId;
     QString m_accessToken;

--- a/src/gui/vsAuth.h
+++ b/src/gui/vsAuth.h
@@ -65,6 +65,7 @@ class VsAuth : public QObject
 
     void authenticate(QString currentRefreshToken);
     void refreshAccessToken(QString refreshToken);
+    Q_INVOKABLE void resetCode();
     void logout();
 
    public slots:

--- a/src/gui/vsftux.qml
+++ b/src/gui/vsftux.qml
@@ -125,5 +125,10 @@ Rectangle {
         function onDisconnected() {
             virtualstudio.windowState = "browse";
         }
+        function onWindowStateUpdated() {
+            if (virtualstudio.windowState === "login") {
+                virtualstudio.login();
+            }
+        }
     }
 }

--- a/src/gui/vsftux.qml
+++ b/src/gui/vsftux.qml
@@ -88,7 +88,6 @@ Rectangle {
     
     Login {
         id: loginScreen
-        showBackButton: false
     }
 
     Settings {


### PR DESCRIPTION
Follow up to #1037 

- Resolves issues with the back button appearing (and acting buggy) on the `vsftux` builds
- Removes the need for an extra sign up screen. This is done by attempting to log in (either through the code flow protocol or via the refresh token) whenever we switch to the login screen.
- If there's a refresh token stored, this doesn't initialize the code flow protocol. If this token is valid, the user shouldn't need to do anything to move to the next screen. If this token is invalid, this is gracefully handled by displaying an error message and initializing the code flow procedure.

Relevant tickets:
https://app.asana.com/0/1204518798614303/1204632412091470/f
https://app.asana.com/0/1204518798614303/1204632410251062/f
https://app.asana.com/0/1204518798614303/1204632410251060/f