### PR TITLE
Prevent mouse click through events

### DIFF
--- a/src/gui/ChangeDevices.qml
+++ b/src/gui/ChangeDevices.qml
@@ -61,6 +61,11 @@ Rectangle {
         return idx;
     }
 
+    MouseArea {
+        anchors.fill: parent
+        propagateComposedEvents: false
+    }
+
     Rectangle {
         width: parent.width; height: 360
         anchors.verticalCenter: parent.verticalCenter


### PR DESCRIPTION
On the "Change Devices" screen, it's possible to click on buttons behind the view (like "Screen share" or "Leave")