### PR TITLE
Fixing for crash when using the JACK audio backend on Windows

### DIFF
--- a/src/JackAudioInterface.cpp
+++ b/src/JackAudioInterface.cpp
@@ -356,7 +356,7 @@ void JackAudioInterface::connectDefaultPorts()
                 break;
             }
         }
-        std::free(ports);
+        jack_free(ports);
     }
 
     // Get physical input (playback) ports
@@ -374,6 +374,6 @@ void JackAudioInterface::connectDefaultPorts()
                 break;
             }
         }
-        std::free(ports);
+        jack_free(ports);
     }
 }

--- a/src/gui/vsAudio.cpp
+++ b/src/gui/vsAudio.cpp
@@ -990,13 +990,7 @@ void VsAudioWorker::openAudioInterface()
     // initialize plugins and start the audio callback process
     m_audioInterfacePtr->initPlugins(false);
     m_audioInterfacePtr->startProcess();
-
-    if (m_parentPtr->m_backend == VsAudio::AudioBackendType::JACK) {
-        // this crashes on windows
-#ifndef _WIN32
-        m_audioInterfacePtr->connectDefaultPorts();
-#endif
-    }
+    m_audioInterfacePtr->connectDefaultPorts();
 
     m_parentPtr->updateDeviceMessages(*m_audioInterfacePtr);
     m_parentPtr->setAudioReady(true);


### PR DESCRIPTION
Jack docs say to use jack_free() not std::free()

Apparently, that matters!