### PR TITLE
PLC auto tolerance experiments

### DIFF
--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -116,6 +116,7 @@ class StdDev
     double longTermMean;
 
    private:
+    double smooth(double avg, double current);
     void reset();
     QElapsedTimer* mTimer;
     std::vector<double> data;


### PR DESCRIPTION
PLC tolerance is a receive buffer latency added to account for network jitter. This can be set manually using "-q #" where # is an integer in milliseconds; or, it can be set automatically using "-q auto"

The calculation of auto tolerance requires measuring the time in between receipt of each audio packet. The current approach takes a maximum of these measurements over a slice of time, and then takes the average of all these max measurements since the connection was first established. The longer a connection is established, the less likely it will get updated as conditions change.

Connection quality changes over time, but the current algorithm doesn't adapt well to this. We don't want it to adapt tolerance too fast though, because temporary abnormalities are normal. Changing tolerance too often can also have undesireable effects from the repeated blending together of discontinuities.

This branch uses exponential weighted moving averages (EWMA) to allow for tolerance to adjust over time. How quickly the moving average changes depends on the AutoSmoothingFactor, and finding the best value for that may require more work.

The other significant change is that the moving average is calculated not using maximum measurements, but rather (mean + 3x standard deviations), which mathematically equates to roughly 99.7% of all values. This prevents extremely abnormal measurements from skewing the calculation. A potential problem here is ensuring that the window is large enough to encompass a statistically significant number of measurements.