### PR TITLE
On app launch, set empty server ID

### DIFF
--- a/src/gui/vsDevice.cpp
+++ b/src/gui/vsDevice.cpp
@@ -120,6 +120,9 @@ void VsDevice::registerApp()
         settings.setValue(QStringLiteral("ApiPrefix"), m_apiPrefix);
         settings.setValue(QStringLiteral("ApiSecret"), m_apiSecret);
         settings.endGroup();
+        if (!m_appID.isEmpty()) {
+            updateState("");
+        }
 
         reply->deleteLater();
     });


### PR DESCRIPTION
Otherwise, it's possible to get "stuck" on a different server and not be able to reset and rejoin.