### PR TITLE
Fixing bug where switching to classic mode would break device stats

### DIFF
--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -496,7 +496,6 @@ void VirtualStudio::setTestMode(bool test)
         m_devicePtr->disconnect();
         m_devicePtr.reset();
     }
-    m_webChannelServer->close();
 
     m_testMode = test;
 
@@ -511,6 +510,9 @@ void VirtualStudio::setTestMode(bool test)
     settings.remove(QStringLiteral("RefreshToken"));
     settings.remove(QStringLiteral("UserId"));
     settings.endGroup();
+
+    // stop timers, clear data, etc.
+    resetState();
 
     // clear user data
     m_userMetadata = QJsonObject();
@@ -621,9 +623,10 @@ void VirtualStudio::toStandard()
     m_uiMode = QJackTrip::STANDARD;
     settings.setValue(QStringLiteral("UiMode"), m_uiMode);
 
-    m_webChannelServer->close();
-    m_refreshTimer.stop();
-    m_heartbeatTimer.stop();
+    // stop timers, clear data, etc.
+    resetState();
+    setWindowState(QStringLiteral("start"));
+    m_auth->logout();
 
     if (m_showFirstRun) {
         m_showFirstRun = false;
@@ -663,8 +666,6 @@ void VirtualStudio::logout()
         m_devicePtr.reset();
     }
 
-    m_webChannelServer->close();
-
     QUrl logoutURL = QUrl("https://auth.jacktrip.org/v2/logout");
     QUrlQuery query;
     query.addQueryItem(QStringLiteral("client_id"), AUTH_CLIENT_ID);
@@ -686,6 +687,9 @@ void VirtualStudio::logout()
     settings.remove(QStringLiteral("RefreshToken"));
     settings.remove(QStringLiteral("UserId"));
     settings.endGroup();
+
+    // stop timers, clear data, etc.
+    resetState();
 
     // clear user data
     m_refreshToken.clear();
@@ -1081,10 +1085,9 @@ void VirtualStudio::exit()
     m_isExiting = true;
     emit isExitingChanged();
 
-    m_startTimer.stop();
-    m_refreshTimer.stop();
-    m_heartbeatTimer.stop();
-    m_networkOutageTimer.stop();
+    // stop timers, clear data, etc.
+    resetState();
+
     if (m_onConnectedScreen) {
         // manually disconnect on self-managed studios
         if (!m_currentStudio.id().isEmpty() && !m_currentStudio.isManaged()) {
@@ -1329,6 +1332,16 @@ void VirtualStudio::sendHeartbeat()
         && m_connectionState != "Preparing audio...") {
         m_devicePtr->sendHeartbeat();
     }
+}
+
+void VirtualStudio::resetState()
+{
+    m_webChannelServer->close();
+    m_refreshTimer.stop();
+    m_heartbeatTimer.stop();
+    m_startTimer.stop();
+    m_networkOutageTimer.stop();
+    m_firstRefresh = true;
 }
 
 void VirtualStudio::getServerList(bool signalRefresh, int index)

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -256,6 +256,7 @@ class VirtualStudio : public QObject
     void exit();
 
    private:
+    void resetState();
     void getServerList(bool signalRefresh = false, int index = -1);
     void getSubscriptions();
     void getRegions();


### PR DESCRIPTION
I feel like I keep fixing the same bug, so I created a new method called resetState() which is now used by all the paths: Logout, Exit, Switch Test/Prod Mode and Switch to Classic Mode.

Decided that it's better to revert back the old behavior of stopping timers, but made sure they are all being stopped, and it sets m_firstRefresh to true so that the ones we want will get restarted later.