### PR TITLE
Optimized performance of virtual studio volume meters

### DIFF
--- a/src/Meter.cpp
+++ b/src/Meter.cpp
@@ -38,6 +38,7 @@
 
 #include "Meter.h"
 
+#include <algorithm>
 #include <iostream>
 
 #include "jacktrip_types.h"
@@ -136,15 +137,10 @@ void Meter::compute(int nframes, float** inputs, float** outputs)
         /* Use the existing value of mValues[i] as
            the threshold - this will be reset to the default floor of -80dB
            on each timeout */
-        float max = mValues[i];
-        for (int j = 0; j < nframes; j++) {
-            if (mBuffer[j] > max) {
-                max = mBuffer[j];
-            }
-        }
+        float maxSample = *std::max_element(mBuffer, mBuffer + nframes);
 
         /* Update mValues */
-        mValues[i] = max;
+        mValues[i] = std::max(mValues[i], maxSample);
     }
 
     /* Set processed audio flag */

--- a/src/gui/AudioSettings.qml
+++ b/src/gui/AudioSettings.qml
@@ -226,7 +226,7 @@ Rectangle {
             anchors.top: outputCombo.bottom
             anchors.topMargin: 16 * virtualstudio.uiScale
             height: 24 * virtualstudio.uiScale
-            model: outputMeterModel
+            model: virtualstudio.outputMeterLevels
             clipped: outputClipped
             enabled: virtualstudio.audioReady && !Boolean(virtualstudio.devicesError)
         }
@@ -535,7 +535,7 @@ Rectangle {
             anchors.top: inputCombo.bottom
             anchors.topMargin: 16 * virtualstudio.uiScale
             height: 24 * virtualstudio.uiScale
-            model: inputMeterModel
+            model: virtualstudio.inputMeterLevels
             clipped: inputClipped
             enabled: virtualstudio.audioReady && !Boolean(virtualstudio.devicesError)
         }
@@ -863,7 +863,7 @@ Rectangle {
             anchors.rightMargin: rightMargin * virtualstudio.uiScale
             anchors.verticalCenter: jackOutputLabel.verticalCenter
             height: 24 * virtualstudio.uiScale
-            model: outputMeterModel
+            model: virtualstudio.outputMeterLevels
             clipped: outputClipped
             enabled: virtualstudio.audioReady && !Boolean(virtualstudio.devicesError)
         }
@@ -1006,7 +1006,7 @@ Rectangle {
             anchors.rightMargin: rightMargin * virtualstudio.uiScale
             anchors.verticalCenter: jackInputLabel.verticalCenter
             height: 24 * virtualstudio.uiScale
-            model: inputMeterModel
+            model: virtualstudio.inputMeterLevels
             clipped: inputClipped
             enabled: virtualstudio.audioReady && !Boolean(virtualstudio.devicesError)
         }

--- a/src/gui/Connected.qml
+++ b/src/gui/Connected.qml
@@ -886,7 +886,7 @@ Item {
             x: 0; y: 0
             width: parent.width
             height: 100 * virtualstudio.uiScale
-            model: inputMeterModel
+            model: virtualstudio.inputMeterLevels
             clipped: inputClipped
         }
 
@@ -1072,7 +1072,7 @@ Item {
             x: 0; y: 0
             width: parent.width
             height: 100 * virtualstudio.uiScale
-            model: outputMeterModel
+            model: virtualstudio.outputMeterLevels
             clipped: outputClipped
         }
 

--- a/src/gui/Meter.qml
+++ b/src/gui/Meter.qml
@@ -5,206 +5,37 @@ import QtGraphicalEffects 1.12
 Item {
     required property var model
     property int bins: 15
-
     property int innerMargin: 2 * virtualstudio.uiScale
     property int clipWidth: 10 * virtualstudio.uiScale
     required property bool clipped
-
     property bool enabled: true
     property string meterColor: enabled ? (virtualstudio.darkMode ? "#5B5858" : "#D3D4D4") : "#EAECEC"
-
-    property string meterGreen: "#61C554"
-    property string meterYellow: "#F5BF4F"
     property string meterRed: "#F21B1B"
 
-    function getBoxColor (idx, level) {
-
-        if (!enabled) {
-            return meterColor;
-        }
-
-        // Case where the meter should be filled
-        if (level > (idx / bins)) {
-            let fillColor = meterGreen;
-            if (idx > 8 && idx <= 11) {
-                fillColor = meterYellow;
-            } else if (idx > 11) {
-                fillColor = meterRed;
-            }
-            return fillColor;
-
-        // Case where the meter should not be filled
-        } else {
-            return meterColor
-        }
-    }
-
-    ListView {
+    Item {
         id: meters
         x: 0; y: 0
         width: parent.width - clipWidth
         height: parent.height
-        model: parent.model
 
-        delegate: Item {
+        MeterBars {
+            id: leftchannel
             x: 0;
-            width: parent.width
+            y: 0;
+            width: parent.width - clipWidth
             height: 14 * virtualstudio.uiScale
-            required property var modelData
+            level: parent.parent.model[0]
+            enabled: parent.parent.enabled
+        }
 
-            property int boxHeight: 10 * virtualstudio.uiScale
-            property int boxWidth: (width / bins) - innerMargin
-            property int boxRadius: 4 * virtualstudio.uiScale
-
-            Rectangle {
-                id: box0
-                x: 0;
-                y: 0;
-                width: boxWidth
-                height: boxHeight
-                color: getBoxColor(0, parent.modelData.level)
-                radius: boxRadius
-            }
-
-            Rectangle {
-                id: box1
-                x: boxWidth + innerMargin;
-                y: 0;
-                width: boxWidth
-                height: boxHeight
-                color: getBoxColor(1, parent.modelData.level)
-                radius: boxRadius
-            }
-
-            Rectangle {
-                id: box2
-                x: (boxWidth) * 2 + innerMargin * 2;
-                y: 0;
-                width: boxWidth
-                height: boxHeight
-                color: getBoxColor(2, parent.modelData.level)
-                radius: boxRadius
-            }
-
-            Rectangle {
-                id: box3
-                x: (boxWidth) * 3 + innerMargin * 3;
-                y: 0;
-                width: boxWidth
-                height: boxHeight
-                color: getBoxColor(3, parent.modelData.level)
-                radius: boxRadius
-            }
-
-            Rectangle {
-                id: box4
-                x: (boxWidth) * 4 + innerMargin * 4;
-                y: 0;
-                width: boxWidth
-                height: boxHeight
-                color: getBoxColor(4, parent.modelData.level)
-                radius: boxRadius
-            }
-
-            Rectangle {
-                id: box5
-                x: (boxWidth) * 5 + innerMargin * 5;
-                y: 0;
-                width: boxWidth
-                height: boxHeight
-                color: getBoxColor(5, parent.modelData.level)
-                radius: boxRadius
-            }
-
-            Rectangle {
-                id: box6
-                x: (boxWidth) * 6 + innerMargin * 6;
-                y: 0;
-                width: boxWidth
-                height: boxHeight
-                color: getBoxColor(6, parent.modelData.level)
-                radius: boxRadius
-            }
-
-            Rectangle {
-                id: box7
-                x: (boxWidth) * 7 + innerMargin * 7;
-                y: 0;
-                width: boxWidth
-                height: boxHeight
-                color: getBoxColor(7, parent.modelData.level)
-                radius: boxRadius
-            }
-
-            Rectangle {
-                id: box8
-                x: (boxWidth) * 8 + innerMargin * 8;
-                y: 0;
-                width: boxWidth
-                height: boxHeight
-                color: getBoxColor(8, parent.modelData.level)
-                radius: boxRadius
-            }
-
-            Rectangle {
-                id: box9
-                x: (boxWidth) * 9 + innerMargin * 9;
-                y: 0;
-                width: boxWidth
-                height: boxHeight
-                color: getBoxColor(9, parent.modelData.level)
-                radius: boxRadius
-            }
-
-            Rectangle {
-                id: box10
-                x: (boxWidth) * 10 + innerMargin * 10;
-                y: 0;
-                width: boxWidth
-                height: boxHeight
-                color: getBoxColor(10, parent.modelData.level)
-                radius: boxRadius
-            }
-
-            Rectangle {
-                id: box11
-                x: (boxWidth) * 11 + innerMargin * 11;
-                y: 0;
-                width: boxWidth
-                height: boxHeight
-                color: getBoxColor(11, parent.modelData.level)
-                radius: boxRadius
-            }
-
-            Rectangle {
-                id: box12
-                x: (boxWidth) * 12 + innerMargin * 12;
-                y: 0;
-                width: boxWidth
-                height: boxHeight
-                color: getBoxColor(12, parent.modelData.level)
-                radius: boxRadius
-            }
-
-            Rectangle {
-                id: box13
-                x: (boxWidth) * 13 + innerMargin * 13;
-                y: 0;
-                width: boxWidth
-                height: boxHeight
-                color: getBoxColor(13, parent.modelData.level)
-                radius: boxRadius
-            }
-
-            Rectangle {
-                id: box14
-                x: (boxWidth) * 14 + innerMargin * 14;
-                y: 0;
-                width: boxWidth
-                height: boxHeight
-                color: getBoxColor(14, parent.modelData.level)
-                radius: boxRadius
-            }
+        MeterBars {
+            id: rightchannel
+            x: 0;
+            y: leftchannel.height
+            width: parent.width - clipWidth
+            height: 14 * virtualstudio.uiScale
+            level: parent.parent.model[1]
+            enabled: parent.parent.enabled
         }
     }
 

--- a/src/gui/MeterBars.qml
+++ b/src/gui/MeterBars.qml
@@ -1,0 +1,182 @@
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtGraphicalEffects 1.12
+
+Item {
+    required property var level
+    required property var enabled
+    property int bins: 15
+    property int innerMargin: 2 * virtualstudio.uiScale
+    property int boxHeight: 10 * virtualstudio.uiScale
+    property int boxWidth: (width / bins) - innerMargin
+    property int boxRadius: 4 * virtualstudio.uiScale
+    property string meterColor: enabled ? (virtualstudio.darkMode ? "#5B5858" : "#D3D4D4") : "#EAECEC"
+    property string meterGreen: "#61C554"
+    property string meterYellow: "#F5BF4F"
+    property string meterRed: "#F21B1B"
+
+    function getBoxColor (idx) {
+        // Case where the meter should not be filled
+        if (!enabled || level <= (idx / bins)) {
+            return meterColor;
+        }
+        // Case where the meter should be filled
+        let fillColor = meterGreen;
+        if (idx > 8 && idx <= 11) {
+            fillColor = meterYellow;
+        } else if (idx > 11) {
+            fillColor = meterRed;
+        }
+        return fillColor;
+    }
+
+    Rectangle {
+        id: box0
+        x: 0;
+        y: 0;
+        width: boxWidth
+        height: boxHeight
+        color: getBoxColor(0)
+        radius: boxRadius
+    }
+
+    Rectangle {
+        id: box1
+        x: boxWidth + innerMargin;
+        y: 0;
+        width: boxWidth
+        height: boxHeight
+        color: getBoxColor(1)
+        radius: boxRadius
+    }
+
+    Rectangle {
+        id: box2
+        x: (boxWidth) * 2 + innerMargin * 2;
+        y: 0;
+        width: boxWidth
+        height: boxHeight
+        color: getBoxColor(2)
+        radius: boxRadius
+    }
+
+    Rectangle {
+        id: box3
+        x: (boxWidth) * 3 + innerMargin * 3;
+        y: 0;
+        width: boxWidth
+        height: boxHeight
+        color: getBoxColor(3)
+        radius: boxRadius
+    }
+
+    Rectangle {
+        id: box4
+        x: (boxWidth) * 4 + innerMargin * 4;
+        y: 0;
+        width: boxWidth
+        height: boxHeight
+        color: getBoxColor(4)
+        radius: boxRadius
+    }
+
+    Rectangle {
+        id: box5
+        x: (boxWidth) * 5 + innerMargin * 5;
+        y: 0;
+        width: boxWidth
+        height: boxHeight
+        color: getBoxColor(5)
+        radius: boxRadius
+    }
+
+    Rectangle {
+        id: box6
+        x: (boxWidth) * 6 + innerMargin * 6;
+        y: 0;
+        width: boxWidth
+        height: boxHeight
+        color: getBoxColor(6)
+        radius: boxRadius
+    }
+
+    Rectangle {
+        id: box7
+        x: (boxWidth) * 7 + innerMargin * 7;
+        y: 0;
+        width: boxWidth
+        height: boxHeight
+        color: getBoxColor(7)
+        radius: boxRadius
+    }
+
+    Rectangle {
+        id: box8
+        x: (boxWidth) * 8 + innerMargin * 8;
+        y: 0;
+        width: boxWidth
+        height: boxHeight
+        color: getBoxColor(8)
+        radius: boxRadius
+    }
+
+    Rectangle {
+        id: box9
+        x: (boxWidth) * 9 + innerMargin * 9;
+        y: 0;
+        width: boxWidth
+        height: boxHeight
+        color: getBoxColor(9)
+        radius: boxRadius
+    }
+
+    Rectangle {
+        id: box10
+        x: (boxWidth) * 10 + innerMargin * 10;
+        y: 0;
+        width: boxWidth
+        height: boxHeight
+        color: getBoxColor(10)
+        radius: boxRadius
+    }
+
+    Rectangle {
+        id: box11
+        x: (boxWidth) * 11 + innerMargin * 11;
+        y: 0;
+        width: boxWidth
+        height: boxHeight
+        color: getBoxColor(11)
+        radius: boxRadius
+    }
+
+    Rectangle {
+        id: box12
+        x: (boxWidth) * 12 + innerMargin * 12;
+        y: 0;
+        width: boxWidth
+        height: boxHeight
+        color: getBoxColor(12)
+        radius: boxRadius
+    }
+
+    Rectangle {
+        id: box13
+        x: (boxWidth) * 13 + innerMargin * 13;
+        y: 0;
+        width: boxWidth
+        height: boxHeight
+        color: getBoxColor(13)
+        radius: boxRadius
+    }
+
+    Rectangle {
+        id: box14
+        x: (boxWidth) * 14 + innerMargin * 14;
+        y: 0;
+        width: boxWidth
+        height: boxHeight
+        color: getBoxColor(14)
+        radius: boxRadius
+    }
+}

--- a/src/gui/qjacktrip.qrc
+++ b/src/gui/qjacktrip.qrc
@@ -14,6 +14,7 @@
     <file>AudioSettings.qml</file>
     <file>Settings.qml</file>
     <file>Meter.qml</file>
+    <file>MeterBars.qml</file>
     <file>Connected.qml</file>
     <file>Failed.qml</file>
     <file>Setup.qml</file>

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -150,6 +150,10 @@ class VirtualStudio : public QObject
                    updatedMonitorVolume)
     Q_PROPERTY(
         bool inputMuted READ inputMuted WRITE setInputMuted NOTIFY updatedInputMuted)
+    Q_PROPERTY(QVector<float> outputMeterLevels READ outputMeterLevels NOTIFY
+                   updatedOutputMeterLevels)
+    Q_PROPERTY(QVector<float> inputMeterLevels READ inputMeterLevels NOTIFY
+                   updatedInputMeterLevels)
     Q_PROPERTY(bool audioActivated READ audioActivated WRITE setAudioActivated NOTIFY
                    audioActivatedChanged)
     Q_PROPERTY(
@@ -214,8 +218,8 @@ class VirtualStudio : public QObject
     QJsonObject userMetadata();
     QString connectionState();
     QJsonObject networkStats();
-    QVector<float> inputMeterLevels();
-    QVector<float> outputMeterLevels();
+    const QVector<float>& inputMeterLevels() const;
+    const QVector<float>& outputMeterLevels() const;
     QString updateChannel();
     void setUpdateChannel(const QString& channel);
     bool showInactive();
@@ -345,6 +349,8 @@ class VirtualStudio : public QObject
     void updatedInputMuted(bool muted);
     void updatedOutputMuted(bool muted);
     void updatedMonitorMuted(bool muted);
+    void updatedInputMeterLevels(const QVector<float>& levels);
+    void updatedOutputMeterLevels(const QVector<float>& levels);
     void audioActivatedChanged();
     void audioReadyChanged();
     void windowStateUpdated();
@@ -377,6 +383,7 @@ class VirtualStudio : public QObject
     void getUserMetadata();
     void stopStudio();
     void toggleAudio();
+    void resetMeters();
     void stopAudio();
     bool readyToJoin();
 #ifdef RT_AUDIO
@@ -443,6 +450,8 @@ class VirtualStudio : public QObject
     bool m_audioActivated = false;
     bool m_audioReady     = false;
 
+    QVector<float> m_inputMeterLevels;
+    QVector<float> m_outputMeterLevels;
     Meter* m_inputMeter;
     Meter* m_outputMeter;
     Meter* m_inputTestMeter;


### PR DESCRIPTION
I discovered that the volume meters in virtual studio mode were using about 3x the CPU versus volume meters in classic mode. These changes bring them in line with each other.

For more context: I created a stable test case and measured that JackTrip command line was using about 5% of a CPU core. JackTrip running in classic mode was using about 10% of a core, and JackTrip running in virtual studio mode was using about 20% of a core. This was all with the same traffic, settings, etc. I narrowed the bulk of the CPU use down to the volume meters and made various optimizations to avoid the performance penalty.

There are several changes in here, most of which probably doesn't make a huge difference. The most impactful change seems to be using a ListView in the QML but rather two fixed channels. I suspect this causes the rendering to be a ton more expensive, but it could also be something else related to those QML changes.

Updated to remove use of setContextProperty for volume meters