### PR TITLE
Don't trigger auth succeeded sequence on token refreshes

### DIFF
--- a/src/gui/vsAuth.h
+++ b/src/gui/vsAuth.h
@@ -101,6 +101,7 @@ class VsAuth : public QObject
     void deviceCodeExpired();
 
    private slots:
+    void handleRefreshSucceeded(QString accessToken);
     void handleAuthSucceeded(QString userId, QString accessToken);
     void handleAuthFailed();
     void initializedCodeFlow(QString code, QString verificationUrl);

--- a/src/gui/vsWebSocket.cpp
+++ b/src/gui/vsWebSocket.cpp
@@ -99,6 +99,7 @@ void VsWebSocket::closeSocket()
 {
     if (!m_webSocket.isNull()
         && m_webSocket->state() != QAbstractSocket::UnconnectedState) {
+        qDebug() << "Closing websocket:" << QUrl(m_url).toString(QUrl::RemoveQuery);
         m_webSocket->abort();
     }
 }
@@ -107,9 +108,8 @@ void VsWebSocket::onError(QAbstractSocket::SocketError error)
 {
     // RemoteHostClosedError may be expected due to finite connection durations
     // ConnectionRefusedError may be expected if the server-side endpoint is closed
-    if (error != QAbstractSocket::RemoteHostClosedError
-        && error != QAbstractSocket::ConnectionRefusedError) {
-        qDebug() << "Websocket error:" << error;
+    if (error != QAbstractSocket::RemoteHostClosedError) {
+        qDebug() << "Websocket error: " << error;
     }
     if (!m_webSocket.isNull()) {
         m_webSocket->abort();
@@ -119,7 +119,7 @@ void VsWebSocket::onError(QAbstractSocket::SocketError error)
 void VsWebSocket::onSslErrors(const QList<QSslError>& errors)
 {
     for (int i = 0; i < errors.size(); ++i) {
-        qDebug() << "SSL error:" << errors.at(i);
+        qDebug() << "SSL error: " << errors.at(i);
     }
     if (!m_webSocket.isNull()) {
         m_webSocket->abort();


### PR DESCRIPTION
This was causing everything to get reset, new device registered, etc. I'm honestly not sure if this works because it's so hard to retrigger the condition, but it seems like this should work..

When connecting to a studio, set enabled flag in local device settings cache. This should help alleviate the problem of it failing to send heartbeats when the initial connection attempt gets refused.

Retry establishing heartbeat webconnection when it fails

Disconnect device if the connection to server is lost

Adding a little more debugging output to help troubleshoot related problems in the future