### PR TITLE
Updating rtaudio to 6.0.1 for meson builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,9 @@ macos/sign-stuff-withcreds.sh
 
 # windows deploy files
 win/deploy
+
+# meson subproject files
+subprojects/packagecache/
+subprojects/rtaudio-5.*/
+subprojects/rtaudio-6.*/
+subprojects/wingetopt/

--- a/jacktrip.pro
+++ b/jacktrip.pro
@@ -37,6 +37,7 @@ nogui {
     QT += svg
     QT += websockets
     QT += webview
+    QT += webenginequick
     vsftux {
       DEFINES += VS_FTUX
     }

--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -1992,17 +1992,19 @@ void QJackTrip::populateDeviceMenu(QComboBox* menu, bool isInput)
         unsigned int devices = rtaudio.getDeviceCount();
         for (unsigned int j = 0; j < devices; j++) {
             RtAudio::DeviceInfo info = rtaudio.getDeviceInfo(j);
-            if (info.probed == true) {
-                // Don't include duplicate entries
-                if (menu->findText(QString::fromStdString(info.name)) != -1) {
-                    continue;
-                }
-
-                if (isInput && info.inputChannels > 0) {
-                    menu->addItem(QString::fromStdString(info.name));
-                } else if (!isInput && info.outputChannels > 0) {
-                    menu->addItem(QString::fromStdString(info.name));
-                }
+#if RTAUDIO_VERSION_MAJOR < 6
+            // probed was removed from DeviceInfo in 6.0
+            if (info.probed == false)
+                continue;
+#endif
+            // Don't include duplicate entries
+            if (menu->findText(QString::fromStdString(info.name)) != -1) {
+                continue;
+            }
+            if (isInput && info.inputChannels > 0) {
+                menu->addItem(QString::fromStdString(info.name));
+            } else if (!isInput && info.outputChannels > 0) {
+                menu->addItem(QString::fromStdString(info.name));
             }
         }
     }

--- a/subprojects/rtaudio.wrap
+++ b/subprojects/rtaudio.wrap
@@ -1,9 +1,8 @@
 [wrap-file]
-directory = rtaudio-5.2.0
-source_url = https://github.com/thestk/rtaudio/archive/refs/tags/5.2.0.tar.gz
-source_filename = 5.2.0.tar.gz
-source_hash = a8d9c738addffd485c3f0bab14cbba72600267e3113f274398c67829bbb49332
+directory = rtaudio-6.0.1
+source_url = https://github.com/thestk/rtaudio/archive/refs/tags/6.0.1.tar.gz
+source_filename = 6.0.1.tar.gz
+source_hash = 7206c8b6cee43b474f43d64988fefaadfdcfc4264ed38d8de5f5d0e6ddb0a123
 
 [provide]
 dependency_names = rtaudio
-


### PR DESCRIPTION
qmake will still build using rtaudio 5.2.0, and care has been taked with the changes in JackTrip's source code to ensure backwards compatibility

Updated local variable names in RtAudioInterface.cpp to be more consistent, as previously they were using several different schemes in the same methods, which I found to be rather confusing.

Also fixed a bug with failing to build virtual studio support using qmake because the webenginequick module was not included in the project file