### PR TITLE
Fixing some bugs with switching between prod & test mode

### DIFF
--- a/src/gui/Settings.qml
+++ b/src/gui/Settings.qml
@@ -689,7 +689,15 @@ Item {
                 border.width: 1
                 border.color: testModeButton.down ? buttonPressedStroke : (testModeButton.hovered ? buttonHoverStroke : buttonStroke)
             }
-            onClicked: { virtualstudio.testMode = !virtualstudio.testMode; }
+            onClicked: {
+                virtualstudio.testMode = !virtualstudio.testMode;
+
+                // behave like "Cancel" and switch back to browse mode
+                audio.stopAudio();
+                virtualstudio.windowState = "browse";
+                virtualstudio.loadSettings();
+                audio.validateDevices();
+            }
             anchors.horizontalCenter: parent.horizontalCenter
             y: logoutButton.y + (48 * virtualstudio.uiScale)
             width: 260 * virtualstudio.uiScale; height: 30 * virtualstudio.uiScale

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -496,6 +496,7 @@ void VirtualStudio::setTestMode(bool test)
         m_devicePtr->disconnect();
         m_devicePtr.reset();
     }
+    m_webChannelServer->close();
 
     m_testMode = test;
 
@@ -511,9 +512,7 @@ void VirtualStudio::setTestMode(bool test)
     settings.remove(QStringLiteral("UserId"));
     settings.endGroup();
 
-    // stop timers, clear data, etc.
-    m_refreshTimer.stop();
-    m_heartbeatTimer.stop();
+    // clear user data
     m_userMetadata = QJsonObject();
     m_userId.clear();
 


### PR DESCRIPTION
Close the webchannel server so that `slotAuthSucceeded` doesn't error

Don't close timers, since these are not going to be restarted

Make clicking the button also cancel any settings changes and return you to browse screen