### PR TITLE
Show friendly message when scanning audio devices

### DIFF
--- a/src/gui/AudioSettings.qml
+++ b/src/gui/AudioSettings.qml
@@ -26,7 +26,6 @@ Rectangle {
     property string buttonStroke: virtualstudio.darkMode ? "#80827D7D" : "#40979797"
     property string buttonHoverStroke: virtualstudio.darkMode ? "#7B7777" : "#BABCBC"
     property string buttonPressedStroke: virtualstudio.darkMode ? "#827D7D" : "#BABCBC"
-    property string warningTextColour: "#DB0A0A"
     property string linkText: virtualstudio.darkMode ? "#8B8D8D" : "#272525"
     property string toolTipBackgroundColour: virtualstudio.darkMode ? "#323232" : "#F3F3F3"
     property string toolTipTextColour: textColour
@@ -36,7 +35,7 @@ Rectangle {
 
     property bool isUsingJack: virtualstudio.audioBackend == "JACK"
     property bool isUsingRtAudio: virtualstudio.audioBackend == "RtAudio"
-    property bool hasNoBackend: !isUsingJack && !isUsingRtAudio && !virtualstudio.backendAvailable;
+    property bool hasNoBackend: !isUsingJack && !isUsingRtAudio && !virtualstudio.backendAvailable
 
     function getCurrentInputDeviceIndex () {
         if (virtualstudio.inputDevice === "") {
@@ -64,7 +63,7 @@ Rectangle {
 
     Loader {
         anchors.fill: parent
-        sourceComponent: Boolean(audioInterface) ? (isUsingRtAudio ? usingRtAudio : (isUsingJack ? usingJACK : noBackend)) : noBackend
+        sourceComponent: hasNoBackend ? nobackend : (Boolean(audioInterface) && Boolean(virtualstudio) && virtualstudio.audioReady) ? (isUsingRtAudio ? usingRtAudio : (isUsingJack ? usingJACK : scanningAudio)) : scanningAudio
     }
 
     Component {
@@ -702,6 +701,29 @@ Rectangle {
                 x: 0; y: 0
                 width: parent.width - (16 * virtualstudio.uiScale)
                 text: "JackTrip has been compiled without an audio backend. Please rebuild with the rtaudio flag or without the nojack flag."
+                font { family: "Poppins"; pixelSize: fontMedium * virtualstudio.fontScale * virtualstudio.uiScale }
+                wrapMode: Text.WordWrap
+                color: textColour
+            }
+        }
+    }
+
+    Component {
+        id: scanningAudio
+
+        Item {
+            anchors.top: parent.top
+            anchors.topMargin: 24 * virtualstudio.uiScale
+            anchors.bottom: parent.bottom
+            anchors.left: parent.left
+            anchors.leftMargin: leftMargin * virtualstudio.uiScale
+            anchors.right: parent.right
+
+            Text {
+                id: scanningAudioLabel
+                x: 0; y: 0
+                width: parent.width - (16 * virtualstudio.uiScale)
+                text: "Scanning audio devices..."
                 font { family: "Poppins"; pixelSize: fontMedium * virtualstudio.fontScale * virtualstudio.uiScale }
                 wrapMode: Text.WordWrap
                 color: textColour

--- a/src/gui/ChangeDevices.qml
+++ b/src/gui/ChangeDevices.qml
@@ -25,7 +25,6 @@ Rectangle {
     property string shadowColour: virtualstudio.darkMode ? "#40000000" : "#80A1A1A1"
     property string toolTipBackgroundColour: virtualstudio.darkMode ? "#323232" : "#F3F3F3"
     property string toolTipTextColour: textColour
-    property string warningTextColour: "#DB0A0A"
 
     property string browserButtonColour: virtualstudio.darkMode ? "#494646" : "#EAECEC"
     property string browserButtonHoverColour: virtualstudio.darkMode ? "#5B5858" : "#D3D4D4"
@@ -453,28 +452,12 @@ Rectangle {
                 color: textColour
             }
 
-            Text {
-                id: warningOrErrorMessage
-                anchors.left: inputLabel.left
-                anchors.right: parent.right
-                anchors.rightMargin: 16 * virtualstudio.uiScale
+            DeviceWarning {
+                id: deviceWarning
+                anchors.left: inputCombo.left
                 anchors.top: inputMixModeHelpMessage.bottom
-                anchors.topMargin: 8 * virtualstudio.uiScale
-                anchors.bottomMargin: 8 * virtualstudio.uiScale
-                textFormat: Text.RichText
-                text: (virtualstudio.devicesError || virtualstudio.devicesWarning)
-                    + ((virtualstudio.devicesErrorHelpUrl || virtualstudio.devicesWarningHelpUrl)
-                        ? `&nbsp;<a style="color: ${linkText};" href=${virtualstudio.devicesErrorHelpUrl || virtualstudio.devicesWarningHelpUrl}>Learn More.</a>`
-                        : ""
-                    )
-                onLinkActivated: link => {
-                    virtualstudio.openLink(link)
-                }
-                horizontalAlignment: Text.AlignHLeft
-                wrapMode: Text.WordWrap
-                color: warningTextColour
-                font { family: "Poppins"; pixelSize: fontTiny * virtualstudio.fontScale * virtualstudio.uiScale }
-                visible: Boolean(virtualstudio.devicesError) || Boolean(virtualstudio.devicesWarning);
+                anchors.topMargin: 48 * virtualstudio.uiScale
+                visible: Boolean(virtualstudio.devicesError) || Boolean(virtualstudio.devicesWarning)
             }
         }
     }

--- a/src/gui/DeviceControls.qml
+++ b/src/gui/DeviceControls.qml
@@ -81,41 +81,9 @@ Item {
                 sliderEnabled: !virtualstudio.inputMuted
             }
 
-            Item {
-                id: warning
-                Layout.fillWidth: true
-                Layout.fillHeight: true
-
-                InfoTooltip {
-                    id: warningIcon
-                    anchors.top: parent.top
-                    anchors.left: parent.left
-                    anchors.leftMargin: 10 * virtualstudio.uiScale
-                    size: 16 * virtualstudio.uiScale
-                    content: qsTr(virtualstudio.devicesError || virtualstudio.devicesWarning)
-                    iconSource: "warning.svg"
-                    iconColor: "red"
-                }
-
-                Text {
-                    id: warningMessageText
-                    color: "red"
-                    font {
-                        family: "Poppins"
-                        pixelSize: 10 * virtualstudio.uiScale
-                    }
-
-                    elide: Text.ElideRight
-                    text: (virtualstudio.devicesError || virtualstudio.devicesWarning)
-
-                    anchors.verticalCenter: warningIcon.verticalCenter
-                    anchors.left: warningIcon.right
-                    anchors.leftMargin: 12 * virtualstudio.uiScale
-                    anchors.right: warning.right
-                    anchors.rightMargin: 12 * virtualstudio.uiScale
-                }
-
-                visible: Boolean(virtualstudio.devicesError) || Boolean(virtualstudio.devicesWarning);
+            DeviceWarning {
+                id: deviceWarning
+                visible: Boolean(virtualstudio.devicesError) || Boolean(virtualstudio.devicesWarning)
             }
         }
     }

--- a/src/gui/DeviceWarning.qml
+++ b/src/gui/DeviceWarning.qml
@@ -1,0 +1,52 @@
+import QtQuick
+import QtQuick.Controls
+
+Item {
+    height: 28 * virtualstudio.uiScale
+    property string devicesWarningColour: "#F21B1B"
+
+    AppIcon {
+        id: devicesWarningIcon
+        anchors.left: parent.left
+        anchors.verticalCenter: parent.verticalCenter
+        width: parent.height
+        height: parent.height
+        icon.source: "warning.svg"
+        color: devicesWarningColour
+        visible: Boolean(virtualstudio.devicesError) || Boolean(virtualstudio.devicesWarning)
+    }
+    
+    Text {
+        id: warningOrErrorText
+        text: Boolean(virtualstudio.devicesError) ? "Audio Configuration Error" : "Audio Configuration Warning"
+        anchors.left: devicesWarningIcon.right
+        anchors.leftMargin: 4 * virtualstudio.uiScale
+        anchors.verticalCenter: devicesWarningIcon.verticalCenter
+        visible: Boolean(virtualstudio.devicesError) || Boolean(virtualstudio.devicesWarning)
+        font { family: "Poppins"; pixelSize: 10 * virtualstudio.fontScale * virtualstudio.uiScale }
+        color: devicesWarningColour
+    }
+
+    InfoTooltip {
+        id: devicesWarningTooltip
+        anchors.left: warningOrErrorText.right
+        anchors.leftMargin: 2 * virtualstudio.uiScale
+        anchors.bottom: warningOrErrorText.bottom
+        anchors.bottomMargin: 6 * virtualstudio.uiScale
+        content: qsTr(virtualstudio.devicesError || virtualstudio.devicesWarning)
+        iconColor: devicesWarningColour
+        size: 16 * virtualstudio.uiScale
+        visible: Boolean(virtualstudio.devicesError) || Boolean(virtualstudio.devicesWarning)
+    }
+
+    MouseArea {
+        id: devicesWarningToolTipArea
+        anchors.top: devicesWarningIcon.top
+        anchors.bottom: devicesWarningIcon.bottom
+        anchors.left: devicesWarningIcon.left
+        anchors.right: warningOrErrorText.right
+        hoverEnabled: true
+        onEntered: devicesWarningTooltip.showToolTip = true
+        onExited: devicesWarningTooltip.showToolTip = false
+    }
+}

--- a/src/gui/Settings.qml
+++ b/src/gui/Settings.qml
@@ -85,39 +85,12 @@ Item {
             id: audioSettings
         }
 
-        AppIcon {
-            id: devicesWarningIcon
+        DeviceWarning {
+            id: deviceWarning
             anchors.left: parent.left
             anchors.leftMargin: 168 * virtualstudio.uiScale
             anchors.bottom: parent.bottom
             anchors.bottomMargin: 48 * virtualstudio.uiScale
-            width: 28 * virtualstudio.uiScale
-            height: 28 * virtualstudio.uiScale
-            icon.source: "warning.svg"
-            color: "#F21B1B"
-            visible: Boolean(virtualstudio.devicesError) || Boolean(virtualstudio.devicesWarning)
-        }
-
-        Text {
-            id: warningOrErrorText
-            text: Boolean(virtualstudio.devicesError) ? "Audio Configuration Error" : "Audio Configuration Warning"
-            anchors.left: devicesWarningIcon.right
-            anchors.leftMargin: 4 * virtualstudio.uiScale
-            anchors.verticalCenter: devicesWarningIcon.verticalCenter
-            visible: Boolean(virtualstudio.devicesError) || Boolean(virtualstudio.devicesWarning)
-            font { family: "Poppins"; pixelSize: 10 * virtualstudio.fontScale * virtualstudio.uiScale }
-            color: "#F21B1B"
-        }
-
-        InfoTooltip {
-            id: devicesWarningTooltip
-            anchors.left: warningOrErrorText.right
-            anchors.leftMargin: 2 * virtualstudio.uiScale
-            anchors.bottom: warningOrErrorText.bottom
-            anchors.bottomMargin: 6 * virtualstudio.uiScale
-            content: qsTr(virtualstudio.devicesError || virtualstudio.devicesWarning)
-            iconColor: "#F21B1B"
-            size: 16 * virtualstudio.uiScale
             visible: Boolean(virtualstudio.devicesError) || Boolean(virtualstudio.devicesWarning)
         }
     }

--- a/src/gui/Setup.qml
+++ b/src/gui/Setup.qml
@@ -29,9 +29,6 @@ Item {
     property string checkboxPressedStroke: "#007AFF"
     property string disabledButtonText: virtualstudio.darkMode ? "#827D7D" : "#BABCBC"
 
-    property bool currShowWarnings: virtualstudio.showWarnings
-    property string warningScreen: virtualstudio.showWarnings ? "ethernet" : ( permissions.micPermission == "unknown" ? "microphone" : "acknowledged")
-
     Item {
         id: setupItem
         width: parent.width; height: parent.height
@@ -106,38 +103,11 @@ Item {
             }
         }
 
-        AppIcon {
-            id: devicesWarningIcon
+        DeviceWarning {
+            id: deviceWarning
             anchors.left: backButton.right
             anchors.leftMargin: 16 * virtualstudio.uiScale
             anchors.verticalCenter: backButton.verticalCenter
-            width: 28 * virtualstudio.uiScale
-            height: 28 * virtualstudio.uiScale
-            icon.source: "warning.svg"
-            color: "#F21B1B"
-            visible: Boolean(virtualstudio.devicesError) || Boolean(virtualstudio.devicesWarning)
-        }
-
-        Text {
-            id: warningOrErrorText
-            text: Boolean(virtualstudio.devicesError) ? "Audio Configuration Error" : "Audio Configuration Warning"
-            anchors.left: devicesWarningIcon.right
-            anchors.leftMargin: 4 * virtualstudio.uiScale
-            anchors.verticalCenter: devicesWarningIcon.verticalCenter
-            visible: Boolean(virtualstudio.devicesError) || Boolean(virtualstudio.devicesWarning)
-            font { family: "Poppins"; pixelSize: 10 * virtualstudio.fontScale * virtualstudio.uiScale }
-            color: "#F21B1B"
-        }
-
-        InfoTooltip {
-            id: devicesWarningTooltip
-            anchors.left: warningOrErrorText.right
-            anchors.leftMargin: 2 * virtualstudio.uiScale
-            anchors.bottom: warningOrErrorText.bottom
-            anchors.bottomMargin: 6 * virtualstudio.uiScale
-            content: qsTr(virtualstudio.devicesError || virtualstudio.devicesWarning)
-            iconColor: "#F21B1B"
-            size: 16 * virtualstudio.uiScale
             visible: Boolean(virtualstudio.devicesError) || Boolean(virtualstudio.devicesWarning)
         }
 

--- a/src/gui/qjacktrip.qrc
+++ b/src/gui/qjacktrip.qrc
@@ -26,6 +26,7 @@
     <file>VolumeSlider.qml</file>
     <file>DeviceControls.qml</file>
     <file>DeviceControlsGroup.qml</file>
+    <file>DeviceWarning.qml</file>
     <file>InfoTooltip.qml</file>
     <file>Web.qml</file>
     <file>WebView.qml</file>


### PR DESCRIPTION
instead of an error about JackTrip being compiled incorrectly

Updated audio warning and error messages spread across 4 components to share a new common DeviceWarning.qml component, so that they look and behave the same way

![Screenshot (32)](https://github.com/jacktrip/jacktrip/assets/1159596/21c57b75-4138-44ff-95b6-b593a8b7e3bc)

![Screenshot (11)](https://github.com/jacktrip/jacktrip/assets/1159596/c693df6a-d2e9-4329-b106-2008cb303f57)

![Screenshot (10)](https://github.com/jacktrip/jacktrip/assets/1159596/a20a77e8-4399-48c2-b8a4-f9254ac2b4e1)

![Screenshot (5)](https://github.com/jacktrip/jacktrip/assets/1159596/e5564278-1a94-453f-a922-f6b04f33026e)