### PR TITLE
Making audio error/warning indicators work better

### DIFF
--- a/src/AudioInterface.cpp
+++ b/src/AudioInterface.cpp
@@ -1004,33 +1004,3 @@ void AudioInterface::setDevicesErrorMsg(errorMessageT msg)
     }
     return;
 }
-
-//*******************************************************************************
-std::string AudioInterface::getDevicesWarningMsg()
-{
-    return mWarningMsg;
-}
-
-//*******************************************************************************
-std::string AudioInterface::getDevicesErrorMsg()
-{
-    return mErrorMsg;
-}
-
-//*******************************************************************************
-std::string AudioInterface::getDevicesWarningHelpUrl()
-{
-    return mWarningHelpUrl;
-}
-
-//*******************************************************************************
-std::string AudioInterface::getDevicesErrorHelpUrl()
-{
-    return mErrorHelpUrl;
-}
-
-//*******************************************************************************
-bool AudioInterface::getHighLatencyFlag()
-{
-    return mHighLatencyFlag;
-}

--- a/src/AudioInterface.h
+++ b/src/AudioInterface.h
@@ -251,11 +251,11 @@ class AudioInterface
      * \return Sample Rate in Hz
      */
     static int getSampleRateFromType(samplingRateT rate_type);
-    std::string getDevicesWarningMsg();
-    std::string getDevicesErrorMsg();
-    std::string getDevicesWarningHelpUrl();
-    std::string getDevicesErrorHelpUrl();
-    bool getHighLatencyFlag();
+    const std::string& getDevicesWarningMsg() const { return mWarningMsg; }
+    const std::string& getDevicesErrorMsg() const { return mErrorMsg; }
+    const std::string& getDevicesWarningHelpUrl() const { return mWarningHelpUrl; }
+    const std::string& getDevicesErrorHelpUrl() const { return mErrorHelpUrl; }
+    bool getHighLatencyFlag() const { return mHighLatencyFlag; }
     //------------------------------------------------------------------
 
    private:

--- a/src/JackTrip.h
+++ b/src/JackTrip.h
@@ -514,6 +514,35 @@ class JackTrip : public QObject
 #endif        // endwhere
             return mAudioInterface->getSizeInBytesPerChannel() * mNumAudioChansOut;
     }
+    QString getDevicesWarningMsg() const
+    {
+        if (mAudioInterface == nullptr)
+            return QLatin1String("");
+        return QString::fromStdString(mAudioInterface->getDevicesWarningMsg());
+    }
+    QString getDevicesErrorMsg() const
+    {
+        if (mAudioInterface == nullptr)
+            return QLatin1String("");
+        return QString::fromStdString(mAudioInterface->getDevicesErrorMsg());
+    }
+    QString getDevicesWarningHelpUrl() const
+    {
+        if (mAudioInterface == nullptr)
+            return QLatin1String("");
+        return QString::fromStdString(mAudioInterface->getDevicesWarningHelpUrl());
+    }
+    QString getDevicesErrorHelpUrl() const
+    {
+        if (mAudioInterface == nullptr)
+            return QLatin1String("");
+        return QString::fromStdString(mAudioInterface->getDevicesErrorHelpUrl());
+    }
+    bool getHighLatencyFlag() const
+    {
+        return (mAudioInterface == nullptr) ? false
+                                            : mAudioInterface->getHighLatencyFlag();
+    }
     //@}
     //------------------------------------------------------------------------------------
 

--- a/src/gui/AudioSettings.qml
+++ b/src/gui/AudioSettings.qml
@@ -33,10 +33,6 @@ Rectangle {
     property string errorFlagColour: "#DB0A0A"
     property string disabledButtonTextColour: virtualstudio.darkMode ? "#827D7D" : "#BABCBC"
 
-    property bool isUsingJack: audio.audioBackend == "JACK"
-    property bool isUsingRtAudio: audio.audioBackend == "RtAudio"
-    property bool hasNoBackend: !isUsingJack && !isUsingRtAudio && !audio.backendAvailable
-
     function getCurrentInputDeviceIndex () {
         if (audio.inputDevice === "") {
             return audio.inputComboModel.findIndex(elem => elem.type === "element");
@@ -61,9 +57,35 @@ Rectangle {
         return idx;
     }
 
+    function getCurrentInputChannelsIndex() {
+        let idx = audio.inputChannelsComboModel.findIndex(elem => elem.baseChannel === audio.baseInputChannel
+            && elem.numChannels === audio.numInputChannels);
+        if (idx < 0) {
+            idx = 0;
+        }
+        return idx;
+    }
+
+    function getCurrentOutputChannelsIndex() {
+        let idx = audio.outputChannelsComboModel.findIndex(elem => elem.baseChannel === audio.baseOutputChannel
+            && elem.numChannels === audio.numOutputChannels);
+        if (idx < 0) {
+            idx = 0;
+        }
+        return idx;
+    }
+
+    function getCurrentMixModeIndex() {
+        let idx = audio.inputMixModeComboModel.findIndex(elem => elem.value === audio.inputMixMode);
+        if (idx < 0) {
+            idx = 0;
+        }
+        return idx;
+    }
+
     Loader {
         anchors.fill: parent
-        sourceComponent: !audio.deviceModelsInitialized || audio.scanningDevices ? scanningDevices : (isUsingRtAudio ? usingRtAudio : (isUsingJack ? usingJACK : scanningDevices))
+        sourceComponent: !audio.deviceModelsInitialized || audio.scanningDevices ? scanningDevices : (audio.audioBackend == "RtAudio" ? usingRtAudio : (audio.audioBackend == "JACK" ? usingJACK : scanningDevices))
     }
 
     Component {
@@ -208,14 +230,7 @@ Rectangle {
                 anchors.top: outputChannelsLabel.bottom
                 anchors.topMargin: 4 * virtualstudio.uiScale
                 model: audio.outputChannelsComboModel
-                currentIndex: (() => {
-                    let idx = audio.outputChannelsComboModel.findIndex(elem => elem.baseChannel === audio.baseOutputChannel
-                        && elem.numChannels === audio.numOutputChannels);
-                    if (idx < 0) {
-                        idx = 0;
-                    }
-                    return idx;
-                })()
+                currentIndex: getCurrentOutputChannelsIndex()
                 delegate: ItemDelegate {
                     required property var modelData
                     required property int index
@@ -408,14 +423,7 @@ Rectangle {
                 anchors.top: inputChannelsLabel.bottom
                 anchors.topMargin: 4 * virtualstudio.uiScale
                 model: audio.inputChannelsComboModel
-                currentIndex: (() => {
-                    let idx = audio.inputChannelsComboModel.findIndex(elem => elem.baseChannel === audio.baseInputChannel
-                        && elem.numChannels === audio.numInputChannels);
-                    if (idx < 0) {
-                        idx = 0;
-                    }
-                    return idx;
-                })()
+                currentIndex: getCurrentInputChannelsIndex()
                 delegate: ItemDelegate {
                     required property var modelData
                     required property int index
@@ -467,13 +475,7 @@ Rectangle {
                 anchors.top: inputMixModeLabel.bottom
                 anchors.topMargin: 4 * virtualstudio.uiScale
                 model: audio.inputMixModeComboModel
-                currentIndex: (() => {
-                    let idx = audio.inputMixModeComboModel.findIndex(elem => elem.value === audio.inputMixMode);
-                    if (idx < 0) {
-                        idx = 0;
-                    }
-                    return idx;
-                })()
+                currentIndex: getCurrentMixModeIndex()
                 delegate: ItemDelegate {
                     required property var modelData
                     required property int index
@@ -539,6 +541,33 @@ Rectangle {
                 })()
                 font { family: "Poppins"; pixelSize: fontExtraSmall * virtualstudio.fontScale * virtualstudio.uiScale }
                 color: textColour
+            }
+
+            Connections {
+                target: audio
+                // anything that sets currentIndex to the value of a function needs
+                // to be manually updated whenever there is a change to any vars it uses
+                function onInputDeviceChanged() {
+                    inputCombo.currentIndex = getCurrentInputDeviceIndex();
+                }
+                function onOutputDeviceChanged() {
+                    outputCombo.currentIndex = getCurrentOutputDeviceIndex();
+                }
+                function onNumInputChannelsChanged() {
+                    inputChannelsCombo.currentIndex = getCurrentInputChannelsIndex();
+                }
+                function onBaseInputChannelChanged() {
+                    inputChannelsCombo.currentIndex = getCurrentInputChannelsIndex();
+                }
+                function onNumOutputChannelsChanged() {
+                    outputChannelsCombo.currentIndex = getCurrentOutputChannelsIndex();
+                }
+                function onBaseOutputChannelChanged() {
+                    outputChannelsCombo.currentIndex = getCurrentOutputChannelsIndex();
+                }
+                function onInputMixModeChanged() {
+                    inputMixModeCombo.currentIndex = getCurrentMixModeIndex();
+                }
             }
         }
     }

--- a/src/gui/ChangeDevices.qml
+++ b/src/gui/ChangeDevices.qml
@@ -89,10 +89,8 @@ Rectangle {
                 y: 0;
                 x: parent.width - (144 + rightMargin) * virtualstudio.uiScale;
                 enabled: !audio.scanningDevices
-                onClicked: {
-                    audio.refreshDevices();
-                    inputCombo.currentIndex = getCurrentInputDeviceIndex();
-                    outputCombo.currentIndex = getCurrentOutputDeviceIndex();
+                onDeviceRefresh: function () {
+                    virtualstudio.triggerReconnect(true);
                 }
             }
 
@@ -171,7 +169,7 @@ Rectangle {
                                         audio.inputDevice = modelData.text
                                     }
                                 }
-                                audio.validateDevices();
+                                virtualstudio.triggerReconnect(false);
                             }
                         }
                     }
@@ -230,7 +228,7 @@ Rectangle {
                             outputChannelsCombo.popup.close()
                             audio.baseOutputChannel = modelData.baseChannel
                             audio.numOutputChannels = modelData.numChannels
-                            audio.validateDevices();
+                            virtualstudio.triggerReconnect(false);
                         }
                     }
                 }
@@ -308,7 +306,7 @@ Rectangle {
                                         audio.outputDevice = modelData.text
                                     }
                                 }
-                                audio.validateDevices();
+                                virtualstudio.triggerReconnect(false);
                             }
                         }
                     }
@@ -367,7 +365,7 @@ Rectangle {
                             inputChannelsCombo.popup.close()
                             audio.baseInputChannel = modelData.baseChannel
                             audio.numInputChannels = modelData.numChannels
-                            audio.validateDevices();
+                            virtualstudio.triggerReconnect(false);
                         }
                     }
                 }
@@ -424,7 +422,7 @@ Rectangle {
                             inputMixModeCombo.currentIndex = index
                             inputMixModeCombo.popup.close()
                             audio.inputMixMode = audio.inputMixModeComboModel[index].value
-                            audio.validateDevices();
+                            virtualstudio.triggerReconnect(false);
                         }
                     }
                 }

--- a/src/gui/DeviceRefreshButton.qml
+++ b/src/gui/DeviceRefreshButton.qml
@@ -13,6 +13,7 @@ Button {
     property string buttonStroke: virtualstudio.darkMode ? "#80827D7D" : "#34979797"
     property string buttonHoverStroke: virtualstudio.darkMode ? "#7B7777" : "#BABCBC"
     property string buttonPressedStroke: virtualstudio.darkMode ? "#827D7D" : "#BABCBC"
+    property var onDeviceRefresh: function () { audio.refreshDevices(); };
 
     width: 144 * virtualstudio.uiScale;
     height: 30 * virtualstudio.uiScale
@@ -29,9 +30,7 @@ Button {
         source: "refresh.svg";
         color: textColour;
     }
-    onClicked: {
-        audio.refreshDevices();
-    }
+    onClicked: { onDeviceRefresh(); }
     font {
         family: "Poppins"
         pixelSize: fontExtraSmall * virtualstudio.fontScale * virtualstudio.uiScale

--- a/src/gui/Settings.qml
+++ b/src/gui/Settings.qml
@@ -41,8 +41,6 @@ Item {
     property string disabledButtonTextColour: virtualstudio.darkMode ? "#827D7D" : "#BABCBC"
 
     property string settingsGroupView: "Audio"
-    property bool currShowWarnings: virtualstudio.showWarnings
-    property bool currShowDeviceSetup: virtualstudio.showDeviceSetup
 
     function getCurrentBufferSizeIndex () {
         let bufferSize = audio.bufferSize;
@@ -515,10 +513,10 @@ Item {
 
         CheckBox {
             id: showStartupSetup
-            checked: currShowDeviceSetup
+            checked: virtualstudio.showDeviceSetup
             text: qsTr("Show device setup screen before connecting to a studio")
             x: updateChannelCombo.x; y: feedbackDetectionCombo.y + (48 * virtualstudio.uiScale)
-            onClicked: { currShowDeviceSetup = showStartupSetup.checkState == Qt.Checked; virtualstudio.showDeviceSetup = currShowDeviceSetup }
+            onClicked: { virtualstudio.showDeviceSetup = showStartupSetup.checkState == Qt.Checked; }
             indicator: Rectangle {
                 implicitWidth: 16 * virtualstudio.uiScale
                 implicitHeight: 16 * virtualstudio.uiScale
@@ -558,10 +556,10 @@ Item {
 
         CheckBox {
             id: showStartupWarnings
-            checked: currShowWarnings
+            checked: virtualstudio.showWarnings
             text: qsTr("Show recommendations on startup again next time")
             x: updateChannelCombo.x; y: showStartupSetup.y + (48 * virtualstudio.uiScale)
-            onClicked: { currShowWarnings = showStartupWarnings.checkState == Qt.Checked; virtualstudio.showWarnings = currShowWarnings; }
+            onClicked: { virtualstudio.showWarnings = showStartupWarnings.checkState == Qt.Checked; }
             indicator: Rectangle {
                 implicitWidth: 16 * virtualstudio.uiScale
                 implicitHeight: 16 * virtualstudio.uiScale

--- a/src/gui/Setup.qml
+++ b/src/gui/Setup.qml
@@ -111,8 +111,8 @@ Item {
             }
             enabled: !Boolean(audio.devicesError) && audio.backendAvailable && audio.audioReady
             onClicked: {
+                audio.stopAudio(true);
                 virtualstudio.windowState = "connected";
-                audio.stopAudio();
                 virtualstudio.saveSettings();
                 virtualstudio.joinStudio();
             }

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -703,8 +703,8 @@ void VirtualStudio::refreshStudios(int index, bool signalRefresh)
 void VirtualStudio::loadSettings()
 {
     QSettings settings;
-    m_updateChannel =
-        settings.value(QStringLiteral("UpdateChannel"), "stable").toString().toLower();
+    setUpdateChannel(
+        settings.value(QStringLiteral("UpdateChannel"), "stable").toString().toLower());
 
     settings.beginGroup(QStringLiteral("VirtualStudio"));
     m_refreshToken   = settings.value(QStringLiteral("RefreshToken"), "").toString();
@@ -717,9 +717,8 @@ void VirtualStudio::loadSettings()
     // user interface will not revert back after cancelling settings changes
     setUiScale(settings.value(QStringLiteral("UiScale"), 1).toFloat());
     setDarkMode(settings.value(QStringLiteral("DarkMode"), false).toBool());
-
-    m_showDeviceSetup = settings.value(QStringLiteral("ShowDeviceSetup"), true).toBool();
-    m_showWarnings    = settings.value(QStringLiteral("ShowWarnings"), true).toBool();
+    setShowDeviceSetup(settings.value(QStringLiteral("ShowDeviceSetup"), true).toBool());
+    setShowWarnings(settings.value(QStringLiteral("ShowWarnings"), true).toBool());
     settings.endGroup();
 
     m_audioConfigPtr->loadSettings();

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -751,7 +751,6 @@ void VirtualStudio::connectToStudio(VsServerInfo& studio)
     m_currentStudio = studio;
     emit currentStudioChanged();
     m_onConnectedScreen = true;
-    m_reconnectState    = ReconnectState::NOT_RECONNECTING;
 
     m_studioSocketPtr.reset(new VsWebSocket(
         QUrl(QStringLiteral("wss://%1/api/servers/%2?auth_code=%3")
@@ -770,6 +769,8 @@ void VirtualStudio::connectToStudio(VsServerInfo& studio)
     } else {
         completeConnection();
     }
+
+    m_reconnectState = ReconnectState::NOT_RECONNECTING;
 }
 
 void VirtualStudio::completeConnection()
@@ -872,9 +873,7 @@ void VirtualStudio::triggerReconnect(bool refresh)
     m_connectionState = QStringLiteral("Reconnecting...");
     emit connectionStateChanged();
 
-    m_devicePtr->stopPinger();
-    m_devicePtr->stopJackTrip();
-    m_devicePtr->disconnect();
+    m_devicePtr->reconnect();
 }
 
 void VirtualStudio::disconnect()

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -183,7 +183,7 @@ class VirtualStudio : public QObject
     void refreshStudios(int index, bool signalRefresh = false);
     void loadSettings();
     void saveSettings();
-    void triggerReconnect();
+    void triggerReconnect(bool refresh);
     void manageStudio(const QString& studioId, bool start = false);
     void launchVideo(const QString& studioId);
     void createStudio();
@@ -260,6 +260,12 @@ class VirtualStudio : public QObject
     void completeConnection();
 
    private:
+    enum ReconnectState {
+        NOT_RECONNECTING = 0,
+        RECONNECTING_VALIDATE,
+        RECONNECTING_REFRESH
+    };
+
     VsQuickView m_view;
     VsServerInfo m_currentStudio;
     QScopedPointer<JackTrip> m_jackTrip;
@@ -287,7 +293,8 @@ class VirtualStudio : public QObject
     QString m_updateChannel;
     QString m_refreshToken;
     QString m_userId;
-    QString m_apiHost = PROD_API_HOST;
+    QString m_apiHost               = PROD_API_HOST;
+    ReconnectState m_reconnectState = ReconnectState::NOT_RECONNECTING;
 
     bool m_jackTripRunning        = false;
     bool m_showFirstRun           = false;
@@ -307,6 +314,7 @@ class VirtualStudio : public QObject
     bool m_testMode               = false;
     bool m_authenticated          = false;
     bool m_networkOutage          = false;
+    bool m_refreshServers         = false;
     float m_fontScale             = 1;
     float m_uiScale               = 1;
     uint32_t m_webChannelPort     = 1;

--- a/src/gui/vsAudio.cpp
+++ b/src/gui/vsAudio.cpp
@@ -38,6 +38,7 @@
 #include "vsAudio.h"
 
 #include <QDebug>
+#include <QEventLoop>
 #include <QJsonObject>
 #include <QSettings>
 #include <QThread>
@@ -66,6 +67,21 @@
 #include "../Tone.h"
 #include "../Volume.h"
 #include "AudioInterfaceMode.h"
+
+// generic function to wait for a signal to be emitted
+template<typename SignalSenderPtr, typename SignalFuncPtr>
+static inline void WaitForSignal(SignalSenderPtr sender, SignalFuncPtr signal)
+{
+    QTimer timer;
+    timer.setTimerType(Qt::CoarseTimer);
+    timer.setSingleShot(true);
+
+    QEventLoop loop;
+    QObject::connect(sender, signal, &loop, &QEventLoop::quit);
+    QObject::connect(&timer, &QTimer::timeout, &loop, &QEventLoop::quit);
+    timer.start(10000);  // wait for max 10 seconds
+    loop.exec();
+}
 
 // Constructor
 VsAudio::VsAudio(QObject* parent)
@@ -184,6 +200,10 @@ void VsAudio::setAudioReady(bool ready)
         return;
     m_audioReady = ready;
     emit signalAudioReadyChanged();
+    if (m_audioReady)
+        emit signalAudioIsReady();
+    else
+        emit signalAudioIsNotReady();
 }
 
 void VsAudio::setScanningDevices(bool b)
@@ -349,32 +369,81 @@ void VsAudio::setOutputDevice([[maybe_unused]] const QString& device)
 
 void VsAudio::setDevicesErrorMsg(const QString& msg)
 {
+    if (m_devicesErrorMsg == msg)
+        return;
     m_devicesErrorMsg = msg;
     emit devicesErrorChanged();
 }
 
 void VsAudio::setDevicesWarningMsg(const QString& msg)
 {
+    if (m_devicesWarningMsg == msg)
+        return;
     m_devicesWarningMsg = msg;
     emit devicesWarningChanged();
 }
 
 void VsAudio::setDevicesErrorHelpUrl(const QString& url)
 {
+    if (m_devicesErrorHelpUrl == url)
+        return;
     m_devicesErrorHelpUrl = url;
     emit devicesErrorHelpUrlChanged();
 }
 
 void VsAudio::setDevicesWarningHelpUrl(const QString& url)
 {
+    if (m_devicesWarningHelpUrl == url)
+        return;
     m_devicesWarningHelpUrl = url;
     emit devicesWarningHelpUrlChanged();
 }
 
 void VsAudio::setHighLatencyFlag(bool highLatencyFlag)
 {
+    if (m_highLatencyFlag == highLatencyFlag)
+        return;
     m_highLatencyFlag = highLatencyFlag;
     emit highLatencyFlagChanged(highLatencyFlag);
+}
+
+void VsAudio::startAudio(bool block)
+{
+    // note this is also used for restartAudio()
+    emit signalStartAudio();
+    if (!block)
+        return;
+    WaitForSignal(this, &VsAudio::signalAudioIsReady);
+}
+
+void VsAudio::stopAudio(bool block)
+{
+    if (!getAudioReady())
+        return;
+    emit signalStopAudio();
+    if (!block)
+        return;
+    WaitForSignal(this, &VsAudio::signalAudioIsNotReady);
+}
+
+void VsAudio::refreshDevices(bool block)
+{
+    if (!getUseRtAudio())
+        return;
+    emit signalRefreshDevices();
+    if (!block)
+        return;
+    WaitForSignal(m_audioWorkerPtr.get(), &VsAudioWorker::signalDevicesValidated);
+}
+
+void VsAudio::validateDevices(bool block)
+{
+    if (!getUseRtAudio())
+        return;
+    emit signalValidateDevices();
+    if (!block)
+        return;
+    WaitForSignal(m_audioWorkerPtr.get(), &VsAudioWorker::signalDevicesValidated);
 }
 
 void VsAudio::loadSettings()
@@ -770,7 +839,8 @@ void VsAudioWorker::openAudioInterface()
     }
 #endif
 
-    setAudioReady(true);
+    updateDeviceMessages(*m_audioInterfacePtr);
+    m_parentPtr->setAudioReady(true);
 }
 
 void VsAudioWorker::openJackAudioInterface()
@@ -795,22 +865,6 @@ void VsAudioWorker::openJackAudioInterface()
         m_audioInterfacePtr->setClientName(QStringLiteral("JackTrip"));
         m_audioInterfacePtr->setup(true);
 
-        std::string devicesWarningMsg = m_audioInterfacePtr->getDevicesWarningMsg();
-        std::string devicesErrorMsg   = m_audioInterfacePtr->getDevicesErrorMsg();
-        bool highLatencyFlag          = m_audioInterfacePtr->getHighLatencyFlag();
-
-        if (devicesWarningMsg != "") {
-            qDebug() << "Devices Warning: " << QString::fromStdString(devicesWarningMsg);
-        }
-
-        if (devicesErrorMsg != "") {
-            qDebug() << "Devices Error: " << QString::fromStdString(devicesErrorMsg);
-        }
-
-        setDevicesWarningMsg(QString::fromStdString(devicesWarningMsg));
-        setDevicesErrorMsg(QString::fromStdString(devicesErrorMsg));
-        setHighLatencyFlag(highLatencyFlag);
-
         m_sampleRate = m_audioInterfacePtr->getSampleRate();
     } else {
         return;
@@ -820,18 +874,49 @@ void VsAudioWorker::openJackAudioInterface()
 #endif
 }
 
+void VsAudioWorker::updateDeviceMessages(AudioInterface& audioInterface)
+{
+    QString devicesWarningMsg =
+        QString::fromStdString(audioInterface.getDevicesWarningMsg());
+    QString devicesErrorMsg = QString::fromStdString(audioInterface.getDevicesErrorMsg());
+    QString devicesWarningHelpUrl =
+        QString::fromStdString(audioInterface.getDevicesWarningHelpUrl());
+    QString devicesErrorHelpUrl =
+        QString::fromStdString(audioInterface.getDevicesErrorHelpUrl());
+
+    if (devicesWarningMsg != "") {
+        qDebug() << "Devices Warning: " << devicesWarningMsg;
+        if (devicesWarningHelpUrl != "") {
+            qDebug() << "Learn More: " << devicesWarningHelpUrl;
+        }
+    }
+
+    if (devicesErrorMsg != "") {
+        qDebug() << "Devices Error: " << devicesErrorMsg;
+        if (devicesErrorHelpUrl != "") {
+            qDebug() << "Learn More: " << devicesErrorHelpUrl;
+        }
+    }
+
+    m_parentPtr->setDevicesWarningMsg(devicesWarningMsg);
+    m_parentPtr->setDevicesErrorMsg(devicesErrorMsg);
+    m_parentPtr->setDevicesWarningHelpUrl(devicesWarningHelpUrl);
+    m_parentPtr->setDevicesErrorHelpUrl(devicesErrorHelpUrl);
+    m_parentPtr->setHighLatencyFlag(m_audioInterfacePtr->getHighLatencyFlag());
+}
+
 void VsAudioWorker::closeAudioInterface()
 {
     if (m_audioInterfacePtr.isNull())
         return;
     std::cout << "Stopping Audio" << std::endl;
-    setAudioReady(false);
     try {
         m_audioInterfacePtr->stopProcess();
     } catch (const std::exception& e) {
         emit signalError(QString::fromUtf8(e.what()));
     }
     m_audioInterfacePtr.clear();
+    m_parentPtr->setAudioReady(false);
 }
 
 #ifdef RT_AUDIO
@@ -863,32 +948,6 @@ void VsAudioWorker::openRtAudioInterface()
 
     // Note: setup might change the number of channels and/or buffer size
     m_audioInterfacePtr->setup(true);
-
-    std::string devicesWarningMsg     = m_audioInterfacePtr->getDevicesWarningMsg();
-    std::string devicesErrorMsg       = m_audioInterfacePtr->getDevicesErrorMsg();
-    std::string devicesWarningHelpUrl = m_audioInterfacePtr->getDevicesWarningHelpUrl();
-    std::string devicesErrorHelpUrl   = m_audioInterfacePtr->getDevicesErrorHelpUrl();
-    bool highLatencyFlag              = m_audioInterfacePtr->getHighLatencyFlag();
-
-    if (devicesWarningMsg != "") {
-        qDebug() << "Devices Warning: " << QString::fromStdString(devicesWarningMsg);
-        if (devicesWarningHelpUrl != "") {
-            qDebug() << "Learn More: " << QString::fromStdString(devicesWarningHelpUrl);
-        }
-    }
-
-    if (devicesErrorMsg != "") {
-        qDebug() << "Devices Error: " << QString::fromStdString(devicesErrorMsg);
-        if (devicesErrorHelpUrl != "") {
-            qDebug() << "Learn More: " << QString::fromStdString(devicesErrorHelpUrl);
-        }
-    }
-
-    setDevicesWarningMsg(QString::fromStdString(devicesWarningMsg));
-    setDevicesErrorMsg(QString::fromStdString(devicesErrorMsg));
-    setDevicesWarningHelpUrl(QString::fromStdString(devicesWarningHelpUrl));
-    setDevicesErrorHelpUrl(QString::fromStdString(devicesErrorHelpUrl));
-    setHighLatencyFlag(highLatencyFlag);
 }
 
 void VsAudioWorker::refreshDevices()

--- a/src/gui/vsAudio.cpp
+++ b/src/gui/vsAudio.cpp
@@ -450,66 +450,75 @@ void VsAudio::loadSettings()
 {
     QSettings settings;
     settings.beginGroup(QStringLiteral("Audio"));
-    m_inMultiplier  = settings.value(QStringLiteral("InMultiplier"), 1).toFloat();
-    m_outMultiplier = settings.value(QStringLiteral("OutMultiplier"), 1).toFloat();
-    m_monMultiplier = settings.value(QStringLiteral("MonMultiplier"), 0).toFloat();
-    m_inMuted       = false;
-    // m_inMuted       = settings.value(QStringLiteral("InMuted"), false).toBool();
+    setInputVolume(settings.value(QStringLiteral("InMultiplier"), 1).toFloat());
+    setOutputVolume(settings.value(QStringLiteral("OutMultiplier"), 1).toFloat());
+    setMonitorVolume(settings.value(QStringLiteral("MonMultiplier"), 0).toFloat());
+    // note: we should always reset input muted to false; otherwise, bad things
+    setInputMuted(false);
+    // setInputMuted(settings.value(QStringLiteral("InMuted"), false).toBool());
+    AudioBackendType audioBackend = m_backend;
     if constexpr (isBackendAvailable<AudioInterfaceMode::ALL>()) {
-        m_backend = (settings.value(QStringLiteral("Backend"), 0).toInt() == 1)
-                        ? AudioBackendType::RTAUDIO
-                        : AudioBackendType::JACK;
+        audioBackend = (settings.value(QStringLiteral("Backend"), 0).toInt() == 1)
+                           ? AudioBackendType::RTAUDIO
+                           : AudioBackendType::JACK;
     } else if constexpr (isBackendAvailable<AudioInterfaceMode::RTAUDIO>()) {
-        m_backend = AudioBackendType::RTAUDIO;
+        audioBackend = AudioBackendType::RTAUDIO;
     } else {
-        m_backend = AudioBackendType::JACK;
+        audioBackend = AudioBackendType::JACK;
+    }
+    if (audioBackend != m_backend) {
+        setAudioBackend(audioBackend == AudioBackendType::RTAUDIO
+                            ? QStringLiteral("RtAudio")
+                            : QStringLiteral("JACK"));
     }
 
-    m_inputDevice  = settings.value(QStringLiteral("InputDevice"), "").toString();
-    m_outputDevice = settings.value(QStringLiteral("OutputDevice"), "").toString();
-    if (m_inputDevice == QStringLiteral("(default)")) {
-        m_inputDevice = "";
+    QString inputDevice  = settings.value(QStringLiteral("InputDevice"), "").toString();
+    QString outputDevice = settings.value(QStringLiteral("OutputDevice"), "").toString();
+    if (inputDevice == QStringLiteral("(default)")) {
+        inputDevice = "";
     }
-    if (m_outputDevice == QStringLiteral("(default)")) {
-        m_outputDevice = "";
+    if (outputDevice == QStringLiteral("(default)")) {
+        outputDevice = "";
     }
+    setInputDevice(inputDevice);
+    setOutputDevice(outputDevice);
 
     // use default base channel 0, if the setting does not exist
-    m_baseInputChannel  = settings.value(QStringLiteral("BaseInputChannel"), 0).toInt();
-    m_baseOutputChannel = settings.value(QStringLiteral("BaseOutputChannel"), 0).toInt();
+    setBaseInputChannel(settings.value(QStringLiteral("BaseInputChannel"), 0).toInt());
+    setBaseOutputChannel(settings.value(QStringLiteral("BaseOutputChannel"), 0).toInt());
 
     // Handle migration scenarios. Assume this is a new user
     // if we have m_inputDevice == "" and m_outputDevice == ""
     if (m_inputDevice == "" && m_outputDevice == "") {
         // for fresh installs, use mono by default
-        m_numInputChannels =
-            settings.value(QStringLiteral("NumInputChannels"), 1).toInt();
-        m_inputMixMode = settings
-                             .value(QStringLiteral("InputMixMode"),
-                                    static_cast<int>(AudioInterface::MONO))
-                             .toInt();
+        setNumInputChannels(
+            settings.value(QStringLiteral("NumInputChannels"), 1).toInt());
+        setInputMixMode(settings
+                            .value(QStringLiteral("InputMixMode"),
+                                   static_cast<int>(AudioInterface::MONO))
+                            .toInt());
 
         // use 2 channels for output
-        m_numOutputChannels =
-            settings.value(QStringLiteral("NumOutputChannels"), 2).toInt();
+        setNumOutputChannels(
+            settings.value(QStringLiteral("NumOutputChannels"), 2).toInt());
     } else {
         // existing installs - keep using stereo
-        m_numInputChannels =
-            settings.value(QStringLiteral("NumInputChannels"), 2).toInt();
-        m_inputMixMode = settings
-                             .value(QStringLiteral("InputMixMode"),
-                                    static_cast<int>(AudioInterface::STEREO))
-                             .toInt();
+        setNumInputChannels(
+            settings.value(QStringLiteral("NumInputChannels"), 2).toInt());
+        setInputMixMode(settings
+                            .value(QStringLiteral("InputMixMode"),
+                                   static_cast<int>(AudioInterface::STEREO))
+                            .toInt());
 
         // use 2 channels for output
-        m_numOutputChannels =
-            settings.value(QStringLiteral("NumOutputChannels"), 2).toInt();
+        setNumOutputChannels(
+            settings.value(QStringLiteral("NumOutputChannels"), 2).toInt());
     }
 
-    m_audioBufferSize = settings.value(QStringLiteral("BufferSize"), 128).toInt();
-    m_bufferStrategy  = settings.value(QStringLiteral("BufferStrategy"), 2).toInt();
-    m_feedbackDetectionEnabled =
-        settings.value(QStringLiteral("FeedbackDetectionEnabled"), true).toBool();
+    setBufferSize(settings.value(QStringLiteral("BufferSize"), 128).toInt());
+    setBufferStrategy(settings.value(QStringLiteral("BufferStrategy"), 2).toInt());
+    setFeedbackDetectionEnabled(
+        settings.value(QStringLiteral("FeedbackDetectionEnabled"), true).toBool());
     settings.endGroup();
 }
 

--- a/src/gui/vsDevice.cpp
+++ b/src/gui/vsDevice.cpp
@@ -299,6 +299,18 @@ void VsDevice::sendHeartbeat()
     }
 }
 
+void VsDevice::reconnect()
+{
+    stopPinger();
+    if (m_webSocket != nullptr && m_webSocket->isValid()) {
+        m_webSocket->closeSocket();
+    }
+    if (!m_jackTrip.isNull()) {
+        m_jackTrip->stop();
+        m_jackTrip.reset();
+    }
+}
+
 bool VsDevice::hasTerminated()
 {
     return m_jackTrip.isNull();

--- a/src/gui/vsDevice.cpp
+++ b/src/gui/vsDevice.cpp
@@ -299,26 +299,6 @@ void VsDevice::sendHeartbeat()
     }
 }
 
-bool VsDevice::reconnect()
-{
-    return m_reconnect;
-}
-
-void VsDevice::setReconnect(bool reconnect)
-{
-    m_reconnect = reconnect;
-    if (reconnect) {
-        stopPinger();
-        if (m_webSocket != nullptr && m_webSocket->isValid()) {
-            m_webSocket->closeSocket();
-        }
-        if (!m_jackTrip.isNull()) {
-            m_jackTrip->stop();
-            m_jackTrip.reset();
-        }
-    }
-}
-
 bool VsDevice::hasTerminated()
 {
     return m_jackTrip.isNull();

--- a/src/gui/vsDevice.h
+++ b/src/gui/vsDevice.h
@@ -66,6 +66,7 @@ class VsDevice : public QObject
     void registerApp();
     void removeApp();
     void sendHeartbeat();
+    void reconnect();
     bool hasTerminated();
     void setServerId(QString studioID);
     JackTrip* initJackTrip(bool useRtAudio, std::string input, std::string output,

--- a/src/gui/vsDevice.h
+++ b/src/gui/vsDevice.h
@@ -66,8 +66,6 @@ class VsDevice : public QObject
     void registerApp();
     void removeApp();
     void sendHeartbeat();
-    bool reconnect();
-    void setReconnect(bool reconnect);
     bool hasTerminated();
     void setServerId(QString studioID);
     JackTrip* initJackTrip(bool useRtAudio, std::string input, std::string output,
@@ -127,7 +125,6 @@ class VsDevice : public QObject
     bool m_playbackMute    = false;
     float m_monitorVolume  = 0;
     QTimer m_sendVolumeTimer;
-    bool m_reconnect       = false;
     bool m_highLatencyFlag = false;
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -269,6 +269,16 @@ bool isRunFromCmd()
             if (size >= 6 && strncmp(pname + size - 6, "wt.exe", 6) == 0) {
                 return true;
             }
+            // a few extras for msys/cygwin/etc
+            if (size >= 8 && strncmp(pname + size - 8, "bash.exe", 8) == 0) {
+                return true;
+            }
+            if (size >= 6 && strncmp(pname + size - 6, "sh.exe", 6) == 0) {
+                return true;
+            }
+            if (size >= 7 && strncmp(pname + size - 7, "zsh.exe", 7) == 0) {
+                return true;
+            }
         } else {
             CloseHandle(h);
         }


### PR DESCRIPTION
after changing devices while connected to a studio

Fixed a bug where connecting to a studio from the audio settings setup screen could fail due to audio not being stopped in time. Updated VsAudio methods to add option for certain methods to block to support this and other fixes.

Reworked how device reconnect is handled from the change devices screen while connected to a studio. The JackTrip connection was previously being reset in parallel to audio validation, which could have caused things to not update correctly.

Refreshing devices while connected to a studio would cause device scans and validation in parallel to reconnect, which was even worse and caused crashes on Windows.

Fixing persistence of studio list filters to settings

Updating QML setters to check existing state before updating and emitting signals. Previously, they would emit even when there were no changes.

Added command line shells for msys and cygwin on windows so that JackTrip works better when run from command line in these environments