### PR TITLE
Removing the screen flicker when you change audio channels or devices

### DIFF
--- a/src/gui/AudioSettings.qml
+++ b/src/gui/AudioSettings.qml
@@ -63,7 +63,7 @@ Rectangle {
 
     Loader {
         anchors.fill: parent
-        sourceComponent: audio.audioReady ? (isUsingRtAudio ? usingRtAudio : (isUsingJack ? usingJACK : scanningAudio)) : scanningAudio
+        sourceComponent: !audio.deviceModelsInitialized || audio.scanningDevices ? scanningDevices : (isUsingRtAudio ? usingRtAudio : (isUsingJack ? usingJACK : scanningDevices))
     }
 
     Component {
@@ -231,6 +231,7 @@ Rectangle {
                             outputChannelsCombo.popup.close()
                             audio.baseOutputChannel = modelData.baseChannel
                             audio.numOutputChannels = modelData.numChannels
+                            audio.validateDevices()
                             audio.restartAudio()
                         }
                     }
@@ -430,6 +431,7 @@ Rectangle {
                             inputChannelsCombo.popup.close()
                             audio.baseInputChannel = modelData.baseChannel
                             audio.numInputChannels = modelData.numChannels
+                            audio.validateDevices()
                             audio.restartAudio()
                         }
                     }
@@ -486,6 +488,7 @@ Rectangle {
                             inputMixModeCombo.currentIndex = index
                             inputMixModeCombo.popup.close()
                             audio.inputMixMode = audio.inputMixModeComboModel[index].value
+                            audio.validateDevices();
                             audio.restartAudio()
                         }
                     }
@@ -711,7 +714,7 @@ Rectangle {
     }
 
     Component {
-        id: scanningAudio
+        id: scanningDevices
 
         Item {
             anchors.top: parent.top
@@ -722,7 +725,7 @@ Rectangle {
             anchors.right: parent.right
 
             Text {
-                id: scanningAudioLabel
+                id: scanningDevicesLabel
                 x: 0; y: 0
                 width: parent.width - (16 * virtualstudio.uiScale)
                 text: "Scanning audio devices..."

--- a/src/gui/ChangeDevices.qml
+++ b/src/gui/ChangeDevices.qml
@@ -88,11 +88,22 @@ Rectangle {
                 id: refreshButton
                 y: 0;
                 x: parent.width - (144 + rightMargin) * virtualstudio.uiScale;
+                enabled: !audio.scanningDevices
                 onClicked: {
                     audio.refreshDevices();
                     inputCombo.currentIndex = getCurrentInputDeviceIndex();
                     outputCombo.currentIndex = getCurrentOutputDeviceIndex();
                 }
+            }
+
+            Text {
+                text: "Scanning Devices"
+                y: 0;
+                anchors.right: refreshButton.left;
+                anchors.rightMargin: 16 * virtualstudio.uiScale;
+                font { family: "Poppins"; pixelSize: fontExtraSmall * virtualstudio.fontScale * virtualstudio.uiScale }
+                color: textColour
+                visible: audio.scanningDevices
             }
 
             Text {

--- a/src/gui/Settings.qml
+++ b/src/gui/Settings.qml
@@ -112,6 +112,17 @@ Item {
                 anchors.right: headerContent.right;
                 anchors.rightMargin: 16 * virtualstudio.uiScale;
                 visible: parent.isUsingRtAudio && settingsGroupView == "Audio"
+                enabled: audio.audioReady && !audio.scanningDevices
+            }
+
+            Text {
+                text: "Restarting Audio"
+                anchors.verticalCenter: pageTitle.verticalCenter;
+                anchors.right: refreshButton.left;
+                anchors.rightMargin: 16 * virtualstudio.uiScale;
+                font { family: "Poppins"; pixelSize: fontExtraSmall * virtualstudio.fontScale * virtualstudio.uiScale }
+                color: textColour
+                visible: !audio.audioReady
             }
         }
     }

--- a/src/gui/Setup.qml
+++ b/src/gui/Setup.qml
@@ -49,6 +49,17 @@ Item {
             anchors.rightMargin: rightMargin * virtualstudio.uiScale
             anchors.verticalCenter: pageTitle.verticalCenter
             visible: parent.isUsingRtAudio
+            enabled: audio.audioReady && !audio.scanningDevices
+        }
+
+        Text {
+            text: "Restarting Audio"
+            anchors.verticalCenter: pageTitle.verticalCenter;
+            anchors.right: refreshButton.left;
+            anchors.rightMargin: 16 * virtualstudio.uiScale;
+            font { family: "Poppins"; pixelSize: fontExtraSmall * virtualstudio.fontScale * virtualstudio.uiScale }
+            color: textColour
+            visible: !audio.audioReady
         }
 
         AudioSettings {

--- a/src/gui/vsAudio.cpp
+++ b/src/gui/vsAudio.cpp
@@ -186,6 +186,14 @@ void VsAudio::setAudioReady(bool ready)
     emit signalAudioReadyChanged();
 }
 
+void VsAudio::setScanningDevices(bool b)
+{
+    if (b == m_scanningDevices)
+        return;
+    m_scanningDevices = b;
+    emit signalScanningDevicesChanged();
+}
+
 void VsAudio::setAudioBackend([[maybe_unused]] const QString& backend)
 {
 #ifdef RT_AUDIO
@@ -891,6 +899,7 @@ void VsAudioWorker::updateDeviceModels()
         return;
 
     // note: audio must not be active when scanning devices
+    m_parentPtr->setScanningDevices(true);
     closeAudioInterface();
     RtAudioInterface::scanDevices(m_devices);
 
@@ -910,6 +919,7 @@ void VsAudioWorker::updateDeviceModels()
     validateDevices();
 
     // let VsAudio know that things have been updated
+    m_parentPtr->setScanningDevices(false);
     emit signalUpdatedDeviceModels(inputComboModel, outputComboModel);
 }
 

--- a/src/gui/vsAudio.h
+++ b/src/gui/vsAudio.h
@@ -68,6 +68,8 @@ class VsAudio : public QObject
 
     // state shared with QML
     Q_PROPERTY(bool audioReady READ getAudioReady NOTIFY signalAudioReadyChanged)
+    Q_PROPERTY(bool scanningDevices READ getScanningDevices WRITE setScanningDevices
+                   NOTIFY signalScanningDevicesChanged)
     Q_PROPERTY(bool feedbackDetectionEnabled READ getFeedbackDetectionEnabled WRITE
                    setFeedbackDetectionEnabled NOTIFY feedbackDetectionEnabledChanged)
     Q_PROPERTY(bool deviceModelsInitialized READ getDeviceModelsInitialized NOTIFY
@@ -153,6 +155,7 @@ class VsAudio : public QObject
     // getters for state shared with QML
     bool backendAvailable() const;
     bool getAudioReady() const { return m_audioReady; }
+    bool getScanningDevices() const { return m_scanningDevices; }
     bool getFeedbackDetectionEnabled() const { return m_feedbackDetectionEnabled; }
     bool getDeviceModelsInitialized() const { return m_deviceModelsInitialized; }
     bool getUseRtAudio() const { return m_backend == AudioBackendType::RTAUDIO; }
@@ -240,6 +243,7 @@ class VsAudio : public QObject
 
     // signals for QML state changes
     void signalAudioReadyChanged();
+    void signalScanningDevicesChanged();
     void deviceModelsInitializedChanged(bool initialized);
     void audioBackendChanged(bool useRtAudio);
     void bufferSizeChanged();
@@ -288,6 +292,7 @@ class VsAudio : public QObject
    private:
     // private methods
     void setAudioReady(bool ready);
+    void setScanningDevices(bool b);
     void detectedFeedbackLoop();
     void updatedInputVuMeasurements(const float* valuesInDecibels, int numChannels);
     void updatedOutputVuMeasurements(const float* valuesInDecibels, int numChannels);
@@ -300,6 +305,7 @@ class VsAudio : public QObject
     // state shared with QML
     AudioBackendType m_backend      = AudioBackendType::JACK;
     bool m_audioReady               = false;
+    bool m_scanningDevices          = false;
     bool m_feedbackDetectionEnabled = true;
     bool m_deviceModelsInitialized  = false;
     int m_audioBufferSize =


### PR DESCRIPTION
Added a new audio.scanningDevices property to help differentiate when audio is offline versus device scans. The device scans tend to be a lot slower versus when we are only restarting audio, so it probably makes sense to handle them differently.

Added a "Restarting Audio" message next to the device refresh buttons. This doesn't really apply as well to the change devices page since it does a reconnect and device scan when you change anything, and an extra refresh on top when you hit the refresh button.. But at least this is an improvement and perhaps change devices can be handled better in another PR..