### PR TITLE
Making mute button darker

### DIFF
--- a/src/gui/DeviceControls.qml
+++ b/src/gui/DeviceControls.qml
@@ -9,6 +9,8 @@ Item {
     clip: true
 
     required property bool isInput
+    property string muteButtonMutedColor: "#FCB6B6"
+    property string buttonColour: virtualstudio.darkMode ? "#494646" : "#D5D9D9"
 
     Component {
         id: controlIndicator


### PR DESCRIPTION
On light mode, I'm finding it hard to see that this has a background/is a button. This makes the shade a little darker.

Before:
![Screenshot 2023-07-17 at 12 20 26 PM](https://github.com/jacktrip/jacktrip/assets/6201822/3b84409b-8e61-4ac9-91ea-ae3ed3d7f897)

After:
![Screenshot 2023-07-17 at 12 19 24 PM](https://github.com/jacktrip/jacktrip/assets/6201822/7d3d2241-c1b9-481e-aa75-cc5add2bc521)
