### PR TITLE
Add a friendly message to the empty window created by the Windows Terminal bug

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -300,6 +300,14 @@ int main(int argc, char* argv[])
         // Remove the console that appears if we're on windows and not running from a
         // command line.
         if (!isRunFromCmd()) {
+            std::cout << "This extra window is caused by a bug in Microsoft Windows. "
+                      << "It can safely be ignored or closed." << std::endl
+                      << std::endl
+                      << "To fix this bug, please upgrade to the latest version of "
+                      << "Windows Terminal available in the Microsoft App Store:"
+                      << std::endl
+                      << "https://aka.ms/terminal" << std::endl;
+
             FreeConsole();
         }
 #endif  // _WIN32


### PR DESCRIPTION
This bug is now finally fixed via upgrade.

Note that the only people who would ever see this are the ones who still have the faulty Terminal application installed.

![Screenshot (1)](https://github.com/jacktrip/jacktrip/assets/1159596/05572793-4bab-424d-9ecf-321d8694c7e0)

