### PR TITLE
Raise to Top Window on Deeplink

### DIFF
--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1015,6 +1015,11 @@ void VirtualStudio::openLink(const QString& link)
 
 void VirtualStudio::handleDeeplinkRequest(const QUrl& link)
 {
+    // always raise to top screen
+    if (link.scheme() == QLatin1String("jacktrip")) {
+        raiseToTop();
+    }
+
     // check link is valid
     if (link.scheme() != QLatin1String("jacktrip")
         || link.host() != QLatin1String("join")) {
@@ -1030,7 +1035,6 @@ void VirtualStudio::handleDeeplinkRequest(const QUrl& link)
 
     qDebug() << "Handling deeplink to " << link;
     setStudioToJoin(link);
-    raiseToTop();
 
     // Switch to virtual studio mode, if necessary
     // Note that this doesn't change the startup preference

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -220,7 +220,8 @@ void VirtualStudio::show()
 void VirtualStudio::raiseToTop()
 {
     m_view.show();             // Restore from systray
-    m_view.requestActivate();  // Raise to top
+    m_view.raise();            // raise to top
+    m_view.requestActivate();  // focus on window
 }
 
 int VirtualStudio::webChannelPort()


### PR DESCRIPTION
I think we've been trying to use [requestActivate](https://doc.qt.io/qt-6/qwindow.html#requestActivate) in place of [raise](https://doc.qt.io/qt-6/qwindow.html#raise) on the QWindow class to bring the window to the top of the screen, when they actually do different things.