### PR TITLE
Use exponential weighted moving averages for PLC auto tolerance

### DIFF
--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -113,9 +113,9 @@ class StdDev
     double longTermStdDevAcc;
     double longTermMax;
     double longTermMaxAcc;
-    double longTermMean;
 
    private:
+    double smooth(double avg, double current);
     void reset();
     QElapsedTimer* mTimer;
     std::vector<double> data;


### PR DESCRIPTION
PLC tolerance is a receive buffer latency added to account for network jitter. This can be set manually using "-q #" where # is an integer in milliseconds; or, it can be set automatically using "-q auto"

The calculation of auto tolerance requires measuring the time in between receipt of each audio packet. The current approach takes a maximum of these measurements over a slice of time, and then takes the average of all these max measurements since the connection was first established. The longer a connection is established, the less it is able to adjust to connection quality, which can change over time.

We don't want auto tolerance to adapt too quickly though, because temporary abnormalities are normal. Changing tolerance too often can also have undesireable effects from the repeated blending together of discontinuities.

This branch introduces the concept of an AutoHistoryWindow, a rolling window of time (in seconds) over which auto tolerance roughly adjusts. For the first AutoHistoryWindow (or startup), we continue to use a simple average to establish a baseline. This should be nearly identical to the previous behavior.

After the startup period, we use exponential weighted moving averages (EWMA) to allow for auto tolerance to slowly adjust over time. How quickly the moving average changes depends on the AutoSmoothingFactor. This is set to a value that should offer gradual weighted adjustments over the same AutoHistoryWindow.

This also includes a few other less significant tweaks which seem desireable:

* Shortens the AutoInitDur from 6 to 1 seconds. I think this provides a sufficient enough number of measurements to start using the calculated values

* Uses peer FPP for pushStats rather than the max of local and peer. I'm not sure why this was using max before; perhaps an earlier iteration only used one StdDev object for both?

* Ignores the first 3 stats instead of just the first one, because I've seen instances where crazy values happen in the second.

* Removes the unused longTermMean statistic.