### PR TITLE
Update to max target for PLC with worker thread

### DIFF
--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -262,7 +262,7 @@ class RegulatorWorker : public QObject
         , mPacketQueue(rPtr->getPacketSize())
         , mPacketQueueTarget(1)
         , mLastUnderrun(0)
-        , mLastQueueUpdate(0)
+        , mSkipQueueUpdate(true)
         , mUnderrun(false)
         , mStarted(false)
     {
@@ -313,16 +313,20 @@ class RegulatorWorker : public QObject
     {
         if (mUnderrun.load(std::memory_order_relaxed)) {
             if (mStarted) {
-                // allow up to 1 underrun per second before adjusting target
-                // only adjust target at most once per 1.0 seconds
                 double now =
                     (double)mRegulatorPtr->mIncomingTimer.nsecsElapsed() / 1000000.0;
-                if (now - mLastQueueUpdate > 1000.0 && mLastUnderrun != 0
-                    && now - mLastUnderrun < 1000.0) {
-                    updateQueueTarget();
-                    mLastQueueUpdate = now;
+                // only adjust target at most once per 1.0 seconds
+                if (now - mLastUnderrun >= 1000.0) {
+                    if (mSkipQueueUpdate) {
+                        // require consecutive underruns periods to bump target
+                        mSkipQueueUpdate = false;
+                    } else if (now - mLastUnderrun < 2000.0) {
+                        // previous period had underruns
+                        updateQueueTarget();
+                        mSkipQueueUpdate = true;
+                    }  // else, skip this period but not the next one
+                    mLastUnderrun = now;
                 }
-                mLastUnderrun = now;
                 mUnderrun.store(false, std::memory_order_relaxed);
             } else {
                 mStarted = true;
@@ -367,8 +371,8 @@ class RegulatorWorker : public QObject
     /// time of last underrun, in milliseconds
     double mLastUnderrun;
 
-    /// time of last packet queue update, in milliseconds
-    double mLastQueueUpdate;
+    /// true if the next packet queue update should be skipped
+    bool mSkipQueueUpdate;
 
     /// last value of packet queue underruns
     std::atomic<bool> mUnderrun;


### PR DESCRIPTION
This changes bufstrategy 3 so that the packet queue is allowed to grow larger, irregardless of the time required for PLC predictions. I found that Realtek audio devices in particular seem to need much bigger queues.