### PR TITLE
Raise window to top after authenticating

### DIFF
--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1105,6 +1105,9 @@ void VirtualStudio::exit()
 
 void VirtualStudio::slotAuthSucceeded()
 {
+    // Make sure window is on top (instead of browser, during first auth)
+    raiseToTop();
+
     // Determine which API host to use
     m_apiHost = PROD_API_HOST;
     if (m_testMode) {


### PR DESCRIPTION
This ensures that JackTrip is brought back to the top after authenticating via code flow