### PR TITLE
Fixing startup screen for linux

### DIFF
--- a/docs/Build/Linux.md
+++ b/docs/Build/Linux.md
@@ -36,13 +36,13 @@ directory or use QtCreator to compile.
 
 ### Ubuntu and Debian/Raspbian (Qt5)
 ```sh
-apt install --no-install-recommends build-essential autoconf automake libtool make libjack-jackd2-dev git help2man
+apt install --no-install-recommends build-essential autoconf automake libtool make libjack-jackd2-dev git help2man python3-jinja2
 apt install qtbase5-dev qtbase5-dev-tools qtchooser qt5-qmake qttools5-dev libqt5svg5-dev libqt5websockets5-dev qtdeclarative5-dev qtquickcontrols2-5-dev
 ```
 
 ### Ubuntu and Debian/Raspbian (Qt6)
 ```sh
-apt install --no-install-recommends build-essential autoconf automake libtool make libjack-jackd2-dev git help2man libclang-dev libdbus-1-dev libdbus-1-dev
+apt install --no-install-recommends build-essential autoconf automake libtool make libjack-jackd2-dev git help2man libclang-dev libdbus-1-dev libdbus-1-dev python3-jinja2
 apt install qt6-base-dev qt6-base-dev-tools qmake6 qt6-tools-dev qt6-declarative-dev qt6-webengine-dev qt6-webview-dev qt6-webview-plugins libqt6svg6-dev libqt6websockets6-dev libgl1-mesa-dev
 # for GUI builds
 apt install libfreetype6-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libx11-xcb-dev libdrm-dev libglu1-mesa-dev libwayland-dev libwayland-egl1-mesa libgles2-mesa-dev libwayland-server0 libwayland-egl-backend-dev libxcb1-dev libxext-dev libfontconfig1-dev libxrender-dev libxcb-keysyms1-dev libxcb-image0-dev libxcb-shm0-dev libxcb-icccm4-dev '^libxcb.*-dev' libxcb-render-util0-dev libxcomposite-dev libgtk-3-dev

--- a/src/gui/AudioSettings.qml
+++ b/src/gui/AudioSettings.qml
@@ -85,7 +85,7 @@ Rectangle {
 
     Loader {
         anchors.fill: parent
-        sourceComponent: !audio.deviceModelsInitialized || audio.scanningDevices ? scanningDevices : (audio.audioBackend == "RtAudio" ? usingRtAudio : (audio.audioBackend == "JACK" ? usingJACK : scanningDevices))
+        sourceComponent: audio.audioBackend == "JACK" ? usingJACK : ((!audio.deviceModelsInitialized || audio.scanningDevices) ? scanningDevices : usingRtAudio);
     }
 
     Component {

--- a/src/gui/FirstLaunch.qml
+++ b/src/gui/FirstLaunch.qml
@@ -93,7 +93,7 @@ Item {
             border.color: standardButton.down ? buttonPressedStroke : (standardButton.hovered ? buttonHoverStroke : buttonStroke)
             layer.enabled: standardButton.hovered && !standardButton.down
         }
-        onClicked: { virtualstudio.windowState = "login"; virtualstudio.toStandard(); }
+        onClicked: { virtualstudio.toStandard(); }
         x: parent.width / 2 + (32 * virtualstudio.uiScale); y: 290 * virtualstudio.uiScale
         width: 234 * virtualstudio.uiScale; height: 49 * virtualstudio.uiScale
         Text {

--- a/src/gui/Settings.qml
+++ b/src/gui/Settings.qml
@@ -457,7 +457,7 @@ Item {
                 audio.restartAudio();
             }
             font.family: "Poppins"
-            visible: audio.audioBackend != "JACK"
+            enabled: audio.audioBackend != "JACK"
         }
 
         Text {

--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -1124,6 +1124,7 @@ void QJackTrip::virtualStudioMode()
 {
     this->hide();
     m_vs->show();
+    m_vs->toVirtualStudio();
 }
 #endif
 

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -695,6 +695,7 @@ void VirtualStudio::logout()
 
     // reset window state
     setWindowState(QStringLiteral("login"));
+    login();  // called to retrieve new code flow token
 }
 
 void VirtualStudio::refreshStudios(int index, bool signalRefresh)

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -136,6 +136,10 @@ VirtualStudio::VirtualStudio(bool firstRun, QObject* parent)
         emit updatedNetworkOutage(m_networkOutage);
     });
 
+    if (vsFtux() || hasRefreshToken()) {
+        m_windowState = QStringLiteral("login");
+    }
+
     // register QML types
     qmlRegisterType<VsServerInfo>("org.jacktrip.jacktrip", 1, 0, "VsServerInfo");
 
@@ -185,6 +189,10 @@ VirtualStudio::VirtualStudio(bool firstRun, QObject* parent)
     // call exit() when the UI window is closed
     connect(&m_view, &VsQuickView::windowClose, this, &VirtualStudio::exit,
             Qt::QueuedConnection);
+
+    if (vsFtux() || hasRefreshToken()) {
+        login();
+    }
 }
 
 void VirtualStudio::setStandardWindow(QSharedPointer<QJackTrip> window)
@@ -212,15 +220,6 @@ void VirtualStudio::show()
         m_checkSsl = false;
     }
     m_view.show();
-    if (m_windowState == "loading") {
-        if (vsFtux() || hasRefreshToken()) {
-            setWindowState(QStringLiteral("login"));
-        } else {
-            setWindowState(QStringLiteral("start"));
-        }
-    } else if (m_windowState == "login") {
-        login();
-    }
 }
 
 void VirtualStudio::raiseToTop()

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -316,7 +316,7 @@ class VirtualStudio : public QObject
     uint32_t m_webChannelPort     = 1;
 
     QString m_failedMessage            = QStringLiteral("");
-    QString m_windowState              = QStringLiteral("loading");
+    QString m_windowState              = QStringLiteral("start");
     QString m_connectedErrorMsg        = QStringLiteral("");
     QString m_logoSection              = QStringLiteral("Your Studios");
     QString m_connectionState          = QStringLiteral("Waiting...");

--- a/src/gui/vs.qml
+++ b/src/gui/vs.qml
@@ -12,23 +12,7 @@ Rectangle {
     id: window
     states: [
         State {
-            name: "loading"
-            PropertyChanges { target: loadingScreen; x: 0; }
-            PropertyChanges { target: startScreen; x: -startScreen.width; }
-            PropertyChanges { target: loginScreen; x: window.width; }
-            PropertyChanges { target: recommendationsScreen; x: window.width }
-            PropertyChanges { target: permissionsScreen; x: window.width }
-            PropertyChanges { target: setupScreen; x: window.width }
-            PropertyChanges { target: browseScreen; x: window.width }
-            PropertyChanges { target: settingsScreen; x: window.width }
-            PropertyChanges { target: connectedScreen; x: window.width }
-            PropertyChanges { target: changeDevicesScreen; x: 2*window.width }
-            PropertyChanges { target: failedScreen; x: window.width }
-        },
-
-        State {
             name: "start"
-            PropertyChanges { target: loadingScreen; x: window.width; }
             PropertyChanges { target: startScreen; x: 0 }
             PropertyChanges { target: loginScreen; x: window.width; }
             PropertyChanges { target: recommendationsScreen; x: window.width }
@@ -43,7 +27,6 @@ Rectangle {
 
         State {
             name: "login"
-            PropertyChanges { target: loadingScreen; x: window.width; }
             PropertyChanges { target: startScreen; x: -startScreen.width }
             PropertyChanges { target: loginScreen; x: 0; }
             PropertyChanges { target: recommendationsScreen; x: window.width }
@@ -58,7 +41,6 @@ Rectangle {
 
         State {
             name: "recommendations"
-            PropertyChanges { target: loadingScreen; x: window.width; }
             PropertyChanges { target: loginScreen; x: -loginScreen.width }
             PropertyChanges { target: startScreen; x: -startScreen.width }
             PropertyChanges { target: recommendationsScreen; x: 0 }
@@ -73,7 +55,6 @@ Rectangle {
 
         State {
             name: "permissions"
-            PropertyChanges { target: loadingScreen; x: window.width; }
             PropertyChanges { target: loginScreen; x: -loginScreen.width }
             PropertyChanges { target: startScreen; x: -startScreen.width }
             PropertyChanges { target: recommendationsScreen; x: -recommendationsScreen.width }
@@ -88,7 +69,6 @@ Rectangle {
 
         State {
             name: "setup"
-            PropertyChanges { target: loadingScreen; x: window.width; }
             PropertyChanges { target: loginScreen; x: -loginScreen.width }
             PropertyChanges { target: startScreen; x: -startScreen.width }
             PropertyChanges { target: recommendationsScreen; x: -recommendationsScreen.width }
@@ -103,7 +83,6 @@ Rectangle {
 
         State {
             name: "browse"
-            PropertyChanges { target: loadingScreen; x: window.width; }
             PropertyChanges { target: loginScreen; x: -loginScreen.width }
             PropertyChanges { target: startScreen; x: -startScreen.width }
             PropertyChanges { target: recommendationsScreen; x: -recommendationsScreen.width }
@@ -118,7 +97,6 @@ Rectangle {
 
         State {
             name: "settings"
-            PropertyChanges { target: loadingScreen; x: window.width; }
             PropertyChanges { target: loginScreen; x: -loginScreen.width }
             PropertyChanges { target: startScreen; x: -startScreen.width }
             PropertyChanges { target: recommendationsScreen; x: -recommendationsScreen.width }
@@ -133,7 +111,6 @@ Rectangle {
 
         State {
             name: "connected"
-            PropertyChanges { target: loadingScreen; x: window.width; }
             PropertyChanges { target: loginScreen; x: -loginScreen.width }
             PropertyChanges { target: startScreen; x: -startScreen.width }
             PropertyChanges { target: recommendationsScreen; x: -recommendationsScreen.width }
@@ -148,7 +125,6 @@ Rectangle {
 
         State {
             name: "change_devices"
-            PropertyChanges { target: loadingScreen; x: window.width; }
             PropertyChanges { target: loginScreen; x: -loginScreen.width }
             PropertyChanges { target: startScreen; x: -startScreen.width }
             PropertyChanges { target: recommendationsScreen; x: -recommendationsScreen.width }
@@ -163,7 +139,6 @@ Rectangle {
 
         State {
             name: "failed"
-            PropertyChanges { target: loadingScreen; x: window.width; }
             PropertyChanges { target: loginScreen; x: -loginScreen.width }
             PropertyChanges { target: startScreen; x: -startScreen.width }
             PropertyChanges { target: recommendationsScreen; x: -recommendationsScreen.width }
@@ -179,10 +154,6 @@ Rectangle {
 
     transitions: Transition {
         NumberAnimation { properties: "x"; duration: 500; easing.type: Easing.InOutQuad }
-    }
-
-    Item {
-        id: loadingScreen
     }
 
     FirstLaunch {
@@ -226,9 +197,7 @@ Rectangle {
     }
 
     onWidthChanged: {
-        if (virtualstudio.windowState === "loading") {
-            loadingScreen.x = 0
-        } else if (virtualstudio.windowState === "start") {
+        if (virtualstudio.windowState === "start") {
             startScreen.x = 0
         } else if (virtualstudio.windowState === "login") {
             loginScreen.x = 0
@@ -252,9 +221,7 @@ Rectangle {
     }
 
     onHeightChanged: {
-        if (virtualstudio.windowState === "loading") {
-            loadingScreen.x = 0
-        } else if (virtualstudio.windowState === "start") {
+        if (virtualstudio.windowState === "start") {
             startScreen.x = 0
         } else if (virtualstudio.windowState === "login") {
             loginScreen.x = 0
@@ -310,11 +277,6 @@ Rectangle {
         }
         function onDisconnected() {
             virtualstudio.windowState = "browse";
-        }
-        function onWindowStateUpdated() {
-            if (virtualstudio.windowState === "login") {
-                virtualstudio.login();
-            }
         }
     }
 }

--- a/src/gui/vsAudio.cpp
+++ b/src/gui/vsAudio.cpp
@@ -99,15 +99,13 @@ VsAudio::VsAudio(QObject* parent)
 {
     loadSettings();
 
-#ifdef USE_WEAK_JACK
+#ifdef RT_AUDIO
+    m_backend = AudioBackendType::RTAUDIO;
+#elif defined(USE_WEAK_JACK)
     // Check if Jack is available
     if (have_libjack() != 0) {
-#ifdef RT_AUDIO
-        m_backend = AudioBackendType::RTAUDIO;
-#else
         // TODO: Handle this more gracefully, even if it's an unlikely scenario
         qFatal("JACK not found and not built with RtAudio support.");
-#endif  // RT_AUDIO
     }
 #endif  // USE_WEAK_JACK
 
@@ -242,8 +240,6 @@ void VsAudio::setFeedbackDetectionEnabled(bool enabled)
 
 void VsAudio::setBufferSize([[maybe_unused]] int bufSize)
 {
-    if (m_backend != AudioBackendType::RTAUDIO)
-        return;
     if (m_audioBufferSize == bufSize)
         return;
     m_audioBufferSize = bufSize;


### PR DESCRIPTION
Removing the loading screen because linux (possibly certain Qt versions?) were having problems with transitions that happen soon after a window is shown.

VS mode will now use default backend of RtAudio, if supported

Various other fixes for Jack audio and Linux things