### PR TITLE
Handle invalid device names more gracefully

### DIFF
--- a/src/RtAudioInterface.cpp
+++ b/src/RtAudioInterface.cpp
@@ -573,8 +573,11 @@ int RtAudioInterface::stopProcess()
 bool RtAudioInterface::getDeviceInfoFromName(const std::string& deviceName,
                                              RtAudioDevice& device, bool isInput) const
 {
+    // convert names to QString to gracefully handle invalid
+    // utf8 character sequences, such as "RØDE Microphone"
+    const QString utf8Name(QString::fromStdString(deviceName));
     for (const RtAudioDevice& d : mDevices) {
-        if (deviceName == d.name) {
+        if (utf8Name == QString::fromStdString(d.name)) {
             if ((isInput && d.inputChannels > 0) || (!isInput && d.outputChannels > 0)) {
                 device = d;
                 return true;

--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -1989,14 +1989,18 @@ void QJackTrip::populateDeviceMenu(QComboBox* menu, bool isInput)
     QVector<RtAudioDevice> devices;
     RtAudioInterface::scanDevices(devices);
     for (auto info : devices) {
+        // convert names to QString to gracefully handle invalid
+        // utf8 character sequences, such as "RØDE Microphone"
+        const QString utf8Name(QString::fromStdString(info.name));
+
         // Don't include duplicate entries
-        if (menu->findText(QString::fromStdString(info.name)) != -1) {
+        if (menu->findText(utf8Name) != -1) {
             continue;
         }
         if (isInput && info.inputChannels > 0) {
-            menu->addItem(QString::fromStdString(info.name));
+            menu->addItem(utf8Name);
         } else if (!isInput && info.outputChannels > 0) {
-            menu->addItem(QString::fromStdString(info.name));
+            menu->addItem(utf8Name);
         }
     }
 


### PR DESCRIPTION
Some device names returned by RtAudio, such as RØDE USB microphones, do not use valid utf8 character sequences. This ensures that the device names we get from RtAudio are converted to utf8 prior to comparisons, so they can still be used (even though their names will still look weird).

See also https://github.com/jacktrip/jacktrip/pull/974