### PR TITLE
This fixes an issue with text color of secondary login page buttons

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -256,7 +256,7 @@ jobs:
       QT_STATIC_OPTIONS: '-static -release -optimize-size -no-pch -nomake tools -nomake tests -nomake examples -opensource -confirm-license -skip webengine -skip qt3d -skip qtactiveqt -skip qtandroidextras -skip qtcharts -skip qtdatavis3d -skip qtdoc -skip qtgamepad -skip qtimageformats -skip qtlocation -skip qtmultimedia -skip qtpurchasing -skip qtpurchasing -skip qtremoteobjects -skip qtscript -skip qtsensors -skip qtserialbus -skip qtserialport -skip qtspeech -skip qttools -skip qtvirtualkeyboard -skip qtwebchannel -skip qtwebengine -skip qtwebglplugin -skip qtwebview -skip qtxmlpatterns' # common for all platforms
       CLANG_TIDY_NAME: clang-tidy-result
       CLANG_TIDY_PATH: ${{ github.workspace }}/clang-tidy-result
-      VCPKG_COMMIT: '19af97cba8ca48474e4ad15a24ed50271a9ecdac'
+      VCPKG_COMMIT: '662dbb50e63af15baa2909b7eac5b1b87e86a0aa'
       
     steps:
       - uses: actions/checkout@v3

--- a/src/gui/Login.qml
+++ b/src/gui/Login.qml
@@ -249,86 +249,78 @@ Item {
             height: 48 * virtualstudio.uiScale
 
             property bool showBackButton: !virtualstudio.vsFtux
-            property bool showClassicModeButton: virtualstudio.showFirstRun && virtualstudio.vsFtux
+            property bool showClassicModeButton: virtualstudio.vsFtux
 
-            Button {
+            Item {
                 id: backButton
                 visible: parent.showBackButton
-                background: Rectangle {
-                    radius: 6 * virtualstudio.uiScale
-                    color: backButton.down ? buttonPressedColour : (backButton.hovered ? buttonHoverColour : buttonColour)
-                    border.color: backButton.down ? buttonPressedStroke : (backButton.hovered ? buttonHoverStroke : buttonStroke)
-                    border.width: 1
-                    layer.enabled: !backButton.down
-                }
-                onClicked: () => { if (!auth.isAuthenticated) { virtualstudio.windowState = "start"; } }
                 anchors.verticalCenter: parent.verticalCenter
                 x: (parent.x + parent.width / 2) - backButton.width - 8 * virtualstudio.uiScale
                 width: 144 * virtualstudio.uiScale; height: 32 * virtualstudio.uiScale
                 Text {
                     text: "Back"
                     font.family: "Poppins"
-                    font.pixelSize: 9 * virtualstudio.fontScale * virtualstudio.uiScale
+                    font.underline: true
+                    font.pixelSize: 11 * virtualstudio.fontScale * virtualstudio.uiScale
                     anchors.horizontalCenter: parent.horizontalCenter
                     anchors.verticalCenter: parent.verticalCenter
-                    color: backButton.down ? buttonTextPressed : (backButton.hovered ? buttonTextHover : textColour)
+                    color: textColour
+                }
+                MouseArea {
+                    anchors.fill: parent
+                    onClicked: () => { if (!auth.isAuthenticated) { virtualstudio.windowState = "start"; } }
+                    cursorShape: Qt.PointingHandCursor
                 }
             }
 
-            Button {
+            Item {
                 id: classicModeButton
                 visible: parent.showClassicModeButton
-                background: Rectangle {
-                    radius: 6 * virtualstudio.uiScale
-                    color: classicModeButton.down ? buttonPressedColour : (classicModeButton.hovered ? buttonHoverColour : buttonColour)
-                    border.color: classicModeButton.down ? buttonPressedStroke : (classicModeButton.hovered ? buttonHoverStroke : buttonStroke)
-                    border.width: 1
-                    layer.enabled: !classicModeButton.down
-                }
-                onClicked: { virtualstudio.windowState = "login"; virtualstudio.toStandard(); }
                 anchors.verticalCenter: parent.verticalCenter
                 x: (parent.x + parent.width / 2) - classicModeButton.width - 8 * virtualstudio.uiScale
                 width: 160 * virtualstudio.uiScale; height: 32 * virtualstudio.uiScale
                 Text {
                     text: "Use Classic Mode"
+                    font.underline: true
                     font.family: "Poppins"
-                    font.pixelSize: 9 * virtualstudio.fontScale * virtualstudio.uiScale
+                    font.pixelSize: 11 * virtualstudio.fontScale * virtualstudio.uiScale
                     anchors.horizontalCenter: parent.horizontalCenter
                     anchors.verticalCenter: parent.verticalCenter
-                    color: classicModeButton.down ? buttonTextPressed : (classicModeButton.hovered ? buttonTextHover : textColour)
+                    color: textColour
+                }
+                MouseArea {
+                    anchors.fill: parent
+                    onClicked: () => { virtualstudio.windowState = "login"; virtualstudio.toStandard(); }
+                    cursorShape: Qt.PointingHandCursor
                 }
             }
 
-            Button {
+            Item {
                 id: resetCodeButton
                 visible: true
-                background: Rectangle {
-                    radius: 6 * virtualstudio.uiScale
-                    color: resetCodeButton.down ? buttonPressedColour : (resetCodeButton.hovered ? buttonHoverColour : buttonColour)
-                    border.color: resetCodeButton.down ? buttonPressedStroke : (resetCodeButton.hovered ? buttonHoverStroke : buttonStroke)
-                    border.width: 1
-                    layer.enabled: !resetCodeButton.down
-                }
-                onClicked: () => {
-                    if (auth.verificationCode && auth.verificationUrl) {
-                        auth.resetCode();
-                    }
-                }
                 x: (parent.showBackButton || parent.showClassicModeButton) ? (parent.x + parent.width / 2) + 8 * virtualstudio.uiScale : (parent.x + parent.width / 2) - resetCodeButton.width / 2
                 anchors.verticalCenter: parent.verticalCenter
                 width: 144 * virtualstudio.uiScale; height: 32 * virtualstudio.uiScale
                 Text {
                     text: "Reset Code"
                     font.family: "Poppins"
-                    font.pixelSize: 9 * virtualstudio.fontScale * virtualstudio.uiScale
+                    font.underline: true
+                    font.pixelSize: 11 * virtualstudio.fontScale * virtualstudio.uiScale
                     anchors.horizontalCenter: parent.horizontalCenter
                     anchors.verticalCenter: parent.verticalCenter
-                    color: resetCodeButton.down ? buttonTextPressed : (resetCodeButton.hovered ? buttonTextHover : textColour)
+                    color: textColour
+                }
+                MouseArea {
+                    anchors.fill: parent
+                    onClicked: () => {
+                        if (auth.verificationCode && auth.verificationUrl) {
+                            auth.resetCode();
+                        }
+                    }
+                    cursorShape: Qt.PointingHandCursor
                 }
             }
         }
-
-
     }
 
     Item {


### PR DESCRIPTION
In dark mode, you can't see the text unless you mouse over it.

This also replaces the button styling with less emphasized text links and makes "Use Classic Mode" show up even if it is not the first time run. Basically, always show "Use Classic Mode" if vsftux; othwerise, always show "Back" to go back to the Yes/No page.

<img width="672" alt="Screenshot 2023-06-02 at 10 08 52 AM" src="https://github.com/jacktrip/jacktrip/assets/1159596/2afa92b8-bd8f-4d43-99ee-873cd477c52b">

<img width="668" alt="Screenshot 2023-06-02 at 10 05 12 AM" src="https://github.com/jacktrip/jacktrip/assets/1159596/36f0f361-29e5-44a2-b13e-569647d7fabf">

<img width="654" alt="Screenshot 2023-06-02 at 9 36 07 AM" src="https://github.com/jacktrip/jacktrip/assets/1159596/b551be38-9416-4400-8f25-16675925c882">

<img width="638" alt="Screenshot 2023-06-02 at 9 41 11 AM" src="https://github.com/jacktrip/jacktrip/assets/1159596/79e5cefc-9d08-4206-a622-fc27485a2e60">
