### PR TITLE
Fixed issue with RTAudio scanning interfaces several times at startup

### DIFF
--- a/src/RtAudioInterface.cpp
+++ b/src/RtAudioInterface.cpp
@@ -48,6 +48,17 @@ using std::cout;
 using std::endl;
 
 //*******************************************************************************
+void RtAudioDevice::print() const
+{
+    std::cout << "[" << RtAudio::getApiDisplayName(this->api) << " - " << this->apiIndex
+              << "]"
+              << ": \"";
+    std::cout << this->name.toStdString() << "\" ";
+    std::cout << "(" << this->inputChannels << " ins, " << this->outputChannels
+              << " outs)" << endl;
+}
+
+//*******************************************************************************
 RtAudioInterface::RtAudioInterface(QVarLengthArray<int> InputChans,
                                    QVarLengthArray<int> OutputChans,
                                    inputMixModeT InputMixMode,
@@ -118,13 +129,11 @@ void RtAudioInterface::setup(bool verbose)
     std::string api_in;
     std::string api_out;
 
-    QStringList all_input_devices;
-    QStringList all_output_devices;
-    getDeviceList(&all_input_devices, NULL, NULL, true);
-    getDeviceList(&all_output_devices, NULL, NULL, false);
+    if (mDevices.empty())
+        scanDevices(mDevices);
 
-    unsigned int n_devices_input  = all_input_devices.size();
-    unsigned int n_devices_output = all_output_devices.size();
+    unsigned int n_devices_input  = getNumInputDevices();
+    unsigned int n_devices_output = getNumOutputDevices();
     unsigned int n_devices_total  = n_devices_input + n_devices_output;
 
     RtAudio* rtAudioIn  = NULL;
@@ -313,29 +322,35 @@ void RtAudioInterface::setup(bool verbose)
 //*******************************************************************************
 void RtAudioInterface::printDevices()
 {
-    std::vector<RtAudio::Api> apis;
-    RtAudio::getCompiledApi(apis);
+    QVector<RtAudioDevice> devices;
+    scanDevices(devices);
+    for (int n = 0; n < devices.size(); ++n) {
+        devices[n].print();
+    }
+}
 
-    for (uint32_t i = 0; i < apis.size(); i++) {
-#ifdef _WIN32
-        if (apis.at(i) == RtAudio::UNIX_JACK) {
-            continue;
-        }
-#endif
-        RtAudio rtaudio(apis.at(i));
-        unsigned int devices = rtaudio.getDeviceCount();
-        for (unsigned int j = 0; j < devices; j++) {
-            RtAudio::DeviceInfo info = rtaudio.getDeviceInfo(j);
-            if (info.probed == true) {
-                std::cout << "[" << RtAudio::getApiDisplayName(rtaudio.getCurrentApi())
-                          << " - " << j << "]"
-                          << ": \"";
-                std::cout << info.name << "\" ";
-                std::cout << "(" << info.inputChannels << " ins, " << info.outputChannels
-                          << " outs)" << endl;
-            }
+//*******************************************************************************
+unsigned int RtAudioInterface::getNumInputDevices() const
+{
+    unsigned int deviceCount = 0;
+    for (int n = 0; n < mDevices.size(); ++n) {
+        if (mDevices[n].inputChannels > 0) {
+            ++deviceCount;
         }
     }
+    return deviceCount;
+}
+
+//*******************************************************************************
+unsigned int RtAudioInterface::getNumOutputDevices() const
+{
+    unsigned int deviceCount = 0;
+    for (int n = 0; n < mDevices.size(); ++n) {
+        if (mDevices[n].outputChannels > 0) {
+            ++deviceCount;
+        }
+    }
+    return deviceCount;
 }
 
 //*******************************************************************************
@@ -481,146 +496,34 @@ int RtAudioInterface::stopProcess()
 }
 
 //*******************************************************************************
-void RtAudioInterface::getDeviceList(QStringList* list, QStringList* categories,
-                                     QList<int>* channels, bool isInput)
+void RtAudioInterface::getDeviceInfoFromName(std::string deviceName, int* index,
+                                             std::string* api, bool isInput) const
 {
-    RtAudio baseRtAudio;
-    RtAudio::Api baseRtAudioApi = baseRtAudio.getCurrentApi();
-    if (categories != NULL) {
-        categories->clear();
-    }
-    if (channels != NULL) {
-        channels->clear();
-    }
-    list->clear();
-
-    // Explicitly add default device
-    QString defaultDeviceName = "";
-    uint32_t defaultDeviceIdx;
-    RtAudio::DeviceInfo defaultDeviceInfo;
-    if (isInput) {
-        defaultDeviceIdx = baseRtAudio.getDefaultInputDevice();
-    } else {
-        defaultDeviceIdx = baseRtAudio.getDefaultOutputDevice();
-    }
-
-    if (defaultDeviceIdx != 0) {
-        defaultDeviceInfo = baseRtAudio.getDeviceInfo(defaultDeviceIdx);
-        defaultDeviceName = QString::fromStdString(defaultDeviceInfo.name);
-    }
-
-    if (defaultDeviceName != "") {
-        list->append(defaultDeviceName);
-        if (categories != NULL) {
-#ifdef _WIN32
-            switch (baseRtAudioApi) {
-            case RtAudio::WINDOWS_ASIO:
-                categories->append(QStringLiteral("Low-Latency (ASIO)"));
-                break;
-            case RtAudio::WINDOWS_WASAPI:
-                categories->append(QStringLiteral("High-Latency (Non-ASIO)"));
-                break;
-            case RtAudio::WINDOWS_DS:
-                categories->append(QStringLiteral("High-Latency (Non-ASIO)"));
-                break;
-            default:
-                categories->append(QStringLiteral(""));
-                break;
-            }
-#else
-            categories->append(QStringLiteral(""));
-#endif
-        }
-        if (channels != NULL) {
-            if (isInput) {
-                channels->append(defaultDeviceInfo.inputChannels);
-            } else {
-                channels->append(defaultDeviceInfo.outputChannels);
+    const QVector<RtAudioDevice>& devices(getDevices());
+    for (int n = 0; n < devices.size(); ++n) {
+        if (deviceName == devices[n].name.toStdString()) {
+            if ((isInput && devices[n].inputChannels > 0)
+                || (!isInput && devices[n].outputChannels > 0)) {
+                *index = devices[n].apiIndex;
+                *api   = RtAudio::getApiName(devices[n].api);
+                return;
             }
         }
     }
 
-    std::vector<RtAudio::Api> apis;
-    RtAudio::getCompiledApi(apis);
-
-    for (uint32_t i = 0; i < apis.size(); i++) {
-#ifdef _WIN32
-        if (apis.at(i) == RtAudio::UNIX_JACK) {
-            continue;
-        }
-#endif
-        RtAudio::Api api = apis.at(i);
-        RtAudio rtaudio(api);
-        unsigned int devices = rtaudio.getDeviceCount();
-        for (unsigned int j = 0; j < devices; j++) {
-            RtAudio::DeviceInfo info = rtaudio.getDeviceInfo(j);
-            if (info.probed == true) {
-                // Don't include duplicate entries
-                if (list->contains(QString::fromStdString(info.name))) {
-                    continue;
-                }
-
-                // Skip the default device, since we already added it
-                if (QString::fromStdString(info.name) == defaultDeviceName
-                    && api == baseRtAudioApi) {
-                    continue;
-                }
-
-                if (QString::fromStdString(info.name) == "JackRouter") {
-                    continue;
-                }
-
-                if (info.probed == false) {
-                    continue;
-                }
-
-                if (isInput && info.inputChannels > 0) {
-                    list->append(QString::fromStdString(info.name));
-                    if (channels != NULL) {
-                        channels->append(info.inputChannels);
-                    }
-                } else if (!isInput && info.outputChannels > 0) {
-                    list->append(QString::fromStdString(info.name));
-                    if (channels != NULL) {
-                        channels->append(info.outputChannels);
-                    }
-                } else {
-                    continue;
-                }
-
-                if (categories == NULL) {
-                    continue;
-                }
-
-#ifdef _WIN32
-                switch (api) {
-                case RtAudio::WINDOWS_ASIO:
-                    categories->append("Low-Latency (ASIO)");
-                    break;
-                case RtAudio::WINDOWS_WASAPI:
-                    categories->append("High-Latency (Non-ASIO)");
-                    break;
-                case RtAudio::WINDOWS_DS:
-                    categories->append("High-Latency (Non-ASIO)");
-                    break;
-                default:
-                    categories->append("");
-                    break;
-                }
-#else
-                categories->append("");
-#endif
-            }
-        }
-    }
+    *index = -1;
+    *api   = "";
+    return;
 }
 
 //*******************************************************************************
-void RtAudioInterface::getDeviceInfoFromName(std::string deviceName, int* index,
-                                             std::string* api, bool isInput)
+void RtAudioInterface::scanDevices(QVector<RtAudioDevice>& devices)
 {
     std::vector<RtAudio::Api> apis;
     RtAudio::getCompiledApi(apis);
+    devices.clear();
+
+    std::cout << "RTAudio: scanning devices..." << std::endl;
 
     for (uint32_t i = 0; i < apis.size(); i++) {
 #ifdef _WIN32
@@ -629,22 +532,17 @@ void RtAudioInterface::getDeviceInfoFromName(std::string deviceName, int* index,
         }
 #endif
         RtAudio rtaudio(apis.at(i));
-        unsigned int devices = rtaudio.getDeviceCount();
-        for (unsigned int j = 0; j < devices; j++) {
+        unsigned int numDevices = rtaudio.getDeviceCount();
+        for (unsigned int j = 0; j < numDevices; j++) {
             RtAudio::DeviceInfo info = rtaudio.getDeviceInfo(j);
-            if (info.probed == true
-                && deviceName == QString::fromStdString(info.name).toStdString()) {
-                if ((isInput && info.inputChannels > 0)
-                    || (!isInput && info.outputChannels > 0)) {
-                    *index = j;
-                    *api   = RtAudio::getApiName(rtaudio.getCurrentApi());
-                    return;
-                }
-            }
+            RtAudioDevice device;
+            device.api            = rtaudio.getCurrentApi();
+            device.apiIndex       = j;
+            device.name           = QString::fromStdString(info.name);
+            device.inputChannels  = info.inputChannels;
+            device.outputChannels = info.outputChannels;
+            devices.push_back(device);
+            device.print();
         }
     }
-
-    *index = -1;
-    *api   = "";
-    return;
 }

--- a/src/RtAudioInterface.cpp
+++ b/src/RtAudioInterface.cpp
@@ -324,9 +324,6 @@ void RtAudioInterface::printDevices()
 {
     QVector<RtAudioDevice> devices;
     scanDevices(devices);
-    for (int n = 0; n < devices.size(); ++n) {
-        devices[n].print();
-    }
 }
 
 //*******************************************************************************
@@ -535,6 +532,8 @@ void RtAudioInterface::scanDevices(QVector<RtAudioDevice>& devices)
         unsigned int numDevices = rtaudio.getDeviceCount();
         for (unsigned int j = 0; j < numDevices; j++) {
             RtAudio::DeviceInfo info = rtaudio.getDeviceInfo(j);
+            if (!info.probed || (info.inputChannels == 0 && info.outputChannels == 0))
+                continue;
             RtAudioDevice device;
             device.api            = rtaudio.getCurrentApi();
             device.apiIndex       = j;

--- a/src/gui/AudioSettings.qml
+++ b/src/gui/AudioSettings.qml
@@ -44,9 +44,6 @@ Rectangle {
     property bool isUsingRtAudio: virtualstudio.audioBackend == "RtAudio"
     property bool hasNoBackend: !isUsingJack && !isUsingRtAudio && !virtualstudio.backendAvailable;
 
-    property int inputCurrIndex: getCurrentInputDeviceIndex()
-    property int outputCurrIndex: getCurrentOutputDeviceIndex()
-
     function getCurrentInputDeviceIndex () {
         if (virtualstudio.inputDevice === "") {
             return virtualstudio.inputComboModel.findIndex(elem => elem.type === "element");
@@ -181,7 +178,7 @@ Rectangle {
                 anchors.rightMargin: rightMargin * virtualstudio.uiScale
                 width: parent.width - leftSpacer.width - rightMargin * virtualstudio.uiScale
                 model: virtualstudio.outputComboModel
-                currentIndex: outputCurrIndex
+                currentIndex: getCurrentOutputDeviceIndex()
                 delegate: ItemDelegate {
                     required property var modelData
                     required property int index
@@ -487,7 +484,7 @@ Rectangle {
             ComboBox {
                 id: inputCombo
                 model: virtualstudio.inputComboModel
-                currentIndex: inputCurrIndex
+                currentIndex: getCurrentInputDeviceIndex()
                 anchors.left: outputCombo.left
                 anchors.right: outputCombo.right
                 anchors.verticalCenter: inputLabel.verticalCenter

--- a/src/gui/AudioSettings.qml
+++ b/src/gui/AudioSettings.qml
@@ -49,24 +49,24 @@ Rectangle {
 
     function getCurrentInputDeviceIndex () {
         if (virtualstudio.inputDevice === "") {
-            return inputComboModel.findIndex(elem => elem.type === "element");
+            return virtualstudio.inputComboModel.findIndex(elem => elem.type === "element");
         }
 
-        let idx = inputComboModel.findIndex(elem => elem.type === "element" && elem.text === virtualstudio.inputDevice);
+        let idx = virtualstudio.inputComboModel.findIndex(elem => elem.type === "element" && elem.text === virtualstudio.inputDevice);
         if (idx < 0) {
-            idx = inputComboModel.findIndex(elem => elem.type === "element");
+            idx = virtualstudio.inputComboModel.findIndex(elem => elem.type === "element");
         }
         return idx;
     }
 
     function getCurrentOutputDeviceIndex() {
         if (virtualstudio.outputDevice === "") {
-            return outputComboModel.findIndex(elem => elem.type === "element");
+            return virtualstudio.outputComboModel.findIndex(elem => elem.type === "element");
         }
 
-        let idx = outputComboModel.findIndex(elem => elem.type === "element" && elem.text === virtualstudio.outputDevice);
+        let idx = virtualstudio.outputComboModel.findIndex(elem => elem.type === "element" && elem.text === virtualstudio.outputDevice);
         if (idx < 0) {
-            idx = outputComboModel.findIndex(elem => elem.type === "element");
+            idx = virtualstudio.outputComboModel.findIndex(elem => elem.type === "element");
         }
         return idx;
     }
@@ -180,7 +180,7 @@ Rectangle {
                 anchors.verticalCenter: outputLabel.verticalCenter
                 anchors.rightMargin: rightMargin * virtualstudio.uiScale
                 width: parent.width - leftSpacer.width - rightMargin * virtualstudio.uiScale
-                model: outputComboModel
+                model: virtualstudio.outputComboModel
                 currentIndex: outputCurrIndex
                 delegate: ItemDelegate {
                     required property var modelData
@@ -221,7 +221,7 @@ Rectangle {
                     horizontalAlignment: Text.AlignHLeft
                     verticalAlignment: Text.AlignVCenter
                     elide: Text.ElideRight
-                    text: outputCombo.model[outputCombo.currentIndex].text ? outputCombo.model[outputCombo.currentIndex].text : ""
+                    text: outputCombo.model[outputCombo.currentIndex]!=undefined && outputCombo.model[outputCombo.currentIndex].text ? outputCombo.model[outputCombo.currentIndex].text : ""
                 }
             }
 
@@ -336,9 +336,9 @@ Rectangle {
                 anchors.rightMargin: 8 * virtualstudio.uiScale
                 anchors.top: outputChannelsLabel.bottom
                 anchors.topMargin: 4 * virtualstudio.uiScale
-                model: outputChannelsComboModel
+                model: virtualstudio.outputChannelsComboModel
                 currentIndex: (() => {
-                    let idx = outputChannelsComboModel.findIndex(elem => elem.baseChannel === virtualstudio.baseOutputChannel
+                    let idx = virtualstudio.outputChannelsComboModel.findIndex(elem => elem.baseChannel === virtualstudio.baseOutputChannel
                         && elem.numChannels === virtualstudio.numOutputChannels);
                     if (idx < 0) {
                         idx = 0;
@@ -486,7 +486,7 @@ Rectangle {
 
             ComboBox {
                 id: inputCombo
-                model: inputComboModel
+                model: virtualstudio.inputComboModel
                 currentIndex: inputCurrIndex
                 anchors.left: outputCombo.left
                 anchors.right: outputCombo.right
@@ -530,7 +530,7 @@ Rectangle {
                     horizontalAlignment: Text.AlignHLeft
                     verticalAlignment: Text.AlignVCenter
                     elide: Text.ElideRight
-                    text: inputCombo.model[inputCombo.currentIndex].text ? inputCombo.model[inputCombo.currentIndex].text : ""
+                    text: inputCombo.model[inputCombo.currentIndex] != undefined && inputCombo.model[inputCombo.currentIndex].text ? inputCombo.model[inputCombo.currentIndex].text : ""
                 }
             }
 
@@ -654,9 +654,9 @@ Rectangle {
                 anchors.rightMargin: 8 * virtualstudio.uiScale
                 anchors.top: inputChannelsLabel.bottom
                 anchors.topMargin: 4 * virtualstudio.uiScale
-                model: inputChannelsComboModel
+                model: virtualstudio.inputChannelsComboModel
                 currentIndex: (() => {
-                    let idx = inputChannelsComboModel.findIndex(elem => elem.baseChannel === virtualstudio.baseInputChannel
+                    let idx = virtualstudio.inputChannelsComboModel.findIndex(elem => elem.baseChannel === virtualstudio.baseInputChannel
                         && elem.numChannels === virtualstudio.numInputChannels);
                     if (idx < 0) {
                         idx = 0;
@@ -712,9 +712,9 @@ Rectangle {
                 anchors.rightMargin: 8 * virtualstudio.uiScale
                 anchors.top: inputMixModeLabel.bottom
                 anchors.topMargin: 4 * virtualstudio.uiScale
-                model: inputMixModeComboModel
+                model: virtualstudio.inputMixModeComboModel
                 currentIndex: (() => {
-                    let idx = inputMixModeComboModel.findIndex(elem => elem.value === virtualstudio.inputMixMode);
+                    let idx = virtualstudio.inputMixModeComboModel.findIndex(elem => elem.value === virtualstudio.inputMixMode);
                     if (idx < 0) {
                         idx = 0;
                     }
@@ -733,7 +733,7 @@ Rectangle {
                         onClicked: {
                             inputMixModeCombo.currentIndex = index
                             inputMixModeCombo.popup.close()
-                            virtualstudio.inputMixMode = inputMixModeComboModel[index].value
+                            virtualstudio.inputMixMode = virtualstudio.inputMixModeComboModel[index].value
                             virtualstudio.validateDevicesState()
                         }
                     }

--- a/src/gui/Connected.qml
+++ b/src/gui/Connected.qml
@@ -65,12 +65,12 @@ Item {
 
     function getCurrentInputDeviceIndex () {
         if (virtualstudio.inputDevice === "") {
-            return inputComboModel.findIndex(elem => elem.type === "element");
+            return virtualstudio.inputComboModel.findIndex(elem => elem.type === "element");
         }
 
-        let idx = inputComboModel.findIndex(elem => elem.type === "element" && elem.text === virtualstudio.inputDevice);
+        let idx = virtualstudio.inputComboModel.findIndex(elem => elem.type === "element" && elem.text === virtualstudio.inputDevice);
         if (idx < 0) {
-            idx = inputComboModel.findIndex(elem => elem.type === "element");
+            idx = virtualstudio.inputComboModel.findIndex(elem => elem.type === "element");
         }
 
         return idx;
@@ -78,12 +78,12 @@ Item {
 
     function getCurrentOutputDeviceIndex() {
         if (virtualstudio.outputDevice === "") {
-            return outputComboModel.findIndex(elem => elem.type === "element");
+            return virtualstudio.outputComboModel.findIndex(elem => elem.type === "element");
         }
 
-        let idx = outputComboModel.findIndex(elem => elem.type === "element" && elem.text === virtualstudio.outputDevice);
+        let idx = virtualstudio.outputComboModel.findIndex(elem => elem.type === "element" && elem.text === virtualstudio.outputDevice);
         if (idx < 0) {
-            idx = outputComboModel.findIndex(elem => elem.type === "element");
+            idx = virtualstudio.outputComboModel.findIndex(elem => elem.type === "element");
         }
 
         return idx;
@@ -329,7 +329,7 @@ Item {
                         anchors.rightMargin: rightMargin * virtualstudio.uiScale
                         width: parent.width - leftSpacer.width - rightMargin * virtualstudio.uiScale
                         enabled: virtualstudio.connectionState == "Connected"
-                        model: outputComboModel
+                        model: virtualstudio.outputComboModel
                         currentIndex: getCurrentOutputDeviceIndex()
                         delegate: ItemDelegate {
                             required property var modelData
@@ -393,9 +393,9 @@ Item {
                         anchors.top: outputChannelsLabel.bottom
                         anchors.topMargin: 4 * virtualstudio.uiScale
                         enabled: virtualstudio.connectionState == "Connected"
-                        model: outputChannelsComboModel
+                        model: virtualstudio.outputChannelsComboModel
                         currentIndex: (() => {
-                            let idx = outputChannelsComboModel.findIndex(elem => elem.baseChannel === virtualstudio.baseOutputChannel
+                            let idx = virtualstudio.outputChannelsComboModel.findIndex(elem => elem.baseChannel === virtualstudio.baseOutputChannel
                                 && elem.numChannels === virtualstudio.numOutputChannels);
                             if (idx < 0) {
                                 idx = 0;
@@ -515,7 +515,7 @@ Item {
 
                     ComboBox {
                         id: inputCombo
-                        model: inputComboModel
+                        model: virtualstudio.inputComboModel
                         currentIndex: getCurrentInputDeviceIndex()
                         anchors.left: outputCombo.left
                         anchors.right: outputCombo.right
@@ -583,9 +583,9 @@ Item {
                         anchors.top: inputChannelsLabel.bottom
                         anchors.topMargin: 4 * virtualstudio.uiScale
                         enabled: virtualstudio.connectionState == "Connected"
-                        model: inputChannelsComboModel
+                        model: virtualstudio.inputChannelsComboModel
                         currentIndex: (() => {
-                            let idx = inputChannelsComboModel.findIndex(elem => elem.baseChannel === virtualstudio.baseInputChannel
+                            let idx = virtualstudio.inputChannelsComboModel.findIndex(elem => elem.baseChannel === virtualstudio.baseInputChannel
                                 && elem.numChannels === virtualstudio.numInputChannels);
                             if (idx < 0) {
                                 idx = 0;
@@ -642,9 +642,9 @@ Item {
                         anchors.top: inputMixModeLabel.bottom
                         anchors.topMargin: 4 * virtualstudio.uiScale
                         enabled: virtualstudio.connectionState == "Connected"
-                        model: inputMixModeComboModel
+                        model: virtualstudio.inputMixModeComboModel
                         currentIndex: (() => {
-                            let idx = inputMixModeComboModel.findIndex(elem => elem.value === virtualstudio.inputMixMode);
+                            let idx = virtualstudio.inputMixModeComboModel.findIndex(elem => elem.value === virtualstudio.inputMixMode);
                             if (idx < 0) {
                                 idx = 0;
                             }
@@ -663,7 +663,7 @@ Item {
                                 onClicked: {
                                     inputMixModeCombo.currentIndex = index
                                     inputMixModeCombo.popup.close()
-                                    virtualstudio.inputMixMode = inputMixModeComboModel[index].value
+                                    virtualstudio.inputMixMode = virtualstudio.inputMixModeComboModel[index].value
                                     virtualstudio.validateDevicesState()
                                 }
                             }

--- a/src/gui/Settings.qml
+++ b/src/gui/Settings.qml
@@ -46,12 +46,12 @@ Item {
 
     function getCurrentInputDeviceIndex () {
         if (virtualstudio.inputDevice === "") {
-            return inputComboModel.findIndex(elem => elem.type === "element");
+            return virtualstudio.inputComboModel.findIndex(elem => elem.type === "element");
         }
 
-        let idx = inputComboModel.findIndex(elem => elem.type === "element" && elem.text === virtualstudio.inputDevice);
+        let idx = virtualstudio.inputComboModel.findIndex(elem => elem.type === "element" && elem.text === virtualstudio.inputDevice);
         if (idx < 0) {
-            idx = inputComboModel.findIndex(elem => elem.type === "element");
+            idx = virtualstudio.inputComboModel.findIndex(elem => elem.type === "element");
         }
 
         return idx;
@@ -59,12 +59,12 @@ Item {
 
     function getCurrentOutputDeviceIndex() {
         if (virtualstudio.outputDevice === "") {
-            return outputComboModel.findIndex(elem => elem.type === "element");
+            return virtualstudio.outputComboModel.findIndex(elem => elem.type === "element");
         }
 
-        let idx = outputComboModel.findIndex(elem => elem.type === "element" && elem.text === virtualstudio.outputDevice);
+        let idx = virtualstudio.outputComboModel.findIndex(elem => elem.type === "element" && elem.text === virtualstudio.outputDevice);
         if (idx < 0) {
-            idx = outputComboModel.findIndex(elem => elem.type === "element");
+            idx = virtualstudio.outputComboModel.findIndex(elem => elem.type === "element");
         }
 
         return idx;

--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -53,7 +53,7 @@
 #include "../Meter.h"
 #include "../Reverb.h"
 
-QJackTrip::QJackTrip(Settings* settings, bool suppressCommandlineWarning, QWidget* parent)
+QJackTrip::QJackTrip(QWidget* parent)
     : QMainWindow(parent)
     , m_ui(new Ui::QJackTrip)
     , m_netManager(new QNetworkAccessManager(this))
@@ -291,7 +291,16 @@ QJackTrip::QJackTrip(Settings* settings, bool suppressCommandlineWarning, QWidge
         m_ui->optionsTabWidget->removeTab(tabIndex);
     }
 #endif
+}
 
+QJackTrip::QJackTrip(Settings* settings, bool suppressCommandlineWarning, QWidget* parent)
+    : QJackTrip(parent)
+{
+    init(settings, suppressCommandlineWarning);
+}
+
+void QJackTrip::init(Settings* settings, bool suppressCommandlineWarning)
+{
     migrateSettings();
     loadSettings(settings);
 

--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -432,7 +432,6 @@ void QJackTrip::showEvent(QShowEvent* event)
             settings.endGroup();
         } else {
             // If we've fallen back to RtAudio before and JACK is now installed, use JACK.
-            QSettings settings;
             settings.beginGroup(QStringLiteral("Audio"));
             if (settings.value(QStringLiteral("UsingFallback"), false).toBool()) {
                 m_ui->backendComboBox->setCurrentIndex(0);

--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -53,7 +53,8 @@
 #include "../Meter.h"
 #include "../Reverb.h"
 
-QJackTrip::QJackTrip(QSharedPointer<Settings> settings, bool suppressCommandlineWarning, QWidget* parent)
+QJackTrip::QJackTrip(QSharedPointer<Settings> settings, bool suppressCommandlineWarning,
+                     QWidget* parent)
     : QMainWindow(parent)
     , m_ui(new Ui::QJackTrip)
     , m_netManager(new QNetworkAccessManager(this))
@@ -400,8 +401,8 @@ void QJackTrip::showEvent(QShowEvent* event)
             }
             m_ui->typeComboBox->removeItem(HUB_SERVER);
             m_ui->backendWarningLabel->setText(
-                "JACK was not found. This means that only the RtAudio backend is available "
-                "and that JackTrip cannot be run in hub server mode.");
+                "JACK was not found. This means that only the RtAudio backend is "
+                "available and that JackTrip cannot be run in hub server mode.");
 
             QSettings settings;
             settings.beginGroup(QStringLiteral("Audio"));
@@ -442,8 +443,8 @@ void QJackTrip::showEvent(QShowEvent* event)
             QMessageBox msgBox;
             msgBox.setText(
                 "An installation of JACK was not found, and no other audio backends are "
-                "available. JackTrip will not be able to start. (Please install JACK to fix "
-                "this.)");
+                "available. JackTrip will not be able to start. (Please install JACK to "
+                "fix this.)");
             msgBox.setWindowTitle("JACK Not Available");
             msgBox.exec();
 #endif  // RT_AUDIO

--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -365,6 +365,7 @@ void QJackTrip::showEvent(QShowEvent* event)
     // VirtualStudio window is shown first.
     QMainWindow::showEvent(event);
     if (m_firstShow) {
+        QSettings settings;
         loadSettings(m_cliSettings.data());
 
         // Display a warning about any ignored command line options.
@@ -404,7 +405,6 @@ void QJackTrip::showEvent(QShowEvent* event)
                 "JACK was not found. This means that only the RtAudio backend is "
                 "available and that JackTrip cannot be run in hub server mode.");
 
-            QSettings settings;
             settings.beginGroup(QStringLiteral("Audio"));
             if (!settings.value(QStringLiteral("HideJackWarning"), false).toBool()) {
                 QCheckBox* dontBugMe =
@@ -451,7 +451,6 @@ void QJackTrip::showEvent(QShowEvent* event)
         }
 #endif  // USE_WEAK_JACK
 
-        QSettings settings;
         settings.beginGroup(QStringLiteral("Window"));
         QByteArray geometry = settings.value(QStringLiteral("Geometry")).toByteArray();
         if (geometry.size() > 0) {

--- a/src/gui/qjacktrip.h
+++ b/src/gui/qjacktrip.h
@@ -66,8 +66,9 @@ class QJackTrip : public QMainWindow
     Q_OBJECT
 
    public:
-    explicit QJackTrip(QSharedPointer<Settings> settings, bool suppressCommandlineWarning = false,
-                       QWidget* parent = nullptr);
+    explicit QJackTrip(QSharedPointer<Settings> settings,
+                       bool suppressCommandlineWarning = false,
+                       QWidget* parent                 = nullptr);
     ~QJackTrip() override;
 
     void closeEvent(QCloseEvent* event) override;

--- a/src/gui/qjacktrip.h
+++ b/src/gui/qjacktrip.h
@@ -66,12 +66,10 @@ class QJackTrip : public QMainWindow
     Q_OBJECT
 
    public:
-    explicit QJackTrip(QWidget* parent = nullptr);
-    explicit QJackTrip(Settings* settings, bool suppressCommandlineWarning = false,
+    explicit QJackTrip(QSharedPointer<Settings> settings, bool suppressCommandlineWarning = false,
                        QWidget* parent = nullptr);
     ~QJackTrip() override;
 
-    void init(Settings* settings, bool suppressCommandlineWarning = false);
     void closeEvent(QCloseEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;
     void showEvent(QShowEvent* event) override;
@@ -144,6 +142,9 @@ class QJackTrip : public QMainWindow
     bool m_isExiting;
     bool m_exitSent;
 
+    QSharedPointer<Settings> m_cliSettings;
+    bool m_suppressCommandlineWarning;
+
     float m_meterMax = 0.0;
     float m_meterMin = -64.0;
 
@@ -160,9 +161,7 @@ class QJackTrip : public QMainWindow
 
     QLabel m_autoQueueIndicator;
     bool m_hideWarning;
-    bool m_audioFallback       = false;
-    bool m_usingRtAudioAlready = false;
-    bool m_firstShow           = true;
+    bool m_firstShow = true;
 
 #ifndef NO_VS
     QSharedPointer<VirtualStudio> m_vs;

--- a/src/gui/qjacktrip.h
+++ b/src/gui/qjacktrip.h
@@ -66,10 +66,12 @@ class QJackTrip : public QMainWindow
     Q_OBJECT
 
    public:
+    explicit QJackTrip(QWidget* parent = nullptr);
     explicit QJackTrip(Settings* settings, bool suppressCommandlineWarning = false,
                        QWidget* parent = nullptr);
     ~QJackTrip() override;
 
+    void init(Settings* settings, bool suppressCommandlineWarning = false);
     void closeEvent(QCloseEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;
     void showEvent(QShowEvent* event) override;

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -215,9 +215,8 @@ VirtualStudio::VirtualStudio(bool firstRun, QObject* parent)
     }
 #else
     m_selectableBackend = false;
-    m_vsAudioInterface.reset(new VsAudioInterface());
-
     QJsonObject element;
+
     element.insert(QString::fromStdString("label"), QString::fromStdString("Mono"));
     element.insert(QString::fromStdString("value"),
                    static_cast<int>(AudioInterface::MONO));

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -46,6 +46,7 @@
 #include <algorithm>
 #include <iostream>
 
+#include "../Settings.h"
 #include "../jacktrip_globals.h"
 #include "about.h"
 #include "qjacktrip.h"
@@ -1150,7 +1151,9 @@ void VirtualStudio::joinStudio()
 void VirtualStudio::toStandard()
 {
     if (!m_standardWindow.isNull()) {
+        Settings jtSettings;
         m_view.hide();
+        m_standardWindow->init(&jtSettings);
         m_standardWindow->show();
         m_vsModeActive = false;
     }

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1150,9 +1150,7 @@ void VirtualStudio::joinStudio()
 void VirtualStudio::toStandard()
 {
     if (!m_standardWindow.isNull()) {
-        Settings jtSettings;
         m_view.hide();
-        m_standardWindow->init(&jtSettings);
         m_standardWindow->show();
         m_vsModeActive = false;
     }

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -158,6 +158,16 @@ class VirtualStudio : public QObject
                    updatedOutputMeterLevels)
     Q_PROPERTY(QVector<float> inputMeterLevels READ inputMeterLevels NOTIFY
                    updatedInputMeterLevels)
+    Q_PROPERTY(
+        QJsonArray inputComboModel READ inputComboModel NOTIFY inputComboModelChanged)
+    Q_PROPERTY(
+        QJsonArray outputComboModel READ outputComboModel NOTIFY outputComboModelChanged)
+    Q_PROPERTY(QJsonArray inputChannelsComboModel READ inputChannelsComboModel NOTIFY
+                   inputChannelsComboModelChanged)
+    Q_PROPERTY(QJsonArray outputChannelsComboModel READ outputChannelsComboModel NOTIFY
+                   outputChannelsComboModelChanged)
+    Q_PROPERTY(QJsonArray inputMixModeComboModel READ inputMixModeComboModel NOTIFY
+                   inputMixModeComboModelChanged)
     Q_PROPERTY(bool inputClipped READ inputClipped NOTIFY updatedInputClipped)
     Q_PROPERTY(bool outputClipped READ outputClipped NOTIFY updatedOutputClipped)
     Q_PROPERTY(bool audioActivated READ audioActivated WRITE setAudioActivated NOTIFY
@@ -228,6 +238,11 @@ class VirtualStudio : public QObject
     QJsonObject networkStats();
     const QVector<float>& inputMeterLevels() const;
     const QVector<float>& outputMeterLevels() const;
+    const QJsonArray& inputComboModel() const;
+    const QJsonArray& outputComboModel() const;
+    const QJsonArray& inputChannelsComboModel() const;
+    const QJsonArray& outputChannelsComboModel() const;
+    const QJsonArray& inputMixModeComboModel() const;
     QString updateChannel();
     void setUpdateChannel(const QString& channel);
     bool showInactive();
@@ -366,6 +381,11 @@ class VirtualStudio : public QObject
     void updatedMonitorMuted(bool muted);
     void updatedInputMeterLevels(const QVector<float>& levels);
     void updatedOutputMeterLevels(const QVector<float>& levels);
+    void inputComboModelChanged();
+    void outputComboModelChanged();
+    void inputChannelsComboModelChanged();
+    void outputChannelsComboModelChanged();
+    void inputMixModeComboModelChanged();
     void updatedInputClipped(bool clip);
     void updatedOutputClipped(bool clip);
     void updatedNetworkOutage(bool outage);
@@ -405,8 +425,8 @@ class VirtualStudio : public QObject
     void stopAudio();
     bool readyToJoin();
 #ifdef RT_AUDIO
-    QVariant formatDeviceList(const QStringList& devices, const QStringList& categories,
-                              const QList<int>& channels);
+    QJsonArray formatDeviceList(const QStringList& devices, const QStringList& categories,
+                                const QList<int>& channels);
 #endif
 
     bool m_showFirstRun = false;
@@ -476,6 +496,11 @@ class VirtualStudio : public QObject
     Analyzer* m_outputAnalyzerPlugin;
     QVector<float> m_inputMeterLevels;
     QVector<float> m_outputMeterLevels;
+    QJsonArray m_inputComboModel;
+    QJsonArray m_outputComboModel;
+    QJsonArray m_inputChannelsComboModel;
+    QJsonArray m_outputChannelsComboModel;
+    QJsonArray m_inputMixModeComboModel;
     Meter* m_inputMeter;
     Meter* m_outputMeter;
     Meter* m_inputTestMeter;

--- a/src/gui/vsAudioInterface.h
+++ b/src/gui/vsAudioInterface.h
@@ -39,9 +39,11 @@
 #define VSDAUDIOINTERFACE_H
 
 #include <QDebug>
+#include <QList>
 #include <QObject>
 #include <QSharedPointer>
 #include <QString>
+#include <QStringList>
 
 #ifndef NO_JACK
 #include "../JackAudioInterface.h"
@@ -94,15 +96,16 @@ class VsAudioInterface : public QObject
 
    public slots:
     void setInputDevice(QString deviceName, bool shouldRestart = true);
+    void setOutputDevice(QString deviceName, bool shouldRestart = true);
 #ifdef RT_AUDIO
     void setBaseInputChannel(int baseChannel, bool shouldRestart = true);
     void setNumInputChannels(int numChannels, bool shouldRestart = true);
     void setInputMixMode(const int mode, bool shouldRestart = true);
-#endif
-    void setOutputDevice(QString deviceName, bool shouldRestart = true);
-#ifdef RT_AUDIO
     void setBaseOutputChannel(int baseChannel, bool shouldRestart = true);
     void setNumOutputChannels(int numChannels, bool shouldRestart = true);
+    void refreshRtAudioDevices();
+    void getDeviceList(QStringList* list, QStringList* categories, QList<int>* channels,
+                       bool isInput);
 #endif
     void setAudioInterfaceMode(bool useRtAudio, bool shouldRestart = true);
     void setInputVolume(float multiplier);
@@ -163,6 +166,10 @@ class VsAudioInterface : public QObject
     Volume* m_inputVolumePlugin;
     Volume* m_outputVolumePlugin;
     Tone* m_outputTonePlugin;
+
+#ifdef RT_AUDIO
+    QVector<RtAudioDevice> m_devices;
+#endif
 
     void updateDevicesErrorMsg(const QString& msg);
     void updateDevicesWarningMsg(const QString& msg);

--- a/src/gui/vsAuth.cpp
+++ b/src/gui/vsAuth.cpp
@@ -92,7 +92,8 @@ void VsAuth::fetchUserInfo(QString accessToken)
     QNetworkReply* reply = m_api->getAuth0UserInfo();
     connect(reply, &QNetworkReply::finished, this, [=]() {
         if (reply->error() != QNetworkReply::NoError) {
-            std::cout << "Error: " << reply->errorString().toStdString() << std::endl;
+            std::cout << "VsAuth::fetchUserInfo Error: "
+                      << reply->errorString().toStdString() << std::endl;
             handleAuthFailed();  // handle failure
             emit fetchUserInfoFailed();
             reply->deleteLater();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -327,7 +327,9 @@ int main(int argc, char* argv[])
         vsInit.reset(new VsInit());
         vsInit->checkForInstance(deeplink);
 #endif  // _WIN32
-        window.reset(new QJackTrip(&cliSettings, !deeplink.isEmpty()));
+        window.reset(new QJackTrip());
+        if (uiMode == QJackTrip::STANDARD)
+            window->init(&cliSettings, !deeplink.isEmpty());
 #else
         window.reset(new QJackTrip(&cliSettings));
 #endif  // NO_VS

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -308,8 +308,9 @@ int main(int argc, char* argv[])
         app->setApplicationName(QStringLiteral("JackTrip"));
         app->setApplicationVersion(gVersion);
 
-        Settings cliSettings(true);
-        cliSettings.parseInput(argc, argv);
+        QSharedPointer<Settings> cliSettings;
+        cliSettings.reset(new Settings(true));
+        cliSettings->parseInput(argc, argv);
 
 #ifndef NO_VS
         // Register clipboard Qml type
@@ -327,11 +328,9 @@ int main(int argc, char* argv[])
         vsInit.reset(new VsInit());
         vsInit->checkForInstance(deeplink);
 #endif  // _WIN32
-        window.reset(new QJackTrip());
-        if (uiMode == QJackTrip::STANDARD)
-            window->init(&cliSettings, !deeplink.isEmpty());
+        window.reset(new QJackTrip(cliSettings, !deeplink.isEmpty()));
 #else
-        window.reset(new QJackTrip(&cliSettings));
+        window.reset(new QJackTrip(cliSettings));
 #endif  // NO_VS
         QObject::connect(window.data(), &QJackTrip::signalExit, app.data(),
                          &QCoreApplication::quit, Qt::QueuedConnection);


### PR DESCRIPTION
I suspect this was causing a lot of problems on windows, but at a minimum this should significantly reduce Windows startup time and improves responsiveness when using RTAudio.

It now only scans interfaces when necessary, and not before trying to log into Virtual Studio (which caused what looks like login failures when there are actually audio interface issues). It also now logs whenever it is scanning devices, and prints out the results.

Eliminated duplicated code by caching the results of device scans.

Fixed some qml bugs/warnings with classic mode and eliminates rootContext()->setContextProperty() calls moving things into QObject properties.

    Defer settings and audio initialization outside of QJackTrip constructor

    There currently is a strange coupling between the QJackTrip gui and the
    Virtual Studio gui, such that they are both running at the same time.
    This should probably be addressed, but is for another PR..

    This one simple defers the settings initialization for QJackTrip, which
    includes RTAudio initialization and scanning, so that it is only done
    when the QJackTrip interface is being used.

    Previously, QJackTrip would try to run RTAudio device scans even before
    the initial window was painted. This likely conflicted with the same
    work being performed by the Virtual Studio interface. At best, this
    would cause unnecessary delays at startup. At worst, I believe it was
    causing crashes on Windows, especially when there are ASIO drivers
    present, since that framework seems to be extremely brittle and touchy.
