### PR TITLE
Remove minify button; always show full controls on self-managed

### DIFF
--- a/src/gui/Connected.qml
+++ b/src/gui/Connected.qml
@@ -87,8 +87,9 @@ Item {
     Connections {
         target: virtualstudio
 
+        // self-managed servers do not support minified controls so keep it full size
         function onCollapseDeviceControlsChanged(collapseDeviceControls) {
-            deviceControlsGroup.showMinified = collapseDeviceControls;
+            deviceControlsGroup.showMinified = virtualstudio.currentStudio.isManaged && collapseDeviceControls;
         }
     }
 }

--- a/src/gui/DeviceControlsGroup.qml
+++ b/src/gui/DeviceControlsGroup.qml
@@ -82,26 +82,10 @@ Rectangle {
                 anchors.fill: parent
                 spacing: 2
 
-                Button {
+                Item {
                     Layout.preferredHeight: 20
                     Layout.preferredWidth: 40
                     Layout.alignment: Qt.AlignHCenter
-
-                    id: expandButton
-                    background: Rectangle {
-                        radius: 4 * virtualstudio.uiScale
-                        color: expandButton.down ? browserButtonPressedColour : (expandButton.hovered ? browserButtonHoverColour : browserButtonColour)
-                    }
-                    onClicked: virtualstudio.collapseDeviceControls = !showMinified
-
-                    AppIcon {
-                        id: expandIcon
-                        anchors { verticalCenter: parent.verticalCenter; horizontalCenter: parent.horizontalCenter }
-                        width: 20 * virtualstudio.uiScale
-                        height: 20 * virtualstudio.uiScale
-                        icon.source: showMinified ? "expand_less.svg" : "expand_more.svg"
-                        onClicked: virtualstudio.collapseDeviceControls = !showMinified
-                    }
                 }
 
                 Item {


### PR DESCRIPTION
![Screenshot 2023-08-24 at 1 31 32 PM](https://github.com/jacktrip/jacktrip/assets/6201822/c9defa32-b268-47b5-8e40-c1ecb5a4dc23)

These settings do persist across joins so this ensures that self-managed studios will always show the full size controls