### PR TITLE
Moving Simple-FFT into source tree

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "externals/rtaudio"]
 	path = externals/rtaudio
 	url = https://github.com/thestk/rtaudio.git
-[submodule "externals/Simple-FFT"]
-	path = externals/Simple-FFT
-	url = https://github.com/jacktrip/Simple-FFT.git

--- a/externals/Simple-FFT/LICENSE.md
+++ b/externals/Simple-FFT/LICENSE.md
@@ -1,0 +1,21 @@
+Copyright (c) 2013-2020 Dmitry Ivanov
+
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/externals/Simple-FFT/README.md
+++ b/externals/Simple-FFT/README.md
@@ -1,0 +1,98 @@
+Simple-FFT
+==========
+
+**Header-only C++ library implementing fast Fourier transform of 1D, 2D and 3D data.**
+
+### What's this
+
+Simple FFT is a C++ library implementing fast Fourier transform. The implemented FFT is a radix-2 Cooley-Turkey algorithm. This algorithm can't handle transform of data which size is not a power of 2. It is not the most optimal known FFT algorithm.
+
+The library is header-only, you don't need to build anything, just include the files in your project. The user-level interface is simple and reminds the one typically found in mathematical software.
+
+The library is distributed under MIT license
+
+#### Why one more FFT library? Does it have any benefits compared to existing libraries?
+
+Why do humans create things even though they already have something similar? Because they are not satisfied with what they have. So was my impression with existing libraries implementing fast Fourier transforms. My desires were:
+ * Free & open-source library
+ * License allowing to use the library in both open and closed-source software.
+ * Convenient API somewhat similar to the one found in typical mathematical software.
+ * Limited size and dependencies, ideally no dependencies (handy for multiple supported platforms and compilers).
+ * As long as my arrays are not going to be huge, I don't need the fastest FFT in the galaxy, I'd be quite happy with some algorithm getting the job done.
+ * Having said that my arrays are not too large, I still want minimal or no overhead for copying the data to objects of types used in the library.
+
+The last statement deserves some explanation: many popular libraries performing FFT use their own data types, sometimes even their own containers. If you already have the data of your own type/container, you are going to either manually transform (e.g. copy) the data or try to cast pointers. Both ways are not elegant.
+
+I didn't find the solution corresponding to the whole wishlist of mine. So I decided to create my own simple library. I've already mentioned some of disadvantages of such approach:
+ * Not the fastest algorithm known nowadays.
+ * Can't handle data which size is not a power of 2.
+
+The advantages of Simple FFT behind some well-known and widely used libraries are:
+ * Tiny size - just some header files.
+ * No need to build it and link a library to your project.
+ * Can handle 1D, 2D and 3D arrays, extendable for larger dimensions.
+ * Designed to support any _reasonable_ multidimensional array/container type one can imagine.
+
+Again, the last statement needs some details to be revealed: C++ natively supports multidimensional arrays via pointers and also via "std vector of std vectors" approach. However, there are a lot of libraries with their own implementations of multidimensional arrays. I wanted to create a library which in theory can use _any_ type of multidimensional array without data copying or pointer casting. It is not possible to guarantee that my library will work with every multidimensional array type you can imagine but there is only a limited number of restrictions for used types.
+
+#### How the API is convenient? How to actually use the library?
+
+By convenience of API I mean the interface somewhat similar to that found in mathematical software like Mathcad, Matlab, Octave, Scilab etc. The simplest API you can think of is something like `A = FFT(B)`. It is not very easy to efficiently implement in C++ (well, without move semantic of C++11 at least) because with such interface you are going to return the result of B transform by value which means data copying i.e. overhead (unless return by value optimization is employed). So in C++ it is better to return the result by reference. The function can also return boolean which would indicate whether the transform was successful or not. So the simplest interface would look like
+
+```c++
+ b = FFT(A,B); // FFT from A to B
+```
+
+But FFT algorithm requires the knowledge of shape and dimensionality of used arrays. Most multidimensional array implementations can provide this information but they do it in different ways and I wanted something very generic. So I decided to create functions with the same name but different signature depending on the number of dimensions:
+
+```c++
+ b = FFT(A,B,n); // FFT from A to B where A and B are 1D arrays with n elements
+ b = FFT(A,B,n,m); // FFT from A to B where A and B are matrices (2D arrays) with n rows and m columns
+ b = FFT(A,B,n,m,l); // FFT from A to B where A and B are 3D arrays with n rows, m columns and l depth number;
+```
+
+One more thing: if the returned value is false then some error has happened. In order to protect user from debugging into 3rdparty library to figure out what happened I decided to return error description as C-style string (because some people don't use `std::string`). So the interface became looking like this:
+
+```c++
+ const char * error = NULL; // error description
+ b = FFT(A,B,n,error); // FFT from A to B where A and B are 1D arrays with n elements
+ b = FFT(A,B,n,m,error); // FFT from A to B where A and B are matrices (2D arrays) with n rows and m columns
+ b = FFT(A,B,n,m,l,error); // FFT from A to B where A and B are 3D arrays with n rows, m columns and l depth number;
+```
+
+But how about the inverse transform? The flag can be used to tell the forward transform from inverse but I thought that different function names would be easier: FFT for forward transform and IFFT for inverse transform:
+
+```c++
+ const char * error = NULL; // error description
+ b = FFT(A,B,n,error); // forward FFT from A to B where A and B are 1D arrays with n elements
+ b = FFT(A,B,n,m,error); // forward FFT from A to B where A and B are matrices (2D arrays) with n rows and m columns
+ b = FFT(A,B,n,m,l,error); // forward FFT from A to B where A and B are 3D arrays with n rows, m columns and l depth number;
+ b = IFFT(B,A,n,error); // inverse FFT from B to A where A and B are 1D arrays with n elements
+ b = IFFT(B,A,n,m,error); // inverse FFT from B to A where A and B are matrices (2D arrays) with n rows and m columns
+ b = IFFT(B,A,n,m,l,error); // inverse FFT from B to A where A and B are 3D arrays with n rows, m columns and l depth number;
+```
+
+Beyond that there are only two settings:
+* User needs to define two types called `real_type` and `complex_type`. These are needed by design to avoid extra problems with template instantiation
+* User needs to define macro `__USE_SQUARE_BRACKETS_FOR_ELEMENT_ACCESS_OPERATOR` if the multidimensional array type you want to use accesses elements via `operator[]` (for example, if it is native C++ multidimensional array or `boost::multi_array` or something similar). Otherwise the library will attempt to use `operator()` for element access.
+
+That's the whole explanation of API.
+
+#### How does it work with multiple libraries implementing matrices and multidimensional arrays in C++ without being aware of those?
+
+Well, the common generic technique of C++ was used - templates. I also added two `typedef`ed types (`real_type` and `complex_type`) to avoid overcomplication of code. But it's not all about templates - I also tried to implement the most generic element access I could imagine. After a bit of thinking I realized that in terms of interface different libraries implementing multidimensional arrays commonly differ only by their element access operator - some implementations use `operator[]` and others - `operator()`. So I splitted every code section using element access operator into two code blocks - the one with `operator[]` and the one with `operator()`. The switch between them is controlled by macro `__USE_SQUARE_BRACKETS_FOR_ELEMENT_ACCESS_OPERATOR` - if it's defined, `operator[]` is used, if not - `operator()`. User can define this macro in some translation units and not define/undef in other ones - just like I did with unit-tests.
+
+#### Are there any examples or, even better, tests?
+I wrote some tests illustrating how to use SimpleFFT library along with some well-known C++ libraries implementing multidimensional arrays. They can also serve as examples (probably, a bit overcomplicated). The tests are based on the following checks:
+* after each forward of inverse FFT [Parseval's theorem](https://en.wikipedia.org/wiki/Parseval%27s_theorem) must be satisfied for input and output data
+* after each sequence of FFT and IFFT the energy conservation law must be satisfied
+* after each sequence of FFT and IFFT the result should be the very same as initial input; so I decided to measure the largest discrepancy between the result and input and calculate the relative error there. If it is small enough (less than 0.01%), this test is considered passed.
+
+I also implemented a simple benchmark test comparing the execution time of multiple loops of Simple FFT and fftw3. The results for Linux with three compilers can be found in the "benchmark-tests" folder. As expected, fftw3 is much faster.
+
+#### There are multiple files here, which I should use?
+There are only two files of interest for library user:
+* `/include/simple_fft/fft_settings.h`
+* `/include/simple_fft/fft.h`
+
+The first one is supposed to contain `typedef`s for `real_type` and `complex_type` and, if needed, the define of `__USE_SQUARE_BRACKETS_FOR_ELEMENT_ACCESS_OPERATOR` macro. This stuff can also be done somewhere else. The second file is what's actually needed to calculate FFT and IFFT: it contains only API declarations and includes some of other files.

--- a/externals/Simple-FFT/include/simple_fft/check_fft.hpp
+++ b/externals/Simple-FFT/include/simple_fft/check_fft.hpp
@@ -1,0 +1,571 @@
+/**
+ * Copyright (c) 2013-2020 Dmitry Ivanov
+ *
+ * This file is a part of Simple-FFT project and is distributed under the terms
+ * of MIT license: https://opensource.org/licenses/MIT
+ */
+
+#ifndef __SIMPLE_FFT__CHECK_FFT_HPP__
+#define __SIMPLE_FFT__CHECK_FFT_HPP__
+
+#include "fft_settings.h"
+#include "error_handling.hpp"
+#include "copy_array.hpp"
+#include <cstddef>
+#include <cmath>
+#include <numeric>
+
+using std::size_t;
+
+namespace simple_fft {
+namespace check_fft_private {
+
+enum CheckMode
+{
+    CHECK_FFT_PARSEVAL,
+    CHECK_FFT_ENERGY,
+    CHECK_FFT_EQUALITY
+};
+
+template <class TArray1D, class TComplexArray1D>
+void getMaxAbsoluteAndRelativeErrorNorms(const TArray1D & array1,
+                                         const TComplexArray1D & array2, const size_t size,
+                                         real_type & max_absolute_error_norm,
+                                         real_type & max_relative_error_norm)
+{
+    using std::abs;
+
+    real_type current_error;
+
+    // NOTE: no parallelization here, it is a completely sequential loop!
+    for(size_t i = 0; i < size; ++i) {
+#ifdef __USE_SQUARE_BRACKETS_FOR_ELEMENT_ACCESS_OPERATOR
+        current_error = abs(array1[i] - array2[i]);
+#else
+        current_error = abs(array1(i) - array2(i));
+#endif
+        if (current_error > max_absolute_error_norm) {
+            max_absolute_error_norm = current_error;
+#ifdef __USE_SQUARE_BRACKETS_FOR_ELEMENT_ACCESS_OPERATOR
+            if (abs(array1[i]) > abs(array2[i])) {
+                max_relative_error_norm = (abs(array1[i]) > 1e-20
+                                           ? max_absolute_error_norm / abs(array1[i])
+                                           : 0.0);
+            }
+            else {
+                max_relative_error_norm = (abs(array2[i]) > 1e-20
+                                           ? max_absolute_error_norm / abs(array2[i])
+                                           : 0.0);
+            }
+#else
+            if (abs(array1(i)) > abs(array2(i))) {
+                max_relative_error_norm = (abs(array1(i)) > 1e-20
+                                           ? max_absolute_error_norm / abs(array1(i))
+                                           : 0.0);
+            }
+            else {
+                max_relative_error_norm = (abs(array2(i)) > 1e-20
+                                           ? max_absolute_error_norm / abs(array2(i))
+                                           : 0.0);
+            }
+#endif
+        }
+    }
+}
+
+template <class TArray2D, class TComplexArray2D>
+void getMaxAbsoluteAndRelativeErrorNorms(const TArray2D & array1,
+                                         const TComplexArray2D & array2,
+                                         const size_t size1, const size_t size2,
+                                         real_type & max_absolute_error_norm,
+                                         real_type & max_relative_error_norm)
+{
+    using std::abs;
+
+    real_type current_error;
+
+    // NOTE: no parallelization here, it is a completely sequential loop!
+    for(int i = 0; i < static_cast<int>(size1); ++i) {
+        for(int j = 0; j < static_cast<int>(size2); ++j) {
+#ifdef __USE_SQUARE_BRACKETS_FOR_ELEMENT_ACCESS_OPERATOR
+            current_error = abs(array1[i][j] - array2[i][j]);
+#else
+            current_error = abs(array1(i,j) - array2(i,j));
+#endif
+            if (current_error > max_absolute_error_norm) {
+                max_absolute_error_norm = current_error;
+#ifdef __USE_SQUARE_BRACKETS_FOR_ELEMENT_ACCESS_OPERATOR
+                if (abs(array1[i][j]) > abs(array2[i][j])) {
+                    max_relative_error_norm = (abs(array1[i][j]) > 1e-20
+                                               ? max_absolute_error_norm / abs(array1[i][j])
+                                               : 0.0);
+                }
+                else {
+                    max_relative_error_norm = (abs(array2[i][j]) > 1e-20
+                                               ? max_absolute_error_norm / abs(array2[i][j])
+                                               : 0.0);
+                }
+#else
+                if (abs(array1(i,j)) > abs(array2(i,j))) {
+                    max_relative_error_norm = (abs(array1(i,j)) > 1e-20
+                                               ? max_absolute_error_norm / abs(array1(i,j))
+                                               : 0.0);
+                }
+                else {
+                    max_relative_error_norm = (abs(array2(i,j)) > 1e-20
+                                               ? max_absolute_error_norm / abs(array2(i,j))
+                                               : 0.0);
+                }
+#endif
+            }
+        }
+    }
+}
+
+template <class TArray3D, class TComplexArray3D>
+void getMaxAbsoluteAndRelativeErrorNorms(const TArray3D & array1, const TComplexArray3D & array2,
+                                         const size_t size1, const size_t size2,
+                                         const size_t size3, real_type & max_absolute_error_norm,
+                                         real_type & max_relative_error_norm)
+{
+    using std::abs;
+
+    real_type current_error;
+
+    // NOTE: no parallelization here, it is a completely sequential loop!
+    for(int i = 0; i < static_cast<int>(size1); ++i) {
+        for(int j = 0; j < static_cast<int>(size2); ++j) {
+            for(int k = 0; k < static_cast<int>(size3); ++k) {
+#ifdef __USE_SQUARE_BRACKETS_FOR_ELEMENT_ACCESS_OPERATOR
+                current_error = abs(array1[i][j][k] - array2[i][j][k]);
+#else
+                current_error = abs(array1(i,j,k) - array2(i,j,k));
+#endif
+                if (current_error > max_absolute_error_norm) {
+                    max_absolute_error_norm = current_error;
+#ifdef __USE_SQUARE_BRACKETS_FOR_ELEMENT_ACCESS_OPERATOR
+                    if (abs(array1[i][j][k]) > abs(array2[i][j][k])) {
+                        max_relative_error_norm = (abs(array1[i][j][k]) > 1e-20
+                                                   ? max_absolute_error_norm / abs(array1[i][j][k])
+                                                   : 0.0);
+                    }
+                    else {
+                        max_relative_error_norm = (abs(array2[i][j][k]) > 1e-20
+                                                   ? max_absolute_error_norm / abs(array2[i][j][k])
+                                                   : 0.0);
+                    }
+#else
+                    if (abs(array1(i,j,k)) > abs(array2(i,j,k))) {
+                        max_relative_error_norm = (abs(array1(i,j,k)) > 1e-20
+                                                   ? max_absolute_error_norm / abs(array1(i,j,k))
+                                                   : 0.0);
+                    }
+                    else {
+                        max_relative_error_norm = (abs(array2(i,j,k)) > 1e-20
+                                                   ? max_absolute_error_norm / abs(array2(i,j,k))
+                                                   : 0.0);
+                    }
+#endif
+                }
+            }
+        }
+    }
+}
+
+template <class TArray1D>
+real_type squareAbsAccumulate(const TArray1D & array, const size_t size,
+                              const real_type init)
+{
+    int size_signed = static_cast<int>(size);
+    real_type sum = init;
+
+    using std::abs;
+
+#ifndef __clang__
+#ifdef __USE_OPENMP
+#pragma omp parallel for reduction(+:sum)
+#endif
+#endif
+    for(int i = 0; i < size_signed; ++i) {
+#ifdef __USE_SQUARE_BRACKETS_FOR_ELEMENT_ACCESS_OPERATOR
+        sum += abs(array[i] * array[i]);
+#else
+        sum += abs(array(i) * array(i));
+#endif
+    }
+
+    return sum;
+}
+
+template <class TArray2D>
+real_type squareAbsAccumulate(const TArray2D & array, const size_t size1,
+                              const size_t size2, const real_type init)
+{
+    int size1_signed = static_cast<int>(size1);
+    int size2_signed = static_cast<int>(size2);
+    real_type sum = init;
+
+    using std::abs;
+
+#ifndef __clang__
+#ifdef __USE_OPENMP
+#pragma omp parallel for reduction(+:sum)
+#endif
+#endif
+    for(int i = 0; i < size1_signed; ++i) {
+        for(int j = 0; j < size2_signed; ++j) {
+#ifdef __USE_SQUARE_BRACKETS_FOR_ELEMENT_ACCESS_OPERATOR
+            sum += abs(array[i][j] * array[i][j]);
+#else
+            sum += abs(array(i,j) * array(i,j));
+#endif
+        }
+    }
+
+    return sum;
+}
+
+template <class TArray3D>
+real_type squareAbsAccumulate(const TArray3D & array, const size_t size1,
+                              const size_t size2, const size_t size3,
+                              const real_type init)
+{
+    int size1_signed = static_cast<int>(size1);
+    int size2_signed = static_cast<int>(size2);
+    int size3_signed = static_cast<int>(size3);
+    real_type sum = init;
+
+    using std::abs;
+
+#ifndef __clang__
+#ifdef __USE_OPENMP
+#pragma omp parallel for reduction(+:sum)
+#endif
+#endif
+    for(int i = 0; i < size1_signed; ++i) {
+        for(int j = 0; j < size2_signed; ++j) {
+            for(int k = 0; k < size3_signed; ++k) {
+#ifdef __USE_SQUARE_BRACKETS_FOR_ELEMENT_ACCESS_OPERATOR
+                sum += abs(array[i][j][k] * array[i][j][k]);
+#else
+                sum += abs(array(i,j,k) * array(i,j,k));
+#endif
+            }
+        }
+    }
+
+    return sum;
+}
+
+// Generic template for CCheckFFT struct followed by its explicit specializations
+// for certain numbers of dimensions. TArray can be either of real or complex type.
+// The technique is similar to the one applied for CFFT struct.
+template <class TArray, class TComplexArray, int NumDims>
+struct CCheckFFT
+{};
+
+template <class TArray1D, class TComplexArray1D>
+struct CCheckFFT<TArray1D,TComplexArray1D,1>
+{
+    static bool check_fft(const TArray1D & data_before,
+                          const TComplexArray1D & data_after,
+                          const size_t size, const real_type relative_tolerance,
+                          real_type & discrepancy, const CheckMode check_mode,
+                          const char *& error_description)
+    {
+        using namespace error_handling;
+
+        if(0 == size) {
+            GetErrorDescription(EC_NUM_OF_ELEMS_IS_ZERO, error_description);
+            return false;
+        }
+
+        if ( (CHECK_FFT_PARSEVAL != check_mode) &&
+             (CHECK_FFT_ENERGY   != check_mode) &&
+             (CHECK_FFT_EQUALITY != check_mode) )
+        {
+            GetErrorDescription(EC_WRONG_CHECK_FFT_MODE, error_description);
+            return false;
+        }
+
+        if (CHECK_FFT_EQUALITY != check_mode)
+        {
+            real_type sum_before = squareAbsAccumulate<TArray1D>(data_before, size, 0.0);
+            real_type sum_after  = squareAbsAccumulate<TComplexArray1D>(data_after, size, 0.0);
+
+            if (CHECK_FFT_PARSEVAL == check_mode) {
+                sum_after /= size;
+            }
+
+            using std::abs;
+
+            discrepancy = abs(sum_before - sum_after);
+
+            if (discrepancy / ((sum_before < 1e-20) ? (sum_before + 1e-20) : sum_before) > relative_tolerance) {
+                GetErrorDescription(EC_RELATIVE_ERROR_TOO_LARGE, error_description);
+                return false;
+            }
+            else {
+                return true;
+            }
+        }
+        else {
+            real_type relative_error;
+            getMaxAbsoluteAndRelativeErrorNorms(data_before, data_after, size,
+                                                discrepancy, relative_error);
+            if (relative_error < relative_tolerance) {
+                return true;
+            }
+            else {
+                GetErrorDescription(EC_RELATIVE_ERROR_TOO_LARGE, error_description);
+                return false;
+            }
+        }
+    }
+};
+
+template <class TArray2D, class TComplexArray2D>
+struct CCheckFFT<TArray2D,TComplexArray2D,2>
+{
+    static bool check_fft(const TArray2D & data_before,
+                          const TComplexArray2D & data_after,
+                          const size_t size1, const size_t size2,
+                          const real_type relative_tolerance, real_type & discrepancy,
+                          const CheckMode check_mode, const char *& error_description)
+    {
+        using namespace error_handling;
+
+        if( (0 == size1) || (0 == size2) ) {
+            GetErrorDescription(EC_NUM_OF_ELEMS_IS_ZERO, error_description);
+            return false;
+        }
+
+        if ( (CHECK_FFT_PARSEVAL != check_mode) &&
+             (CHECK_FFT_ENERGY   != check_mode) &&
+             (CHECK_FFT_EQUALITY != check_mode) )
+        {
+            GetErrorDescription(EC_WRONG_CHECK_FFT_MODE, error_description);
+            return false;
+        }
+
+        if (CHECK_FFT_EQUALITY != check_mode)
+        {
+            real_type sum_before = squareAbsAccumulate<TArray2D>(data_before, size1, size2, 0.0);
+            real_type sum_after  = squareAbsAccumulate<TComplexArray2D>(data_after, size1, size2, 0.0);
+
+            if (CHECK_FFT_PARSEVAL == check_mode) {
+                sum_after /= size1 * size2;
+            }
+
+            using std::abs;
+
+            discrepancy = abs(sum_before - sum_after);
+
+            if (discrepancy / ((sum_before < 1e-20) ? (sum_before + 1e-20) : sum_before) > relative_tolerance) {
+                GetErrorDescription(EC_RELATIVE_ERROR_TOO_LARGE, error_description);
+                return false;
+            }
+            else {
+                return true;
+            }
+        }
+        else {
+            real_type relative_error;
+            getMaxAbsoluteAndRelativeErrorNorms(data_before, data_after, size1,
+                                                size2, discrepancy, relative_error);
+            if (relative_error < relative_tolerance) {
+                return true;
+            }
+            else {
+                GetErrorDescription(EC_RELATIVE_ERROR_TOO_LARGE, error_description);
+                return false;
+            }
+        }
+    }
+};
+
+template <class TArray3D, class TComplexArray3D>
+struct CCheckFFT<TArray3D,TComplexArray3D,3>
+{
+    static bool check_fft(const TArray3D & data_before,
+                          const TComplexArray3D & data_after,
+                          const size_t size1, const size_t size2, const size_t size3,
+                          const real_type relative_tolerance, real_type & discrepancy,
+                          const CheckMode check_mode, const char *& error_description)
+    {
+        using namespace error_handling;
+
+        if( (0 == size1) || (0 == size2) || (0 == size3) ) {
+            GetErrorDescription(EC_NUM_OF_ELEMS_IS_ZERO, error_description);
+            return false;
+        }
+
+        if ( (CHECK_FFT_PARSEVAL != check_mode) &&
+             (CHECK_FFT_ENERGY   != check_mode) &&
+             (CHECK_FFT_EQUALITY != check_mode) )
+        {
+            GetErrorDescription(EC_WRONG_CHECK_FFT_MODE, error_description);
+            return false;
+        }
+
+        if (CHECK_FFT_EQUALITY != check_mode)
+        {
+            real_type sum_before = squareAbsAccumulate<TArray3D>(data_before, size1, size2, size3, 0.0);
+            real_type sum_after  = squareAbsAccumulate<TComplexArray3D>(data_after, size1, size2, size3, 0.0);
+
+            if (CHECK_FFT_PARSEVAL == check_mode) {
+                sum_after /= size1 * size2 * size3;
+            }
+
+            using std::abs;
+
+            discrepancy = abs(sum_before - sum_after);
+
+            if (discrepancy / ((sum_before < 1e-20) ? (sum_before + 1e-20) : sum_before) > relative_tolerance) {
+                GetErrorDescription(EC_RELATIVE_ERROR_TOO_LARGE, error_description);
+                return false;
+            }
+            else {
+                return true;
+            }
+        }
+        else {
+            real_type relative_error;
+            getMaxAbsoluteAndRelativeErrorNorms(data_before, data_after, size1,
+                                                size2, size3, discrepancy, relative_error);
+            if (relative_error < relative_tolerance) {
+                return true;
+            }
+            else {
+                GetErrorDescription(EC_RELATIVE_ERROR_TOO_LARGE, error_description);
+                return false;
+            }
+        }
+    }
+};
+
+} // namespace check_fft_private
+
+namespace check_fft {
+
+template <class TArray1D, class TComplexArray1D>
+bool checkParsevalTheorem(const TArray1D & data_before_FFT,
+                          const TComplexArray1D & data_after_FFT,
+                          const size_t size, const real_type relative_tolerance,
+                          real_type & discrepancy, const char *& error_description)
+{
+    return check_fft_private::CCheckFFT<TArray1D,TComplexArray1D,1>::check_fft(data_before_FFT,
+                                             data_after_FFT, size, relative_tolerance,
+                                             discrepancy, check_fft_private::CHECK_FFT_PARSEVAL,
+                                             error_description);
+}
+
+template <class TArray2D, class TComplexArray2D>
+bool checkParsevalTheorem(const TArray2D & data_before_FFT,
+                          const TComplexArray2D & data_after_FFT,
+                          const size_t size1, const size_t size2,
+                          const real_type relative_tolerance,
+                          real_type & discrepancy, const char *& error_description)
+{
+    return check_fft_private::CCheckFFT<TArray2D,TComplexArray2D,2>::check_fft(data_before_FFT,
+                                             data_after_FFT, size1, size2, relative_tolerance,
+                                             discrepancy, check_fft_private::CHECK_FFT_PARSEVAL,
+                                             error_description);
+}
+
+template <class TArray3D, class TComplexArray3D>
+bool checkParsevalTheorem(const TArray3D & data_before_FFT,
+                          const TComplexArray3D & data_after_FFT,
+                          const size_t size1, const size_t size2, const size_t size3,
+                          const real_type relative_tolerance, real_type & discrepancy,
+                          const char *& error_description)
+{
+    return check_fft_private::CCheckFFT<TArray3D,TComplexArray3D,3>::check_fft(data_before_FFT,
+                                                  data_after_FFT, size1, size2, size3,
+                                                  relative_tolerance, discrepancy,
+                                                  check_fft_private::CHECK_FFT_PARSEVAL,
+                                                  error_description);
+}
+
+template <class TArray1D, class TComplexArray1D>
+bool checkEnergyConservation(const TArray1D & data_before_FFT,
+                             const TComplexArray1D & data_after_FFT_and_IFFT,
+                             const size_t size, const real_type relative_tolerance,
+                             real_type & discrepancy, const char *& error_description)
+{
+    return check_fft_private::CCheckFFT<TArray1D,TComplexArray1D,1>::check_fft(data_before_FFT,
+                                    data_after_FFT_and_IFFT, size, relative_tolerance,
+                                    discrepancy, check_fft_private::CHECK_FFT_ENERGY,
+                                    error_description);
+}
+
+template <class TArray2D, class TComplexArray2D>
+bool checkEnergyConservation(const TArray2D & data_before_FFT,
+                             const TComplexArray2D & data_after_FFT_and_IFFT,
+                             const size_t size1, const size_t size2,
+                             const real_type relative_tolerance,
+                             real_type & discrepancy, const char *& error_description)
+{
+    return check_fft_private::CCheckFFT<TArray2D,TComplexArray2D,2>::check_fft(data_before_FFT,
+                                                data_after_FFT_and_IFFT, size1, size2,
+                                                relative_tolerance, discrepancy,
+                                                check_fft_private::CHECK_FFT_ENERGY,
+                                                error_description);
+}
+
+template <class TArray3D, class TComplexArray3D>
+bool checkEnergyConservation(const TArray3D & data_before_FFT,
+                             const TComplexArray3D & data_after_FFT_and_IFFT,
+                             const size_t size1, const size_t size2, const size_t size3,
+                             const real_type relative_tolerance, real_type & discrepancy,
+                             const char *& error_description)
+{
+    return check_fft_private::CCheckFFT<TArray3D,TComplexArray3D,3>::check_fft(data_before_FFT,
+                                                data_after_FFT_and_IFFT, size1, size2,
+                                                size3, relative_tolerance, discrepancy,
+                                                check_fft_private::CHECK_FFT_ENERGY,
+                                                error_description);
+}
+
+template <class TArray1D, class TComplexArray1D>
+bool checkEquality(const TArray1D & data_before_FFT,
+                   const TComplexArray1D & data_after_FFT_and_IFFT,
+                   const size_t size, const real_type relative_tolerance,
+                   real_type & discrepancy, const char *& error_description)
+{
+    return check_fft_private::CCheckFFT<TArray1D,TComplexArray1D,1>::check_fft(data_before_FFT,
+                                             data_after_FFT_and_IFFT, size, relative_tolerance,
+                                             discrepancy, check_fft_private::CHECK_FFT_EQUALITY,
+                                             error_description);
+}
+
+template <class TArray2D, class TComplexArray2D>
+bool checkEquality(const TArray2D & data_before_FFT,
+                   const TComplexArray2D & data_after_FFT_and_IFFT, const size_t size1,
+                   const size_t size2, const real_type relative_tolerance,
+                   real_type & discrepancy, const char *& error_description)
+{
+    return check_fft_private::CCheckFFT<TArray2D,TComplexArray2D,2>::check_fft(data_before_FFT,
+                                                         data_after_FFT_and_IFFT, size1, size2,
+                                                         relative_tolerance, discrepancy,
+                                                         check_fft_private::CHECK_FFT_EQUALITY,
+                                                         error_description);
+}
+
+template <class TArray3D, class TComplexArray3D>
+bool checkEquality(const TArray3D & data_before_FFT,
+                   const TComplexArray3D & data_after_FFT_and_IFFT, const size_t size1,
+                   const size_t size2, const size_t size3, const real_type relative_tolerance,
+                   real_type & discrepancy, const char *& error_description)
+{
+    return check_fft_private::CCheckFFT<TArray3D,TComplexArray3D,3>::check_fft(data_before_FFT,
+                                                         data_after_FFT_and_IFFT, size1, size2,
+                                                         size3, relative_tolerance, discrepancy,
+                                                         check_fft_private::CHECK_FFT_EQUALITY,
+                                                         error_description);
+}
+
+} // namespace check_fft
+} // namespace simple_fft
+
+#endif // __SIMPLE_FFT__CHECK_FFT_HPP__

--- a/externals/Simple-FFT/include/simple_fft/copy_array.hpp
+++ b/externals/Simple-FFT/include/simple_fft/copy_array.hpp
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) 2013-2020 Dmitry Ivanov
+ *
+ * This file is a part of Simple-FFT project and is distributed under the terms
+ * of MIT license: https://opensource.org/licenses/MIT
+ */
+
+#ifndef __SIMPLE_FFT__COPY_ARRAY_HPP
+#define __SIMPLE_FFT__COPY_ARRAY_HPP
+
+#include "fft_settings.h"
+#include "error_handling.hpp"
+#include <cstddef>
+
+using std::size_t;
+
+namespace simple_fft {
+namespace copy_array {
+
+template <class TComplexArray1D>
+void copyArray(const TComplexArray1D & data_from, TComplexArray1D & data_to,
+               const size_t size)
+{
+    int size_signed = static_cast<int>(size);
+
+#ifndef __clang__
+#ifdef __USE_OPENMP
+#pragma omp parallel for
+#endif
+#endif
+    for(int i = 0; i < size_signed; ++i) {
+#ifdef __USE_SQUARE_BRACKETS_FOR_ELEMENT_ACCESS_OPERATOR
+        data_to[i] = data_from[i];
+#else
+        data_to(i) = data_from(i);
+#endif
+    }
+}
+
+template <class TComplexArray1D, class TRealArray1D>
+void copyArray(const TRealArray1D & data_from, TComplexArray1D & data_to,
+               const size_t size)
+{
+    int size_signed = static_cast<int>(size);
+
+    // NOTE: user's complex type should have constructor like
+    // "complex(real, imag)", where each of real and imag has
+    // real type.
+
+#ifndef __clang__
+#ifdef __USE_OPENMP
+#pragma omp parallel for
+#endif
+#endif
+    for(int i = 0; i < size_signed; ++i) {
+#ifdef __USE_SQUARE_BRACKETS_FOR_ELEMENT_ACCESS_OPERATOR
+        data_to[i] = complex_type(data_from[i], 0.0);
+#else
+        data_to(i) = complex_type(data_from(i), 0.0);
+#endif
+    }
+}
+
+template <class TComplexArray2D>
+void copyArray(const TComplexArray2D & data_from, TComplexArray2D & data_to,
+               const size_t size1, const size_t size2)
+{
+    int size1_signed = static_cast<int>(size1);
+    int size2_signed = static_cast<int>(size2);
+
+#ifndef __clang__
+#ifdef __USE_OPENMP
+#pragma omp parallel for
+#endif
+#endif
+    for(int i = 0; i < size1_signed; ++i) {
+        for(int j = 0; j < size2_signed; ++j) {
+#ifdef __USE_SQUARE_BRACKETS_FOR_ELEMENT_ACCESS_OPERATOR
+            data_to[i][j] = data_from[i][j];
+#else
+            data_to(i,j) = data_from(i,j);
+#endif
+        }
+    }
+}
+
+template <class TComplexArray2D, class TRealArray2D>
+void copyArray(const TRealArray2D & data_from, TComplexArray2D & data_to,
+               const size_t size1, const size_t size2)
+{
+    int size1_signed = static_cast<int>(size1);
+    int size2_signed = static_cast<int>(size2);
+
+    // NOTE: user's complex type should have constructor like
+    // "complex(real, imag)", where each of real and imag has
+    // real type.
+
+#ifndef __clang__
+#ifdef __USE_OPENMP
+#pragma omp parallel for
+#endif
+#endif
+    for(int i = 0; i < size1_signed; ++i) {
+        for(int j = 0; j < size2_signed; ++j) {
+#ifdef __USE_SQUARE_BRACKETS_FOR_ELEMENT_ACCESS_OPERATOR
+            data_to[i][j] = complex_type(data_from[i][j], 0.0);
+#else
+            data_to(i,j) = complex_type(data_from(i,j), 0.0);
+#endif
+        }
+    }
+}
+
+template <class TComplexArray3D>
+void copyArray(const TComplexArray3D & data_from, TComplexArray3D & data_to,
+               const size_t size1, const size_t size2, const size_t size3)
+{
+    int size1_signed = static_cast<int>(size1);
+    int size2_signed = static_cast<int>(size2);
+    int size3_signed = static_cast<int>(size3);
+
+#ifndef __clang__
+#ifdef __USE_OPENMP
+#pragma omp parallel for
+#endif
+#endif
+    for(int i = 0; i < size1_signed; ++i) {
+        for(int j = 0; j < size2_signed; ++j) {
+            for(int k = 0; k < size3_signed; ++k) {
+#ifdef __USE_SQUARE_BRACKETS_FOR_ELEMENT_ACCESS_OPERATOR
+                data_to[i][j][k] = data_from[i][j][k];
+#else
+                data_to(i,j,k) = data_from(i,j,k);
+#endif
+            }
+        }
+    }
+}
+
+template <class TComplexArray3D, class TRealArray3D>
+void copyArray(const TRealArray3D & data_from, TComplexArray3D & data_to,
+               const size_t size1, const size_t size2, const size_t size3)
+{
+    int size1_signed = static_cast<int>(size1);
+    int size2_signed = static_cast<int>(size2);
+    int size3_signed = static_cast<int>(size3);
+
+    // NOTE: user's complex type should have constructor like
+    // "complex(real, imag)", where each of real and imag has
+    // real type.
+
+#ifndef __clang__
+#ifdef __USE_OPENMP
+#pragma omp parallel for
+#endif
+#endif
+    for(int i = 0; i < size1_signed; ++i) {
+        for(int j = 0; j < size2_signed; ++j) {
+            for(int k = 0; k < size3_signed; ++k) {
+#ifdef __USE_SQUARE_BRACKETS_FOR_ELEMENT_ACCESS_OPERATOR
+                data_to[i][j][k] = complex_type(data_from[i][j][k], 0.0);
+#else
+                data_to(i,j,k) = complex_type(data_from(i,j,k), 0.0);
+#endif
+            }
+        }
+    }
+}
+
+} // namespace copy_array
+} // namespace simple_fft
+
+#endif // __SIMPLE_FFT__COPY_ARRAY_HPP

--- a/externals/Simple-FFT/include/simple_fft/error_handling.hpp
+++ b/externals/Simple-FFT/include/simple_fft/error_handling.hpp
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2013-2020 Dmitry Ivanov
+ *
+ * This file is a part of Simple-FFT project and is distributed under the terms
+ * of MIT license: https://opensource.org/licenses/MIT
+ */
+
+#ifndef __SIMPLE_FFT__ERROR_HANDLING_HPP
+#define __SIMPLE_FFT__ERROR_HANDLING_HPP
+
+namespace simple_fft {
+namespace error_handling {
+
+enum EC_SimpleFFT
+{
+    EC_SUCCESS = 0,
+    EC_UNSUPPORTED_DIMENSIONALITY,
+    EC_WRONG_FFT_DIRECTION,
+    EC_ONE_OF_DIMS_ISNT_POWER_OF_TWO,
+    EC_NUM_OF_ELEMS_IS_ZERO,
+    EC_WRONG_CHECK_FFT_MODE,
+    EC_RELATIVE_ERROR_TOO_LARGE
+};
+
+inline void GetErrorDescription(const EC_SimpleFFT error_code,
+                                const char *& error_description)
+{
+    switch(error_code)
+    {
+    case EC_SUCCESS:
+        error_description = "Calculation was successful!";
+        break;
+    case EC_UNSUPPORTED_DIMENSIONALITY:
+        error_description = "Unsupported dimensionality: currently only 1D, 2D "
+                            "and 3D arrays are supported";
+        break;
+    case EC_WRONG_FFT_DIRECTION:
+        error_description = "Wrong direction for FFT was specified";
+        break;
+    case EC_ONE_OF_DIMS_ISNT_POWER_OF_TWO:
+        error_description = "Unsupported dimensionality: one of dimensions is not "
+                            "a power of 2";
+        break;
+    case EC_NUM_OF_ELEMS_IS_ZERO:
+        error_description = "Number of elements for FFT or IFFT is zero!";
+        break;
+    case EC_WRONG_CHECK_FFT_MODE:
+        error_description = "Wrong check FFT mode was specified (should be either "
+                            "Parseval theorem or energy conservation check";
+        break;
+    case EC_RELATIVE_ERROR_TOO_LARGE:
+        error_description = "Relative error returned by FFT test exceeds specified "
+                            "relative tolerance";
+        break;
+    default:
+        error_description = "Unknown error";
+        break;
+    }
+}
+
+} // namespace error_handling
+} // namespace simple_fft
+
+#endif // __SIMPLE_FFT__ERROR_HANDLING_HPP

--- a/externals/Simple-FFT/include/simple_fft/fft.h
+++ b/externals/Simple-FFT/include/simple_fft/fft.h
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2013-2020 Dmitry Ivanov
+ *
+ * This file is a part of Simple-FFT project and is distributed under the terms
+ * of MIT license: https://opensource.org/licenses/MIT
+ */
+
+#ifndef __SIMPLE_FFT__FFT_H__
+#define __SIMPLE_FFT__FFT_H__
+
+#include <cstddef>
+
+using std::size_t;
+
+/// The public API
+namespace simple_fft {
+
+/// FFT and IFFT functions
+
+// in-place, complex, forward
+template <class TComplexArray1D>
+bool FFT(TComplexArray1D & data, const size_t size, const char *& error_description);
+
+template <class TComplexArray2D>
+bool FFT(TComplexArray2D & data, const size_t size1, const size_t size2,
+         const char *& error_description);
+
+template <class TComplexArray3D>
+bool FFT(TComplexArray3D & data, const size_t size1, const size_t size2, const size_t size3,
+         const char *& error_description);
+
+// in-place, complex, inverse
+template <class TComplexArray1D>
+bool IFFT(TComplexArray1D & data, const size_t size, const char *& error_description);
+
+template <class TComplexArray2D>
+bool IFFT(TComplexArray2D & data, const size_t size1, const size_t size2,
+          const char *& error_description);
+
+template <class TComplexArray3D>
+bool IFFT(TComplexArray3D & data, const size_t size1, const size_t size2, const size_t size3,
+          const char *& error_description);
+
+// not-in-place, complex, forward
+template <class TComplexArray1D>
+bool FFT(const TComplexArray1D & data_in, TComplexArray1D & data_out,
+         const size_t size, const char *& error_description);
+
+template <class TComplexArray2D>
+bool FFT(const TComplexArray2D & data_in, TComplexArray2D & data_out,
+         const size_t size1, const size_t size2, const char *& error_description);
+
+template <class TComplexArray3D>
+bool FFT(const TComplexArray3D & data_in, TComplexArray3D & data_out,
+         const size_t size1, const size_t size2, const size_t size3,
+         const char *& error_description);
+
+// not-in-place, complex, inverse
+template <class TComplexArray1D>
+bool IFFT(const TComplexArray1D & data_in, TComplexArray1D & data_out,
+          const size_t size, const char *& error_description);
+
+template <class TComplexArray2D>
+bool IFFT(const TComplexArray2D & data_in, TComplexArray2D & data_out,
+          const size_t size1, const size_t size2, const char *& error_description);
+
+template <class TComplexArray3D>
+bool IFFT(const TComplexArray3D & data_in, TComplexArray3D & data_out,
+          const size_t size1, const size_t size2, const size_t size3,
+          const char *& error_description);
+
+// not-in-place, real, forward
+template <class TRealArray1D, class TComplexArray1D>
+bool FFT(const TRealArray1D & data_in, TComplexArray1D & data_out,
+         const size_t size, const char *& error_description);
+
+template <class TRealArray2D, class TComplexArray2D>
+bool FFT(const TRealArray2D & data_in, TComplexArray2D & data_out,
+         const size_t size1, const size_t size2, const char *& error_description);
+
+template <class TRealArray3D, class TComplexArray3D>
+bool FFT(const TRealArray3D & data_in, TComplexArray3D & data_out,
+         const size_t size1, const size_t size2, const size_t size3,
+         const char *& error_description);
+
+// NOTE: There is no inverse transform from complex spectrum to real signal
+// because round-off errors during computation of inverse FFT lead to the appearance
+// of signal imaginary components even though they are small by absolute value.
+// These can be ignored but the author of this file thinks adding such an function
+// would be wrong methodogically: looking at complex result, you can estimate
+// the value of spurious imaginary part. Otherwise you may never know that IFFT
+// provides too large imaginary values due to too small grid size, for example.
+
+} // namespace simple_fft
+
+#endif // __SIMPLE_FFT__FFT_H__
+
+#include "fft.hpp"

--- a/externals/Simple-FFT/include/simple_fft/fft.hpp
+++ b/externals/Simple-FFT/include/simple_fft/fft.hpp
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) 2013-2020 Dmitry Ivanov
+ *
+ * This file is a part of Simple-FFT project and is distributed under the terms
+ * of MIT license: https://opensource.org/licenses/MIT
+ */
+
+#ifndef __SIMPLE_FFT__FFT_HPP__
+#define __SIMPLE_FFT__FFT_HPP__
+
+#include "copy_array.hpp"
+#include "fft_impl.hpp"
+
+namespace simple_fft {
+
+// in-place, complex, forward
+template <class TComplexArray1D>
+bool FFT(TComplexArray1D & data, const size_t size, const char *& error_description)
+{
+    return impl::CFFT<TComplexArray1D,1>::FFT_inplace(data, size, impl::FFT_FORWARD,
+                                                      error_description);
+}
+
+template <class TComplexArray2D>
+bool FFT(TComplexArray2D & data, const size_t size1, const size_t size2,
+         const char *& error_description)
+{
+    return impl::CFFT<TComplexArray2D,2>::FFT_inplace(data, size1, size2, impl::FFT_FORWARD,
+                                                      error_description);
+}
+
+template <class TComplexArray3D>
+bool FFT(TComplexArray3D & data, const size_t size1, const size_t size2, const size_t size3,
+         const char *& error_description)
+{
+    return impl::CFFT<TComplexArray3D,3>::FFT_inplace(data, size1, size2, size3,
+                                                      impl::FFT_FORWARD,
+                                                      error_description);
+}
+
+// in-place, complex, inverse
+template <class TComplexArray1D>
+bool IFFT(TComplexArray1D & data, const size_t size, const char *& error_description)
+{
+    return impl::CFFT<TComplexArray1D,1>::FFT_inplace(data, size, impl::FFT_BACKWARD,
+                                                      error_description);
+}
+
+template <class TComplexArray2D>
+bool IFFT(TComplexArray2D & data, const size_t size1, const size_t size2,
+          const char *& error_description)
+{
+    return impl::CFFT<TComplexArray2D,2>::FFT_inplace(data, size1, size2, impl::FFT_BACKWARD,
+                                                      error_description);
+}
+
+template <class TComplexArray3D>
+bool IFFT(TComplexArray3D & data, const size_t size1, const size_t size2, const size_t size3,
+          const char *& error_description)
+{
+    return impl::CFFT<TComplexArray3D,3>::FFT_inplace(data, size1, size2, size3,
+                                                      impl::FFT_BACKWARD,
+                                                      error_description);
+}
+
+// not-in-place, complex, forward
+template <class TComplexArray1D>
+bool FFT(const TComplexArray1D & data_in, TComplexArray1D & data_out,
+         const size_t size, const char *& error_description)
+{
+    copy_array::copyArray(data_in, data_out, size);
+    return impl::CFFT<TComplexArray1D,1>::FFT_inplace(data_out, size, impl::FFT_FORWARD,
+                                                      error_description);
+}
+
+template <class TComplexArray2D>
+bool FFT(const TComplexArray2D & data_in, TComplexArray2D & data_out,
+         const size_t size1, const size_t size2, const char *& error_description)
+{
+    copy_array::copyArray(data_in, data_out, size1, size2);
+    return impl::CFFT<TComplexArray2D,2>::FFT_inplace(data_out, size1, size2,
+                                                      impl::FFT_FORWARD,
+                                                      error_description);
+}
+
+template <class TComplexArray3D>
+bool FFT(const TComplexArray3D & data_in, TComplexArray3D & data_out,
+         const size_t size1, const size_t size2, const size_t size3,
+         const char *& error_description)
+{
+    copy_array::copyArray(data_in, data_out, size1, size2, size3);
+    return impl::CFFT<TComplexArray3D,3>::FFT_inplace(data_out, size1, size2, size3,
+                                                      impl::FFT_FORWARD,
+                                                      error_description);
+}
+
+// not-in-place, complex, inverse
+template <class TComplexArray1D>
+bool IFFT(const TComplexArray1D & data_in, TComplexArray1D & data_out,
+          const size_t size, const char *& error_description)
+{
+    copy_array::copyArray(data_in, data_out, size);
+    return impl::CFFT<TComplexArray1D,1>::FFT_inplace(data_out, size, impl::FFT_BACKWARD,
+                                                      error_description);
+}
+
+template <class TComplexArray2D>
+bool IFFT(const TComplexArray2D & data_in, TComplexArray2D & data_out,
+          const size_t size1, const size_t size2, const char *& error_description)
+{
+    copy_array::copyArray(data_in, data_out, size1, size2);
+    return impl::CFFT<TComplexArray2D,2>::FFT_inplace(data_out, size1, size2,
+                                                      impl::FFT_BACKWARD,
+                                                      error_description);
+}
+
+template <class TComplexArray3D>
+bool IFFT(const TComplexArray3D & data_in, TComplexArray3D & data_out,
+          const size_t size1, const size_t size2, const size_t size3,
+          const char *& error_description)
+{
+    copy_array::copyArray(data_in, data_out, size1, size2, size3);
+    return impl::CFFT<TComplexArray3D,3>::FFT_inplace(data_out, size1, size2, size3,
+                                                      impl::FFT_BACKWARD,
+                                                      error_description);
+}
+
+// not-in-place, real, forward
+template <class TRealArray1D, class TComplexArray1D>
+bool FFT(const TRealArray1D & data_in, TComplexArray1D & data_out,
+         const size_t size, const char *& error_description)
+{
+    copy_array::copyArray(data_in, data_out, size);
+    return impl::CFFT<TComplexArray1D,1>::FFT_inplace(data_out, size,
+                                                      impl::FFT_FORWARD,
+                                                      error_description);
+}
+
+template <class TRealArray2D, class TComplexArray2D>
+bool FFT(const TRealArray2D & data_in, TComplexArray2D & data_out,
+         const size_t size1, const size_t size2, const char *& error_description)
+{
+    copy_array::copyArray(data_in, data_out, size1, size2);
+    return impl::CFFT<TComplexArray2D,2>::FFT_inplace(data_out, size1, size2,
+                                                      impl::FFT_FORWARD,
+                                                      error_description);
+}
+
+template <class TRealArray3D, class TComplexArray3D>
+bool FFT(const TRealArray3D & data_in, TComplexArray3D & data_out,
+         const size_t size1, const size_t size2, const size_t size3,
+         const char *& error_description)
+{
+    copy_array::copyArray(data_in, data_out, size1, size2, size3);
+    return impl::CFFT<TComplexArray3D,3>::FFT_inplace(data_out, size1, size2, size3,
+                                                      impl::FFT_FORWARD,
+                                                      error_description);
+}
+
+} // simple_fft
+
+#endif // __SIMPLE_FFT__FFT_HPP__

--- a/externals/Simple-FFT/include/simple_fft/fft_impl.hpp
+++ b/externals/Simple-FFT/include/simple_fft/fft_impl.hpp
@@ -1,0 +1,515 @@
+/**
+ * Copyright (c) 2013-2020 Dmitry Ivanov
+ *
+ * This file is a part of Simple-FFT project and is distributed under the terms
+ * of MIT license: https://opensource.org/licenses/MIT
+ */
+
+#ifndef __SIMPLE_FFT__FFT_IMPL_HPP__
+#define __SIMPLE_FFT__FFT_IMPL_HPP__
+
+#include "fft_settings.h"
+#include "error_handling.hpp"
+#include <cstddef>
+#include <math.h>
+#include <vector>
+
+using std::size_t;
+
+#ifndef M_PI
+#define M_PI 3.1415926535897932
+#endif
+
+namespace simple_fft {
+namespace impl {
+
+enum FFT_direction
+{
+    FFT_FORWARD = 0,
+    FFT_BACKWARD
+};
+
+// checking whether the size of array dimension is power of 2
+// via "complement and compare" method
+inline bool isPowerOfTwo(const size_t num)
+{
+    return num && (!(num & (num - 1)));
+}
+
+inline bool checkNumElements(const size_t num_elements, const char *& error_description)
+{
+    using namespace error_handling;
+
+    if (!isPowerOfTwo(num_elements)) {
+        GetErrorDescription(EC_ONE_OF_DIMS_ISNT_POWER_OF_TWO, error_description);
+        return false;
+    }
+
+    return true;
+}
+
+template <class TComplexArray1D>
+inline void scaleValues(TComplexArray1D & data, const size_t num_elements)
+{
+    real_type mult = 1.0 / num_elements;
+    int num_elements_signed = static_cast<int>(num_elements);
+
+#ifndef __clang__
+#ifdef __USE_OPENMP
+#pragma omp parallel for
+#endif
+#endif
+    for(int i = 0; i < num_elements_signed; ++i) {
+#ifdef __USE_SQUARE_BRACKETS_FOR_ELEMENT_ACCESS_OPERATOR
+        data[i] *= mult;
+#else
+        data(i) *= mult;
+#endif
+    }
+}
+
+// NOTE: explicit template specialization for the case of std::vector<complex_type>
+// because it is used in 2D and 3D FFT for both array classes with square and round
+// brackets of element access operator; I need to guarantee that sub-FFT 1D will
+// use square brackets for element access operator anyway. It is pretty ugly
+// to duplicate the code but I haven't found more elegant solution.
+template <>
+inline void scaleValues<std::vector<complex_type> >(std::vector<complex_type> & data,
+                                                    const size_t num_elements)
+{
+    real_type mult = 1.0 / num_elements;
+    int num_elements_signed = static_cast<int>(num_elements);
+
+#ifndef __clang__
+#ifdef __USE_OPENMP
+#pragma omp parallel for
+#endif
+#endif
+    for(int i = 0; i < num_elements_signed; ++i) {
+        data[i] *= mult;
+    }
+}
+
+template <class TComplexArray1D>
+inline void bufferExchangeHelper(TComplexArray1D & data, const size_t index_from,
+                                 const size_t index_to, complex_type & buf)
+{
+#ifdef __USE_SQUARE_BRACKETS_FOR_ELEMENT_ACCESS_OPERATOR
+    buf = data[index_from];
+    data[index_from] = data[index_to];
+    data[index_to]= buf;
+#else
+    buf = data(index_from);
+    data(index_from) = data(index_to);
+    data(index_to)= buf;
+#endif
+}
+
+// NOTE: explicit template specialization for the case of std::vector<complex_type>
+// because it is used in 2D and 3D FFT for both array classes with square and round
+// brackets of element access operator; I need to guarantee that sub-FFT 1D will
+// use square brackets for element access operator anyway. It is pretty ugly
+// to duplicate the code but I haven't found more elegant solution.
+template <>
+inline void bufferExchangeHelper<std::vector<complex_type> >(std::vector<complex_type> & data,
+                                                             const size_t index_from,
+                                                             const size_t index_to,
+                                                             complex_type & buf)
+{
+    buf = data[index_from];
+    data[index_from] = data[index_to];
+    data[index_to]= buf;
+}
+
+template <class TComplexArray1D>
+void rearrangeData(TComplexArray1D & data, const size_t num_elements)
+{
+    complex_type buf;
+
+    size_t target_index = 0;
+    size_t bit_mask;
+
+    for (size_t i = 0; i < num_elements; ++i)
+    {
+        if (target_index > i)
+        {
+            bufferExchangeHelper(data, target_index, i, buf);
+        }
+
+        // Initialize the bit mask
+        bit_mask = num_elements;
+
+        // While bit is 1
+        while (target_index & (bit_mask >>= 1)) // bit_mask = bit_mask >> 1
+        {
+            // Drop bit:
+            // & is bitwise AND,
+            // ~ is bitwise NOT
+            target_index &= ~bit_mask; // target_index = target_index & (~bit_mask)
+        }
+
+        // | is bitwise OR
+        target_index |= bit_mask; // target_index = target_index | bit_mask
+    }
+}
+
+template <class TComplexArray1D>
+inline void fftTransformHelper(TComplexArray1D & data, const size_t match,
+                               const size_t k, complex_type & product,
+                               const complex_type factor)
+{
+#ifdef __USE_SQUARE_BRACKETS_FOR_ELEMENT_ACCESS_OPERATOR
+    product = data[match] * factor;
+    data[match] = data[k] - product;
+    data[k] += product;
+#else
+    product = data(match) * factor;
+    data(match) = data(k) - product;
+    data(k) += product;
+#endif
+}
+
+// NOTE: explicit template specialization for the case of std::vector<complex_type>
+// because it is used in 2D and 3D FFT for both array classes with square and round
+// brackets of element access operator; I need to guarantee that sub-FFT 1D will
+// use square brackets for element access operator anyway. It is pretty ugly
+// to duplicate the code but I haven't found more elegant solution.
+template <>
+inline void fftTransformHelper<std::vector<complex_type> >(std::vector<complex_type> & data,
+                                                           const size_t match,
+                                                           const size_t k,
+                                                           complex_type & product,
+                                                           const complex_type factor)
+{
+    product = data[match] * factor;
+    data[match] = data[k] - product;
+    data[k] += product;
+}
+
+template <class TComplexArray1D>
+bool makeTransform(TComplexArray1D & data, const size_t num_elements,
+                   const FFT_direction fft_direction, const char *& error_description)
+{
+    using namespace error_handling;
+    using std::sin;
+
+    double local_pi;
+    switch(fft_direction)
+    {
+    case(FFT_FORWARD):
+        local_pi = -M_PI;
+        break;
+    case(FFT_BACKWARD):
+        local_pi = M_PI;
+        break;
+    default:
+        GetErrorDescription(EC_WRONG_FFT_DIRECTION, error_description);
+        return false;
+    }
+
+    // declare variables to cycle the bits of initial signal
+    size_t next, match;
+    real_type sine;
+    real_type delta;
+    complex_type mult, factor, product;
+
+    // NOTE: user's complex type should have constructor like
+    // "complex(real, imag)", where each of real and imag has
+    // real type.
+
+    // cycle for all bit positions of initial signal
+    for (size_t i = 1; i < num_elements; i <<= 1)
+    {
+        next = i << 1;  // getting the next bit
+        delta = local_pi / i;    // angle increasing
+        sine = sin(0.5 * delta);    // supplementary sin
+        // multiplier for trigonometric recurrence
+        mult = complex_type(-2.0 * sine * sine, sin(delta));
+        factor = 1.0;   // start transform factor
+
+        for (size_t j = 0; j < i; ++j) // iterations through groups
+                                       // with different transform factors
+        {
+            for (size_t k = j; k < num_elements; k += next) // iterations through
+                                                            // pairs within group
+            {
+                match = k + i;
+                fftTransformHelper(data, match, k, product, factor);
+            }
+            factor = mult * factor + factor;
+        }
+    }
+
+    return true;
+}
+
+// Generic template for complex FFT followed by its explicit specializations
+template <class TComplexArray, int NumDims>
+struct CFFT
+{};
+
+// 1D FFT:
+template <class TComplexArray1D>
+struct CFFT<TComplexArray1D,1>
+{
+    // NOTE: passing by pointer is needed to avoid using element access operator
+    static bool FFT_inplace(TComplexArray1D & data, const size_t size,
+                            const FFT_direction fft_direction,
+                            const char *& error_description)
+    {
+        if(!checkNumElements(size, error_description)) {
+            return false;
+        }
+
+        rearrangeData(data, size);
+
+        if(!makeTransform(data, size, fft_direction, error_description)) {
+            return false;
+        }
+
+        if (FFT_BACKWARD == fft_direction) {
+            scaleValues(data, size);
+        }
+
+        return true;
+    }
+};
+
+// 2D FFT
+template <class TComplexArray2D>
+struct CFFT<TComplexArray2D,2>
+{
+    static bool FFT_inplace(TComplexArray2D & data, const size_t size1, const size_t size2,
+                            const FFT_direction fft_direction, const char *& error_description)
+    {
+        int n_rows = static_cast<int>(size1);
+        int n_cols = static_cast<int>(size2);
+
+        // fft for columns
+        std::vector<complex_type> subarray(n_rows); // each column has n_rows elements
+
+        for(int j = 0; j < n_cols; ++j)
+        {
+#ifndef __clang__
+#ifdef __USE_OPENMP
+#pragma omp parallel for
+#endif
+#endif
+            for(int i = 0; i < n_rows; ++i) {
+#ifdef __USE_SQUARE_BRACKETS_FOR_ELEMENT_ACCESS_OPERATOR
+                subarray[i] = data[i][j];
+#else
+                subarray[i] = data(i,j);
+#endif
+            }
+
+            if(!CFFT<std::vector<complex_type>,1>::FFT_inplace(subarray, size1,
+                                                               fft_direction,
+                                                               error_description))
+            {
+                return false;
+            }
+
+#ifndef __clang__
+#ifdef __USE_OPENMP
+#pragma omp parallel for
+#endif
+#endif
+            for(int i = 0; i < n_rows; ++i) {
+#ifdef __USE_SQUARE_BRACKETS_FOR_ELEMENT_ACCESS_OPERATOR
+                data[i][j] = subarray[i];
+#else
+                data(i,j) = subarray[i];
+#endif
+            }
+        }
+
+        // fft for rows
+        subarray.resize(n_cols); // each row has n_cols elements
+
+        for(int i = 0; i < n_rows; ++i)
+        {
+#ifndef __clang__
+#ifdef __USE_OPENMP
+#pragma omp parallel for
+#endif
+#endif
+            for(int j = 0; j < n_cols; ++j) {
+#ifdef __USE_SQUARE_BRACKETS_FOR_ELEMENT_ACCESS_OPERATOR
+                subarray[j] = data[i][j];
+#else
+                subarray[j] = data(i,j);
+#endif
+            }
+
+            if(!CFFT<std::vector<complex_type>,1>::FFT_inplace(subarray, size2,
+                                                               fft_direction,
+                                                               error_description))
+            {
+                return false;
+            }
+
+#ifndef __clang__
+#ifdef __USE_OPENMP
+#pragma omp parallel for
+#endif
+#endif
+            for(int j = 0; j < n_cols; ++j) {
+#ifdef __USE_SQUARE_BRACKETS_FOR_ELEMENT_ACCESS_OPERATOR
+                data[i][j] = subarray[j];
+#else
+                data(i,j) = subarray[j];
+#endif
+            }
+        }
+
+        return true;
+    }
+};
+
+// 3D FFT
+template <class TComplexArray3D>
+struct CFFT<TComplexArray3D,3>
+{
+    static bool FFT_inplace(TComplexArray3D & data, const size_t size1, const size_t size2,
+                            const size_t size3, const FFT_direction fft_direction,
+                            const char *& error_description)
+    {
+        int n_rows  = static_cast<int>(size1);
+        int n_cols  = static_cast<int>(size2);
+        int n_depth = static_cast<int>(size3);
+
+        std::vector<complex_type> subarray(n_rows); // for fft for columns: each column has n_rows elements
+
+        for(int k = 0; k < n_depth; ++k) // for all depth layers
+        {
+            // fft for columns
+            for(int j = 0; j < n_cols; ++j)
+            {
+#ifndef __clang__
+#ifdef __USE_OPENMP
+#pragma omp parallel for
+#endif
+#endif
+                for(int i = 0; i < n_rows; ++i) {
+#ifdef __USE_SQUARE_BRACKETS_FOR_ELEMENT_ACCESS_OPERATOR
+                    subarray[i] = data[i][j][k];
+#else
+                    subarray[i] = data(i,j,k);
+#endif
+                }
+
+                if(!CFFT<std::vector<complex_type>,1>::FFT_inplace(subarray, size1,
+                                                                   fft_direction,
+                                                                   error_description))
+                {
+                    return false;
+                }
+
+#ifndef __clang__
+#ifdef __USE_OPENMP
+#pragma omp parallel for
+#endif
+#endif
+                for(int i = 0; i < n_rows; ++i) {
+#ifdef __USE_SQUARE_BRACKETS_FOR_ELEMENT_ACCESS_OPERATOR
+                    data[i][j][k] = subarray[i];
+#else
+                    data(i,j,k) = subarray[i];
+#endif
+                }
+            }
+        }
+
+        subarray.resize(n_cols); // for fft for rows: each row has n_cols elements
+
+        for(int k = 0; k < n_depth; ++k) // for all depth layers
+        {
+            // fft for rows
+            for(int i = 0; i < n_rows; ++i)
+            {
+#ifndef __clang__
+#ifdef __USE_OPENMP
+#pragma omp parallel for
+#endif
+#endif
+                for(int j = 0; j < n_cols; ++j) {
+#ifdef __USE_SQUARE_BRACKETS_FOR_ELEMENT_ACCESS_OPERATOR
+                    subarray[j] = data[i][j][k];
+#else
+                    subarray[j] = data(i,j,k);
+#endif
+                }
+
+                if(!CFFT<std::vector<complex_type>,1>::FFT_inplace(subarray, size2,
+                                                                   fft_direction,
+                                                                   error_description))
+                {
+                    return false;
+                }
+
+#ifndef __clang__
+#ifdef __USE_OPENMP
+#pragma omp parallel for
+#endif
+#endif
+                for(int j = 0; j < n_cols; ++j) {
+#ifdef __USE_SQUARE_BRACKETS_FOR_ELEMENT_ACCESS_OPERATOR
+                    data[i][j][k] = subarray[j];
+#else
+                    data(i,j,k) = subarray[j];
+#endif
+                }
+            }
+        }
+
+        // fft for depth
+        subarray.resize(n_depth); // each depth strip contains n_depth elements
+
+        for(int i = 0; i < n_rows; ++i) // for all rows layers
+        {
+            for(int j = 0; j < n_cols; ++j) // for all cols layers
+            {
+#ifndef __clang__
+#ifdef __USE_OPENMP
+#pragma omp parallel for
+#endif
+#endif
+                for(int k = 0; k < n_depth; ++k) {
+#ifdef __USE_SQUARE_BRACKETS_FOR_ELEMENT_ACCESS_OPERATOR
+                    subarray[k] = data[i][j][k];
+#else
+                    subarray[k] = data(i,j,k);
+#endif
+                }
+
+                if(!CFFT<std::vector<complex_type>,1>::FFT_inplace(subarray, size3,
+                                                                   fft_direction,
+                                                                   error_description))
+                {
+                    return false;
+                }
+
+#ifndef __clang__
+#ifdef __USE_OPENMP
+#pragma omp parallel for
+#endif
+#endif
+                for(int k = 0; k < n_depth; ++k) {
+#ifdef __USE_SQUARE_BRACKETS_FOR_ELEMENT_ACCESS_OPERATOR
+                    data[i][j][k] = subarray[k];
+#else
+                    data(i,j,k) = subarray[k];
+#endif
+                }
+            }
+        }
+
+        return true;
+    }
+};
+
+} // namespace impl
+} // namespace simple_fft
+
+#endif // __SIMPLE_FFT__FFT_IMPL_HPP__

--- a/externals/Simple-FFT/include/simple_fft/fft_settings.h
+++ b/externals/Simple-FFT/include/simple_fft/fft_settings.h
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2013-2020 Dmitry Ivanov
+ *
+ * This file is a part of Simple-FFT project and is distributed under the terms
+ * of MIT license: https://opensource.org/licenses/MIT
+ */
+
+// In this file you can alter some settings of the library:
+// 1) Specify the desired real and complex types by typedef'ing real_type and complex_type.
+//    By default real_type is double and complex_type is std::complex<real_type>.
+// 2) If the array class uses square brackets for element access operator, define
+//    the macro __USE_SQUARE_BRACKETS_FOR_ELEMENT_ACCESS_OPERATOR
+
+#ifndef __SIMPLE_FFT__FFT_SETTINGS_H__
+#define __SIMPLE_FFT__FFT_SETTINGS_H__
+
+#include <complex>
+
+typedef float real_type;
+typedef std::complex<real_type> complex_type;
+
+#ifndef __USE_SQUARE_BRACKETS_FOR_ELEMENT_ACCESS_OPERATOR
+#define __USE_SQUARE_BRACKETS_FOR_ELEMENT_ACCESS_OPERATOR
+#endif
+
+#endif // __SIMPLE_FFT__FFT_SETTINGS_H__

--- a/meson.build
+++ b/meson.build
@@ -39,7 +39,6 @@ endif
 src = [	'src/DataProtocol.cpp',
 	'src/JackTrip.cpp',
 	'src/ProcessPlugin.cpp',
-	'src/Analyzer.cpp',
 	'src/AudioTester.cpp',
 	'src/jacktrip_globals.cpp',
 	'src/JackTripWorker.cpp',
@@ -67,7 +66,6 @@ src = [	'src/DataProtocol.cpp',
 moc_h = ['src/DataProtocol.h',
 	'src/JackTrip.h',
 	'src/ProcessPlugin.h',
-	'src/Analyzer.h',
 	'src/Meter.h',
 	'src/Monitor.h',
 	'src/StereoToMono.h',
@@ -214,6 +212,13 @@ else
 			'src/dblsqd/update_dialog.h'
 		]
 		ui_h += ['src/dblsqd/update_dialog.ui']
+	endif
+
+	if get_option('nofeedback') == true
+		defines += '-DNO_FEEDBACK'
+	else
+		src += [ 'src/Analyzer.cpp' ]
+		moc_h += [ 'src/Analyzer.h' ]
 	endif
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,5 +6,6 @@ option('nogui', type : 'boolean', value : 'false', description: 'Build without g
 option('novs', type : 'boolean', value : 'false', description: 'Build without Virtual Studio support')
 option('vsftux', type : 'boolean', value : 'false', description: 'Build with Virtual Studio first launch experience')
 option('noupdater', type : 'boolean', value : 'false', description: 'Build without auto-update support')
+option('nofeedback', type : 'boolean', value : 'false', description: 'Build without feedback detection')
 option('profile', type: 'combo', choices: ['default', 'development'], value: 'default', description: 'Choose build profile / Sets desktop id accordingly')
 option('qtversion', type : 'combo', choices: ['', '5', '6'], description: 'Choose to build with either Qt5 or Qt6')

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1705,6 +1705,7 @@ void VirtualStudio::completeConnection()
         connect(this, &VirtualStudio::updatedMonitorVolume, m_monitor,
                 &Monitor::volumeUpdated);
 
+#ifndef NO_FEEDBACK
         // Setup output analyzer
         if (m_feedbackDetectionEnabled) {
             m_outputAnalyzerPlugin = new Analyzer(jackTrip->getNumOutputChannels());
@@ -1713,6 +1714,7 @@ void VirtualStudio::completeConnection()
             connect(m_outputAnalyzerPlugin, &Analyzer::signalFeedbackDetected, this,
                     &VirtualStudio::detectedFeedbackLoop);
         }
+#endif
 
         // Setup output meter
         // Note: Add this to monitor process to include self-volume

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -47,7 +47,10 @@
 #include <QTimer>
 #include <QVector>
 
+#ifndef NO_FEEDBACK
 #include "../Analyzer.h"
+#endif
+
 #include "../JackTrip.h"
 #include "../Meter.h"
 #include "../Monitor.h"
@@ -491,8 +494,11 @@ class VirtualStudio : public QObject
     bool m_outputClipped  = false;
     bool m_networkOutage  = false;
 
+#ifndef NO_FEEDBACK
     Analyzer* m_inputAnalyzerPlugin;
     Analyzer* m_outputAnalyzerPlugin;
+#endif
+
     QVector<float> m_inputMeterLevels;
     QVector<float> m_outputMeterLevels;
     QJsonArray m_inputComboModel;


### PR DESCRIPTION
so that git submodules are not required to create builds of JackTrip

Also added a `nofeedback` option for meson, so that JackTrip can be built without support for feedback detection, causing it to not use Simple-FFT at all.