### PR TITLE
Fixing deadlock conditions involving studio join

### DIFF
--- a/src/Analyzer.cpp
+++ b/src/Analyzer.cpp
@@ -136,7 +136,7 @@ void Analyzer::onTick()
         return;
     }
 
-    const uint32_t buffers = mCircularBufferPtr->size();
+    const uint32_t buffers = uint32_t(mCircularBufferPtr->size());
     const uint32_t samples = buffers * mBufferSize;
 
     // require at least mFftSize values to process, otherwise return

--- a/src/Analyzer.h
+++ b/src/Analyzer.h
@@ -87,9 +87,9 @@ class Analyzer : public ProcessPlugin
     bool testSpectralPeakGrowing();
 
     int mInterval                           = 100;
-    float mPeakThresholdMultipler           = 0.5;
-    float mPeakDeviationThresholdMultiplier = 0.4;
-    float mDifferentialThresholdMultiplier  = 0.05;
+    float mPeakThresholdMultipler           = float(0.5);
+    float mPeakDeviationThresholdMultiplier = float(0.4);
+    float mDifferentialThresholdMultiplier  = float(0.05);
 
     float fs;
     int mNumChannels;

--- a/src/AudioInterface.cpp
+++ b/src/AudioInterface.cpp
@@ -77,7 +77,7 @@ AudioInterface::AudioInterface(QVarLengthArray<int> InputChans,
 #ifndef WAIR
     // cc
     // Initialize and assign memory for ProcessPlugins Buffers
-    int monitorChans = std::min<size_t>(mInputChans.size(), mOutputChans.size());
+    int monitorChans = int(std::min<size_t>(mInputChans.size(), mOutputChans.size()));
     mInProcessBuffer.resize(mInputChans.size());
     mOutProcessBuffer.resize(mOutputChans.size());
     mMonProcessBuffer.resize(monitorChans);
@@ -187,8 +187,8 @@ void AudioInterface::setup(bool /*verbose*/)
     // Allocate buffer memory to read and write
     mSizeInBytesPerChannel = getSizeInBytesPerChannel();
 
-    int size_audio_input  = mSizeInBytesPerChannel * nChansIn;
-    int size_audio_output = mSizeInBytesPerChannel * nChansOut;
+    int size_audio_input  = int(mSizeInBytesPerChannel * nChansIn);
+    int size_audio_output = int(mSizeInBytesPerChannel * nChansOut);
 #ifdef WAIR               // WAIR
     if (mNumNetRevChans)  // else don't change sizes
     {

--- a/src/Effects.h
+++ b/src/Effects.h
@@ -384,7 +384,7 @@ class Effects
             if (gVerboseFlag) {
                 std::cout << "parseCompressorArgs = " << args << std::endl;
             }
-            ulong argLen   = strlen(args);
+            ulong argLen   = ulong(strlen(args));
             char lastParam = '\0';
 
             CompressorPreset newPreset(
@@ -510,7 +510,7 @@ class Effects
             if (gVerboseFlag) {
                 std::cout << cmd << " argument = " << optarg << std::endl;
             }
-            ulong argLen = strlen(optarg);
+            ulong argLen = ulong(strlen(optarg));
 
             for (ulong i = 0; i < argLen; i++) {
                 if (optarg[i] != ')' && parenLevel > 0) {

--- a/src/JackTrip.h
+++ b/src/JackTrip.h
@@ -502,7 +502,7 @@ class JackTrip : public QObject
             return mAudioInterface->getSizeInBytesPerChannel() * mNumNetRevChans;
         else  // not wair
 #endif        // endwhere
-            return mAudioInterface->getSizeInBytesPerChannel() * mNumAudioChansIn;
+            return int(mAudioInterface->getSizeInBytesPerChannel()) * mNumAudioChansIn;
     }
 
     int getTotalAudioOutputPacketSizeInBytes() const
@@ -512,7 +512,7 @@ class JackTrip : public QObject
             return mAudioInterface->getSizeInBytesPerChannel() * mNumNetRevChans;
         else  // not wair
 #endif        // endwhere
-            return mAudioInterface->getSizeInBytesPerChannel() * mNumAudioChansOut;
+            return int(mAudioInterface->getSizeInBytesPerChannel()) * mNumAudioChansOut;
     }
     QString getDevicesWarningMsg() const
     {

--- a/src/UdpDataProtocol.cpp
+++ b/src/UdpDataProtocol.cpp
@@ -338,7 +338,7 @@ void UdpDataProtocol::processControlPacket(const char* buf)
 //*******************************************************************************
 int UdpDataProtocol::receivePacket(char* buf, const size_t n)
 {
-    int n_bytes = ::recv(mSocket, buf, n, 0);
+    int n_bytes = ::recv(mSocket, buf, int(n), 0);
     if (n_bytes == mControlPacketSize) {
         processControlPacket(buf);
         return 0;
@@ -366,11 +366,11 @@ functions. DWORD n_bytes; WSABUF buffer; int error; buffer.len = n; buffer.buf =
 #else*/
     int n_bytes;
     if (mIPv6) {
-        n_bytes = ::sendto(mSocket, buf, n, 0, (struct sockaddr*)&mPeerAddr6,
+        n_bytes = ::sendto(mSocket, buf, int(n), 0, (struct sockaddr*)&mPeerAddr6,
                            sizeof(mPeerAddr6));
     } else {
-        n_bytes =
-            ::sendto(mSocket, buf, n, 0, (struct sockaddr*)&mPeerAddr, sizeof(mPeerAddr));
+        n_bytes = ::sendto(mSocket, buf, int(n), 0, (struct sockaddr*)&mPeerAddr,
+                           sizeof(mPeerAddr));
     }
     return n_bytes;
     //#endif
@@ -941,7 +941,7 @@ void UdpDataProtocol::sendPacketRedundancy(int8_t* full_redundant_packet,
     int8_t* src = mAudioPacket;
     if (1 < mChans) {
         // Convert internal interleaved layout to non-interleaved
-        int N       = getAudioPacketSizeInBites() / mChans / mSmplSize;
+        int N       = int(getAudioPacketSizeInBites() / mChans / mSmplSize);
         int8_t* dst = mBuffer.data();
         for (int n = 0; n < N; ++n) {
             for (int c = 0; c < mChans; ++c) {

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -197,8 +197,6 @@ class VirtualStudio : public QObject
     void collectFeedbackSurvey(QString serverId, int rating, QString message);
 
    signals:
-    void authSucceeded();
-    void authFailed();
     void failed();
     void connected();
     void disconnected();
@@ -237,7 +235,6 @@ class VirtualStudio : public QObject
 
    private slots:
     void slotAuthSucceeded();
-    void slotAuthFailed();
     void receivedConnectionFromPeer();
     void handleWebsocketMessage(const QString& msg);
     void launchBrowser(const QUrl& url);
@@ -249,8 +246,7 @@ class VirtualStudio : public QObject
     void exit();
 
    private:
-    void getServerList(bool firstLoad = false, bool signalRefresh = false,
-                       int index = -1);
+    void getServerList(bool signalRefresh = false, int index = -1);
     void getSubscriptions();
     void getRegions();
     void getUserMetadata();
@@ -296,11 +292,11 @@ class VirtualStudio : public QObject
     QString m_apiHost               = PROD_API_HOST;
     ReconnectState m_reconnectState = ReconnectState::NOT_RECONNECTING;
 
+    bool m_firstRefresh           = true;
     bool m_jackTripRunning        = false;
     bool m_showFirstRun           = false;
     bool m_checkSsl               = true;
     bool m_vsModeActive           = false;
-    bool m_allowRefresh           = true;
     bool m_refreshInProgress      = false;
     bool m_onConnectedScreen      = false;
     bool m_isExiting              = false;
@@ -314,7 +310,6 @@ class VirtualStudio : public QObject
     bool m_testMode               = false;
     bool m_authenticated          = false;
     bool m_networkOutage          = false;
-    bool m_refreshServers         = false;
     float m_fontScale             = 1;
     float m_uiScale               = 1;
     uint32_t m_webChannelPort     = 1;

--- a/src/gui/vs.qml
+++ b/src/gui/vs.qml
@@ -278,7 +278,7 @@ Rectangle {
     }
 
     Connections {
-        target: virtualstudio
+        target: auth
         function onAuthSucceeded() {
             if (virtualstudio.windowState !== "login") {
                 // can happen on settings screen when switching between prod and test
@@ -296,6 +296,9 @@ Rectangle {
                 virtualstudio.joinStudio();
             }
         }
+    }
+    Connections {
+        target: virtualstudio
         function onConnected() {
             if (virtualstudio.windowState == "change_devices") {
                 return;

--- a/src/gui/vsAuth.cpp
+++ b/src/gui/vsAuth.cpp
@@ -39,10 +39,9 @@
 
 #include "./vsConstants.h"
 
-VsAuth::VsAuth(VsQuickView* view, QNetworkAccessManager* networkAccessManager, VsApi* api)
+VsAuth::VsAuth(QNetworkAccessManager* networkAccessManager, VsApi* api)
     : m_clientId(AUTH_CLIENT_ID), m_authorizationServerHost(AUTH_SERVER_HOST)
 {
-    m_view                 = view;
     m_networkAccessManager = networkAccessManager;
     m_api                  = api;
     m_deviceCodeFlow.reset(new VsDeviceCodeFlow(networkAccessManager));
@@ -55,8 +54,6 @@ VsAuth::VsAuth(VsQuickView* view, QNetworkAccessManager* networkAccessManager, V
             &VsAuth::codeFlowCompleted);
     connect(m_deviceCodeFlow.data(), &VsDeviceCodeFlow::deviceCodeFlowTimedOut, this,
             &VsAuth::codeExpired);
-
-    m_view->engine()->rootContext()->setContextProperty(QStringLiteral("auth"), this);
 
     m_verificationUrl = QStringLiteral("https://auth.jacktrip.org/activate");
 }

--- a/src/gui/vsAuth.h
+++ b/src/gui/vsAuth.h
@@ -46,7 +46,6 @@
 
 #include "vsApi.h"
 #include "vsDeviceCodeFlow.h"
-#include "vsQuickView.h"
 
 class VsAuth : public QObject
 {
@@ -66,7 +65,7 @@ class VsAuth : public QObject
     Q_PROPERTY(QString accessToken READ accessToken CONSTANT);
 
    public:
-    VsAuth(VsQuickView* view, QNetworkAccessManager* networkAccessManager, VsApi* api);
+    VsAuth(QNetworkAccessManager* networkAccessManager, VsApi* api);
 
     void authenticate(QString currentRefreshToken);
     void refreshAccessToken(QString refreshToken);
@@ -125,7 +124,6 @@ class VsAuth : public QObject
     QString m_accessToken;
     QString m_refreshToken;
 
-    VsQuickView* m_view;
     QNetworkAccessManager* m_networkAccessManager;
     VsApi* m_api;
     QScopedPointer<VsDeviceCodeFlow> m_deviceCodeFlow;


### PR DESCRIPTION
Removing VsQuickView from VsAuth since there seems to be no good reason for it to have visibility into that, and it breaks the pattern of VirtualStudio owning that exclusively.

Removed the authSucceeded and authFailed signals
from VirtualStudio because: (a) these were duplicates from VsAuth, (b) nothing used authFailed, (c) there was only a single qml connection really using
authSucceeded and it was easy to wire that up directly instead, since auth is a context variable, (d) having these in both places and meaning different things was very confusing and made it harder to grok and maintain

Replaced the firstLoad parameter in VirtualStudio::serverList with a m_firstRefresh class member, which is a lot easier to track and understand.

Changing use of m_refreshMutex to be a guard specifically for any access to m_servers or m_refreshInProgress. Fixing a few cases where these were not handled properly.

Fixing various compiler warnings in other source code