### PR TITLE
Bump jacktrip version for dev

### DIFF
--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -40,7 +40,7 @@
 
 #include "AudioInterface.h"
 
-constexpr const char* const gVersion = "1.10.0";  ///< JackTrip version
+constexpr const char* const gVersion = "1.11.0-beta1";  ///< JackTrip version
 
 //*******************************************************************************
 /// \name Default Values

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -40,7 +40,7 @@
 
 #include "AudioInterface.h"
 
-constexpr const char* const gVersion = "1.11.0-beta1";  ///< JackTrip version
+constexpr const char* const gVersion = "2.0.0-beta1";  ///< JackTrip version
 
 //*******************************************************************************
 /// \name Default Values


### PR DESCRIPTION
I don't know if this is what we want it to be, I'm just changing it so it is not equal to `1.10.0` which is the latest released version