### PR TITLE
Fixing some QML syntax warning

### DIFF
--- a/src/gui/Settings.qml
+++ b/src/gui/Settings.qml
@@ -164,7 +164,9 @@ Item {
 
         ButtonGroup {
             buttons: viewControls.children
-            onClicked: { settingsGroupView = button.text }
+            onClicked: function(button) {
+                settingsGroupView = button.text
+            }
         }
 
         Column {


### PR DESCRIPTION
From:
```
qrc:/vs/Settings.qml:167:13 Parameter "button" is not declared. Injection of parameters into signal handlers is deprecated. Use JavaScript functions with formal parameters instead.
```