### PR TITLE
Adding lock on stopJacktrip

### DIFF
--- a/src/gui/Footer.qml
+++ b/src/gui/Footer.qml
@@ -65,6 +65,11 @@ Rectangle {
         return texts;
     }
 
+    MouseArea {
+        anchors.fill: parent
+        propagateComposedEvents: false
+    }
+
     RowLayout {
         id: layout
         anchors.fill: parent

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1103,7 +1103,7 @@ void VirtualStudio::slotAuthSucceeded()
     m_vsModeActive = true;
 
     // initialize new VsDevice and wire up signals/slots before registering app
-    m_devicePtr.reset(new VsDevice(m_auth.data(), m_api.data()));
+    m_devicePtr.reset(new VsDevice(m_auth, m_api));
     connect(m_devicePtr.get(), &VsDevice::updateNetworkStats, this,
             &VirtualStudio::updatedStats);
     connect(m_devicePtr.get(), &VsDevice::updatedCaptureVolumeFromServer,

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -839,29 +839,7 @@ void VirtualStudio::completeConnection()
 
         m_connectionState = QStringLiteral("Connecting...");
         emit connectionStateChanged();
-        m_devicePtr->setServerId(m_currentStudio.id());
-        connect(m_devicePtr.get(), &VsDevice::updateNetworkStats, this,
-                &VirtualStudio::updatedStats);
-        connect(m_devicePtr.get(), &VsDevice::updatedCaptureVolumeFromServer,
-                m_audioConfigPtr.get(), &VsAudio::setInputVolume);
-        connect(m_devicePtr.get(), &VsDevice::updatedCaptureMuteFromServer,
-                m_audioConfigPtr.get(), &VsAudio::setInputMuted);
-        connect(m_devicePtr.get(), &VsDevice::updatedPlaybackVolumeFromServer,
-                m_audioConfigPtr.get(), &VsAudio::setOutputVolume);
-        connect(m_devicePtr.get(), &VsDevice::updatedMonitorVolume,
-                m_audioConfigPtr.get(), &VsAudio::setMonitorVolume);
-        connect(m_audioConfigPtr.get(), &VsAudio::updatedInputVolume, m_devicePtr.get(),
-                &VsDevice::updateCaptureVolume);
-        connect(m_audioConfigPtr.get(), &VsAudio::updatedInputMuted, m_devicePtr.get(),
-                &VsDevice::updateCaptureMute);
-        connect(m_audioConfigPtr.get(), &VsAudio::updatedOutputVolume, m_devicePtr.get(),
-                &VsDevice::updatePlaybackVolume);
-        connect(m_audioConfigPtr.get(), &VsAudio::updatedMonitorVolume, m_devicePtr.get(),
-                &VsDevice::updateMonitorVolume);
-        connect(m_audioConfigPtr.get(), &VsAudio::highLatencyFlagChanged,
-                m_devicePtr.get(), &VsDevice::updateHighLatencyFlag);
-
-        m_devicePtr->startJackTrip();
+        m_devicePtr->startJackTrip(m_currentStudio.id());
         m_devicePtr->startPinger(&m_currentStudio);
 
         // update device error messages and warnings based on latest results
@@ -918,7 +896,6 @@ void VirtualStudio::disconnect()
     if (m_jackTripRunning) {
         m_devicePtr->stopPinger();
         m_devicePtr->stopJackTrip();
-        m_devicePtr->disconnect();
         // persist any volume level or device changes
         m_audioConfigPtr->saveSettings();
     } else {

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -270,8 +270,8 @@ class VirtualStudio : public QObject
     VsServerInfo m_currentStudio;
     QSharedPointer<QJackTrip> m_standardWindow;
     QScopedPointer<QNetworkAccessManager> m_networkAccessManager;
-    QScopedPointer<VsAuth> m_auth;
-    QScopedPointer<VsApi> m_api;
+    QSharedPointer<VsAuth> m_auth;
+    QSharedPointer<VsApi> m_api;
     QScopedPointer<VsDevice> m_devicePtr;
     QScopedPointer<VsWebSocket> m_studioSocketPtr;
     QScopedPointer<VsAudio> m_audioConfigPtr;

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -268,7 +268,6 @@ class VirtualStudio : public QObject
 
     VsQuickView m_view;
     VsServerInfo m_currentStudio;
-    QScopedPointer<JackTrip> m_jackTrip;
     QSharedPointer<QJackTrip> m_standardWindow;
     QScopedPointer<QNetworkAccessManager> m_networkAccessManager;
     QScopedPointer<VsAuth> m_auth;

--- a/src/gui/vsDevice.cpp
+++ b/src/gui/vsDevice.cpp
@@ -464,9 +464,8 @@ VsPinger* VsDevice::startPinger(VsServerInfo* studioInfo)
     QString host = studioInfo->sessionId();
     host.append(QString::fromStdString(".jacktrip.cloud"));
 
-    m_pinger.reset(
-        new VsPinger(QString::fromStdString("wss"), host,
-                     QString::fromStdString("/ping")));
+    m_pinger.reset(new VsPinger(QString::fromStdString("wss"), host,
+                                QString::fromStdString("/ping")));
     return m_pinger.get();
 }
 

--- a/src/gui/vsDevice.cpp
+++ b/src/gui/vsDevice.cpp
@@ -435,6 +435,7 @@ void VsDevice::startJackTrip()
 // stopJackTrip stops the current jacktrip process if applicable
 void VsDevice::stopJackTrip()
 {
+    QMutexLocker stopLock(&m_stopMutex);
     if (!m_jackTrip.isNull()) {
         if (m_webSocket != nullptr && m_webSocket->isValid()) {
             m_webSocket->closeSocket();

--- a/src/gui/vsDevice.cpp
+++ b/src/gui/vsDevice.cpp
@@ -38,7 +38,7 @@
 #include "vsDevice.h"
 
 // Constructor
-VsDevice::VsDevice(QSharedPointer<VsAuth> auth, QSharedPointer<VsApi> api,
+VsDevice::VsDevice(QSharedPointer<VsAuth>& auth, QSharedPointer<VsApi>& api,
                    QObject* parent)
     : QObject(parent), m_auth(auth), m_api(api), m_sendVolumeTimer(this)
 {
@@ -389,7 +389,7 @@ JackTrip* VsDevice::initJackTrip(
 }
 
 // startJackTrip starts the current jacktrip process if applicable
-void VsDevice::startJackTrip(QString serverId)
+void VsDevice::startJackTrip(const QString& serverId)
 {
     setServerId(serverId);
 

--- a/src/gui/vsDevice.cpp
+++ b/src/gui/vsDevice.cpp
@@ -38,7 +38,8 @@
 #include "vsDevice.h"
 
 // Constructor
-VsDevice::VsDevice(QSharedPointer<VsAuth> auth, QSharedPointer<VsApi> api, QObject* parent)
+VsDevice::VsDevice(QSharedPointer<VsAuth> auth, QSharedPointer<VsApi> api,
+                   QObject* parent)
     : QObject(parent), m_auth(auth), m_api(api), m_sendVolumeTimer(this)
 {
     QSettings settings;

--- a/src/gui/vsDevice.cpp
+++ b/src/gui/vsDevice.cpp
@@ -264,20 +264,9 @@ void VsDevice::sendHeartbeat()
         // Send heartbeat via websocket
         m_deviceSocketPtr->sendMessage(request.toJson());
     } else {
-        // Send heartbeat via POST API
-        QNetworkReply* reply = m_api->postDeviceHeartbeat(m_appID, request.toJson());
-        connect(reply, &QNetworkReply::finished, this, [=]() {
-            if (reply->error() != QNetworkReply::NoError) {
-                std::cout << "Error: " << reply->errorString().toStdString() << std::endl;
-                reply->deleteLater();
-                return;
-            } else {
-                QJsonDocument response = QJsonDocument::fromJson(reply->readAll());
-                reconcileAgentConfig(response);
-            }
-
-            reply->deleteLater();
-        });
+        if (enabled()) {
+            qDebug() << "Heartbeat not sent";
+        }
     }
 }
 

--- a/src/gui/vsDevice.cpp
+++ b/src/gui/vsDevice.cpp
@@ -402,8 +402,10 @@ JackTrip* VsDevice::initJackTrip(
 }
 
 // startJackTrip starts the current jacktrip process if applicable
-void VsDevice::startJackTrip()
+void VsDevice::startJackTrip(QString serverId)
 {
+    setServerId(serverId);
+
     // setup websocket listener
     m_deviceSocketPtr.reset(
         new VsWebSocket(QUrl(QStringLiteral("wss://%1/api/devices/%2/heartbeat")

--- a/src/gui/vsDevice.h
+++ b/src/gui/vsDevice.h
@@ -60,7 +60,7 @@ class VsDevice : public QObject
 
    public:
     // Constructor
-    explicit VsDevice(VsAuth* auth, VsApi* api, QObject* parent = nullptr);
+    explicit VsDevice(QSharedPointer<VsAuth> auth, QSharedPointer<VsApi> api, QObject* parent = nullptr);
     virtual ~VsDevice();
 
     // Public functions
@@ -109,9 +109,9 @@ class VsDevice : public QObject
     int selectBindPort();
     QString randomString(int stringLength);
 
-    VsAuth* m_auth     = nullptr;
-    VsApi* m_api       = nullptr;
-    VsPinger* m_pinger = NULL;
+    QSharedPointer<VsAuth> m_auth;
+    QSharedPointer<VsApi> m_api;
+    QScopedPointer<VsPinger> m_pinger;
 
     QString m_appID;
     QString m_appUUID;

--- a/src/gui/vsDevice.h
+++ b/src/gui/vsDevice.h
@@ -60,7 +60,8 @@ class VsDevice : public QObject
 
    public:
     // Constructor
-    explicit VsDevice(QSharedPointer<VsAuth> auth, QSharedPointer<VsApi> api, QObject* parent = nullptr);
+    explicit VsDevice(QSharedPointer<VsAuth> auth, QSharedPointer<VsApi> api,
+                      QObject* parent = nullptr);
     virtual ~VsDevice();
 
     // Public functions

--- a/src/gui/vsDevice.h
+++ b/src/gui/vsDevice.h
@@ -74,7 +74,7 @@ class VsDevice : public QObject
                            int baseInputChannel, int numChannelsIn, int baseOutputChannel,
                            int numChannelsOut, int inputMixMode, int bufferSize,
                            int bufferStrategy, VsServerInfo* studioInfo);
-    void startJackTrip();
+    void startJackTrip(QString serverId);
     void stopJackTrip();
     void reconcileAgentConfig(QJsonDocument newState);
 

--- a/src/gui/vsDevice.h
+++ b/src/gui/vsDevice.h
@@ -100,6 +100,7 @@ class VsDevice : public QObject
    private slots:
     void terminateJackTrip();
     void onTextMessageReceived(const QString& message);
+    void restartDeviceSocket();
     void sendLevels();
 
    private:
@@ -119,7 +120,7 @@ class VsDevice : public QObject
     QString m_apiSecret;
     QMutex m_stopMutex;
     QJsonObject m_deviceAgentConfig;
-    VsWebSocket* m_webSocket = NULL;
+    QScopedPointer<VsWebSocket> m_deviceSocketPtr;
     QScopedPointer<JackTrip> m_jackTrip;
     QRandomGenerator m_randomizer;
     float m_captureVolume  = 1.0;

--- a/src/gui/vsDevice.h
+++ b/src/gui/vsDevice.h
@@ -60,7 +60,7 @@ class VsDevice : public QObject
 
    public:
     // Constructor
-    explicit VsDevice(QSharedPointer<VsAuth> auth, QSharedPointer<VsApi> api,
+    explicit VsDevice(QSharedPointer<VsAuth>& auth, QSharedPointer<VsApi>& api,
                       QObject* parent = nullptr);
     virtual ~VsDevice();
 
@@ -75,7 +75,7 @@ class VsDevice : public QObject
                            int baseInputChannel, int numChannelsIn, int baseOutputChannel,
                            int numChannelsOut, int inputMixMode, int bufferSize,
                            int bufferStrategy, VsServerInfo* studioInfo);
-    void startJackTrip(QString serverId);
+    void startJackTrip(const QString& serverId);
     void stopJackTrip();
     void reconcileAgentConfig(QJsonDocument newState);
 

--- a/src/gui/vsDevice.h
+++ b/src/gui/vsDevice.h
@@ -38,6 +38,7 @@
 #ifndef VSDEVICE_H
 #define VSDEVICE_H
 
+#include <QMutex>
 #include <QObject>
 #include <QString>
 #include <QTimer>
@@ -116,6 +117,7 @@ class VsDevice : public QObject
     QString m_token;
     QString m_apiPrefix;
     QString m_apiSecret;
+    QMutex m_stopMutex;
     QJsonObject m_deviceAgentConfig;
     VsWebSocket* m_webSocket = NULL;
     QScopedPointer<JackTrip> m_jackTrip;

--- a/src/gui/vsWebSocket.cpp
+++ b/src/gui/vsWebSocket.cpp
@@ -51,6 +51,7 @@ VsWebSocket::VsWebSocket(const QUrl& url, QString token, QString apiPrefix,
 {
     connect(&m_webSocket, &QWebSocket::connected, this, &VsWebSocket::onConnected);
     connect(&m_webSocket, &QWebSocket::disconnected, this, &VsWebSocket::onClosed);
+    connect(&m_webSocket, &QWebSocket::disconnected, this, &VsWebSocket::disconnected);
     connect(&m_webSocket, QOverload<const QList<QSslError>&>::of(&QWebSocket::sslErrors),
             this, &VsWebSocket::onSslErrors);
     connect(&m_webSocket, QOverload<QAbstractSocket::SocketError>::of(&QWebSocket::error),
@@ -80,8 +81,8 @@ void VsWebSocket::openSocket()
 
 void VsWebSocket::closeSocket()
 {
-    if (m_connected) {
-        m_webSocket.close();
+    if (m_webSocket.state() != QAbstractSocket::UnconnectedState) {
+        m_webSocket.abort();
     }
 }
 
@@ -119,5 +120,5 @@ void VsWebSocket::sendMessage(const QByteArray& message)
 
 bool VsWebSocket::isValid()
 {
-    return !m_error && m_connected;
+    return m_webSocket.state() == QAbstractSocket::ConnectedState;
 }

--- a/src/gui/vsWebSocket.h
+++ b/src/gui/vsWebSocket.h
@@ -62,6 +62,7 @@ class VsWebSocket : public QObject
 
    signals:
     void textMessageReceived(const QString& message);
+    void disconnected();
 
    private slots:
     void onConnected();


### PR DESCRIPTION
Fixing:
* Clicking on certain spots in the Footer will "leave" the room (audio/video are still connected but the view changes)
* Refactoring how vsDevice creates and uses websockets
* Refactoring some methods within VsWebSocket
* Fixing leave sequence so it doesn't crash