### PR TITLE
Bumping qt version from 6.2.5 to 6.2.6

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -131,23 +131,6 @@ jobs:
             qt-version: '5.15.10'
             qt-type: 'static'
 
-          - name: macOS-x64-qmake-clang-shared
-            runs-on: macos-12
-            system-rtaudio: true
-            bundled-rtaudio: false
-            nogui: false
-            novs: true
-            weakjack: true
-            # jacktrip-path: jacktrip
-            # binary-path: binary
-            # bundle-path: bundle
-            # installer-path: installer
-            build-system: qmake
-            qt-version: '5.15.10'
-            qt-type: 'dynamic'
-            macosx-deployment-target: 10.13
-            xcode-directory: /Applications/Xcode_14.0.1.app # uses SDK macOS 12.3 which is latest supported by qt5
-
           - name: macOS-x64-meson-clang-shared-bundled_rtaudio
             release-name: macOS-x64
             runs-on: macos-12
@@ -162,7 +145,7 @@ jobs:
             installer-path: installer
             build-system: meson
             meson-library-type: both
-            qt-version: '6.2.5'
+            qt-version: '6.2.6'
             qt-type: 'dynamic'
             macosx-architectures: 'x86_64;arm64'
             macosx-deployment-target: 10.14
@@ -175,27 +158,12 @@ jobs:
             nogui: true
             novs: true
             weakjack: true
-            qt-version: '6.2.5'
+            qt-version: '6.2.6'
             qt-type: 'static'
             # jacktrip-path: jacktrip.exe
             # binary-path: binary
             build-system: meson
             meson-library-type: static
-
-          - name: Windows-x64-meson-msvc-qt5
-            #release-name: Windows-x64
-            runs-on: windows-2019
-            system-rtaudio: false
-            bundled-rtaudio: true
-            nogui: false
-            novs: true
-            weakjack: true
-            qt-version: '5.15.10'
-            qt-type: 'dynamic'
-            # jacktrip-path: jacktrip.exe
-            # binary-path: binary
-            build-system: meson
-            meson-library-type: shared
 
           - name: Windows-x64-meson-msvc-qt6
             release-name: Windows-x64
@@ -205,7 +173,7 @@ jobs:
             nogui: false
             novs: false
             weakjack: true
-            qt-version: '6.5.2'
+            qt-version: '6.5.3'
             qt-type: 'dynamic'
             jacktrip-path: jacktrip.exe
             installer-path: installer
@@ -218,7 +186,7 @@ jobs:
       CLANG_TIDY_NAME: clang-tidy-result
       CLANG_TIDY_PATH: ${{ github.workspace }}/clang-tidy-result
       QT_DOWNLOAD_BASE_URL: 'https://files.jacktrip.org/contrib/qt'
-      QT_DOWNLOAD_COMMIT: '150bc20'
+      QT_DOWNLOAD_COMMIT: 'b09fbe4'
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Also bumping Windows dynamic build to 6.5.3 to pull in the latest Chromium updates. Note that Qt 6.5 has same system requirements on Windows as 6.2.

Removing dynamic builds using 5.15.10, since these aren't used and it consumes a lot of resources (and $$$) to create the 5.15.10 dynamic builds