### PR TITLE
Set the PIPEWIRE_LATENCY environment variable with GUI on Linux

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -3,6 +3,7 @@
   Description:
   - (added) VS Mode latency categories for Linux audio devices
   - (added) VS Mode audio warnings for high latency Linux devices
+  - (updated) Improved support for Pipewire latency on Linux
   - (fixed) Crash on Windows when using the JACK audio backend
   - (fixed) Include ALSA support for Linux builds using meson
   - (fixed) VS Mode overlapping UI elements with max scaling

--- a/src/AudioInterface.cpp
+++ b/src/AudioInterface.cpp
@@ -742,6 +742,18 @@ void AudioInterface::fromBitToSampleConversion(
 }
 
 //*******************************************************************************
+void AudioInterface::setPipewireLatency(unsigned int bufferSize, unsigned int sampleRate)
+{
+    if (bufferSize == 0 || sampleRate == 0)
+        return;
+#if defined(__unix__)
+    char latency_env[40];
+    sprintf(latency_env, "%d/%d", bufferSize, sampleRate);
+    setenv("PIPEWIRE_LATENCY", latency_env, 1);
+#endif
+}
+
+//*******************************************************************************
 void AudioInterface::appendProcessPluginToNetwork(ProcessPlugin* plugin)
 {
     if (!plugin) {

--- a/src/AudioInterface.h
+++ b/src/AudioInterface.h
@@ -193,6 +193,9 @@ class AudioInterface
         const int8_t* const input, sample_t* output,
         const AudioInterface::audioBitResolutionT sourceBitResolution);
 
+    /** \brief Sets PIPEWIRE_LATENCY environment variable on unix */
+    static void setPipewireLatency(unsigned int bufferSize, unsigned int sampleRate);
+
     //--------------SETTERS---------------------------------------------
     virtual void setInputChannels(QVarLengthArray<int> inputChans)
     {

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -1125,9 +1125,7 @@ JackTrip* Settings::getConfiguredJackTrip()
 
 #if defined(__unix__)
     if (mChangeDefaultBS or mChangeDefaultSR) {
-        char latency_env[40];
-        sprintf(latency_env, "%d/%d", mAudioBufferSize, mSampleRate);
-        setenv("PIPEWIRE_LATENCY", latency_env, 1);
+        AudioInterface::setPipewireLatency(mAudioBufferSize, mSampleRate);
     }
 #endif
 

--- a/src/gui/Settings.qml
+++ b/src/gui/Settings.qml
@@ -464,7 +464,6 @@ Item {
                 audio.restartAudio();
             }
             font.family: "Poppins"
-            enabled: audio.audioBackend != "JACK"
         }
 
         Text {
@@ -472,7 +471,6 @@ Item {
             x: 48 * virtualstudio.uiScale
             text: "Buffer Size"
             font { family: "Poppins"; pixelSize: fontMedium * virtualstudio.fontScale * virtualstudio.uiScale }
-            visible: audio.audioBackend != "JACK"
             color: textColour
         }
 

--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -930,11 +930,11 @@ void QJackTrip::start()
 
 #ifdef RT_AUDIO
             if (m_ui->backendComboBox->currentIndex() == 1) {
+                unsigned int bufferSize = m_ui->bufferSizeComboBox->currentText().toInt();
+                unsigned int sampleRate = m_ui->sampleRateComboBox->currentText().toInt();
                 m_jackTrip->setAudiointerfaceMode(JackTrip::RTAUDIO);
-                m_jackTrip->setSampleRate(
-                    m_ui->sampleRateComboBox->currentText().toInt());
-                m_jackTrip->setAudioBufferSizeInSamples(
-                    m_ui->bufferSizeComboBox->currentText().toInt());
+                m_jackTrip->setSampleRate(sampleRate);
+                m_jackTrip->setAudioBufferSizeInSamples(bufferSize);
                 // we assume that first entry is "(default)"
                 if (m_ui->inputDeviceComboBox->currentIndex() == 0) {
                     m_jackTrip->setInputDevice("");
@@ -948,6 +948,7 @@ void QJackTrip::start()
                     m_jackTrip->setOutputDevice(
                         m_ui->outputDeviceComboBox->currentText().toStdString());
                 }
+                AudioInterface::setPipewireLatency(bufferSize, sampleRate);
             }
 #endif
 

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1239,8 +1239,6 @@ void VirtualStudio::processError(const QString& errorMessage)
     }
     msgBox.exec();
 
-    if (shouldSwitchToRtAudio)
-        m_audioConfigPtr->setAudioBackend("RtAudio");
     if (m_jackTripRunning)
         connectionFinished();
 }


### PR DESCRIPTION
When using Virtual Studio or QJackTrip GUI on Linux, this sets the environment variable based on GUI settings, so there is no longer any need to set any environment variables or command line parameters for pipewire.

I think this should still work the same when running JackTrip from command line.

Also improving logic for rtaudio backend fallback