### PR TITLE
Exposing isExiting over webchannel

### DIFF
--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -411,6 +411,11 @@ bool VirtualStudio::vsFtux()
     return m_vsFtux;
 }
 
+bool VirtualStudio::isExiting()
+{
+    return m_isExiting;
+}
+
 void VirtualStudio::collectFeedbackSurvey(QString serverId, int rating, QString message)
 {
     QJsonObject feedback;
@@ -1053,19 +1058,19 @@ void VirtualStudio::handleDeeplinkRequest(const QUrl& link)
 
 void VirtualStudio::exit()
 {
+    // triggering isExitingChanged will force any WebEngine things to close properly
+    m_isExiting = true;
+    emit isExitingChanged();
+
     m_startTimer.stop();
     m_refreshTimer.stop();
     m_heartbeatTimer.stop();
     m_networkOutageTimer.stop();
     if (m_onConnectedScreen) {
-        m_isExiting = true;
-
-        if (!m_devicePtr.isNull()) {
-            m_devicePtr->stopPinger();
-            m_devicePtr->stopJackTrip();
+        // manually disconnect on self-managed studios
+        if (!m_currentStudio.id().isEmpty() && !m_currentStudio.isManaged()) {
+            disconnect();
         }
-
-        disconnect();
     } else {
         emit signalExit();
     }

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -111,6 +111,7 @@ class VirtualStudio : public QObject
                    showDeviceSetupChanged)
     Q_PROPERTY(bool showWarnings READ showWarnings WRITE setShowWarnings NOTIFY
                    showWarningsChanged)
+    Q_PROPERTY(bool isExiting READ isExiting NOTIFY isExitingChanged)
     Q_PROPERTY(bool noUpdater READ noUpdater CONSTANT)
     Q_PROPERTY(bool psiBuild READ psiBuild CONSTANT)
     Q_PROPERTY(QString failedMessage READ failedMessage NOTIFY failedMessageChanged)
@@ -174,6 +175,7 @@ class VirtualStudio : public QObject
     QString apiHost();
     void setApiHost(QString host);
     bool vsFtux();
+    bool isExiting();
 
    public slots:
     void toStandard();
@@ -230,6 +232,7 @@ class VirtualStudio : public QObject
     void studioToJoinChanged();
     void updatedNetworkOutage(bool outage);
     void windowStateUpdated();
+    void isExitingChanged();
     void apiHostChanged();
     void feedbackDetected();
     void openFeedbackSurveyModal(QString serverId);


### PR DESCRIPTION
The exit handler when clicking "x" on the window or force-quitting doesn't always leave property. I'm hoping that by exposing this `m_isExiting` we can do something with it over the web transport channel