### PR TITLE
Discard PLC auto measurements that exceed the maximum wait time

### DIFF
--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -345,9 +345,10 @@ void Settings::parseInput(int argc, char** argv)
         case 'q':
             //-------------------------------------------------------
             if (0 == strncmp(optarg, "auto", 4)) {
-                mBufferQueueLength = -atoi(optarg + 4);
-                if (0 == mBufferQueueLength) {
+                if (optarg[4] == 0) {
                     mBufferQueueLength = -500;
+                } else {
+                    mBufferQueueLength = -atoi(optarg + 4);
                 }
             } else if (atoi(optarg) <= 0) {
                 printUsage();


### PR DESCRIPTION
This can happen on regular intervals for unreliable connections, such as wifi. Including it in the tolerance/jitter calculations simply makes latency excessively high for no benefits.

Fix to make "-q auto0" work again