### PR TITLE
Removing need to have git installed for meson builds

### DIFF
--- a/docs/Build/Linux.md
+++ b/docs/Build/Linux.md
@@ -105,6 +105,8 @@ the following parameters:
 
 * `qtversion`: Choose to build with either Qt5 or Qt6
 
+* `buildinfo`: Additional info used to describe the build
+
 For example:
 ```sh
 $ meson setup -Drtaudio=enabled builddir

--- a/meson.build
+++ b/meson.build
@@ -36,12 +36,20 @@ if get_option('buildtype') == 'release'
 	c_defines += ['-DNDEBUG']
 endif
 
-git_tags_cmd = run_command('git', 'describe', '--tags', check: false)
-git_hash_cmd = run_command('git', 'rev-parse', '--short', 'HEAD', check: false)
-if git_tags_cmd.returncode() == 0 and git_hash_cmd.returncode() == 0
-	git_tags = git_tags_cmd.stdout().strip()
-	git_hash = git_hash_cmd.stdout().strip()
-	defines += ['-DJACKTRIP_BUILD_INFO=' + git_tags + '-' + git_hash]
+build_info = get_option('buildinfo')
+git = find_program('git', required: false)
+if build_info == '' and git.found()
+	git_tags_cmd = run_command(git, 'describe', '--tags', check: false)
+	git_hash_cmd = run_command(git, 'rev-parse', '--short', 'HEAD', check: false)
+	if git_tags_cmd.returncode() == 0 and git_hash_cmd.returncode() == 0
+		git_tags = git_tags_cmd.stdout().strip()
+		git_hash = git_hash_cmd.stdout().strip()
+		build_info = git_tags + '-' + git_hash
+	endif
+endif
+if build_info != ''
+	message('Build info: ' + build_info)
+	defines += ['-DJACKTRIP_BUILD_INFO=' + build_info]
 endif
 
 src = [	'src/DataProtocol.cpp',
@@ -290,6 +298,7 @@ if (host_machine.system() == 'linux')
 	if help2man.found()
 		gzip = find_program('gzip', required: false)
 		help2man_opts = [
+			'--name="high-quality system for audio network performances"',
 			'--no-info',
 			'--section=1']
 		manfile = custom_target('jacktrip.1',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -9,3 +9,4 @@ option('noupdater', type : 'boolean', value : 'false', description: 'Build witho
 option('nofeedback', type : 'boolean', value : 'false', description: 'Build without feedback detection')
 option('profile', type: 'combo', choices: ['default', 'development'], value: 'default', description: 'Choose build profile / Sets desktop id accordingly')
 option('qtversion', type : 'combo', choices: ['', '5', '6'], description: 'Choose to build with either Qt5 or Qt6')
+option('buildinfo', type : 'string', value : '', yield : true, description: 'Additional info used to describe the build')


### PR DESCRIPTION
Added a buildinfo flag to set this manually

Adding help2man option to set a synopsis

From @umlaeute