### PR TITLE
Cleanup Audio When Switching to Classic Mode

### DIFF
--- a/src/gui/Settings.qml
+++ b/src/gui/Settings.qml
@@ -402,7 +402,16 @@ Item {
                 border.width: 1
                 border.color: modeButton.down ? buttonPressedStroke : (modeButton.hovered ? buttonHoverStroke : buttonStroke)
             }
-            onClicked: { virtualstudio.windowState = "login"; virtualstudio.toStandard(); }
+            onClicked: {
+                // essentially the same here as clicking the cancel button
+                virtualstudio.windowState = "browse";
+                inputCurrIndex = virtualstudio.previousInput;
+                outputCurrIndex = virtualstudio.previousOutput;
+                virtualstudio.revertSettings();
+
+                // switch mode
+                virtualstudio.toStandard();
+            }
             x: 234 * virtualstudio.uiScale; y: 100 * virtualstudio.uiScale
             width: 216 * virtualstudio.uiScale; height: 30 * virtualstudio.uiScale
             Text {

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -367,8 +367,9 @@ void VirtualStudio::show()
         }
         m_checkSsl = false;
     }
-
-    login();
+    if (m_windowState == "login") {
+        login();
+    }
     m_view.show();
 }
 
@@ -1103,7 +1104,9 @@ void VirtualStudio::toStandard()
 
 void VirtualStudio::toVirtualStudio()
 {
-    login();
+    if (m_windowState == "login") {
+        login();
+    }
 }
 
 void VirtualStudio::login()
@@ -2480,6 +2483,7 @@ void VirtualStudio::getUserMetadata()
 
 void VirtualStudio::startAudio()
 {
+    std::cout << "Starting Audio" << std::endl;
 #ifdef __APPLE__
     if (m_permissions->micPermission() != "granted") {
         return;
@@ -2557,6 +2561,7 @@ void VirtualStudio::startAudio()
 
 void VirtualStudio::restartAudio()
 {
+    std::cout << "Restarting Audio" << std::endl;
 #ifdef __APPLE__
     if (m_permissions->micPermission() != "granted") {
         return;


### PR DESCRIPTION
Fixes a bug where the audio stream would stay open when switching from Virtual Studio mode to classic mode, a regression introduced by the "Code Flow" update. The reason is that the app tries to log in whenever it goes to the login screen (a UX requirement for the "Code Flow" feature), which then successfully re-authenticates using the existing token in the background, and automatically starts audio after successful re-login.

Note that with this, switching to classic mode and returning back to Virtual Studio brings the user back to "browse" rather than "login". This seems to be the easiest and cleanest way to fix the issue.