### PR TITLE
Fixing slider jitter due to int/float casting

### DIFF
--- a/src/gui/AudioSettings.qml
+++ b/src/gui/AudioSettings.qml
@@ -240,6 +240,7 @@ Rectangle {
                 value: audioInterface.outputVolume
                 onMoved: { audioInterface.outputVolume = value }
                 to: 1.0
+                stepSize: 0.01
                 padding: 0
                 anchors.left: outputQuieterIcon.right
                 anchors.leftMargin: 8 * virtualstudio.uiScale
@@ -549,6 +550,7 @@ Rectangle {
                 value: audioInterface.inputVolume
                 onMoved: { audioInterface.inputVolume = value }
                 to: 1.0
+                stepSize: 0.01
                 padding: 0
                 anchors.left: inputQuieterIcon.right
                 anchors.leftMargin: 8 * virtualstudio.uiScale
@@ -899,6 +901,7 @@ Rectangle {
                 value: audioInterface.outputVolume
                 onMoved: { audioInterface.outputVolume = value }
                 to: 1.0
+                stepSize: 0.01
                 padding: 0
                 anchors.left: jackOutputQuieterButton.right
                 anchors.leftMargin: 8 * virtualstudio.uiScale
@@ -1021,6 +1024,7 @@ Rectangle {
                 value: audioInterface.inputVolume
                 onMoved: { audioInterface.inputVolume = value }
                 to: 1.0
+                stepSize: 0.01
                 padding: 0
                 anchors.left: jackInputQuieterButton.right
                 anchors.leftMargin: 8 * virtualstudio.uiScale

--- a/src/gui/Connected.qml
+++ b/src/gui/Connected.qml
@@ -965,6 +965,7 @@ Item {
             value: virtualstudio.inputVolume
             onMoved: { virtualstudio.inputVolume = value }
             to: 1.0
+            stepSize: 0.01
             enabled: !virtualstudio.inputMuted
             padding: 0
             y: inputDeviceMeters.y + 36 * virtualstudio.uiScale
@@ -1151,6 +1152,7 @@ Item {
             value: virtualstudio.outputVolume
             onMoved: { virtualstudio.outputVolume = value }
             to: 1.0
+            stepSize: 0.01
             padding: 0
             y: outputDeviceMeters.y + 36 * virtualstudio.uiScale
             anchors.left: outputDeviceMeters.left
@@ -1192,6 +1194,7 @@ Item {
             value: virtualstudio.monitorVolume
             onMoved: { virtualstudio.monitorVolume = value }
             to: 1.0
+            stepSize: 0.01
             padding: 0
             y: outputSlider.y + 36 * virtualstudio.uiScale
             anchors.left: outputDeviceMeters.left


### PR DESCRIPTION
As a result of https://github.com/jacktrip/jacktrip/pull/1087, I think there's some jitter in the slider that occurs due to the precision in the way we interpret volume in the API as an int and the value interpreted by the slider components as a real number. This should fix it.