### PR TITLE
PLC startup and other optimizations

### DIFF
--- a/docs/Build/Linux.md
+++ b/docs/Build/Linux.md
@@ -25,7 +25,7 @@ dnf install "pkgconfig(jack)" rtaudio-devel git help2man python3-jinja2
 
 ### Fedora (Qt6)
 ```sh
-dnf install qt6-qtbase-devel qt5-qtnetworkauth-devel qt5-qtwebsockets-devel qt5-qtquickcontrols2-devel qt5-qtsvg-devel qt6-qtwebengine-devel qt6-qtwebchannel-devel qt6-qt5compat-devel
+dnf install qt6-qtbase-devel qt5-qtnetworkauth-devel qt5-qtwebsockets-devel qt5-qtquickcontrols2-devel qt5-qtsvg-devel qt6-qtwebengine-devel qt6-qtwebchannel-devel qt6-qt5compat-devel qt6-qtshadertools-devel
 dnf groupinstall "C Development Tools and Libraries"
 dnf groupinstall "Development Tools"
 dnf install "pkgconfig(jack)" rtaudio-devel git help2man python3-jinja2

--- a/src/DataProtocol.cpp
+++ b/src/DataProtocol.cpp
@@ -51,7 +51,7 @@ using std::endl;
 //*******************************************************************************
 DataProtocol::DataProtocol(JackTrip* jacktrip, const runModeT runmode, int /*bind_port*/,
                            int /*peer_port*/)
-    : mStopped(false)
+    : mStopped(true)
     , mHasPacketsToReceive(false)
     , mRunMode(runmode)
     , mJackTrip(jacktrip)
@@ -61,3 +61,20 @@ DataProtocol::DataProtocol(JackTrip* jacktrip, const runModeT runmode, int /*bin
 
 //*******************************************************************************
 DataProtocol::~DataProtocol() {}
+
+//*******************************************************************************
+void DataProtocol::threadHasStarted()
+{
+    QMutexLocker lock(&mMutex);
+    mStopped = false;
+    mThreadHasStarted.notify_all();
+}
+
+//*******************************************************************************
+void DataProtocol::waitForStart()
+{
+    QMutexLocker lock(&mMutex);
+    while (mStopped) {
+        mThreadHasStarted.wait(&mMutex);
+    }
+}

--- a/src/DataProtocol.h
+++ b/src/DataProtocol.h
@@ -54,6 +54,7 @@
 #include <QMutex>
 #include <QMutexLocker>
 #include <QThread>
+#include <QWaitCondition>
 #include <iostream>
 
 class JackTrip;  // forward declaration
@@ -183,6 +184,9 @@ class DataProtocol : public QThread
     }
     void setUseRtPriority(bool use) { mUseRtPriority = use; }
 
+    /// @brief wait for the thread to start up
+    void waitForStart();
+
    signals:
 
     void signalError(const char* error_message);
@@ -195,6 +199,9 @@ class DataProtocol : public QThread
      */
     runModeT getRunMode() const { return mRunMode; }
 
+    /// @brief called by the thread during startup
+    void threadHasStarted();
+
     /// Boolean stop the execution of the thread
     volatile bool mStopped;
     /// Boolean to indicate if the RECEIVER is waiting to obtain peer address
@@ -202,6 +209,7 @@ class DataProtocol : public QThread
     /// Boolean that indicates if a packet was received
     volatile bool mHasPacketsToReceive;
     QMutex mMutex;
+    QWaitCondition mThreadHasStarted;
 
    private:
     int mLocalPort;           ///< Local Port number to Bind

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -658,18 +658,17 @@ void JackTrip::completeConnection()
         std::cout << "  JackTrip:startProcess before mDataProtocolReceiver->start"
                   << std::endl;
     mDataProtocolReceiver->start();
-    QThread::msleep(1);
+    mDataProtocolReceiver->waitForStart();
     if (gVerboseFlag)
         std::cout << "  JackTrip:startProcess before mDataProtocolSender->start"
                   << std::endl;
     mDataProtocolSender->start();
+    mDataProtocolSender->waitForStart();
     /*
      * changed order so that audio starts after receiver and sender
      * because UdpDataProtocol:run0 before setRealtimeProcessPriority()
      * causes an audio hiccup from jack JackPosixSemaphore::TimedWait err = Interrupted
-     * system call new QThread::msleep(1); to allow sender to start
      */
-    QThread::msleep(1);
     if (gVerboseFlag)
         std::cout << "step 5" << std::endl;
     if (gVerboseFlag)

--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -113,6 +113,7 @@ class StdDev
     double longTermStdDevAcc;
     double longTermMax;
     double longTermMaxAcc;
+    double longTermMean;
 
    private:
     void reset();

--- a/src/UdpDataProtocol.cpp
+++ b/src/UdpDataProtocol.cpp
@@ -91,8 +91,7 @@ UdpDataProtocol::UdpDataProtocol(JackTrip* jacktrip, const runModeT runmode,
     , mControlPacketSize(63)
     , mStopSignalSent(false)
 {
-    mStopped = false;
-    mIPv6    = false;
+    mIPv6 = false;
     std::memset(&mPeerAddr, 0, sizeof(mPeerAddr));
     std::memset(&mPeerAddr6, 0, sizeof(mPeerAddr6));
     mPeerAddr.sin_port   = htons(mPeerPort);
@@ -550,6 +549,8 @@ void UdpDataProtocol::run()
     // jack puts its clients in FF at 5 points below itself
     //
     // clang-format off
+
+    threadHasStarted();
 
     switch (mRunMode) {
     case RECEIVER: {

--- a/src/gui/vsDevice.cpp
+++ b/src/gui/vsDevice.cpp
@@ -307,13 +307,7 @@ JackTrip* VsDevice::initJackTrip(
     m_jackTrip->setRemoteClientName(m_appID);
     // increment m_bufferStrategy by 1 for array-index mapping
     m_jackTrip->setBufferStrategy(bufferStrategy + 1);
-    if (bufferStrategy == 2 || bufferStrategy == 3) {
-        // use -q auto3 for loss concealment
-        m_jackTrip->setBufferQueueLength(-3);
-    } else {
-        // use -q auto
-        m_jackTrip->setBufferQueueLength(-500);
-    }
+    m_jackTrip->setBufferQueueLength(-500);  // use -q auto
     m_jackTrip->setPeerAddress(studioInfo->host());
     m_jackTrip->setPeerPorts(studioInfo->port());
     m_jackTrip->setPeerHandshakePort(studioInfo->port());


### PR DESCRIPTION
Drop PLC stats measurements for first period since these are always very skewed by things starting up

Actually wait for DataProtocol to start running before starting audio rather than just sleeping for 1 millisecond and hoping that it works

When calculating PLC tolerance, accomodate poor audio interface clocks that have a wide range callback inconsistency (i.e. realtek), by using the max(pullStats, pushStats)

Allow PLC with auto headroom set to zero

Tick PLC pullStats for underruns and zeros

Add qt6-qtshadertools-devel to required packages for Fedora Linux