### PR TITLE
Added an error dialog displayed when required QML plugins are missing

### DIFF
--- a/linux/README.md
+++ b/linux/README.md
@@ -13,7 +13,7 @@ dnf install -y qt6-qtbase qt6-qtbase-common qt6-qtbase-gui qt6-qtsvg qt6-qtwebso
 For Debian or Ubuntu:
 
 ```
-apt install -y libqt6core6 libqt6gui6 libqt6network6 libqt6widgets6 libqt6qml6 libqt6qmlcore6 libqt6quick6 libqt6quickcontrols2-6 libqt6svg6  libqt6webchannel6 libqt6webengine6-data libqt6webenginecore6 libqt6webenginecore6-bin libqt6webenginequick6 libqt6websockets6 libqt6shadertools6 qt6-qpa-plugins qml6-module-qtquick-controls qml6-module-qtqml-workerscript qml6-module-qtquick-templates qml6-module-qtquick-layouts qml6-module-qt5compat-graphicaleffects qml6-module-qtwebchannel qml6-module-qtwebengine
+apt install -y libqt6core6 libqt6gui6 libqt6network6 libqt6widgets6 libqt6qml6 libqt6qmlcore6 libqt6quick6 libqt6quickcontrols2-6 libqt6svg6  libqt6webchannel6 libqt6webengine6-data libqt6webenginecore6 libqt6webenginecore6-bin libqt6webenginequick6 libqt6websockets6 libqt6shadertools6 qt6-qpa-plugins qml6-module-qtquick-controls qml6-module-qtqml-workerscript qml6-module-qtquick-templates qml6-module-qtquick-layouts qml6-module-qt5compat-graphicaleffects qml6-module-qtwebchannel qml6-module-qtwebengine qml6-module-qtquick-window
 ```
 
 To install JackTrip as a Linux desktop application:

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -99,6 +99,7 @@ enum JTLongOptIDS {
     OPT_AUDIOINPUTDEVICE,
     OPT_AUDIOOUTPUTDEVICE,
     OPT_GUI,
+    OPT_CLASSIC_GUI,
     OPT_DEEPLINK
 };
 
@@ -207,7 +208,8 @@ void Settings::parseInput(int argc, char** argv)
         {"help", no_argument, NULL, 'h'},  // Print Help
         {"examine-audio-delay", required_argument, NULL,
          'x'},  // test mode - measure audio round-trip latency statistics
-        {"gui", no_argument, NULL, OPT_GUI},  // Force GUI mode
+        {"gui", no_argument, NULL, OPT_GUI},                  // Force GUI mode
+        {"classic-gui", no_argument, NULL, OPT_CLASSIC_GUI},  // Force Classic Mode GUI
         {"deeplink", optional_argument, NULL,
          OPT_DEEPLINK},  // Deeplink URL (should be in the form jacktrip://...)
         {NULL, 0, NULL, 0}};
@@ -683,6 +685,9 @@ void Settings::parseInput(int argc, char** argv)
         // main. Included here so that we don't get an unrecognized option error.
         case OPT_GUI:
             break;
+        case OPT_CLASSIC_GUI:
+            mGuiForceClassicMode = true;
+            break;
         case OPT_DEEPLINK:
             if (optarg == NULL && optind < argc && argv[optind][0] != '-') {
                 optarg = argv[optind++];
@@ -958,6 +963,7 @@ void Settings::printUsage()
     cout << endl;
     cout << "ARGUMENTS FOR THE GUI:" << endl;
     cout << " --gui                                    Force JackTrip to run with the GUI. If not using VirtualStudio mode, command line switches in the required arguments, optional arguments (except -l, -j, -L, --appendthreadid), audio patching, and authentication sections will be honoured, and default settings will be used where arguments aren't supplied. Options from other sections will be ignored (and the last used settings will be loaded), except for -V, and the --version and --help switches which will override this." << endl;
+    cout << " --classic-gui                            Force JackTrip to run with the Classic Mode GUI." << endl;
     cout << " --deeplink                               Handle a deeplink URL in the format jacktrip://join/<studio_id> by connecting as a hub client" << endl;
     cout << endl;
     cout << "HELP ARGUMENTS: " << endl;

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -84,6 +84,7 @@ class Settings : public QObject
     bool getLoopBack() { return mLoopBack; }
     bool isHubServer() { return mJackTripMode == JackTrip::SERVERPINGSERVER; }
     bool guiIgnoresArguments() { return mGuiIgnoresArguments; }
+    bool guiForceClassicMode() { return mGuiForceClassicMode; }
     bool isModeSet() { return mModeSet; }
 
     JackTrip::jacktripModeT getJackTripMode() { return mJackTripMode; }
@@ -124,6 +125,7 @@ class Settings : public QObject
 
     bool mGuiEnabled          = false;
     bool mGuiIgnoresArguments = false;
+    bool mGuiForceClassicMode = false;
 
     JackTrip::jacktripModeT mJackTripMode =
         JackTrip::SERVER;  ///< JackTrip::jacktripModeT

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -228,10 +228,14 @@ void VirtualStudio::show()
     if (m_view.status() != QQuickView::Ready) {
         QMessageBox msgBox;
         msgBox.setText(
-            "JackTrip failed to load the QML view. "
-            "This is likely caused by missing QML plugins.");
-        msgBox.setWindowTitle(QStringLiteral("JackTrip QML Error"));
-        connect(&msgBox, &QMessageBox::finished, this, &VirtualStudio::exit,
+            "JackTrip detected that some modules required for the "
+            "Virtual Studio mode are missing on your system. "
+            "Click \"OK\" to proceed to classic mode.\n\n"
+            "Details: JackTrip failed to load the QML view. "
+            "This is likely caused by missing QML plugins. "
+            "Please consult help.jacktrip.org for possible solutions.");
+        msgBox.setWindowTitle(QStringLiteral("JackTrip Is Missing QML Modules"));
+        connect(&msgBox, &QMessageBox::finished, this, &VirtualStudio::toStandard,
                 Qt::QueuedConnection);
         msgBox.exec();
         return;

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -87,17 +87,20 @@ VirtualStudio::VirtualStudio(bool firstRun, QObject* parent)
     QSvgGenerator svgImageHack;
 
     // use a singleton QNetworkAccessManager
-    m_networkAccessManager.reset(new QNetworkAccessManager);
+    // WARNING: using a raw pointer and intentionally leaking this because
+    // it crashes at shutdown if you try to destruct it directly or try
+    // calling QObject::deleteLater()
+    m_networkAccessManagerPtr = new QNetworkAccessManager;
 
     // instantiate API
-    m_api.reset(new VsApi(m_networkAccessManager.data()));
+    m_api.reset(new VsApi(m_networkAccessManagerPtr));
     m_api->setApiHost(PROD_API_HOST);
     if (m_testMode) {
         m_api->setApiHost(TEST_API_HOST);
     }
 
     // instantiate auth
-    m_auth.reset(new VsAuth(m_networkAccessManager.data(), m_api.data()));
+    m_auth.reset(new VsAuth(m_networkAccessManagerPtr, m_api.data()));
     connect(m_auth.data(), &VsAuth::authSucceeded, this,
             &VirtualStudio::slotAuthSucceeded);
     connect(m_auth.data(), &VsAuth::refreshTokenFailed, this, [=]() {
@@ -214,11 +217,33 @@ void VirtualStudio::show()
         }
         m_checkSsl = false;
     }
-    m_view.show();
+
+    while (m_view.status() == QQuickView::Loading) {
+        // I don't think there is any need to load network data, but just in case
+        // See https://doc.qt.io/qt-6/qquickview.html#Status-enum
+        qDebug() << "JackTrip is still loading the QML view";
+        QThread::sleep(1);
+    }
+
+    if (m_view.status() != QQuickView::Ready) {
+        QMessageBox msgBox;
+        msgBox.setText(
+            "JackTrip failed to load the QML view. "
+            "This is likely caused by missing QML plugins.");
+        msgBox.setWindowTitle(QStringLiteral("JackTrip QML Error"));
+        connect(&msgBox, &QMessageBox::finished, this, &VirtualStudio::exit,
+                Qt::QueuedConnection);
+        msgBox.exec();
+        return;
+    }
+
+    raiseToTop();
 }
 
 void VirtualStudio::raiseToTop()
 {
+    if (m_view.status() != QQuickView::Ready)
+        return;
     m_view.show();             // Restore from systray
     m_view.raise();            // raise to top
     m_view.requestActivate();  // focus on window
@@ -1014,11 +1039,6 @@ void VirtualStudio::openLink(const QString& link)
 
 void VirtualStudio::handleDeeplinkRequest(const QUrl& link)
 {
-    // always raise to top screen
-    if (link.scheme() == QLatin1String("jacktrip")) {
-        raiseToTop();
-    }
-
     // check link is valid
     if (link.scheme() != QLatin1String("jacktrip")
         || link.host() != QLatin1String("join")) {
@@ -1034,12 +1054,12 @@ void VirtualStudio::handleDeeplinkRequest(const QUrl& link)
 
     qDebug() << "Handling deeplink to " << link;
     setStudioToJoin(link);
+    raiseToTop();
 
     // Switch to virtual studio mode, if necessary
     // Note that this doesn't change the startup preference
     if (m_uiMode != QJackTrip::VIRTUAL_STUDIO) {
         m_standardWindow->hide();
-        m_view.show();
         if (m_windowState == "start") {
             setWindowState(QStringLiteral("login"));
         }
@@ -1644,4 +1664,6 @@ void VirtualStudio::detectedFeedbackLoop()
 VirtualStudio::~VirtualStudio()
 {
     QDesktopServices::unsetUrlHandler("jacktrip");
+    // stop the audio worker thread before destructing other things
+    m_audioConfigPtr.reset();
 }

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -275,8 +275,8 @@ class VirtualStudio : public QObject
 
     VsQuickView m_view;
     VsServerInfo m_currentStudio;
+    QNetworkAccessManager* m_networkAccessManagerPtr;
     QSharedPointer<QJackTrip> m_standardWindow;
-    QScopedPointer<QNetworkAccessManager> m_networkAccessManager;
     QSharedPointer<VsAuth> m_auth;
     QSharedPointer<VsApi> m_api;
     QScopedPointer<VsDevice> m_devicePtr;

--- a/src/gui/vsAudio.cpp
+++ b/src/gui/vsAudio.cpp
@@ -154,10 +154,10 @@ VsAudio::VsAudio(QObject* parent)
     });
 
     // move audio worker to its own thread
-    m_workerThread.reset(new QThread);
-    m_workerThread->setObjectName("VsAudioWorker");
-    m_workerThread->start();
-    m_audioWorkerPtr->moveToThread(m_workerThread.get());
+    m_workerThreadPtr = new QThread;
+    m_workerThreadPtr->setObjectName("VsAudioWorker");
+    m_workerThreadPtr->start();
+    m_audioWorkerPtr->moveToThread(m_workerThreadPtr);
 
     // connect worker signals to slots
     connect(this, &VsAudio::signalStartAudio, m_audioWorkerPtr.get(),
@@ -183,6 +183,15 @@ VsAudio::VsAudio(QObject* parent)
 #else
     m_permissionsPtr.reset(new VsPermissions());
 #endif
+}
+
+VsAudio::~VsAudio()
+{
+    if (m_workerThreadPtr == nullptr)
+        return;
+    m_workerThreadPtr->quit();
+    WaitForSignal(m_workerThreadPtr, &QThread::finished);
+    m_workerThreadPtr->deleteLater();
 }
 
 bool VsAudio::backendAvailable() const

--- a/src/gui/vsAudio.h
+++ b/src/gui/vsAudio.h
@@ -143,7 +143,7 @@ class VsAudio : public QObject
 
     // Constructor
     explicit VsAudio(QObject* parent = nullptr);
-    virtual ~VsAudio() {}
+    virtual ~VsAudio();
 
     // allow VirtualStudio to get Permissions to bind to QML view
     VsPermissions& getPermissions() { return *m_permissionsPtr; }
@@ -363,7 +363,7 @@ class VsAudio : public QObject
     // other state not shared with QML
     QSharedPointer<VsPermissions> m_permissionsPtr;
     QScopedPointer<VsAudioWorker> m_audioWorkerPtr;
-    QScopedPointer<QThread> m_workerThread;
+    QThread* m_workerThreadPtr;
     QTimer m_inputClipTimer;
     QTimer m_outputClipTimer;
     Meter* m_inputMeterPluginPtr;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -98,6 +98,7 @@ QCoreApplication* createApplication(int& argc, char* argv[])
     bool forceGui = false;
     for (int i = 1; i < argc; i++) {
         if (strncmp(argv[i], "--gui", 5) == 0 || strncmp(argv[i], "--deeplink", 10) == 0
+            || strncmp(argv[i], "--classic-gui", 13) == 0
             || strncmp(argv[i], "jacktrip://", 11) == 0) {
             forceGui = true;
         } else if (strncmp(argv[i], "--test-gui", 10) == 0) {
@@ -371,9 +372,20 @@ int main(int argc, char* argv[])
                 return 0;
         }
 
-        // Check if we need to show our first run window.
+        // Check which mode we are running in
         QSettings settings;
-        int uiMode = settings.value(QStringLiteral("UiMode"), QJackTrip::UNSET).toInt();
+        int uiMode = QJackTrip::UNSET;
+        if (!vsDeeplinkPtr->getDeeplink().isEmpty()) {
+            uiMode = QJackTrip::VIRTUAL_STUDIO;
+        } else if (cliSettings->guiForceClassicMode()) {
+            uiMode = QJackTrip::STANDARD;
+            // force settings change; otherwise, virtual studio
+            // window will still be displayed
+            settings.setValue(QStringLiteral("UiMode"), uiMode);
+        } else {
+            uiMode = settings.value(QStringLiteral("UiMode"), QJackTrip::UNSET).toInt();
+        }
+
         window.reset(new QJackTrip(cliSettings, !vsDeeplinkPtr->getDeeplink().isEmpty()));
 #else
         window.reset(new QJackTrip(cliSettings));


### PR DESCRIPTION
Added --classic-gui command line parameter to force classic GUI mode

Added qml6-module-qtquick-window to Linux README.md to account for broken dependencies on Debian

Fixed segmentation fault caused when destructing QNetworkManager during shutdown on OSX. Seems like Qt has bigger bugs underlying that since the only way I could work-around it was to leak it.