### PR TITLE
Disable default context menu on right click

### DIFF
--- a/src/gui/WebEngine.qml
+++ b/src/gui/WebEngine.qml
@@ -32,6 +32,11 @@ Item {
             //     console.log("onLoadingChanged", loadRequest.errorCode, loadRequest.errorDomain, loadRequest.errorString, loadRequest.status, loadRequest.url);
             // }
 
+            onContextMenuRequested: function(request) {
+                // this disables the default context menu: https://doc.qt.io/qt-6.2/qml-qtwebengine-contextmenurequest.html#accepted-prop
+                request.accepted = true;
+            }
+
             onNewWindowRequested: function(request) {
                 Qt.openUrlExternally(request.requestedUrl);
             }


### PR DESCRIPTION
This disables the right-click menu on the webview which allows a user to navigate away and potentially break things.

![Screenshot 2023-07-24 at 9 51 30 AM](https://github.com/jacktrip/jacktrip/assets/6201822/b2f375aa-b581-467c-b1c5-dcee83bde1c4)
