### PR TITLE
Fixing potential crash on Windows within the AudioSettings dialog.

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -331,7 +331,7 @@ jobs:
         run: |
           sudo chmod a+rwx /opt
           sudo apt-get update
-          sudo apt-get install --yes libjack-dev libclang-dev ninja-build
+          sudo apt-get install --yes libjack-dev libclang-dev libclang-12-dev llvm-12-dev ninja-build
           if [[ -n "${{ matrix.static-qt-version }}" ]]; then 
             sudo apt-get install --yes libfreetype6-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libx11-xcb-dev libdrm-dev libglu1-mesa-dev libwayland-dev libwayland-egl1-mesa libgles2-mesa-dev libwayland-server0 libwayland-egl-backend-dev libxcb1-dev libxext-dev libfontconfig1-dev libxrender-dev libxcb-keysyms1-dev libxcb-image0-dev libxcb-shm0-dev libxcb-icccm4-dev '^libxcb.*-dev' libxcb-render-util0-dev libxcomposite-dev libgtk-3-dev
           else

--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -1,3 +1,7 @@
+- Version: "1.10.1"
+  Date: 2023-08-03
+  Description:
+  - (fixed) VS Mode crashes involving ASIO device selection
 - Version: "1.10.0"
   Date: 2023-06-16
   Description:

--- a/src/gui/AudioSettings.qml
+++ b/src/gui/AudioSettings.qml
@@ -207,7 +207,6 @@ Rectangle {
                                     }
                                 }
                                 virtualstudio.restartAudio()
-                                virtualstudio.validateDevicesState()
                             }
                         }
                     }
@@ -516,7 +515,6 @@ Rectangle {
                                     }
                                 }
                                 virtualstudio.restartAudio()
-                                virtualstudio.validateDevicesState()
                             }
                         }
                     }

--- a/src/gui/vsAudioInterface.cpp
+++ b/src/gui/vsAudioInterface.cpp
@@ -424,6 +424,8 @@ void VsAudioInterface::setNumOutputChannels(int numChannels, bool shouldRestart)
 
 void VsAudioInterface::refreshRtAudioDevices()
 {
+    // note: audio must not be active when scanning devices
+    closeAudio();
     RtAudioInterface::scanDevices(m_devices);
 }
 

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -40,7 +40,7 @@
 
 #include "AudioInterface.h"
 
-constexpr const char* const gVersion = "1.10.0";  ///< JackTrip version
+constexpr const char* const gVersion = "1.10.1";  ///< JackTrip version
 
 //*******************************************************************************
 /// \name Default Values


### PR DESCRIPTION
When an ASIO device is selected and you try to change to another (ASIO or non-ASIO) device on Windows, it would potentially cause a crash when using rtaudio to rescan devices while an ASIO device while already open.

Also removing a redundant call to validatedevices.

Bumping version to 1.10.1 for bugfix release