### PR TITLE
Automatically calculate headroom for PLC

### DIFF
--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -188,10 +188,12 @@ class Regulator : public RingBuffer
     void pushPacket(const int8_t* buf, int seq_num);
     void assemblePacket(const int8_t* buf, int peer_seq_num);
     void pullPacket();
+    void updateTolerance();
     void setFPPratio();
-    bool mFPPratioIsSet;
     void processPacket(bool glitch);
     void processChannel(int ch, bool glitch, int packetCnt, bool lastWasGlitch);
+
+    bool mFPPratioIsSet;
     int mNumChannels;
     int mAudioBitRes;
     int mFPP;

--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -95,8 +95,8 @@ class ChanData
 class StdDev
 {
    public:
-    StdDev(int id, QElapsedTimer* timer, int fps);
-    void tick();
+    StdDev(int id, QElapsedTimer* timer, int w);
+    bool tick();  // returns true if stats were updated
     double calcAuto();
     int mId;
     int plcOverruns;
@@ -107,15 +107,13 @@ class StdDev
     double lastMax;
     int lastPlcOverruns;
     int lastPlcUnderruns;
-    int lastGlitches;
-    bool skipAutoHeadroom;
-    double autoHeadroom;
     double lastPLCdspElapsed;
     double lastStdDev;
     double longTermStdDev;
     double longTermStdDevAcc;
     double longTermMax;
     double longTermMaxAcc;
+    int longTermCnt;
 
    private:
     double smooth(double avg, double current);
@@ -124,12 +122,10 @@ class StdDev
     std::vector<double> data;
     double mean;
     int window;
-    int framesPerSecond;
     double acc;
     double min;
     double max;
     int ctr;
-    int longTermCnt;
 };
 
 class Regulator : public RingBuffer
@@ -232,6 +228,9 @@ class Regulator : public RingBuffer
     int mFPPratioNumerator;
     int mFPPratioDenominator;
     bool mAuto;
+    bool mSkipAutoHeadroom;
+    int mLastGlitches;
+    double mCurrentHeadroom;
     double mAutoHeadroom;
     double mFPPdurMsec;
     double mPeerFPPdurMsec;

--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -113,6 +113,7 @@ class StdDev
     double longTermStdDevAcc;
     double longTermMax;
     double longTermMaxAcc;
+    double autoHeadroom;
 
    private:
     double smooth(double avg, double current);

--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -95,9 +95,9 @@ class ChanData
 class StdDev
 {
    public:
-    StdDev(int id, QElapsedTimer* timer, int w);
+    StdDev(int id, QElapsedTimer* timer, int fps);
     void tick();
-    double calcAuto(double autoHeadroom, double localFPPdur, double peerFPPdur);
+    double calcAuto();
     int mId;
     int plcOverruns;
     int plcUnderruns;
@@ -107,13 +107,15 @@ class StdDev
     double lastMax;
     int lastPlcOverruns;
     int lastPlcUnderruns;
+    int lastGlitches;
+    bool skipAutoHeadroom;
+    double autoHeadroom;
     double lastPLCdspElapsed;
     double lastStdDev;
     double longTermStdDev;
     double longTermStdDevAcc;
     double longTermMax;
     double longTermMaxAcc;
-    double autoHeadroom;
 
    private:
     double smooth(double avg, double current);
@@ -122,6 +124,7 @@ class StdDev
     std::vector<double> data;
     double mean;
     int window;
+    int framesPerSecond;
     double acc;
     double min;
     double max;


### PR DESCRIPTION
This updates the default behavior for "-q auto" so that it tries to automatically calculate a headroom value for you. You can still specify an explicit value, including 0.

The best value depends on the quality of your connection. When plugged into ethernet, on fiber Internet, 0 works great for me. Even cross-content. There's no need to add an extra 6 ms of latency (3 for server and 3 for client) when it doesn't improve quality.

Switching to wifi is a different story. Stdev goes up from about 0.1 ms to 0.6 ms, and about 3 ms headroom seems like a worthy tradeoff to minimize glitches. How about other connections? It's hard to say without being able to do a bunch of testing..

This branch combines the statistical auto tolerance calculation with observations of how it is actually performing (starting with auto0), and adjusts it over time to the best value for your connection. Every second, it checks the number of glitches for the previous second, and if it exceeds 0.7% (AutoHeadroomGlitchTolerance) for two 1-second periods in a row, it will increase the headroom value added to the plc stats calculations up to MaxAutoHeadroom.