### PR TITLE
Updates to handle bad audio interface buffer sizes

### DIFF
--- a/src/AudioInterface.cpp
+++ b/src/AudioInterface.cpp
@@ -937,30 +937,28 @@ int AudioInterface::getSampleRateFromType(samplingRateT rate_type)
 void AudioInterface::setDevicesWarningMsg(warningMessageT msg)
 {
     switch (msg) {
-    case DEVICE_WARN_LATENCY:
+    case DEVICE_WARN_BUFFER_LATENCY:
         mWarningMsg =
-            "The selected Input and Output devices are Non-ASIO and may cause high "
-            "latency or audio delay. Installing ASIO drivers and using ASIO Input and "
-            "Output devices will lower audio delays for a 'same room experience'.";
-#ifdef _WIN32
-        mWarningHelpUrl = "https://help.jacktrip.org/hc/en-us/articles/4409919243155";
-#else
-        mWarningHelpUrl = "";
-#endif
+            "The buffer size setting for your audio device will cause high latency "
+            "or audio delay. Use an audio device that supports small buffer sizes "
+            "to reduce audio delays.";
+        mWarningHelpUrl  = "";
+        mHighLatencyFlag = true;
+        break;
+    case DEVICE_WARN_ASIO_LATENCY:
+        mWarningMsg =
+            "You audio device drivers may cause high latency or audio delay. Install "
+            "and use ASIO drivers provided by your device's manufacturer to reduce "
+            "audio delays.";
+        mWarningHelpUrl  = "https://help.jacktrip.org/hc/en-us/articles/4409919243155";
+        mHighLatencyFlag = true;
         break;
     default:
-        mWarningMsg     = "";
-        mWarningHelpUrl = "";
+        mWarningMsg      = "";
+        mWarningHelpUrl  = "";
+        mHighLatencyFlag = false;
         break;
     }
-
-    if (msg == DEVICE_WARN_LATENCY) {
-        mHighLatencyFlag = true;
-    } else {
-        mHighLatencyFlag = false;
-    }
-
-    return;
 }
 
 //*******************************************************************************
@@ -975,7 +973,7 @@ void AudioInterface::setDevicesErrorMsg(errorMessageT msg)
 #ifdef _WIN32
         mErrorHelpUrl = "https://help.jacktrip.org/hc/en-us/articles/4409919243155";
 #else
-        mErrorHelpUrl   = "";
+        mErrorHelpUrl = "";
 #endif
         break;
     case DEVICE_ERR_NO_INPUTS:
@@ -1002,5 +1000,4 @@ void AudioInterface::setDevicesErrorMsg(errorMessageT msg)
         mErrorHelpUrl = "";
         break;
     }
-    return;
 }

--- a/src/AudioInterface.h
+++ b/src/AudioInterface.h
@@ -76,7 +76,11 @@ class AudioInterface
         UNDEF   ///< Undefined
     };
 
-    enum warningMessageT { DEVICE_WARN_NONE, DEVICE_WARN_LATENCY };
+    enum warningMessageT {
+        DEVICE_WARN_NONE,
+        DEVICE_WARN_BUFFER_LATENCY,
+        DEVICE_WARN_ASIO_LATENCY
+    };
 
     enum errorMessageT {
         DEVICE_ERR_NONE,
@@ -255,6 +259,7 @@ class AudioInterface
     const std::string& getDevicesErrorMsg() const { return mErrorMsg; }
     const std::string& getDevicesWarningHelpUrl() const { return mWarningHelpUrl; }
     const std::string& getDevicesErrorHelpUrl() const { return mErrorHelpUrl; }
+    bool highLatencyBufferSize() const { return getBufferSizeInSamples() > 256; }
     bool getHighLatencyFlag() const { return mHighLatencyFlag; }
     //------------------------------------------------------------------
 

--- a/src/JackAudioInterface.cpp
+++ b/src/JackAudioInterface.cpp
@@ -88,6 +88,12 @@ void JackAudioInterface::setup(bool verbose)
     setupClient();
     AudioInterface::setup(verbose);
     setProcessCallback();
+    if (highLatencyBufferSize()) {
+        AudioInterface::setDevicesWarningMsg(AudioInterface::DEVICE_WARN_BUFFER_LATENCY);
+    } else {
+        AudioInterface::setDevicesWarningMsg(AudioInterface::DEVICE_WARN_NONE);
+    }
+    AudioInterface::setDevicesErrorMsg(AudioInterface::DEVICE_ERR_NONE);
 }
 
 //*******************************************************************************

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -557,6 +557,12 @@ void JackTrip::startProcess(
         return;
     }
 
+    // AudioInterface::setup() can return a different buffer size
+    // if the audio interface doesn't support the one that was requested
+    if (mAudioInterface->getBufferSizeInSamples() != getBufferSizeInSamples()) {
+        setAudioBufferSizeInSamples(mAudioInterface->getBufferSizeInSamples());
+    }
+
     // cc redundant with instance creator  createHeader(mPacketHeaderType); next line
     // fixme
     createHeader(mPacketHeaderType);

--- a/src/gui/DeviceWarning.qml
+++ b/src/gui/DeviceWarning.qml
@@ -23,7 +23,7 @@ Item {
         anchors.leftMargin: 4 * virtualstudio.uiScale
         anchors.verticalCenter: devicesWarningIcon.verticalCenter
         visible: Boolean(audio.devicesError) || Boolean(audio.devicesWarning)
-        font { family: "Poppins"; pixelSize: 10 * virtualstudio.fontScale * virtualstudio.uiScale }
+        font { family: "Poppins"; pixelSize: 9 * virtualstudio.fontScale * virtualstudio.uiScale }
         color: devicesWarningColour
     }
 

--- a/src/gui/vsAudio.cpp
+++ b/src/gui/vsAudio.cpp
@@ -805,11 +805,17 @@ AudioInterface* VsAudio::newAudioInterface(JackTrip* jackTripPtr)
     if (ifPtr == nullptr)
         return ifPtr;
 
+    // AudioInterface::setup() can return a different buffer size
+    // if the audio interface doesn't support the one that was requested
+    if (ifPtr->getBufferSizeInSamples() != uint32_t(getBufferSize())) {
+        setBufferSize(ifPtr->getBufferSizeInSamples());
+    }
+
     std::cout << "The Sampling Rate is: " << m_sampleRate << std::endl;
     std::cout << gPrintSeparator << std::endl;
-    int AudioBufferSizeInBytes = getBufferSize() * sizeof(sample_t);
-    std::cout << "The Audio Buffer Size is: " << getBufferSize() << " samples"
-              << std::endl;
+    int AudioBufferSizeInBytes = ifPtr->getBufferSizeInSamples() * sizeof(sample_t);
+    std::cout << "The Audio Buffer Size is: " << ifPtr->getBufferSizeInSamples()
+              << " samples" << std::endl;
     std::cout << "                      or: " << AudioBufferSizeInBytes << " bytes"
               << std::endl;
     std::cout << gPrintSeparator << std::endl;


### PR DESCRIPTION
Attemping to better handle the case where an audio interface rejects the buffer size that is configured. If VS audio settings is loaded (the default), it will reset the buffer size to the one used by the interface, and all seems to work ok. If you try to connect to a JackTrip server before this, it attempts to stop with a nice error message, but most of the time this still crashes. I tried to pinpoint why, but there are so many things done assuming this never changes that it may be a very hard task, which isn't worthwhile for just an edge case..

I also updated replaced DEVICE_WARN_LATENCY with DEVICE_WARN_BUFFER_LATENCY and DEVICE_WARN_ASIO_LATENCY to differentiate the two high latency scenarios for audio interfaces: the former is set if you have buffer size > 256 (2x default), and the latter is set if you have a Windows computer without ASIO drivers. Both will set the high latency flag, which we plan to use in the UI to notify someone of the problem.