### PR TITLE
Fixing device levels on registration

### DIFF
--- a/src/gui/AudioSettings.qml
+++ b/src/gui/AudioSettings.qml
@@ -70,7 +70,7 @@ Rectangle {
 
     Loader {
         anchors.fill: parent
-        sourceComponent: isUsingRtAudio ? usingRtAudio : (isUsingJack ? usingJACK : noBackend)
+        sourceComponent: Boolean(audioInterface) ? (isUsingRtAudio ? usingRtAudio : (isUsingJack ? usingJACK : noBackend)) : noBackend
     }
 
     Component {
@@ -237,7 +237,7 @@ Rectangle {
             Slider {
                 id: outputSlider
                 from: 0.0
-                value: audioInterface ? audioInterface.outputVolume : 0.5
+                value: audioInterface.outputVolume
                 onMoved: { audioInterface.outputVolume = value }
                 to: 1.0
                 padding: 0
@@ -546,7 +546,7 @@ Rectangle {
             Slider {
                 id: inputSlider
                 from: 0.0
-                value: audioInterface ? audioInterface.inputVolume : 0.5
+                value: audioInterface.inputVolume
                 onMoved: { audioInterface.inputVolume = value }
                 to: 1.0
                 padding: 0
@@ -896,7 +896,7 @@ Rectangle {
             Slider {
                 id: jackOutputVolumeSlider
                 from: 0.0
-                value: audioInterface ? audioInterface.outputVolume : 0.5
+                value: audioInterface.outputVolume
                 onMoved: { audioInterface.outputVolume = value }
                 to: 1.0
                 padding: 0
@@ -1018,7 +1018,7 @@ Rectangle {
             Slider {
                 id: jackInputVolumeSlider
                 from: 0.0
-                value: audioInterface ? audioInterface.inputVolume : 0.5
+                value: audioInterface.inputVolume
                 onMoved: { audioInterface.inputVolume = value }
                 to: 1.0
                 padding: 0

--- a/src/gui/Connected.qml
+++ b/src/gui/Connected.qml
@@ -1000,7 +1000,7 @@ Item {
         Slider {
             id: inputSlider
             from: 0.0
-            value: virtualstudio ? virtualstudio.inputVolume : 0.5
+            value: virtualstudio.inputVolume
             onMoved: { virtualstudio.inputVolume = value }
             to: 1.0
             enabled: !virtualstudio.inputMuted
@@ -1186,7 +1186,7 @@ Item {
         Slider {
             id: outputSlider
             from: 0.0
-            value: virtualstudio ? virtualstudio.outputVolume : 0.5
+            value: virtualstudio.outputVolume
             onMoved: { virtualstudio.outputVolume = value }
             to: 1.0
             padding: 0
@@ -1227,7 +1227,7 @@ Item {
         Slider {
             id: monitorSlider
             from: 0.0
-            value: virtualstudio ? virtualstudio.monitorVolume : 0.5
+            value: virtualstudio.monitorVolume
             onMoved: { virtualstudio.monitorVolume = value }
             to: 1.0
             padding: 0

--- a/src/gui/Settings.qml
+++ b/src/gui/Settings.qml
@@ -78,7 +78,7 @@ Item {
         y: header.height
         visible: settingsGroupView == "Audio"
 
-        AudioSettings{
+        AudioSettings {
             id: audioSettings
         }
     }


### PR DESCRIPTION
I think this fixes some of the level settings behavior across different parts of the app.

Fixes here include:
* When switching between prod/test, move app de-registration before revoking the authorization token. I noticed I had a lot of "stale" app devices registered so I don't think these was being cleaned up properly
* Changing input + output volume in Setup view should get reflected in the Connected/Settings views
* Changing input + output volume in Settings view should get reflected in the Connected/Setup views
* Changing input + output volume in Connected view should get reflected in the Setup/Settings views
