### PR TITLE
Let people know when they experience a network outage

### DIFF
--- a/src/gui/AudioSettings.qml
+++ b/src/gui/AudioSettings.qml
@@ -227,7 +227,7 @@ Rectangle {
             anchors.topMargin: 16 * virtualstudio.uiScale
             height: 24 * virtualstudio.uiScale
             model: virtualstudio.outputMeterLevels
-            clipped: outputClipped
+            clipped: virtualstudio.outputClipped
             enabled: virtualstudio.audioReady && !Boolean(virtualstudio.devicesError)
         }
 
@@ -536,7 +536,7 @@ Rectangle {
             anchors.topMargin: 16 * virtualstudio.uiScale
             height: 24 * virtualstudio.uiScale
             model: virtualstudio.inputMeterLevels
-            clipped: inputClipped
+            clipped: virtualstudio.inputClipped
             enabled: virtualstudio.audioReady && !Boolean(virtualstudio.devicesError)
         }
 
@@ -864,7 +864,7 @@ Rectangle {
             anchors.verticalCenter: jackOutputLabel.verticalCenter
             height: 24 * virtualstudio.uiScale
             model: virtualstudio.outputMeterLevels
-            clipped: outputClipped
+            clipped: virtualstudio.outputClipped
             enabled: virtualstudio.audioReady && !Boolean(virtualstudio.devicesError)
         }
 
@@ -1007,7 +1007,7 @@ Rectangle {
             anchors.verticalCenter: jackInputLabel.verticalCenter
             height: 24 * virtualstudio.uiScale
             model: virtualstudio.inputMeterLevels
-            clipped: inputClipped
+            clipped: virtualstudio.inputClipped
             enabled: virtualstudio.audioReady && !Boolean(virtualstudio.devicesError)
         }
 

--- a/src/gui/Connected.qml
+++ b/src/gui/Connected.qml
@@ -89,12 +89,18 @@ Item {
         return idx;
     }
 
-    function getNetworkStatsText (networkStats) {
-        let minRtt = networkStats.minRtt;
-        let maxRtt = networkStats.maxRtt;
-        let avgRtt = networkStats.avgRtt;
+    function getNetworkStatsText () {
+        let minRtt = virtualstudio.networkStats.minRtt;
+        let maxRtt = virtualstudio.networkStats.maxRtt;
+        let avgRtt = virtualstudio.networkStats.avgRtt;
 
-        let texts = ["Measuring stats ...", ""];
+        let texts = ["<b>Outage detected! Your connection is unstable.</b>", "Please plug into Ethernet & turn off WIFI."];
+
+        if (virtualstudio.networkOutage) {
+            return texts;
+        }
+
+        texts = ["Measuring stats ...", ""];
 
         if (!minRtt || !maxRtt) {
             return texts;
@@ -887,7 +893,7 @@ Item {
             width: parent.width
             height: 100 * virtualstudio.uiScale
             model: virtualstudio.inputMeterLevels
-            clipped: inputClipped
+            clipped: virtualstudio.inputClipped
         }
 
         Slider {
@@ -1073,7 +1079,7 @@ Item {
             width: parent.width
             height: 100 * virtualstudio.uiScale
             model: virtualstudio.outputMeterLevels
-            clipped: outputClipped
+            clipped: virtualstudio.outputClipped
         }
 
         Slider {
@@ -1340,7 +1346,7 @@ Item {
         Text {
             id: netstat0
             x: 0; y: 0
-            text: getNetworkStatsText(virtualstudio.networkStats)[0]
+            text: getNetworkStatsText()[0]
             font {family: "Poppins"; pixelSize: fontTiny * virtualstudio.fontScale * virtualstudio.uiScale }
             color: textColour
         }
@@ -1348,7 +1354,7 @@ Item {
         Text {
             id: netstat1
             x: 0
-            text: getNetworkStatsText(virtualstudio.networkStats)[1]
+            text: getNetworkStatsText()[1]
             font {family: "Poppins"; pixelSize: fontTiny * virtualstudio.fontScale * virtualstudio.uiScale }
             topPadding: 8 * virtualstudio.uiScale
             anchors.top: netstat0.bottom

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -128,6 +128,7 @@ class VirtualStudio : public QObject
                    NOTIFY showCreateStudioChanged)
     Q_PROPERTY(QString connectionState READ connectionState NOTIFY connectionStateChanged)
     Q_PROPERTY(QJsonObject networkStats READ networkStats NOTIFY networkStatsChanged)
+    Q_PROPERTY(bool networkOutage READ networkOutage NOTIFY updatedNetworkOutage)
 
     Q_PROPERTY(QString updateChannel READ updateChannel WRITE setUpdateChannel NOTIFY
                    updateChannelChanged)
@@ -154,6 +155,8 @@ class VirtualStudio : public QObject
                    updatedOutputMeterLevels)
     Q_PROPERTY(QVector<float> inputMeterLevels READ inputMeterLevels NOTIFY
                    updatedInputMeterLevels)
+    Q_PROPERTY(bool inputClipped READ inputClipped NOTIFY updatedInputClipped)
+    Q_PROPERTY(bool outputClipped READ outputClipped NOTIFY updatedOutputClipped)
     Q_PROPERTY(bool audioActivated READ audioActivated WRITE setAudioActivated NOTIFY
                    audioActivatedChanged)
     Q_PROPERTY(
@@ -253,6 +256,9 @@ class VirtualStudio : public QObject
     Q_INVOKABLE void restartAudio();
     bool audioActivated();
     bool audioReady();
+    bool inputClipped();
+    bool outputClipped();
+    bool networkOutage();
     bool backendAvailable();
     QString windowState();
     QString apiHost();
@@ -285,6 +291,7 @@ class VirtualStudio : public QObject
     void openLink(const QString& url);
     void updatedInputVuMeasurements(const float* valuesInDecibels, int numChannels);
     void updatedOutputVuMeasurements(const float* valuesInDecibels, int numChannels);
+    void udpWaitingTooLong();
     void setInputVolume(float multiplier);
     void setOutputVolume(float multiplier);
     void setMonitorVolume(float multiplier);
@@ -351,6 +358,9 @@ class VirtualStudio : public QObject
     void updatedMonitorMuted(bool muted);
     void updatedInputMeterLevels(const QVector<float>& levels);
     void updatedOutputMeterLevels(const QVector<float>& levels);
+    void updatedInputClipped(bool clip);
+    void updatedOutputClipped(bool clip);
+    void updatedNetworkOutage(bool outage);
     void audioActivatedChanged();
     void audioReadyChanged();
     void windowStateUpdated();
@@ -449,6 +459,9 @@ class VirtualStudio : public QObject
     bool m_authenticated  = false;
     bool m_audioActivated = false;
     bool m_audioReady     = false;
+    bool m_inputClipped   = false;
+    bool m_outputClipped  = false;
+    bool m_networkOutage  = false;
 
     QVector<float> m_inputMeterLevels;
     QVector<float> m_outputMeterLevels;
@@ -460,6 +473,7 @@ class VirtualStudio : public QObject
     Monitor* m_monitor;
     QTimer m_inputClipTimer;
     QTimer m_outputClipTimer;
+    QTimer m_networkOutageTimer;
 
     QString m_devicesWarningMsg     = QStringLiteral("");
     QString m_devicesErrorMsg       = QStringLiteral("");


### PR DESCRIPTION
We currently detect and report these in Classic Mode (albeit with a cryptic warning message), but we don't currently say anything in Virtual Studio Mode, so the interface ends up telling someone their "connection quality is excellent" (for example) despite having regular outages and bad audio resulting from it.

This happens pretty much continuously if you are using WIFI, for example. So it's a great way to quickly identify root cause of audio issues caused by that, like forgetting to turn off WIFI and think you are using Ethernet when you actually are not.

Also updating clip indicators to use object variables instead of context properties

<img width="687" alt="Screenshot 2023-05-29 at 4 12 16 PM" src="https://github.com/jacktrip/jacktrip/assets/1159596/31cf5e78-4df8-4409-b8cf-10b09fdac8f8">

