### PR TITLE
Fix minimum version required for OSX builds (10.14)

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -157,6 +157,7 @@ jobs:
             build-system: qmake
             qt-version: '5.15.10'
             qt-type: 'dynamic'
+            macosx-deployment-target: 10.13
             xcode-directory: /Applications/Xcode_14.0.1.app # uses SDK macOS 12.3 which is latest supported by qt5
 
           - name: macOS-x64-meson-clang-shared-bundled_rtaudio
@@ -176,6 +177,7 @@ jobs:
             qt-version: '6.2.5'
             qt-type: 'dynamic'
             macosx-architectures: 'x86_64;arm64'
+            macosx-deployment-target: 10.14
             xcode-directory: /Applications/Xcode_14.2.app
 
           - name: Windows-x64-meson-msvc-static
@@ -463,7 +465,13 @@ jobs:
           fi
           if [[ -n "${{ matrix.macosx-architectures }}" ]]; then
             # TODO: for now, just assume that we want universal if it is not empty
-            CONFIG_STRING="--native-file macos/meson_native_universal.ini $CONFIG_STRING"
+            if [[ -n "${{ matrix.macosx-deployment-target }}" ]]; then
+              CONFIG_STRING="--native-file macos/meson_native_universal_${{ matrix.macosx-deployment-target }}.ini $CONFIG_STRING"
+            else
+              CONFIG_STRING="--native-file macos/meson_native_universal.ini $CONFIG_STRING"
+            fi
+          elif [[ -n "${{ matrix.macosx-deployment-target }}" ]]; then
+            CONFIG_STRING="--native-file macos/meson_native_minversion_${{ matrix.macosx-deployment-target }}.ini $CONFIG_STRING"
           fi
           if [[ "${{ runner.os }}" == 'Windows' && "${{ matrix.qt-type }}" == "static" ]]; then
             CONFIG_STRING="-Db_vscrt=mt $CONFIG_STRING"

--- a/macos/meson_native_minversion_10.13.ini
+++ b/macos/meson_native_minversion_10.13.ini
@@ -1,0 +1,10 @@
+[constants]
+minversion_args = ['-mmacosx-version-min=10.13']
+
+[built-in options]
+c_args = minversion_args
+cpp_args = minversion_args
+objcpp_args = minversion_args
+c_link_args = minversion_args
+cpp_link_args = minversion_args
+objcpp_link_args = minversion_args

--- a/macos/meson_native_minversion_10.14.ini
+++ b/macos/meson_native_minversion_10.14.ini
@@ -1,0 +1,10 @@
+[constants]
+minversion_args = ['-mmacosx-version-min=10.14']
+
+[built-in options]
+c_args = minversion_args
+cpp_args = minversion_args
+objcpp_args = minversion_args
+c_link_args = minversion_args
+cpp_link_args = minversion_args
+objcpp_link_args = minversion_args

--- a/macos/meson_native_universal_10.13.ini
+++ b/macos/meson_native_universal_10.13.ini
@@ -1,0 +1,11 @@
+[constants]
+minversion_args = ['-mmacosx-version-min=10.13']
+universal_args = ['-arch', 'x86_64', '-arch', 'arm64']
+
+[built-in options]
+c_args = universal_args + minversion_args
+cpp_args = universal_args + minversion_args
+objcpp_args = universal_args + minversion_args
+c_link_args = universal_args + minversion_args
+cpp_link_args = universal_args + minversion_args
+objcpp_link_args = universal_args + minversion_args

--- a/macos/meson_native_universal_10.14.ini
+++ b/macos/meson_native_universal_10.14.ini
@@ -1,0 +1,11 @@
+[constants]
+minversion_args = ['-mmacosx-version-min=10.14']
+universal_args = ['-arch', 'x86_64', '-arch', 'arm64']
+
+[built-in options]
+c_args = universal_args + minversion_args
+cpp_args = universal_args + minversion_args
+objcpp_args = universal_args + minversion_args
+c_link_args = universal_args + minversion_args
+cpp_link_args = universal_args + minversion_args
+objcpp_link_args = universal_args + minversion_args


### PR DESCRIPTION
```
$ otool -l jacktrip | grep -E -A4 '(LC_VERSION_MIN_MACOSX|LC_BUILD_VERSION)' | grep -B1 sdk
    minos 10.14
      sdk 13.3
--
    minos 11.0
      sdk 13.3
```