### PR TITLE
Ensure that QTimer objects are stopped before destruction

### DIFF
--- a/src/Analyzer.cpp
+++ b/src/Analyzer.cpp
@@ -72,6 +72,8 @@ Analyzer::Analyzer(int numchans, bool verboseFlag)
 //*******************************************************************************
 Analyzer::~Analyzer()
 {
+    mTimer.stop();
+
     int fftChans = static_cast<fftdsp*>(mFftP)->getNumOutputs();
     for (int i = 0; i < fftChans; i++) {
         delete mAnalysisBuffers[i];

--- a/src/JackTripWorker.h
+++ b/src/JackTripWorker.h
@@ -76,7 +76,7 @@ class JackTripWorker : public QObject
         AudioInterface::audioBitResolutionT AudioBitResolution = AudioInterface::BIT16,
         const QString& clientName                              = QLatin1String(""));
     /// \brief The class destructor
-    ~JackTripWorker() = default;
+    virtual ~JackTripWorker() { stopThread(); }
 
     /// \brief Starts the jacktrip process
     void start();

--- a/src/Meter.cpp
+++ b/src/Meter.cpp
@@ -56,6 +56,7 @@ Meter::Meter(int numchans, bool verboseFlag) : mNumChannels(numchans)
 //*******************************************************************************
 Meter::~Meter()
 {
+    mTimer.stop();
     for (int i = 0; i < mNumChannels; i++) {
         delete static_cast<meterdsp*>(meterP[i]);
     }

--- a/src/UdpHubListener.cpp
+++ b/src/UdpHubListener.cpp
@@ -122,6 +122,7 @@ UdpHubListener::UdpHubListener(int server_port, int server_udp_port, QObject* pa
 //*******************************************************************************
 UdpHubListener::~UdpHubListener()
 {
+    mStopCheckTimer.stop();
     QMutexLocker lock(&mMutex);
     if (mRegulatorThreadPtr != NULL) {
         mRegulatorThreadPtr->quit();

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1910,8 +1910,13 @@ void VirtualStudio::openLink(const QString& link)
 
 void VirtualStudio::exit()
 {
+    m_startTimer.stop();
+    m_retryPeriodTimer.stop();
     m_refreshTimer.stop();
     m_heartbeatTimer.stop();
+    m_inputClipTimer.stop();
+    m_outputClipTimer.stop();
+    m_networkOutageTimer.stop();
     if (m_onConnectedScreen) {
         m_isExiting = true;
 

--- a/src/gui/vsDevice.cpp
+++ b/src/gui/vsDevice.cpp
@@ -41,7 +41,7 @@
 
 // Constructor
 VsDevice::VsDevice(VsAuth* auth, VsApi* api, QObject* parent)
-    : QObject(parent), m_auth(auth), m_api(api)
+    : QObject(parent), m_auth(auth), m_api(api), m_sendVolumeTimer(this)
 {
     QSettings settings;
     settings.beginGroup(QStringLiteral("VirtualStudio"));
@@ -61,9 +61,8 @@ VsDevice::VsDevice(VsAuth* auth, VsApi* api, QObject* parent)
         (float)settings.value(QStringLiteral("MonMultiplier"), 0).toDouble();
     settings.endGroup();
 
-    m_sendVolumeTimer = new QTimer(this);
-    m_sendVolumeTimer->setSingleShot(true);
-    connect(m_sendVolumeTimer, &QTimer::timeout, this, &VsDevice::sendLevels);
+    m_sendVolumeTimer.setSingleShot(true);
+    connect(&m_sendVolumeTimer, &QTimer::timeout, this, &VsDevice::sendLevels);
 
     // Set server levels to stored versions
     QJsonObject json = {
@@ -124,6 +123,13 @@ VsDevice::VsDevice(VsAuth* auth, VsApi* api, QObject* parent)
 
         reply->deleteLater();
     });
+}
+
+VsDevice::~VsDevice()
+{
+    m_sendVolumeTimer.stop();
+    stopJackTrip();
+    stopPinger();
 }
 
 // registerApp idempotently registers an emulated device belonging to the current user
@@ -487,10 +493,7 @@ void VsDevice::updateCaptureVolume(float multiplier)
         return;
     }
     m_captureVolume = multiplier;
-
-    if (m_sendVolumeTimer) {
-        m_sendVolumeTimer->start(200);
-    }
+    m_sendVolumeTimer.start(100);
 }
 
 // updateCaptureMute sets VsDevice's capture (input) mute to the provided boolean
@@ -500,10 +503,7 @@ void VsDevice::updateCaptureMute(bool muted)
         return;
     }
     m_captureMute = muted;
-
-    if (m_sendVolumeTimer) {
-        m_sendVolumeTimer->start(200);
-    }
+    m_sendVolumeTimer.start(100);
 }
 
 // updatePlaybackVolume sets VsDevice's playback (output) volume to the provided float
@@ -513,10 +513,7 @@ void VsDevice::updatePlaybackVolume(float multiplier)
         return;
     }
     m_playbackVolume = multiplier;
-
-    if (m_sendVolumeTimer) {
-        m_sendVolumeTimer->start(200);
-    }
+    m_sendVolumeTimer.start(100);
 }
 
 // updatePlaybackMute sets VsDevice's playback (output) mute to the provided boolean
@@ -526,10 +523,7 @@ void VsDevice::updatePlaybackMute(bool muted)
         return;
     }
     m_playbackMute = muted;
-
-    if (m_sendVolumeTimer) {
-        m_sendVolumeTimer->start(200);
-    }
+    m_sendVolumeTimer.start(100);
 }
 
 // updateMonitorVolume sets VsDevice's monitor to the provided float
@@ -538,12 +532,8 @@ void VsDevice::updateMonitorVolume(float multiplier)
     if (multiplier == m_monitorVolume) {
         return;
     }
-
     m_monitorVolume = multiplier;
-
-    if (m_sendVolumeTimer) {
-        m_sendVolumeTimer->start(200);
-    }
+    m_sendVolumeTimer.start(100);
 }
 
 // terminateJackTrip is a slot intended to be triggered on jacktrip process signals

--- a/src/gui/vsDevice.h
+++ b/src/gui/vsDevice.h
@@ -61,6 +61,7 @@ class VsDevice : public QObject
    public:
     // Constructor
     explicit VsDevice(VsAuth* auth, VsApi* api, QObject* parent = nullptr);
+    virtual ~VsDevice();
 
     // Public functions
     void registerApp();
@@ -125,7 +126,7 @@ class VsDevice : public QObject
     float m_playbackVolume = 1.0;
     bool m_playbackMute    = false;
     float m_monitorVolume  = 0;
-    QTimer* m_sendVolumeTimer;
+    QTimer m_sendVolumeTimer;
     bool m_reconnect = false;
 };
 

--- a/src/gui/vsDeviceCodeFlow.h
+++ b/src/gui/vsDeviceCodeFlow.h
@@ -57,6 +57,7 @@ class VsDeviceCodeFlow : public QObject
 
    public:
     explicit VsDeviceCodeFlow(QNetworkAccessManager* networkAccessManager);
+    virtual ~VsDeviceCodeFlow() { stopPolling(); }
 
     void grant();
     void refreshAccessToken(){};

--- a/src/gui/vsPing.h
+++ b/src/gui/vsPing.h
@@ -54,6 +54,7 @@ class VsPing : public QObject
 
    public:
     explicit VsPing(uint32_t pingNum, uint32_t timeout_msec);
+    virtual ~VsPing() { mTimer.stop(); }
     uint32_t pingNumber() { return mPingNumber; }
 
     QDateTime sentTimestamp() { return mSent; }

--- a/src/gui/vsPinger.h
+++ b/src/gui/vsPinger.h
@@ -64,6 +64,7 @@ class VsPinger : public QObject
      * \param path The path to ping the server on
      */
     explicit VsPinger(QString scheme, QString host, QString path);
+    virtual ~VsPinger() { stop(); }
     void start();
     void stop();
     bool active() { return mStarted; };


### PR DESCRIPTION
Otherwise, it's possible that the timer callbacks could be called while or after things are being deleted, which causes bad things to happen.