### PR TITLE
Fix support for sample rates other than 48khz

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -257,6 +257,7 @@ jobs:
           HOMEBREW_NO_ANALYTICS: 1
           HOMEBREW_NO_AUTO_UPDATE: 1
           HOMEBREW_NO_INSTALL_CLEANUP: 1
+          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
         run: |
           # brew install jack
           # instead of using homebrew, install jack 1.9.16 from the installer, which should provide compatibility with both jackosx and the newer jack2

--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -1,3 +1,8 @@
+- Version: "2.1.1"
+  Date: 2023-12-xx
+  Description:
+  - (updated) VS Mode error message for disconnected audio interfaces
+  - (fixed) VS Mode refused to connect to studios not 48khz
 - Version: "2.1.0"
   Date: 2023-11-06
   Description:

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -411,7 +411,7 @@ void Regulator::pullPacket()
             int next = lastSeqNumIn - i;
             if (next < 0)
                 next += mNumSlots;
-            if (mFPPratioNumerator) {
+            if (mFPPratioNumerator > 1) {
                 // time for assembly has passed; reset for next time
                 mAssemblyCounts[next] = 0;
             }

--- a/src/RtAudioInterface.cpp
+++ b/src/RtAudioInterface.cpp
@@ -38,6 +38,7 @@
 #include "RtAudioInterface.h"
 
 #include <QString>
+#include <QTextStream>
 #include <cstdlib>
 
 #include "JackTrip.h"
@@ -80,6 +81,16 @@ void RtAudioDevice::printVerbose() const
         cout << "  --Probed Successful--" << endl;
     }
 #endif
+}
+
+//*******************************************************************************
+bool RtAudioDevice::checkSampleRate(unsigned int srate) const
+{
+    for (unsigned int i = 0; i < this->sampleRates.size(); i++) {
+        if (this->sampleRates[i] == srate)
+            return true;
+    }
+    return false;
 }
 
 //*******************************************************************************
@@ -217,6 +228,21 @@ void RtAudioInterface::setup(bool verbose)
         cout << "OUTPUT DEVICE:" << endl;
         out_device.printVerbose();
         cout << gPrintSeparator << endl;
+    }
+
+    if (!in_device.checkSampleRate(getSampleRate())) {
+        QString errorMsg;
+        QTextStream(&errorMsg) << "Input device \"" << QString::fromStdString(in_name)
+                               << "\" does not support sample rate of "
+                               << getSampleRate();
+        throw std::runtime_error(errorMsg.toStdString());
+    }
+    if (!out_device.checkSampleRate(getSampleRate())) {
+        QString errorMsg;
+        QTextStream(&errorMsg) << "Output device \"" << QString::fromStdString(out_name)
+                               << "\" does not support sample rate of "
+                               << getSampleRate();
+        throw std::runtime_error(errorMsg.toStdString());
     }
 
     if (in_device.api == out_device.api) {

--- a/src/RtAudioInterface.h
+++ b/src/RtAudioInterface.h
@@ -64,6 +64,7 @@ class RtAudioDevice : public RtAudio::DeviceInfo
     RtAudio::Api api;
     void print() const;
     void printVerbose() const;
+    bool checkSampleRate(unsigned int srate) const;
     RtAudioDevice& operator=(const RtAudio::DeviceInfo& info);
 };
 

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1309,8 +1309,8 @@ void VirtualStudio::processError(const QString& errorMessage)
     } else if (errorMessage.startsWith(RtAudioErrorMsg)) {
         if (errorMessage.length() > RtAudioErrorMsg.length() + 2) {
             const QString details(errorMessage.sliced(RtAudioErrorMsg.length() + 2));
-            if (details.startsWith(
-                    QStringLiteral("RtApiCore: the stream device was disconnected"))) {
+            if (details.contains(QStringLiteral("device was disconnected"))
+                || details.contains(QStringLiteral("Unable to retrieve capture buffer"))) {
                 msgBox.setText(QStringLiteral("Your audio interface was disconnected."));
             } else {
                 msgBox.setText(details);

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -1310,7 +1310,8 @@ void VirtualStudio::processError(const QString& errorMessage)
         if (errorMessage.length() > RtAudioErrorMsg.length() + 2) {
             const QString details(errorMessage.sliced(RtAudioErrorMsg.length() + 2));
             if (details.contains(QStringLiteral("device was disconnected"))
-                || details.contains(QStringLiteral("Unable to retrieve capture buffer"))) {
+                || details.contains(
+                    QStringLiteral("Unable to retrieve capture buffer"))) {
                 msgBox.setText(QStringLiteral("Your audio interface was disconnected."));
             } else {
                 msgBox.setText(details);

--- a/src/gui/vsAudio.cpp
+++ b/src/gui/vsAudio.cpp
@@ -841,10 +841,6 @@ AudioInterface* VsAudio::newAudioInterface(JackTrip* jackTripPtr)
     if (ifPtr == nullptr)
         return ifPtr;
 
-#if defined(__unix__)
-    AudioInterface::setPipewireLatency(getBufferSize(), ifPtr->getSampleRate());
-#endif
-
     // AudioInterface::setup() can return a different buffer size
     // if the audio interface doesn't support the one that was requested
     if (ifPtr->getBufferSizeInSamples() != uint32_t(getBufferSize())) {
@@ -892,6 +888,11 @@ AudioInterface* VsAudio::newJackAudioInterface([[maybe_unused]] JackTrip* jackTr
         ifPtr = new JackAudioInterface(inputChans, outputChans, m_audioBitResolution,
                                        jackTripPtr != nullptr, jackTripPtr);
         ifPtr->setClientName(QStringLiteral("JackTrip"));
+#if defined(__unix__)
+        AudioInterface::setPipewireLatency(
+            getBufferSize(),
+            jackTripPtr == nullptr ? 44100 : jackTripPtr->getSampleRate());
+#endif
         ifPtr->setup(true);
     }
 #endif
@@ -926,6 +927,10 @@ AudioInterface* VsAudio::newRtAudioInterface([[maybe_unused]] JackTrip* jackTrip
     QVector<RtAudioDevice> devices = m_audioWorkerPtr->getDevices();
     if (!devices.empty())
         static_cast<RtAudioInterface*>(ifPtr)->setRtAudioDevices(devices);
+
+#if defined(__unix__)
+    AudioInterface::setPipewireLatency(getBufferSize(), ifPtr->getSampleRate());
+#endif
 
     // Note: setup might change the number of channels and/or buffer size
     ifPtr->setup(true);

--- a/src/gui/vsAudio.h
+++ b/src/gui/vsAudio.h
@@ -343,7 +343,6 @@ class VsAudio : public QObject
     float m_inMultiplier    = 1.0;
     float m_outMultiplier   = 1.0;
     float m_monMultiplier   = 0;
-    uint32_t m_sampleRate   = gDefaultSampleRate;
 
     QString m_inputDevice;
     QString m_outputDevice;

--- a/src/gui/vsDevice.cpp
+++ b/src/gui/vsDevice.cpp
@@ -293,12 +293,12 @@ JackTrip* VsDevice::initJackTrip(
 #ifdef RT_AUDIO
     if (useRtAudio) {
         m_jackTrip->setAudiointerfaceMode(JackTrip::RTAUDIO);
-        m_jackTrip->setSampleRate(studioInfo->sampleRate());
         m_jackTrip->setAudioBufferSizeInSamples(bufferSize);
         m_jackTrip->setInputDevice(input);
         m_jackTrip->setOutputDevice(output);
     }
 #endif
+    m_jackTrip->setSampleRate(studioInfo->sampleRate());
     int bindPort = selectBindPort();
     if (bindPort == 0) {
         return 0;

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -40,7 +40,7 @@
 
 #include "AudioInterface.h"
 
-constexpr const char* const gVersion = "2.1.0";  ///< JackTrip version
+constexpr const char* const gVersion = "2.1.1";  ///< JackTrip version
 
 //*******************************************************************************
 /// \name Default Values


### PR DESCRIPTION
Fix 2.x virtual studio regression that starting forcing sample rate of 48000 even if the studio was configured to use a different one.

Use 44100 instead of 48000 when configuring an audio interface in virtual studio mode, since this seems to be supported by a greater range of devices.

Improve error message when an audio interface is disconnected on Windows computers.

Adding some extra sample rate checks and error handling

Fixing a benign bug in PLC code