### PR TITLE
Fix for failed artifact deployment to google cloud

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -792,6 +792,8 @@ jobs:
           create_credentials_file: true
       - name: Upload files
         run: |
+          # this feature seems to produce permission denied errors on osx and linux runners (for larger files)
+          gcloud config set storage/parallel_composite_upload_enabled False
           gcloud storage cp ${{ env.DOWNLOAD_PATH }}/JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}-${{ steps.set-version.outputs.type }}${{ steps.set-version.outputs.extension }} gs://files.jacktrip.org/app-builds
       - name: Update edge manifests
         id: update-edge


### PR DESCRIPTION
The 2.0.0-beta1 release artifact failed to automatically deploy to google cloud when it was released.

https://github.com/jacktriplabs/jacktrip/actions/runs/5790324332/job/15693619792

I believe this is the same problem I ran into working on the Qt build artifacts. There is a gcloud storage feature that breaks large file uploads on osx and linux runners.

Copying over the same patch I used to disable this feature, and will test it with the beta2 release