### PR TITLE
Fixing bug with "Change Device Settings" dialog being empty

### DIFF
--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1946,11 +1946,15 @@ void VirtualStudio::slotAuthSucceeded()
     m_device = new VsDevice(m_auth.data(), m_api.data());
     m_device->registerApp();
 
-    if (m_showDeviceSetup) {
-        if constexpr (isBackendAvailable<AudioInterfaceMode::JACK>()
-                      || isBackendAvailable<AudioInterfaceMode::RTAUDIO>()) {
-            setAudioActivated(true);
-        }
+    // always activate audio at startup for now.
+    // otherwise, IF someone has the device setup disabled/unchecked,
+    // AND IF they don't manually navigate to audio settings before connecting,
+    // the "Change Device Settings" dialog will have all empty dropdown lists
+    // TODO: rework so it can be deferred properly
+    // if (m_showDeviceSetup) {
+    if constexpr (isBackendAvailable<AudioInterfaceMode::JACK>()
+                  || isBackendAvailable<AudioInterfaceMode::RTAUDIO>()) {
+        setAudioActivated(true);
     }
 
     getUserId();


### PR DESCRIPTION
This is a regression from other recent changes. If you disable showing the audio settings at startup, and you connect to a studio without first manually opening the audio settings, the "Change Device Settings" dialog would have all empty dropdown lists.