### PR TITLE
Updating styles of meter bars to be responsive

### DIFF
--- a/src/gui/Meter.qml
+++ b/src/gui/Meter.qml
@@ -4,17 +4,17 @@ import QtGraphicalEffects 1.12
 
 Item {
     required property var model
-    property int bins: 15
+    property int bins: Math.max(15, width/20)
     property int innerMargin: 2 * virtualstudio.uiScale
-    property int clipWidth: 10 * virtualstudio.uiScale
+    property int clipWidth: 8 * virtualstudio.uiScale
+    property int boxRadius: 4 * virtualstudio.uiScale
     required property bool clipped
     property bool enabled: true
-    property string meterColor: enabled ? (virtualstudio.darkMode ? "#5B5858" : "#D3D4D4") : "#EAECEC"
+    property string meterColor: enabled ? (virtualstudio.darkMode ? "#5B5858" : "#D3D4D4") : (virtualstudio.darkMode ? "#7b7979" : "#EAECEC")
     property string meterRed: "#F21B1B"
 
     Item {
         id: meters
-        x: 0; y: 0
         width: parent.width - clipWidth
         height: parent.height
 
@@ -22,8 +22,8 @@ Item {
             id: leftchannel
             x: 0;
             y: 0;
-            width: parent.width - clipWidth
-            height: 14 * virtualstudio.uiScale
+            width: parent.width
+            height: Math.min((parent.height/2 - innerMargin/2), 12) * virtualstudio.uiScale
             level: parent.parent.model[0]
             enabled: parent.parent.enabled
         }
@@ -31,9 +31,10 @@ Item {
         MeterBars {
             id: rightchannel
             x: 0;
-            y: leftchannel.height
-            width: parent.width - clipWidth
-            height: 14 * virtualstudio.uiScale
+            anchors.top: leftchannel.bottom
+            anchors.topMargin: innerMargin
+            width: parent.width
+            height: Math.min((parent.height/2 - innerMargin/2), 12) * virtualstudio.uiScale
             level: parent.parent.model[1]
             enabled: parent.parent.enabled
         }
@@ -41,10 +42,13 @@ Item {
 
     Rectangle {
         id: clipIndicator
-        x: meters.x + meters.width; y: 0
-        width: Math.min(clipWidth, ((parent.width - clipWidth) / bins) - innerMargin)
-        height: 24 * virtualstudio.uiScale
-        radius: 4 * virtualstudio.uiScale
+        y: 0
+        anchors.left: meters.right
+        anchors.leftMargin: innerMargin
+
+        width: Math.min(leftchannel.height, ((parent.width - clipWidth) / bins) - innerMargin)
+        height: leftchannel.height + rightchannel.height + innerMargin
+        radius: boxRadius
         color: clipped ? meterRed : meterColor
     }
 }

--- a/src/gui/MeterBars.qml
+++ b/src/gui/MeterBars.qml
@@ -1,19 +1,17 @@
 import QtQuick 2.12
 import QtQuick.Controls 2.12
+import QtQuick.Layouts 1.15
 import QtGraphicalEffects 1.12
 
 Item {
     required property var level
     required property var enabled
-    property int bins: 15
-    property int innerMargin: 2 * virtualstudio.uiScale
-    property int boxHeight: 10 * virtualstudio.uiScale
+    property int boxHeight: height
     property int boxWidth: (width / bins) - innerMargin
-    property int boxRadius: 4 * virtualstudio.uiScale
-    property string meterColor: enabled ? (virtualstudio.darkMode ? "#5B5858" : "#D3D4D4") : "#EAECEC"
-    property string meterGreen: "#61C554"
-    property string meterYellow: "#F5BF4F"
-    property string meterRed: "#F21B1B"
+    property string meterColor: enabled ? (virtualstudio.darkMode ? "5B5858" : "D3D4D4") : (virtualstudio.darkMode ? "7b7979" : "EAECEC")
+    property string meterGreen: "61C554"
+    property string meterYellow: "F5BF4F"
+    property string meterRed: "F21B1B"
 
     function getBoxColor (idx) {
         // Case where the meter should not be filled
@@ -22,161 +20,39 @@ Item {
         }
         // Case where the meter should be filled
         let fillColor = meterGreen;
-        if (idx > 8 && idx <= 11) {
+        if (idx > 0.5*bins && idx <= 0.8*bins) {
             fillColor = meterYellow;
-        } else if (idx > 11) {
+        } else if (idx > 0.8*bins) {
             fillColor = meterRed;
         }
         return fillColor;
     }
 
-    Rectangle {
-        id: box0
-        x: 0;
-        y: 0;
-        width: boxWidth
-        height: boxHeight
-        color: getBoxColor(0)
-        radius: boxRadius
-    }
+    RowLayout {
+        anchors.fill: parent
+        spacing: innerMargin
 
-    Rectangle {
-        id: box1
-        x: boxWidth + innerMargin;
-        y: 0;
-        width: boxWidth
-        height: boxHeight
-        color: getBoxColor(1)
-        radius: boxRadius
-    }
-
-    Rectangle {
-        id: box2
-        x: (boxWidth) * 2 + innerMargin * 2;
-        y: 0;
-        width: boxWidth
-        height: boxHeight
-        color: getBoxColor(2)
-        radius: boxRadius
-    }
-
-    Rectangle {
-        id: box3
-        x: (boxWidth) * 3 + innerMargin * 3;
-        y: 0;
-        width: boxWidth
-        height: boxHeight
-        color: getBoxColor(3)
-        radius: boxRadius
-    }
-
-    Rectangle {
-        id: box4
-        x: (boxWidth) * 4 + innerMargin * 4;
-        y: 0;
-        width: boxWidth
-        height: boxHeight
-        color: getBoxColor(4)
-        radius: boxRadius
-    }
-
-    Rectangle {
-        id: box5
-        x: (boxWidth) * 5 + innerMargin * 5;
-        y: 0;
-        width: boxWidth
-        height: boxHeight
-        color: getBoxColor(5)
-        radius: boxRadius
-    }
-
-    Rectangle {
-        id: box6
-        x: (boxWidth) * 6 + innerMargin * 6;
-        y: 0;
-        width: boxWidth
-        height: boxHeight
-        color: getBoxColor(6)
-        radius: boxRadius
-    }
-
-    Rectangle {
-        id: box7
-        x: (boxWidth) * 7 + innerMargin * 7;
-        y: 0;
-        width: boxWidth
-        height: boxHeight
-        color: getBoxColor(7)
-        radius: boxRadius
-    }
-
-    Rectangle {
-        id: box8
-        x: (boxWidth) * 8 + innerMargin * 8;
-        y: 0;
-        width: boxWidth
-        height: boxHeight
-        color: getBoxColor(8)
-        radius: boxRadius
-    }
-
-    Rectangle {
-        id: box9
-        x: (boxWidth) * 9 + innerMargin * 9;
-        y: 0;
-        width: boxWidth
-        height: boxHeight
-        color: getBoxColor(9)
-        radius: boxRadius
-    }
-
-    Rectangle {
-        id: box10
-        x: (boxWidth) * 10 + innerMargin * 10;
-        y: 0;
-        width: boxWidth
-        height: boxHeight
-        color: getBoxColor(10)
-        radius: boxRadius
-    }
-
-    Rectangle {
-        id: box11
-        x: (boxWidth) * 11 + innerMargin * 11;
-        y: 0;
-        width: boxWidth
-        height: boxHeight
-        color: getBoxColor(11)
-        radius: boxRadius
-    }
-
-    Rectangle {
-        id: box12
-        x: (boxWidth) * 12 + innerMargin * 12;
-        y: 0;
-        width: boxWidth
-        height: boxHeight
-        color: getBoxColor(12)
-        radius: boxRadius
-    }
-
-    Rectangle {
-        id: box13
-        x: (boxWidth) * 13 + innerMargin * 13;
-        y: 0;
-        width: boxWidth
-        height: boxHeight
-        color: getBoxColor(13)
-        radius: boxRadius
-    }
-
-    Rectangle {
-        id: box14
-        x: (boxWidth) * 14 + innerMargin * 14;
-        y: 0;
-        width: boxWidth
-        height: boxHeight
-        color: getBoxColor(14)
-        radius: boxRadius
+        Repeater {
+            model: bins
+            Rectangle {
+                Layout.fillHeight: true
+                Layout.fillWidth: true
+                x: (boxWidth) * index + innerMargin * index;
+                y: 0
+                z: 1
+                width: boxWidth
+                height: boxHeight
+                color: `#${getBoxColor(index)}`
+                radius: boxRadius
+                layer.enabled: getBoxColor(index) != meterColor
+                layer.effect: Glow {
+                    radius: 6
+                    samples: 13
+                    color: `#66${getBoxColor(index)}`
+                    transparentBorder: true
+                    visible: getBoxColor(index) != meterColor
+                }
+            }
+        }
     }
 }

--- a/src/gui/MeterBars.qml
+++ b/src/gui/MeterBars.qml
@@ -8,10 +8,10 @@ Item {
     required property var enabled
     property int boxHeight: height
     property int boxWidth: (width / bins) - innerMargin
-    property string meterColor: enabled ? (virtualstudio.darkMode ? "5B5858" : "D3D4D4") : (virtualstudio.darkMode ? "7b7979" : "EAECEC")
-    property string meterGreen: "61C554"
-    property string meterYellow: "F5BF4F"
-    property string meterRed: "F21B1B"
+    property string meterColor: enabled ? (virtualstudio.darkMode ? "#5B5858" : "#D3D4D4") : (virtualstudio.darkMode ? "#7b7979" : "#EAECEC")
+    property string meterGreen: "#61C554"
+    property string meterYellow: "#F5BF4F"
+    property string meterRed: "#F21B1B"
 
     function getBoxColor (idx) {
         // Case where the meter should not be filled
@@ -42,16 +42,8 @@ Item {
                 z: 1
                 width: boxWidth
                 height: boxHeight
-                color: `#${getBoxColor(index)}`
+                color: getBoxColor(index)
                 radius: boxRadius
-                layer.enabled: getBoxColor(index) != meterColor
-                layer.effect: Glow {
-                    radius: 6
-                    samples: 13
-                    color: `#66${getBoxColor(index)}`
-                    transparentBorder: true
-                    visible: getBoxColor(index) != meterColor
-                }
             }
         }
     }


### PR DESCRIPTION
Adds a faint glow when bars are lit up, and also makes the bars scale responsively + fill in any gaps when the width changes.


https://github.com/jacktrip/jacktrip/assets/6201822/8d255365-b959-4c0a-bf31-1466b016c536

