### PR TITLE
Fix for update channel not persisting when changed

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -1,3 +1,7 @@
+- Version: "2.1.0-beta2"
+  Date: 2023-11-xx
+  Description:
+  - (fixed) VS Mode unable to change update channel
 - Version: "2.1.0-beta1"
   Date: 2023-10-30
   Description:

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -774,6 +774,7 @@ void VirtualStudio::loadSettings()
 void VirtualStudio::saveSettings()
 {
     QSettings settings;
+    settings.setValue(QStringLiteral("UpdateChannel"), m_updateChannel);
     settings.beginGroup(QStringLiteral("VirtualStudio"));
     settings.setValue(QStringLiteral("UiScale"), m_uiScale);
     settings.setValue(QStringLiteral("DarkMode"), m_darkMode);

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -40,7 +40,7 @@
 
 #include "AudioInterface.h"
 
-constexpr const char* const gVersion = "2.1.0-beta1";  ///< JackTrip version
+constexpr const char* const gVersion = "2.1.0-beta2";  ///< JackTrip version
 
 //*******************************************************************************
 /// \name Default Values


### PR DESCRIPTION
Bumping version to 2.1.0-beta2