### PR TITLE
Use the VsAudio device cache when connecting to a JackTrip server

### DIFF
--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -177,13 +177,8 @@ void JackTrip::setupAudio(
 )
 {
     // Check if mAudioInterface has already been created or not
-    if (mAudioInterface
-        != NULL) {  // if it has been created, disconnect it from JACK and delete it
-        cout << "WARNING: JackAudio interface was setup already:" << endl;
-        cout << "It will be erased and setup again." << endl;
-        cout << gPrintSeparator << endl;
-        closeAudio();
-    }
+    if (mAudioInterface != nullptr)
+        return;
 
     // Create AudioInterface Client Object
     if (mAudiointerfaceMode == JackTrip::JACK) {


### PR DESCRIPTION
This eliminates having to rescan devices every time a connection to a JackTrip server is (re)established by reusing the scan results cached in the VsAudio class.