### PR TITLE
Adding network_outage flag to device json stats

### DIFF
--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -135,8 +135,10 @@ VirtualStudio::VirtualStudio(bool firstRun, QObject* parent)
     m_networkOutageTimer.setSingleShot(true);
     m_networkOutageTimer.setInterval(5000);
     m_networkOutageTimer.callOnTimeout([&]() {
-        m_networkOutage = false;
-        emit updatedNetworkOutage(m_networkOutage);
+        if (m_devicePtr.isNull())
+            return;
+        m_devicePtr->setNetworkOutage(false);
+        emit updatedNetworkOutage(false);
     });
 
     if ((m_uiMode == QJackTrip::UNSET && vsFtux())
@@ -301,7 +303,7 @@ void VirtualStudio::setConnectedErrorMsg(const QString& msg)
 
 bool VirtualStudio::networkOutage()
 {
-    return m_networkOutage;
+    return m_devicePtr.isNull() ? false : m_devicePtr->getNetworkOutage();
 }
 
 QJsonObject VirtualStudio::regions()
@@ -1362,9 +1364,11 @@ void VirtualStudio::updatedStats(const QJsonObject& stats)
 
 void VirtualStudio::udpWaitingTooLong()
 {
+    if (m_devicePtr.isNull())
+        return;
     m_networkOutageTimer.start();
-    m_networkOutage = true;
-    emit updatedNetworkOutage(m_networkOutage);
+    m_devicePtr->setNetworkOutage(true);
+    emit updatedNetworkOutage(true);
 }
 
 void VirtualStudio::sendHeartbeat()

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -319,7 +319,6 @@ class VirtualStudio : public QObject
     bool m_collapseDeviceControls = false;
     bool m_testMode               = false;
     bool m_authenticated          = false;
-    bool m_networkOutage          = false;
     float m_fontScale             = 1;
     float m_uiScale               = 1;
     uint32_t m_webChannelPort     = 1;

--- a/src/gui/vsDevice.cpp
+++ b/src/gui/vsDevice.cpp
@@ -189,6 +189,7 @@ void VsDevice::sendHeartbeat()
         json.insert(QLatin1String("stddev_rtt"), (qint64)(stats.stdDevRtt * ns_per_ms));
         json.insert(QLatin1String("high_latency"),
                     m_audioConfigPtr->getHighLatencyFlag());
+        json.insert(QLatin1String("network_outage"), m_networkOutage);
 
         // For the internal application UI, ms will suffice. No conversion needed
         QJsonObject pingStats = {};
@@ -328,7 +329,8 @@ JackTrip* VsDevice::initJackTrip(
 // startJackTrip starts the current jacktrip process if applicable
 void VsDevice::startJackTrip(const VsServerInfo& studioInfo)
 {
-    m_stopping = false;
+    m_stopping      = false;
+    m_networkOutage = false;
     updateState(studioInfo.id());
 
     // setup websocket listener

--- a/src/gui/vsDevice.h
+++ b/src/gui/vsDevice.h
@@ -77,6 +77,8 @@ class VsDevice : public QObject
     void startJackTrip(const VsServerInfo& studioInfo);
     void stopJackTrip(bool isReconnecting = false);
     void reconcileAgentConfig(QJsonDocument newState);
+    void setNetworkOutage(bool outage = true) { m_networkOutage = outage; }
+    bool getNetworkOutage() const { return m_networkOutage; }
 
    signals:
     void updateNetworkStats(QJsonObject stats);
@@ -113,8 +115,8 @@ class VsDevice : public QObject
     QScopedPointer<JackTrip> m_jackTrip;
     QRandomGenerator m_randomizer;
     QTimer m_sendVolumeTimer;
-    bool m_highLatencyFlag = false;
-    bool m_stopping        = false;
+    bool m_networkOutage = false;
+    bool m_stopping      = false;
 };
 
 #endif  // VSDEVICE_H


### PR DESCRIPTION
I think we need to bubble this up into the UI using the latency indicators