### PR TITLE
Handle crash by checking value prior to read from index

### DIFF
--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -2104,6 +2104,9 @@ void VirtualStudio::handleWebsocketMessage(const QString& msg)
     if (!message.isEmpty()) {
         return;
     }
+    if (m_currentStudio < 0) {
+        return;
+    }
     VsServerInfo* studioInfo = static_cast<VsServerInfo*>(m_servers.at(m_currentStudio));
     studioInfo->setStatus(serverStatus);
     studioInfo->setEnabled(serverEnabled);


### PR DESCRIPTION
There's a QList crash here when `m_currentStudio = -1`