### PR TITLE
Rewriting vswebsocket class to check QWebsocket object properties

### DIFF
--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -930,6 +930,12 @@ void VirtualStudio::disconnect()
     // cleanup
     m_currentStudio.setId("");
     emit currentStudioChanged();
+
+    if (!m_studioSocketPtr.isNull()) {
+        m_studioSocketPtr->closeSocket();
+    }
+    m_studioSocketPtr->disconnect();
+    m_studioSocketPtr.reset();
 }
 
 void VirtualStudio::manageStudio(const QString& studioId, bool start)

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -933,9 +933,9 @@ void VirtualStudio::disconnect()
 
     if (!m_studioSocketPtr.isNull()) {
         m_studioSocketPtr->closeSocket();
+        m_studioSocketPtr->disconnect();
+        m_studioSocketPtr.reset();
     }
-    m_studioSocketPtr->disconnect();
-    m_studioSocketPtr.reset();
 }
 
 void VirtualStudio::manageStudio(const QString& studioId, bool start)

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -769,9 +769,9 @@ void VirtualStudio::connectToStudio(VsServerInfo& studio)
                  .arg(m_api->getApiHost(), m_currentStudio.id(), m_auth->accessToken())),
         m_auth->accessToken(), QString(), QString()));
     connect(m_studioSocketPtr.get(), &VsWebSocket::textMessageReceived, this,
-            [&](QString message) {
-                handleWebsocketMessage(message);
-            });
+            &VirtualStudio::handleWebsocketMessage);
+    connect(m_studioSocketPtr.get(), &VsWebSocket::disconnected, this,
+            &VirtualStudio::restartStudioSocket);
     m_studioSocketPtr->openSocket();
 
     // Check if we have an address for our server
@@ -1262,6 +1262,15 @@ void VirtualStudio::handleWebsocketMessage(const QString& msg)
     }
 
     emit currentStudioChanged();
+}
+
+void VirtualStudio::restartStudioSocket()
+{
+    if (m_onConnectedScreen) {
+        if (!m_studioSocketPtr.isNull()) {
+            m_studioSocketPtr->openSocket();
+        }
+    }
 }
 
 void VirtualStudio::launchBrowser(const QUrl& url)

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -240,6 +240,7 @@ class VirtualStudio : public QObject
     void slotAuthSucceeded();
     void receivedConnectionFromPeer();
     void handleWebsocketMessage(const QString& msg);
+    void restartStudioSocket();
     void launchBrowser(const QUrl& url);
     void updatedStats(const QJsonObject& stats);
     void processError(const QString& errorMessage);

--- a/src/gui/vsWebSocket.cpp
+++ b/src/gui/vsWebSocket.cpp
@@ -102,7 +102,9 @@ void VsWebSocket::closeSocket()
 void VsWebSocket::onError(QAbstractSocket::SocketError error)
 {
     // RemoteHostClosedError may be expected due to finite connection durations
-    if (error != QAbstractSocket::RemoteHostClosedError) {
+    // ConnectionRefusedError may be expected if the server-side endpoint is closed
+    if (error != QAbstractSocket::RemoteHostClosedError
+        && error != QAbstractSocket::ConnectionRefusedError) {
         qDebug() << "Websocket error:" << error;
     }
     if (!m_webSocket.isNull()) {

--- a/src/gui/vsWebSocket.cpp
+++ b/src/gui/vsWebSocket.cpp
@@ -49,20 +49,31 @@ VsWebSocket::VsWebSocket(const QUrl& url, QString token, QString apiPrefix,
     , m_apiPrefix(apiPrefix)
     , m_apiSecret(apiSecret)
 {
-    connect(&m_webSocket, &QWebSocket::connected, this, &VsWebSocket::onConnected);
-    connect(&m_webSocket, &QWebSocket::disconnected, this, &VsWebSocket::onClosed);
-    connect(&m_webSocket, &QWebSocket::disconnected, this, &VsWebSocket::disconnected);
-    connect(&m_webSocket, QOverload<const QList<QSslError>&>::of(&QWebSocket::sslErrors),
-            this, &VsWebSocket::onSslErrors);
-    connect(&m_webSocket, QOverload<QAbstractSocket::SocketError>::of(&QWebSocket::error),
-            this, &VsWebSocket::onError);
-    connect(&m_webSocket, &QWebSocket::textMessageReceived, this,
+    m_webSocket.reset(new QWebSocket());
+    connect(m_webSocket.get(), &QWebSocket::disconnected, this,
+            &VsWebSocket::disconnected);
+    connect(m_webSocket.get(),
+            QOverload<const QList<QSslError>&>::of(&QWebSocket::sslErrors), this,
+            &VsWebSocket::onSslErrors);
+    connect(m_webSocket.get(),
+            QOverload<QAbstractSocket::SocketError>::of(&QWebSocket::error), this,
+            &VsWebSocket::onError);
+    connect(m_webSocket.get(), &QWebSocket::textMessageReceived, this,
             &VsWebSocket::textMessageReceived);
+}
+
+VsWebSocket::~VsWebSocket()
+{
+    if (isValid()) {
+        closeSocket();
+    }
+    m_webSocket->disconnect();
+    m_webSocket.reset();
 }
 
 void VsWebSocket::openSocket()
 {
-    if (m_connected) {
+    if (isValid()) {
         return;
     }
 
@@ -76,49 +87,48 @@ void VsWebSocket::openSocket()
     req.setRawHeader(QByteArray("APIPrefix"), m_apiPrefix.toUtf8());
     req.setRawHeader(QByteArray("APISecret"), m_apiSecret.toUtf8());
 
-    m_webSocket.open(req);
+    m_webSocket->open(req);
+    qDebug() << "Opened websocket:" << QUrl(m_url).toString(QUrl::RemoveQuery);
 }
 
 void VsWebSocket::closeSocket()
 {
-    if (m_webSocket.state() != QAbstractSocket::UnconnectedState) {
-        m_webSocket.abort();
+    if (!m_webSocket.isNull()
+        && m_webSocket->state() != QAbstractSocket::UnconnectedState) {
+        m_webSocket->abort();
     }
 }
 
-// Fires when connected to websocket
-void VsWebSocket::onConnected()
+void VsWebSocket::onError(QAbstractSocket::SocketError error)
 {
-    m_connected = true;
-    m_error     = false;
-}
-
-// Fires when disconnected from websocket
-void VsWebSocket::onClosed()
-{
-    m_connected = false;
-}
-
-void VsWebSocket::onError(QAbstractSocket::SocketError /*error*/)
-{
-    // qDebug() << error;
-    m_error = true;
+    // RemoteHostClosedError may be expected due to finite connection durations
+    if (error != QAbstractSocket::RemoteHostClosedError) {
+        qDebug() << "Websocket error:" << error;
+    }
+    if (!m_webSocket.isNull()) {
+        m_webSocket->abort();
+    }
 }
 
 void VsWebSocket::onSslErrors(const QList<QSslError>& errors)
 {
     for (int i = 0; i < errors.size(); ++i) {
-        // qDebug() << errors.at(i);
+        qDebug() << "SSL error:" << errors.at(i);
     }
-    m_error = true;
+    if (!m_webSocket.isNull()) {
+        m_webSocket->abort();
+    }
 }
 
 void VsWebSocket::sendMessage(const QByteArray& message)
 {
-    m_webSocket.sendBinaryMessage(message);
+    if (isValid()) {
+        m_webSocket->sendBinaryMessage(message);
+    }
 }
 
 bool VsWebSocket::isValid()
 {
-    return m_webSocket.state() == QAbstractSocket::ConnectedState;
+    return !m_webSocket.isNull()
+           && m_webSocket->state() == QAbstractSocket::ConnectedState;
 }

--- a/src/gui/vsWebSocket.cpp
+++ b/src/gui/vsWebSocket.cpp
@@ -51,7 +51,7 @@ VsWebSocket::VsWebSocket(const QUrl& url, QString token, QString apiPrefix,
 {
     m_webSocket.reset(new QWebSocket());
     connect(m_webSocket.get(), &QWebSocket::disconnected, this,
-            &VsWebSocket::onDisconnected);
+            &VsWebSocket::disconnected);
     connect(m_webSocket.get(),
             QOverload<const QList<QSslError>&>::of(&QWebSocket::sslErrors), this,
             &VsWebSocket::onSslErrors);
@@ -59,7 +59,7 @@ VsWebSocket::VsWebSocket(const QUrl& url, QString token, QString apiPrefix,
             QOverload<QAbstractSocket::SocketError>::of(&QWebSocket::error), this,
             &VsWebSocket::onError);
     connect(m_webSocket.get(), &QWebSocket::textMessageReceived, this,
-            &VsWebSocket::onTextMessageReceived);
+            &VsWebSocket::textMessageReceived);
 }
 
 VsWebSocket::~VsWebSocket()
@@ -101,16 +101,6 @@ void VsWebSocket::closeSocket()
         && m_webSocket->state() != QAbstractSocket::UnconnectedState) {
         m_webSocket->abort();
     }
-}
-
-void VsWebSocket::onTextMessageReceived(const QString& message)
-{
-    emit textMessageReceived(message);
-}
-
-void VsWebSocket::onDisconnected()
-{
-    emit disconnected();
 }
 
 void VsWebSocket::onError(QAbstractSocket::SocketError error)

--- a/src/gui/vsWebSocket.h
+++ b/src/gui/vsWebSocket.h
@@ -40,6 +40,7 @@
 
 #include <QList>
 #include <QObject>
+#include <QScopedPointer>
 #include <QSslError>
 #include <QString>
 #include <QUrl>
@@ -53,6 +54,7 @@ class VsWebSocket : public QObject
     // Constructor
     explicit VsWebSocket(const QUrl& url, QString token, QString apiPrefix,
                          QString apiSecret, QObject* parent = nullptr);
+    virtual ~VsWebSocket();
 
     // Public functions
     void openSocket();
@@ -65,16 +67,12 @@ class VsWebSocket : public QObject
     void disconnected();
 
    private slots:
-    void onConnected();
-    void onClosed();
     void onError(QAbstractSocket::SocketError error);
     void onSslErrors(const QList<QSslError>& errors);
 
    private:
-    QWebSocket m_webSocket;
+    QScopedPointer<QWebSocket> m_webSocket;
     QUrl m_url;
-    bool m_connected = false;
-    bool m_error     = false;
     QString m_token;
     QString m_apiPrefix;
     QString m_apiSecret;

--- a/src/gui/vsWebSocket.h
+++ b/src/gui/vsWebSocket.h
@@ -67,8 +67,6 @@ class VsWebSocket : public QObject
     void disconnected();
 
    private slots:
-    void onTextMessageReceived(const QString& message);
-    void onDisconnected();
     void onError(QAbstractSocket::SocketError error);
     void onSslErrors(const QList<QSslError>& errors);
 

--- a/src/gui/vsWebSocket.h
+++ b/src/gui/vsWebSocket.h
@@ -67,6 +67,8 @@ class VsWebSocket : public QObject
     void disconnected();
 
    private slots:
+    void onTextMessageReceived(const QString& message);
+    void onDisconnected();
     void onError(QAbstractSocket::SocketError error);
     void onSslErrors(const QList<QSslError>& errors);
 


### PR DESCRIPTION
Removing `m_connected` and `m_error` because I don't think those are reliable for the lifecycle of a given websocket connection. Instead we can inspect the [state](https://doc.qt.io/qt-6/qwebsocket.html#state) of the given websocket and use that to determine what should happen.

Also putting things inside of a `QScopedPointer` and adding a destructor