### PR TITLE
Adjust Feedback Detection Sensitivity

### DIFF
--- a/src/Analyzer.cpp
+++ b/src/Analyzer.cpp
@@ -337,7 +337,8 @@ bool Analyzer::testSpectralPeakGrowing()
         }
     }
 
-    if (numPositiveDifferentials == (uint32_t)mNumSpectra * (mNumSpectra * 0.8) && numLargeDifferentials >= 1) {
+    if (numPositiveDifferentials == (uint32_t)mNumSpectra * (mNumSpectra * 0.8)
+        && numLargeDifferentials >= 1) {
         return true;
     }
 

--- a/src/Analyzer.h
+++ b/src/Analyzer.h
@@ -82,7 +82,9 @@ class Analyzer : public ProcessPlugin
     bool testSpectralPeakGrowing();
 
     int mInterval              = 100;
-    float mThresholdMultiplier = 0.5;
+    float mPeakThresholdMultipler = 0.5;
+    float mPeakDeviationThresholdMultiplier = .4;
+    float mDifferentialThresholdMultiplier = 0.05;
 
     float fs;
     int mNumChannels;

--- a/src/Analyzer.h
+++ b/src/Analyzer.h
@@ -81,10 +81,10 @@ class Analyzer : public ProcessPlugin
     bool testSpectralPeakAbnormallyHigh();
     bool testSpectralPeakGrowing();
 
-    int mInterval              = 100;
-    float mPeakThresholdMultipler = 0.5;
+    int mInterval                           = 100;
+    float mPeakThresholdMultipler           = 0.5;
     float mPeakDeviationThresholdMultiplier = .4;
-    float mDifferentialThresholdMultiplier = 0.05;
+    float mDifferentialThresholdMultiplier  = 0.05;
 
     float fs;
     int mNumChannels;

--- a/src/Analyzer.h
+++ b/src/Analyzer.h
@@ -83,7 +83,7 @@ class Analyzer : public ProcessPlugin
 
     int mInterval                           = 100;
     float mPeakThresholdMultipler           = 0.5;
-    float mPeakDeviationThresholdMultiplier = .4;
+    float mPeakDeviationThresholdMultiplier = 0.4;
     float mDifferentialThresholdMultiplier  = 0.05;
 
     float fs;

--- a/src/compressordsp.h
+++ b/src/compressordsp.h
@@ -1133,8 +1133,8 @@ class FAUST_API AccUpDownConverter : public UpdatableValueConverter
     Interpolator fF2A;
 
    public:
-    AccUpDownConverter(double amin, double amid, double amax, double fmin,
-                       double /*fmid*/, double fmax)
+    AccUpDownConverter(double amin, double amid, double amax, double fmin, double /*fmid*/,
+                       double fmax)
         : fA2F(amin, amid, amax, fmin, fmax, fmin)
         , fF2A(fmin, fmax, amin,
                amax)  // Special, pseudo inverse of a non monotonic function
@@ -1170,8 +1170,8 @@ class FAUST_API AccDownUpConverter : public UpdatableValueConverter
     Interpolator fF2A;
 
    public:
-    AccDownUpConverter(double amin, double amid, double amax, double fmin,
-                       double /*fmid*/, double fmax)
+    AccDownUpConverter(double amin, double amid, double amax, double fmin, double /*fmid*/,
+                       double fmax)
         : fA2F(amin, amid, amax, fmax, fmin, fmax)
         , fF2A(fmin, fmax, amin,
                amax)  // Special, pseudo inverse of a non monotonic function
@@ -1210,9 +1210,8 @@ class FAUST_API ZoneControl
 
     virtual void update(double /*v*/) const {}
 
-    virtual void setMappingValues(int /*curve*/, double /*amin*/, double /*amid*/,
-                                  double /*amax*/, double /*min*/, double /*init*/,
-                                  double /*max*/)
+    virtual void setMappingValues(int /*curve*/, double /*amin*/, double /*amid*/, double /*amax*/,
+                                  double /*min*/, double /*init*/, double /*max*/)
     {
     }
     virtual void getMappingValues(double& /*amin*/, double& /*amid*/, double& /*amax*/) {}

--- a/src/compressordsp.h
+++ b/src/compressordsp.h
@@ -1133,8 +1133,8 @@ class FAUST_API AccUpDownConverter : public UpdatableValueConverter
     Interpolator fF2A;
 
    public:
-    AccUpDownConverter(double amin, double amid, double amax, double fmin, double /*fmid*/,
-                       double fmax)
+    AccUpDownConverter(double amin, double amid, double amax, double fmin,
+                       double /*fmid*/, double fmax)
         : fA2F(amin, amid, amax, fmin, fmax, fmin)
         , fF2A(fmin, fmax, amin,
                amax)  // Special, pseudo inverse of a non monotonic function
@@ -1170,8 +1170,8 @@ class FAUST_API AccDownUpConverter : public UpdatableValueConverter
     Interpolator fF2A;
 
    public:
-    AccDownUpConverter(double amin, double amid, double amax, double fmin, double /*fmid*/,
-                       double fmax)
+    AccDownUpConverter(double amin, double amid, double amax, double fmin,
+                       double /*fmid*/, double fmax)
         : fA2F(amin, amid, amax, fmax, fmin, fmax)
         , fF2A(fmin, fmax, amin,
                amax)  // Special, pseudo inverse of a non monotonic function
@@ -1210,8 +1210,9 @@ class FAUST_API ZoneControl
 
     virtual void update(double /*v*/) const {}
 
-    virtual void setMappingValues(int /*curve*/, double /*amin*/, double /*amid*/, double /*amax*/,
-                                  double /*min*/, double /*init*/, double /*max*/)
+    virtual void setMappingValues(int /*curve*/, double /*amin*/, double /*amid*/,
+                                  double /*amax*/, double /*min*/, double /*init*/,
+                                  double /*max*/)
     {
     }
     virtual void getMappingValues(double& /*amin*/, double& /*amid*/, double& /*amax*/) {}


### PR DESCRIPTION
Hopefully this is a little better? I tried to define the thresholds a little better in relation to what the expected FFT outputs would be, and adjust the sensitivities that way.

Note that we are squaring in our Faust callback to get a power spectrum. The FFT outputs complex values with a magnitude of less than or equal to 128 for (size N = 128 and non-clipping input signals). We square to get real valued magnitudes and use that for the analysis.