### PR TITLE
Fixing RC2 regression: changing devices disconnects you from studio

### DIFF
--- a/src/gui/ChangeDevices.qml
+++ b/src/gui/ChangeDevices.qml
@@ -203,7 +203,7 @@ Rectangle {
                 anchors.rightMargin: 8 * virtualstudio.uiScale
                 anchors.top: outputChannelsLabel.bottom
                 anchors.topMargin: 4 * virtualstudio.uiScale
-                enabled: virtualstudio.connectionState == "Connected"
+                enabled: audio.outputChannelsComboModel.length > 1 && virtualstudio.connectionState == "Connected"
                 model: audio.outputChannelsComboModel
                 currentIndex: (() => {
                     let idx = audio.outputChannelsComboModel.findIndex(elem => elem.baseChannel === audio.baseOutputChannel
@@ -340,7 +340,7 @@ Rectangle {
                 anchors.rightMargin: 8 * virtualstudio.uiScale
                 anchors.top: inputChannelsLabel.bottom
                 anchors.topMargin: 4 * virtualstudio.uiScale
-                enabled: virtualstudio.connectionState == "Connected"
+                enabled: audio.inputChannelsComboModel.length > 1 && virtualstudio.connectionState == "Connected"
                 model: audio.inputChannelsComboModel
                 currentIndex: (() => {
                     let idx = audio.inputChannelsComboModel.findIndex(elem => elem.baseChannel === audio.baseInputChannel
@@ -399,7 +399,7 @@ Rectangle {
                 anchors.rightMargin: 8 * virtualstudio.uiScale
                 anchors.top: inputMixModeLabel.bottom
                 anchors.topMargin: 4 * virtualstudio.uiScale
-                enabled: virtualstudio.connectionState == "Connected"
+                enabled: audio.inputMixModeComboModel.length > 1 && virtualstudio.connectionState == "Connected"
                 model: audio.inputMixModeComboModel
                 currentIndex: (() => {
                     let idx = audio.inputMixModeComboModel.findIndex(elem => elem.value === audio.inputMixMode);
@@ -445,7 +445,7 @@ Rectangle {
                 anchors.topMargin: 8 * virtualstudio.uiScale
                 textFormat: Text.RichText
                 wrapMode: Text.WordWrap
-                text: "Choose up to 2 channels"
+                text: audio.inputChannelsComboModel.length > 1 ? "Choose up to 2 channels" : "Only 1 channel available"
                 font { family: "Poppins"; pixelSize: fontTiny * virtualstudio.fontScale * virtualstudio.uiScale }
                 color: textColour
             }

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -839,8 +839,7 @@ void VirtualStudio::completeConnection()
 
         m_connectionState = QStringLiteral("Connecting...");
         emit connectionStateChanged();
-        m_devicePtr->startJackTrip(m_currentStudio.id());
-        m_devicePtr->startPinger(&m_currentStudio);
+        m_devicePtr->startJackTrip(m_currentStudio);
 
         // update device error messages and warnings based on latest results
         // this is necessary because we may have never loaded audio settings,
@@ -884,7 +883,8 @@ void VirtualStudio::triggerReconnect(bool refresh)
     m_connectionState = QStringLiteral("Reconnecting...");
     emit connectionStateChanged();
 
-    m_devicePtr->reconnect();
+    // keep device enabled while stopping jacktrip
+    m_devicePtr->stopJackTrip(true);
 }
 
 void VirtualStudio::disconnect()
@@ -894,8 +894,7 @@ void VirtualStudio::disconnect()
     setConnectedErrorMsg("");
 
     if (m_jackTripRunning) {
-        m_devicePtr->stopPinger();
-        m_devicePtr->stopJackTrip();
+        m_devicePtr->stopJackTrip(false);
         // persist any volume level or device changes
         m_audioConfigPtr->saveSettings();
     } else {

--- a/src/gui/vsDevice.cpp
+++ b/src/gui/vsDevice.cpp
@@ -356,7 +356,7 @@ void VsDevice::startJackTrip(const VsServerInfo& studioInfo)
 }
 
 // stopJackTrip stops the current jacktrip process if applicable
-void VsDevice::stopJackTrip(bool enabled)
+void VsDevice::stopJackTrip(bool isReconnecting)
 {
     // check if another process has already initiated
     QMutexLocker stopLock(&m_stopMutex);
@@ -365,7 +365,7 @@ void VsDevice::stopJackTrip(bool enabled)
     m_stopping = true;
 
     // only clear state if we are not reconnecting
-    if (!enabled)
+    if (!isReconnecting)
         updateState("");
 
     // stop the Virtual Studio pinger

--- a/src/gui/vsDevice.h
+++ b/src/gui/vsDevice.h
@@ -69,19 +69,14 @@ class VsDevice : public QObject
     void registerApp();
     void removeApp();
     void sendHeartbeat();
-    void reconnect();
     bool hasTerminated();
-    void setServerId(QString studioID);
     JackTrip* initJackTrip(bool useRtAudio, std::string input, std::string output,
                            int baseInputChannel, int numChannelsIn, int baseOutputChannel,
                            int numChannelsOut, int inputMixMode, int bufferSize,
                            int bufferStrategy, VsServerInfo* studioInfo);
-    void startJackTrip(const QString& serverId);
-    void stopJackTrip();
+    void startJackTrip(const VsServerInfo& studioInfo);
+    void stopJackTrip(bool enabled);
     void reconcileAgentConfig(QJsonDocument newState);
-
-    VsPinger* startPinger(VsServerInfo* studioInfo);
-    void stopPinger();
 
    signals:
     void updateNetworkStats(QJsonObject stats);
@@ -90,12 +85,13 @@ class VsDevice : public QObject
     void syncDeviceSettings();
 
    private slots:
-    void terminateJackTrip();
+    void handleJackTripError();
     void onTextMessageReceived(const QString& message);
     void restartDeviceSocket();
     void sendLevels();
 
    private:
+    void updateState(const QString& serverId);
     void registerJTAsDevice();
     bool enabled();
     int selectBindPort();
@@ -118,6 +114,7 @@ class VsDevice : public QObject
     QRandomGenerator m_randomizer;
     QTimer m_sendVolumeTimer;
     bool m_highLatencyFlag = false;
+    bool m_stopping        = false;
 };
 
 #endif  // VSDEVICE_H

--- a/src/gui/vsDevice.h
+++ b/src/gui/vsDevice.h
@@ -75,7 +75,7 @@ class VsDevice : public QObject
                            int numChannelsOut, int inputMixMode, int bufferSize,
                            int bufferStrategy, VsServerInfo* studioInfo);
     void startJackTrip(const VsServerInfo& studioInfo);
-    void stopJackTrip(bool enabled);
+    void stopJackTrip(bool isReconnecting = false);
     void reconcileAgentConfig(QJsonDocument newState);
 
    signals:


### PR DESCRIPTION
Added an m_stopping flag in vsDevice to prevent multiple things from trying to trigger the stop sequence at the same time.

Cleaned up vsDevice JackTrip start/stop so that only startJackTrip() and stopJackTrip() are required. Eliminated other methods that just made everything more confusing.

Eliminated startPinger and stopPinger because there was no reason at all for these to be exposed outside of vsDevice, and no good reason for them to even exist as separate methods

Renamed terminateJackTrip to handleJackTripError, since that is what its purpose is. Although it probably could be eliminated since I've rewritten it to just be a wrapper around stopJackTrip.

Copying some changes from AudioSettings.qml over to ChangeDevices.qml