### PR TITLE
Flatpak: update to Qt 6.6

### DIFF
--- a/build-aux/flatpak/org.jacktrip.JackTrip.json
+++ b/build-aux/flatpak/org.jacktrip.JackTrip.json
@@ -1,10 +1,10 @@
 {
     "app-id": "org.jacktrip.JackTrip",
     "runtime": "org.kde.Platform",
-    "runtime-version": "6.4",
+    "runtime-version": "6.6",
     "sdk": "org.kde.Sdk",
     "base": "io.qt.qtwebengine.BaseApp",
-    "base-version": "6.4",
+    "base-version": "6.6",
     "command": "jacktrip",
     "finish-args": [
         "--share=ipc",


### PR DESCRIPTION
Just to be in sync with the Flathub version.

https://github.com/flathub/org.jacktrip.JackTrip/pull/11