### PR TITLE
Reuse AudioSettings.qml in ChangeDevice.qml

### DIFF
--- a/src/gui/AudioSettings.qml
+++ b/src/gui/AudioSettings.qml
@@ -6,6 +6,10 @@ Rectangle {
     height: parent.height
     color: backgroundColour
 
+    property bool connected: false
+    property bool showMeters: true
+    property bool showTestAudio: true
+
     property int fontBig: 20
     property int fontMedium: 13
     property int fontSmall: 11
@@ -112,6 +116,7 @@ Rectangle {
                 x: 0; y: 0
                 text: "Output Device"
                 font { family: "Poppins"; pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale }
+                bottomPadding: 10 * virtualstudio.uiScale
                 color: textColour
             }
 
@@ -127,7 +132,7 @@ Rectangle {
             AppIcon {
                 id: headphonesIcon
                 anchors.left: outputLabel.left
-                anchors.verticalCenter: outputDeviceMeters.verticalCenter
+                anchors.top: outputLabel.bottom
                 width: 28 * virtualstudio.uiScale
                 height: 28 * virtualstudio.uiScale
                 icon.source: "headphones.svg"
@@ -168,8 +173,12 @@ Rectangle {
                                         audio.inputDevice = modelData.text
                                     }
                                 }
-                                audio.validateDevices()
-                                audio.restartAudio()
+                                if (connected) {
+                                    virtualstudio.triggerReconnect(false);
+                                } else {
+                                    audio.validateDevices()
+                                    audio.restartAudio()
+                                }
                             }
                         }
                     }
@@ -191,8 +200,9 @@ Rectangle {
                 anchors.top: outputCombo.bottom
                 anchors.topMargin: 16 * virtualstudio.uiScale
                 height: 24 * virtualstudio.uiScale
-                model: audio.outputMeterLevels
+                model: showMeters ? audio.outputMeterLevels : [0, 0]
                 clipped: audio.outputClipped
+                visible: showMeters
                 enabled: audio.audioReady && !Boolean(audio.devicesError)
             }
 
@@ -208,13 +218,14 @@ Rectangle {
                 tooltipText: "How loudly you hear other participants"
                 showLabel: false
                 sliderEnabled: true
+                visible: showMeters
             }
 
             Text {
                 id: outputChannelsLabel
                 anchors.left: outputCombo.left
                 anchors.right: outputCombo.horizontalCenter
-                anchors.top: outputSlider.bottom
+                anchors.top: showMeters ? outputSlider.bottom : outputCombo.bottom
                 anchors.topMargin: 12 * virtualstudio.uiScale
                 textFormat: Text.RichText
                 text: "Output Channel(s)"
@@ -247,8 +258,12 @@ Rectangle {
                             outputChannelsCombo.popup.close()
                             audio.baseOutputChannel = modelData.baseChannel
                             audio.numOutputChannels = modelData.numChannels
-                            audio.validateDevices()
-                            audio.restartAudio()
+                            if (connected) {
+                                virtualstudio.triggerReconnect(false);
+                            } else {
+                                audio.validateDevices()
+                                audio.restartAudio()
+                            }
                         }
                     }
                 }
@@ -264,6 +279,7 @@ Rectangle {
 
             Button {
                 id: testOutputAudioButton
+                visible: showTestAudio
                 background: Rectangle {
                     radius: 6 * virtualstudio.uiScale
                     color: testOutputAudioButton.down ? buttonPressedColour : (testOutputAudioButton.hovered ? buttonHoverColour : buttonColour)
@@ -285,7 +301,7 @@ Rectangle {
 
             Rectangle {
                 id: divider1
-                anchors.top: testOutputAudioButton.bottom
+                anchors.top: showTestAudio ? testOutputAudioButton.bottom : outputChannelsCombo.bottom
                 anchors.topMargin: 24 * virtualstudio.uiScale
                 width: parent.width - x - (16 * virtualstudio.uiScale); height: 2 * virtualstudio.uiScale
                 color: "#E0E0E0"
@@ -295,9 +311,10 @@ Rectangle {
                 id: inputLabel
                 anchors.left: outputLabel.left
                 anchors.top: divider1.bottom
-                anchors.topMargin: 32 * virtualstudio.uiScale
+                anchors.topMargin: 24 * virtualstudio.uiScale
                 text: "Input Device"
                 font { family: "Poppins"; pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale }
+                bottomPadding: 10 * virtualstudio.uiScale
                 color: textColour
             }
 
@@ -312,8 +329,8 @@ Rectangle {
 
             AppIcon {
                 id: microphoneIcon
-                anchors.left: outputLabel.left
-                anchors.verticalCenter: inputDeviceMeters.verticalCenter
+                anchors.left: inputLabel.left
+                anchors.top: inputLabel.bottom
                 width: 32 * virtualstudio.uiScale
                 height: 32 * virtualstudio.uiScale
                 icon.source: "mic.svg"
@@ -353,8 +370,12 @@ Rectangle {
                                         audio.outputDevice = modelData.text
                                     }
                                 }
-                                audio.validateDevices()
-                                audio.restartAudio()
+                                if (connected) {
+                                    virtualstudio.triggerReconnect(false);
+                                } else {
+                                    audio.validateDevices()
+                                    audio.restartAudio()
+                                }
                             }
                         }
                     }
@@ -376,14 +397,15 @@ Rectangle {
                 anchors.top: inputCombo.bottom
                 anchors.topMargin: 16 * virtualstudio.uiScale
                 height: 24 * virtualstudio.uiScale
-                model: audio.inputMeterLevels
+                model: showMeters ? audio.inputMeterLevels : [0, 0]
                 clipped: audio.inputClipped
+                visible: showMeters
                 enabled: audio.audioReady && !Boolean(audio.devicesError)
             }
 
             VolumeSlider {
                 id: inputSlider
-                anchors.left: inputDeviceMeters.left
+                anchors.left: inputCombo.left
                 anchors.right: parent.right
                 anchors.rightMargin: rightMargin * virtualstudio.uiScale
                 anchors.top: inputDeviceMeters.bottom
@@ -393,6 +415,7 @@ Rectangle {
                 tooltipText: "How loudly other participants hear you"
                 showLabel: false
                 sliderEnabled: true
+                visible: showMeters
             }
 
             Button {
@@ -408,7 +431,7 @@ Rectangle {
                 id: inputChannelsLabel
                 anchors.left: inputCombo.left
                 anchors.right: inputCombo.horizontalCenter
-                anchors.top: inputSlider.bottom
+                anchors.top: showMeters ? inputSlider.bottom : inputCombo.bottom
                 anchors.topMargin: 12 * virtualstudio.uiScale
                 textFormat: Text.RichText
                 text: "Input Channel(s)"
@@ -441,8 +464,12 @@ Rectangle {
                             inputChannelsCombo.popup.close()
                             audio.baseInputChannel = modelData.baseChannel
                             audio.numInputChannels = modelData.numChannels
-                            audio.validateDevices()
-                            audio.restartAudio()
+                            if (connected) {
+                                virtualstudio.triggerReconnect(false);
+                            } else {
+                                audio.validateDevices()
+                                audio.restartAudio()
+                            }
                         }
                     }
                 }
@@ -461,7 +488,7 @@ Rectangle {
                 anchors.left: inputCombo.horizontalCenter
                 anchors.right: inputCombo.right
                 anchors.rightMargin: 8 * virtualstudio.uiScale
-                anchors.top: inputSlider.bottom
+                anchors.top: showMeters ? inputSlider.bottom : inputCombo.bottom
                 anchors.topMargin: 12 * virtualstudio.uiScale
                 textFormat: Text.RichText
                 text: "Mono / Stereo"
@@ -493,8 +520,12 @@ Rectangle {
                             inputMixModeCombo.currentIndex = index
                             inputMixModeCombo.popup.close()
                             audio.inputMixMode = audio.inputMixModeComboModel[index].value
-                            audio.validateDevices();
-                            audio.restartAudio()
+                            if (connected) {
+                                virtualstudio.triggerReconnect(false);
+                            } else {
+                                audio.validateDevices()
+                                audio.restartAudio()
+                            }
                         }
                     }
                 }
@@ -605,13 +636,14 @@ Rectangle {
                 text: "Output Volume"
                 font { family: "Poppins"; pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale }
                 wrapMode: Text.WordWrap
+                bottomPadding: 10 * virtualstudio.uiScale
                 color: textColour
             }
 
             AppIcon {
                 id: jackHeadphonesIcon
                 anchors.left: jackOutputLabel.left
-                anchors.verticalCenter: jackOutputVolumeSlider.verticalCenter
+                anchors.top: jackOutputLabel.bottom
                 width: 28 * virtualstudio.uiScale
                 height: 28 * virtualstudio.uiScale
                 icon.source: "headphones.svg"
@@ -624,7 +656,7 @@ Rectangle {
                 anchors.rightMargin: rightMargin * virtualstudio.uiScale
                 anchors.verticalCenter: jackOutputLabel.verticalCenter
                 height: 24 * virtualstudio.uiScale
-                model: audio.outputMeterLevels
+                model: showMeters ? audio.outputMeterLevels : [0, 0]
                 clipped: audio.outputClipped
                 enabled: audio.audioReady && !Boolean(audio.devicesError)
             }
@@ -673,13 +705,14 @@ Rectangle {
                 text: "Input Volume"
                 font { family: "Poppins"; pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale }
                 wrapMode: Text.WordWrap
+                bottomPadding: 10 * virtualstudio.uiScale
                 color: textColour
             }
 
             AppIcon {
                 id: jackMicrophoneIcon
                 anchors.left: jackInputLabel.left
-                anchors.verticalCenter: jackInputVolumeSlider.verticalCenter
+                anchors.top: jackInputLabel.bottom
                 width: 32 * virtualstudio.uiScale
                 height: 32 * virtualstudio.uiScale
                 icon.source: "mic.svg"
@@ -692,7 +725,7 @@ Rectangle {
                 anchors.rightMargin: rightMargin * virtualstudio.uiScale
                 anchors.verticalCenter: jackInputLabel.verticalCenter
                 height: 24 * virtualstudio.uiScale
-                model: audio.inputMeterLevels
+                model: showMeters ? audio.inputMeterLevels : [0, 0]
                 clipped: audio.inputClipped
                 enabled: audio.audioReady && !Boolean(audio.devicesError)
             }

--- a/src/gui/ChangeDevices.qml
+++ b/src/gui/ChangeDevices.qml
@@ -35,457 +35,48 @@ Rectangle {
 
     property string linkText: virtualstudio.darkMode ? "#8B8D8D" : "#272525"
 
-    function getCurrentInputDeviceIndex () {
-        if (audio.inputDevice === "") {
-            return audio.inputComboModel.findIndex(elem => elem.type === "element");
-        }
-
-        let idx = audio.inputComboModel.findIndex(elem => elem.type === "element" && elem.text === audio.inputDevice);
-        if (idx < 0) {
-            idx = audio.inputComboModel.findIndex(elem => elem.type === "element");
-        }
-
-        return idx;
-    }
-
-    function getCurrentOutputDeviceIndex() {
-        if (audio.outputDevice === "") {
-            return audio.outputComboModel.findIndex(elem => elem.type === "element");
-        }
-
-        let idx = audio.outputComboModel.findIndex(elem => elem.type === "element" && elem.text === audio.outputDevice);
-        if (idx < 0) {
-            idx = audio.outputComboModel.findIndex(elem => elem.type === "element");
-        }
-
-        return idx;
-    }
-
     MouseArea {
         anchors.fill: parent
         propagateComposedEvents: false
     }
 
     Rectangle {
-        width: parent.width; height: 360
-        anchors.verticalCenter: parent.verticalCenter
+        id: audioSettingsView
+        width: parent.width;
+        height: parent.height;
         color: backgroundColour
         radius: 6 * virtualstudio.uiScale
 
-        Item {
-            id: usingRtAudio
-            anchors.top: parent.top
-            anchors.topMargin: 24 * virtualstudio.uiScale
-            anchors.bottom: parent.bottom
-            anchors.left: parent.left
-            anchors.leftMargin: 24 * virtualstudio.uiScale
-            anchors.right: parent.right
-
-            Rectangle {
-                id: leftSpacer
-                x: 0; y: 0
-                width: 144 * virtualstudio.uiScale
-                height: 0
-                color: "transparent"
+        DeviceRefreshButton {
+            id: refreshButton
+            anchors.top: parent.top;
+            anchors.topMargin: 16 * virtualstudio.uiScale;
+            anchors.right: parent.right;
+            anchors.rightMargin: 16 * virtualstudio.uiScale;
+            enabled: !audio.scanningDevices
+            onDeviceRefresh: function () {
+                virtualstudio.triggerReconnect(true);
             }
+        }
 
-            DeviceRefreshButton {
-                id: refreshButton
-                y: 0;
-                x: parent.width - (144 + rightMargin) * virtualstudio.uiScale;
-                enabled: !audio.scanningDevices
-                onDeviceRefresh: function () {
-                    virtualstudio.triggerReconnect(true);
-                }
-            }
+        Text {
+            text: "Restarting Audio"
+            anchors.verticalCenter: refreshButton.verticalCenter
+            anchors.right: refreshButton.left;
+            anchors.rightMargin: 16 * virtualstudio.uiScale;
+            font { family: "Poppins"; pixelSize: fontTiny * virtualstudio.fontScale * virtualstudio.uiScale }
+            color: textColour
+            visible: audio.scanningDevices
+        }
 
-            Text {
-                text: "Scanning Devices"
-                y: 0;
-                anchors.right: refreshButton.left;
-                anchors.rightMargin: 16 * virtualstudio.uiScale;
-                font { family: "Poppins"; pixelSize: fontTiny * virtualstudio.fontScale * virtualstudio.uiScale }
-                color: textColour
-                visible: audio.scanningDevices
-            }
-
-            Text {
-                id: outputLabel
-                x: 0;
-                anchors.top: refreshButton.bottom
-                anchors.topMargin: 24 * virtualstudio.uiScale
-                text: "Output Device"
-                font { family: "Poppins"; pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale }
-                color: textColour
-            }
-
-            InfoTooltip {
-                id: outputHelpIcon
-                anchors.left: outputLabel.right
-                anchors.bottom: outputLabel.top
-                anchors.bottomMargin: -8 * virtualstudio.uiScale
-                size: 16 * virtualstudio.uiScale
-                content: qsTr("How you'll hear the studio audio")
-            }
-
-            AppIcon {
-                id: headphonesIcon
-                anchors.left: outputLabel.left
-                anchors.top: outputLabel.bottom
-                anchors.topMargin: bottomToolTipMargin * virtualstudio.uiScale
-                width: 28 * virtualstudio.uiScale
-                height: 28 * virtualstudio.uiScale
-                icon.source: "headphones.svg"
-            }
-
-            ComboBox {
-                id: outputCombo
-                anchors.left: leftSpacer.right
-                anchors.verticalCenter: outputLabel.verticalCenter
-                anchors.rightMargin: rightMargin * virtualstudio.uiScale
-                width: parent.width - leftSpacer.width - rightMargin * virtualstudio.uiScale
-                enabled: virtualstudio.connectionState == "Connected"
-                model: audio.outputComboModel
-                currentIndex: getCurrentOutputDeviceIndex()
-                delegate: ItemDelegate {
-                    required property var modelData
-                    required property int index
-
-                    leftPadding: 0
-
-                    width: parent.width
-                    contentItem: Text {
-                        leftPadding: modelData.type === "element" && outputCombo.model.filter(it => it.type === "header").length > 0 ? 24 : 12
-                        text: modelData.text || ""
-                        font.bold: modelData.type === "header"
-                    }
-                    highlighted: outputCombo.highlightedIndex === index
-                    MouseArea {
-                        anchors.fill: parent
-                        onClicked: {
-                            if (modelData.type == "element") {
-                                outputCombo.currentIndex = index
-                                outputCombo.popup.close()
-                                audio.outputDevice = modelData.text
-                                if (modelData.category.startsWith("Low-Latency")) {
-                                    let inputComboIdx = inputCombo.model.findIndex(it => it.category.startsWith("Low-Latency") && it.text === modelData.text);
-                                    if (inputComboIdx !== null && inputComboIdx !== undefined) {
-                                        inputCombo.currentIndex = inputComboIdx;
-                                        audio.inputDevice = modelData.text
-                                    }
-                                }
-                                virtualstudio.triggerReconnect(false);
-                            }
-                        }
-                    }
-                }
-                contentItem: Text {
-                    leftPadding: 12
-                    font: outputCombo.font
-                    horizontalAlignment: Text.AlignHLeft
-                    verticalAlignment: Text.AlignVCenter
-                    elide: Text.ElideRight
-                    text: outputCombo.model[outputCombo.currentIndex] && outputCombo.model[outputCombo.currentIndex].text ? outputCombo.model[outputCombo.currentIndex].text : ""
-                }
-            }
-
-            Text {
-                id: outputChannelsLabel
-                anchors.left: outputCombo.left
-                anchors.right: outputCombo.horizontalCenter
-                anchors.top: outputCombo.bottom
-                anchors.topMargin: 12 * virtualstudio.uiScale
-                textFormat: Text.RichText
-                text: "Output Channel(s)"
-                font { family: "Poppins"; pixelSize: fontTiny * virtualstudio.fontScale * virtualstudio.uiScale }
-                color: textColour
-            }
-
-            ComboBox {
-                id: outputChannelsCombo
-                anchors.left: outputCombo.left
-                anchors.right: outputCombo.horizontalCenter
-                anchors.rightMargin: 8 * virtualstudio.uiScale
-                anchors.top: outputChannelsLabel.bottom
-                anchors.topMargin: 4 * virtualstudio.uiScale
-                enabled: audio.outputChannelsComboModel.length > 1 && virtualstudio.connectionState == "Connected"
-                model: audio.outputChannelsComboModel
-                currentIndex: (() => {
-                    let idx = audio.outputChannelsComboModel.findIndex(elem => elem.baseChannel === audio.baseOutputChannel
-                        && elem.numChannels === audio.numOutputChannels);
-                    if (idx < 0) {
-                        idx = 0;
-                    }
-                    return idx;
-                })()
-                delegate: ItemDelegate {
-                    required property var modelData
-                    required property int index
-                    width: parent.width
-                    contentItem: Text {
-                        text: modelData.label
-                    }
-                    highlighted: outputChannelsCombo.highlightedIndex === index
-                    MouseArea {
-                        anchors.fill: parent
-                        onClicked: {
-                            outputChannelsCombo.currentIndex = index
-                            outputChannelsCombo.popup.close()
-                            audio.baseOutputChannel = modelData.baseChannel
-                            audio.numOutputChannels = modelData.numChannels
-                            virtualstudio.triggerReconnect(false);
-                        }
-                    }
-                }
-                contentItem: Text {
-                    leftPadding: 12
-                    font: inputCombo.font
-                    horizontalAlignment: Text.AlignHLeft
-                    verticalAlignment: Text.AlignVCenter
-                    elide: Text.ElideRight
-                    text: outputChannelsCombo.model[outputChannelsCombo.currentIndex].label || ""
-                }
-            }
-
-            Text {
-                id: inputLabel
-                anchors.left: outputLabel.left
-                anchors.top: outputChannelsCombo.bottom
-                anchors.topMargin: 32 * virtualstudio.uiScale
-                text: "Input Device"
-                font { family: "Poppins"; pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale }
-                color: textColour
-            }
-
-            InfoTooltip {
-                id: inputHelpIcon
-                anchors.left: inputLabel.right
-                anchors.bottom: inputLabel.top
-                anchors.bottomMargin: -8 * virtualstudio.uiScale
-                size: 16 * virtualstudio.uiScale
-                content: qsTr("Audio sent to the studio (microphone, instrument, mixer, etc.)")
-            }
-
-            AppIcon {
-                id: microphoneIcon
-                anchors.left: inputLabel.left
-                anchors.top: inputLabel.bottom
-                anchors.topMargin: bottomToolTipMargin * virtualstudio.uiScale
-                width: 32 * virtualstudio.uiScale
-                height: 32 * virtualstudio.uiScale
-                icon.source: "mic.svg"
-            }
-
-            ComboBox {
-                id: inputCombo
-                model: audio.inputComboModel
-                currentIndex: getCurrentInputDeviceIndex()
-                anchors.left: outputCombo.left
-                anchors.right: outputCombo.right
-                anchors.verticalCenter: inputLabel.verticalCenter
-                enabled: virtualstudio.connectionState == "Connected"
-                delegate: ItemDelegate {
-                    required property var modelData
-                    required property int index
-
-                    leftPadding: 0
-
-                    width: parent.width
-                    contentItem: Text {
-                        leftPadding: modelData.type === "element" && inputCombo.model.filter(it => it.type === "header").length > 0 ? 24 : 12
-                        text: modelData.text || ""
-                        font.bold: modelData.type === "header"
-                    }
-                    highlighted: inputCombo.highlightedIndex === index
-                    MouseArea {
-                        anchors.fill: parent
-                        onClicked: {
-                            if (modelData.type == "element") {
-                                inputCombo.currentIndex = index
-                                inputCombo.popup.close()
-                                audio.inputDevice = modelData.text
-                                if (modelData.category.startsWith("Low-Latency")) {
-                                    let outputComboIdx = outputCombo.model.findIndex(it => it.category.startsWith("Low-Latency") && it.text === modelData.text);
-                                    if (outputComboIdx !== null && outputComboIdx !== undefined) {
-                                        outputCombo.currentIndex = outputComboIdx;
-                                        audio.outputDevice = modelData.text
-                                    }
-                                }
-                                virtualstudio.triggerReconnect(false);
-                            }
-                        }
-                    }
-                }
-                contentItem: Text {
-                    leftPadding: 12
-                    font: inputCombo.font
-                    horizontalAlignment: Text.AlignHLeft
-                    verticalAlignment: Text.AlignVCenter
-                    elide: Text.ElideRight
-                    text: inputCombo.model[inputCombo.currentIndex] && inputCombo.model[inputCombo.currentIndex].text ? inputCombo.model[inputCombo.currentIndex].text : ""
-                }
-            }
-
-            Text {
-                id: inputChannelsLabel
-                anchors.left: inputCombo.left
-                anchors.right: inputCombo.horizontalCenter
-                anchors.top: inputCombo.bottom
-                anchors.topMargin: 12 * virtualstudio.uiScale
-                textFormat: Text.RichText
-                text: "Input Channel(s)"
-                font { family: "Poppins"; pixelSize: fontTiny * virtualstudio.fontScale * virtualstudio.uiScale }
-                color: textColour
-            }
-
-            ComboBox {
-                id: inputChannelsCombo
-                anchors.left: inputCombo.left
-                anchors.right: inputCombo.horizontalCenter
-                anchors.rightMargin: 8 * virtualstudio.uiScale
-                anchors.top: inputChannelsLabel.bottom
-                anchors.topMargin: 4 * virtualstudio.uiScale
-                enabled: audio.inputChannelsComboModel.length > 1 && virtualstudio.connectionState == "Connected"
-                model: audio.inputChannelsComboModel
-                currentIndex: (() => {
-                    let idx = audio.inputChannelsComboModel.findIndex(elem => elem.baseChannel === audio.baseInputChannel
-                        && elem.numChannels === audio.numInputChannels);
-                    if (idx < 0) {
-                        idx = 0;
-                    }
-                    return idx;
-                })()
-                delegate: ItemDelegate {
-                    required property var modelData
-                    required property int index
-                    width: parent.width
-                    contentItem: Text {
-                        text: modelData.label
-                    }
-                    highlighted: inputChannelsCombo.highlightedIndex === index
-                    MouseArea {
-                        anchors.fill: parent
-                        onClicked: {
-                            inputChannelsCombo.currentIndex = index
-                            inputChannelsCombo.popup.close()
-                            audio.baseInputChannel = modelData.baseChannel
-                            audio.numInputChannels = modelData.numChannels
-                            virtualstudio.triggerReconnect(false);
-                        }
-                    }
-                }
-                contentItem: Text {
-                    leftPadding: 12
-                    font: inputCombo.font
-                    horizontalAlignment: Text.AlignHLeft
-                    verticalAlignment: Text.AlignVCenter
-                    elide: Text.ElideRight
-                    text: inputChannelsCombo.model[inputChannelsCombo.currentIndex].label || ""
-                }
-            }
-
-            Text {
-                id: inputMixModeLabel
-                anchors.left: inputCombo.horizontalCenter
-                anchors.right: inputCombo.right
-                anchors.rightMargin: 8 * virtualstudio.uiScale
-                anchors.top: inputCombo.bottom
-                anchors.topMargin: 12 * virtualstudio.uiScale
-                textFormat: Text.RichText
-                text: "Mono / Stereo"
-                font { family: "Poppins"; pixelSize: fontTiny * virtualstudio.fontScale * virtualstudio.uiScale }
-                color: textColour
-            }
-
-            ComboBox {
-                id: inputMixModeCombo
-                anchors.left: inputCombo.horizontalCenter
-                anchors.right: inputCombo.right
-                anchors.rightMargin: 8 * virtualstudio.uiScale
-                anchors.top: inputMixModeLabel.bottom
-                anchors.topMargin: 4 * virtualstudio.uiScale
-                enabled: audio.inputMixModeComboModel.length > 1 && virtualstudio.connectionState == "Connected"
-                model: audio.inputMixModeComboModel
-                currentIndex: (() => {
-                    let idx = audio.inputMixModeComboModel.findIndex(elem => elem.value === audio.inputMixMode);
-                    if (idx < 0) {
-                        idx = 0;
-                    }
-                    return idx;
-                })()
-                delegate: ItemDelegate {
-                    required property var modelData
-                    required property int index
-                    width: parent.width
-                    contentItem: Text {
-                        text: modelData.label
-                    }
-                    highlighted: inputMixModeCombo.highlightedIndex === index
-                    MouseArea {
-                        anchors.fill: parent
-                        onClicked: {
-                            inputMixModeCombo.currentIndex = index
-                            inputMixModeCombo.popup.close()
-                            audio.inputMixMode = audio.inputMixModeComboModel[index].value
-                            virtualstudio.triggerReconnect(false);
-                        }
-                    }
-                }
-                contentItem: Text {
-                    leftPadding: 12
-                    font: inputCombo.font
-                    horizontalAlignment: Text.AlignHLeft
-                    verticalAlignment: Text.AlignVCenter
-                    elide: Text.ElideRight
-                    text: inputMixModeCombo.model[inputMixModeCombo.currentIndex].label || ""
-                }
-            }
-
-            Text {
-                id: inputChannelHelpMessage
-                anchors.left: inputChannelsCombo.left
-                anchors.leftMargin: 2 * virtualstudio.uiScale
-                anchors.right: inputChannelsCombo.right
-                anchors.top: inputChannelsCombo.bottom
-                anchors.topMargin: 8 * virtualstudio.uiScale
-                textFormat: Text.RichText
-                wrapMode: Text.WordWrap
-                text: audio.inputChannelsComboModel.length > 1 ? "Choose up to 2 channels" : "Only 1 channel available"
-                font { family: "Poppins"; pixelSize: fontTiny * virtualstudio.fontScale * virtualstudio.uiScale }
-                color: textColour
-            }
-
-            Text {
-                id: inputMixModeHelpMessage
-                anchors.left: inputMixModeCombo.left
-                anchors.leftMargin: 2 * virtualstudio.uiScale
-                anchors.right: inputMixModeCombo.right
-                anchors.top: inputMixModeCombo.bottom
-                anchors.topMargin: 8 * virtualstudio.uiScale
-                textFormat: Text.RichText
-                wrapMode: Text.WordWrap
-                text: (() => {
-                    if (audio.inputMixMode === 2) {
-                        return "Treat the channels as Left and Right signals, coming through each speaker separately.";
-                    } else if (audio.inputMixMode === 3) {
-                        return "Combine the channels into one central channel coming through both speakers.";
-                    } else if (audio.inputMixMode === 1) {
-                        return "Send a single channel of audio";
-                    } else {
-                        return "";
-                    }
-                })()
-                font { family: "Poppins"; pixelSize: fontTiny * virtualstudio.fontScale * virtualstudio.uiScale }
-                color: textColour
-            }
-
-            DeviceWarning {
-                id: deviceWarning
-                anchors.left: inputCombo.left
-                anchors.top: inputMixModeHelpMessage.bottom
-                anchors.topMargin: 48 * virtualstudio.uiScale
-                visible: Boolean(audio.devicesError) || Boolean(audio.devicesWarning)
-            }
+        AudioSettings {
+            id: audioSettings
+            showMeters: false
+            showTestAudio: false
+            connected: true
+            height: 300 * virtualstudio.uiScale
+            anchors.top: refreshButton.bottom;
+            anchors.topMargin: 16 * virtualstudio.uiScale;
         }
     }
 
@@ -511,5 +102,14 @@ Rectangle {
             anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter }
             color: textColour
         }
+    }
+
+    DeviceWarning {
+        id: deviceWarning
+        anchors.left: backButton.right
+        anchors.leftMargin: 24 * virtualstudio.uiScale
+        anchors.bottom: parent.bottom
+        anchors.bottomMargin: 16 * virtualstudio.uiScale;
+        visible: Boolean(audio.devicesError) || Boolean(audio.devicesWarning)
     }
 }

--- a/src/gui/DeviceControls.qml
+++ b/src/gui/DeviceControls.qml
@@ -22,7 +22,6 @@ Item {
 
             anchors.left: parent.left
             anchors.leftMargin: 8 * virtualstudio.uiScale
-            anchors.verticalCenter: parent.verticalCenter
 
             background: Rectangle {
                 color: isInput ? (audio.inputMuted ? muteButtonMutedColor : buttonColour) : "transparent"
@@ -71,7 +70,7 @@ Item {
 
         ColumnLayout {
             anchors.fill: parent
-            spacing: 2
+            spacing: 2 * virtualstudio.uiScale
 
             VolumeSlider {
                 Layout.fillWidth: true
@@ -93,7 +92,7 @@ Item {
 
         ColumnLayout {
             anchors.fill: parent
-            spacing: 2
+            spacing: 4 * virtualstudio.uiScale
 
             VolumeSlider {
                 Layout.fillWidth: true
@@ -115,15 +114,16 @@ Item {
 
     ColumnLayout {
         anchors.fill: parent
-        spacing: 2
+        spacing: 5 * virtualstudio.uiScale
 
         Item {
-            Layout.preferredHeight: minifiedHeight
+            Layout.topMargin: 5 * virtualstudio.uiScale
+            Layout.preferredHeight: 30 * virtualstudio.uiScale
             Layout.fillWidth: true
 
             RowLayout {
                 anchors.fill: parent
-                spacing: 8
+                spacing: 8 * virtualstudio.uiScale
 
                 Item {
                     Layout.fillHeight: true
@@ -132,7 +132,6 @@ Item {
                     Loader {
                         id: typeIconIndicator
                         anchors.left: parent.left
-                        anchors.verticalCenter: parent.verticalCenter
                         sourceComponent: controlIndicator
                     }
 
@@ -140,7 +139,6 @@ Item {
                         id: label
                         anchors.left: parent.left
                         anchors.leftMargin: 36 * virtualstudio.uiScale
-                        anchors.verticalCenter: parent.verticalCenter
 
                         text: isInput ? "Input" : "Output"
                         font { family: "Poppins"; weight: Font.Bold; pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale }
@@ -159,12 +157,11 @@ Item {
                 Item {
                     Layout.fillHeight: true
                     Layout.fillWidth: true
-                    Layout.preferredWidth: 200
+                    Layout.preferredWidth: 200 * virtualstudio.uiScale
 
                     Meter {
                         anchors.fill: parent
-                        anchors.topMargin: 5
-                        anchors.rightMargin: 8
+                        anchors.rightMargin: 8 * virtualstudio.uiScale
                         model: isInput ? audio.inputMeterLevels : audio.outputMeterLevels
                         clipped: isInput ? audio.inputClipped : audio.outputClipped
                         enabled: true
@@ -174,25 +171,23 @@ Item {
         }
 
         Item {
-            Layout.preferredHeight: 42
-            Layout.minimumHeight: 42
-            Layout.maximumHeight: 42
             Layout.fillWidth: true
+            Layout.fillHeight: true
+            Layout.bottomMargin: 5 * virtualstudio.uiScale
 
             RowLayout {
                 anchors.fill: parent
-                spacing: 2
+                spacing: 8 * virtualstudio.uiScale
 
                 Item {
                     Layout.fillHeight: true
                     Layout.fillWidth: true
-                    Layout.alignment: Qt.AlignVCenter
                     Layout.leftMargin: 8 * virtualstudio.uiScale
                     Layout.rightMargin: 8 * virtualstudio.uiScale
 
                     Loader {
                         anchors.fill: parent
-                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.top: parent.top
                         sourceComponent: isInput ? inputControls : outputControls
                     }
                 }

--- a/src/gui/DeviceControlsGroup.qml
+++ b/src/gui/DeviceControlsGroup.qml
@@ -7,8 +7,8 @@ Rectangle {
 
     property string disabledButtonText: "#D3D4D4"
     property string saveButtonText: "#DB0A0A"
-    property int minifiedHeight: 36
-    property int fullHeight: 84
+    property int minifiedHeight: 0
+    property int fullHeight: 88 * virtualstudio.uiScale
 
     id: deviceControlsGroup
     width: parent.width
@@ -75,7 +75,7 @@ Rectangle {
 
         Item {
             Layout.fillHeight: true
-            Layout.preferredWidth: 48
+            Layout.preferredWidth: 48 * virtualstudio.uiScale
             visible: showDeviceControls
 
             ColumnLayout {
@@ -83,21 +83,21 @@ Rectangle {
                 spacing: 2
 
                 Item {
-                    Layout.preferredHeight: 20
-                    Layout.preferredWidth: 40
+                    Layout.preferredHeight: 20 * virtualstudio.uiScale
+                    Layout.preferredWidth: 40 * virtualstudio.uiScale
                     Layout.alignment: Qt.AlignHCenter
                 }
 
                 Item {
-                    Layout.preferredHeight: 48
-                    Layout.preferredWidth: 40
+                    Layout.preferredHeight: 48 * virtualstudio.uiScale
+                    Layout.preferredWidth: 40 * virtualstudio.uiScale
                     Layout.alignment: Qt.AlignHCenter
                     visible: !showMinified
 
                     Button {
                         id: changeDevicesButton
-                        width: 36
-                        height: 36
+                        width: 36 * virtualstudio.uiScale
+                        height: 36 * virtualstudio.uiScale
                         anchors.top: parent.top
                         anchors.horizontalCenter: parent.horizontalCenter
                         background: Rectangle {

--- a/src/gui/DeviceWarning.qml
+++ b/src/gui/DeviceWarning.qml
@@ -31,8 +31,7 @@ Item {
         id: devicesWarningTooltip
         anchors.left: warningOrErrorText.right
         anchors.leftMargin: 2 * virtualstudio.uiScale
-        anchors.bottom: warningOrErrorText.bottom
-        anchors.bottomMargin: 6 * virtualstudio.uiScale
+        anchors.top: devicesWarningIcon.top
         content: qsTr(audio.devicesError || audio.devicesWarning)
         iconColor: devicesWarningColour
         size: 16 * virtualstudio.uiScale

--- a/src/gui/Settings.qml
+++ b/src/gui/Settings.qml
@@ -70,15 +70,6 @@ Item {
         AudioSettings {
             id: audioSettings
         }
-
-        DeviceWarning {
-            id: deviceWarning
-            anchors.left: parent.left
-            anchors.leftMargin: 168 * virtualstudio.uiScale
-            anchors.bottom: parent.bottom
-            anchors.bottomMargin: 48 * virtualstudio.uiScale
-            visible: Boolean(audio.devicesError) || Boolean(audio.devicesWarning)
-        }
     }
 
     ToolBar {
@@ -281,6 +272,7 @@ Item {
                 width: parent.width
                 horizontalAlignment: Text.AlignHCenter
                 verticalAlignment: Text.AlignVCenter
+                bottomPadding: 5 * virtualstudio.uiScale
             }
         }
     }
@@ -296,7 +288,8 @@ Item {
 
         Slider {
             id: scaleSlider
-            x: 234 * virtualstudio.uiScale; y: 100 * virtualstudio.uiScale
+            x: 220 * virtualstudio.uiScale;
+            y: 100 * virtualstudio.uiScale
             width: backendCombo.width
             from: 1; to: 1.25; value: virtualstudio.uiScale
             onMoved: { virtualstudio.uiScale = value }
@@ -393,8 +386,10 @@ Item {
                 // switch mode
                 virtualstudio.toStandard();
             }
-            x: 234 * virtualstudio.uiScale; y: 100 * virtualstudio.uiScale
-            width: 216 * virtualstudio.uiScale; height: 30 * virtualstudio.uiScale
+            x: 220 * virtualstudio.uiScale;
+            y: 100 * virtualstudio.uiScale
+            width: 216 * virtualstudio.uiScale;
+            height: 30 * virtualstudio.uiScale
             Text {
                 text: virtualstudio.psiBuild ? "Switch to Standard Mode" : "Switch to Classic Mode"
                 font { family: "Poppins"; pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale }
@@ -413,13 +408,13 @@ Item {
 
         ComboBox {
             id: updateChannelCombo
-            x: 234 * virtualstudio.uiScale; y: modeButton.y + (48 * virtualstudio.uiScale)
+            x: 220 * virtualstudio.uiScale; y: modeButton.y + (48 * virtualstudio.uiScale)
             width: parent.width - x - (16 * virtualstudio.uiScale); height: 36 * virtualstudio.uiScale
             model: virtualstudio.updateChannelComboModel
             currentIndex: virtualstudio.updateChannel == "stable" ? 0 : 1
             onActivated: { virtualstudio.updateChannel = currentIndex == 0 ? "stable": "edge" }
             font.family: "Poppins"
-            visible: !virtualstudio.noUpdater
+            enabled: !virtualstudio.noUpdater
         }
 
         Text {
@@ -428,7 +423,6 @@ Item {
             text: "Update Channel"
             font { family: "Poppins"; pixelSize: fontMedium * virtualstudio.fontScale * virtualstudio.uiScale }
             color: textColour
-            visible: !virtualstudio.noUpdater
         }
 
         ComboBox {
@@ -440,7 +434,7 @@ Item {
                 audio.audioBackend = currentText
                 audio.restartAudio();
             }
-            x: 234 * virtualstudio.uiScale; y: updateChannelCombo.y + (48 * virtualstudio.uiScale)
+            x: 220 * virtualstudio.uiScale; y: updateChannelCombo.y + (48 * virtualstudio.uiScale)
             width: updateChannelCombo.width; height: updateChannelCombo.height
         }
 
@@ -455,7 +449,7 @@ Item {
 
         ComboBox {
             id: bufferCombo
-            x: 234 * virtualstudio.uiScale; y: backendCombo.y + (48 * virtualstudio.uiScale)
+            x: 220 * virtualstudio.uiScale; y: backendCombo.y + (48 * virtualstudio.uiScale)
             width: backendCombo.width; height: updateChannelCombo.height
             model: audio.bufferSizeComboModel
             currentIndex: getCurrentBufferSizeIndex()
@@ -763,6 +757,13 @@ Item {
                 anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter }
                 color: Boolean(audio.devicesError) ? disabledButtonTextColour : textColour
             }
+        }
+
+        DeviceWarning {
+            id: deviceWarning
+            x: (0.2 * window.width) + 16 * virtualstudio.uiScale
+            anchors.verticalCenter: parent.verticalCenter
+            visible: Boolean(audio.devicesError) || Boolean(audio.devicesWarning)
         }
     }
 

--- a/src/gui/Setup.qml
+++ b/src/gui/Setup.qml
@@ -13,6 +13,7 @@ Item {
     property int leftMargin: 48
     property int rightMargin: 16
 
+    property string strokeColor: virtualstudio.darkMode ? "#80827D7D" : "#34979797"
     property string textColour: virtualstudio.darkMode ? "#FAFBFB" : "#0F0D0D"
     property string buttonColour: virtualstudio.darkMode ? "#494646" : "#EAECEC"
     property string buttonHoverColour: virtualstudio.darkMode ? "#5B5858" : "#D3D4D4"	
@@ -37,7 +38,8 @@ Item {
 
         Text {
             id: pageTitle
-            x: 16 * virtualstudio.uiScale; y: 32 * virtualstudio.uiScale
+            x: 16 * virtualstudio.uiScale;
+            y: 16 * virtualstudio.uiScale
             text: "Choose your audio devices"
             font { family: "Poppins"; weight: Font.Bold; pixelSize: fontBig * virtualstudio.fontScale * virtualstudio.uiScale }
             color: textColour
@@ -66,108 +68,132 @@ Item {
             id: audioSettings
             width: parent.width
             anchors.top: pageTitle.bottom
-            anchors.topMargin: 24 * virtualstudio.uiScale
+            anchors.topMargin: 16 * virtualstudio.uiScale
         }
 
-        Button {
-            id: backButton
-            background: Rectangle {
-                radius: 6 * virtualstudio.uiScale
-                color: backButton.down ? buttonPressedColour : buttonColour
-                border.width: 1
-                border.color: backButton.down || backButton.hovered ? buttonPressedStroke : buttonStroke
-            }
-            onClicked: { virtualstudio.windowState = "browse"; virtualstudio.studioToJoin = ""; audio.stopAudio(); }
-            anchors.left: parent.left
-            anchors.leftMargin: 16 * virtualstudio.uiScale
-            anchors.bottomMargin: rightMargin * virtualstudio.uiScale
-            anchors.bottom: parent.bottom
-            width: 150 * virtualstudio.uiScale; height: 30 * virtualstudio.uiScale
-            Text {
-                text: "Back"
-                font.family: "Poppins"
-                font.pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale
-                color: textColour
-                anchors.horizontalCenter: parent.horizontalCenter
-                anchors.verticalCenter: parent.verticalCenter
-            }
+        Rectangle {
+            id: headerBorder
+            width: parent.width
+            height: 1
+            anchors.top: audioSettings.top
+            color: strokeColor
         }
 
-        DeviceWarning {
-            id: deviceWarning
-            anchors.left: backButton.right
-            anchors.leftMargin: 16 * virtualstudio.uiScale
-            anchors.verticalCenter: backButton.verticalCenter
-            visible: Boolean(audio.devicesError) || Boolean(audio.devicesWarning)
+        Rectangle {
+            id: footerBorder
+            width: parent.width
+            height: 1
+            anchors.top: audioSettings.bottom
+            color: strokeColor
         }
 
-        Button {
-            id: saveButton
-            background: Rectangle {
-                radius: 6 * virtualstudio.uiScale
-                color: saveButton.down ? saveButtonPressedColour : saveButtonBackgroundColour
-                border.width: 1
-                border.color: saveButton.down || saveButton.hovered ? saveButtonPressedStroke : saveButtonStroke
-            }
-            enabled: !Boolean(audio.devicesError) && audio.backendAvailable && audio.audioReady
-            onClicked: {
-                audio.stopAudio(true);
-                virtualstudio.windowState = "connected";
-                virtualstudio.saveSettings();
-                virtualstudio.joinStudio();
-            }
-            anchors.right: parent.right
-            anchors.rightMargin: rightMargin * virtualstudio.uiScale
-            anchors.bottomMargin: rightMargin * virtualstudio.uiScale
-            anchors.bottom: parent.bottom
-            width: 150 * virtualstudio.uiScale; height: 30 * virtualstudio.uiScale
-            Text {
-                text: "Connect to Studio"
-                font.family: "Poppins"
-                font.pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale
-                font.weight: Font.Bold
-                color: !Boolean(audio.devicesError) && audio.backendAvailable && audio.audioReady ? saveButtonText : disabledButtonText
-                anchors.horizontalCenter: parent.horizontalCenter
-                anchors.verticalCenter: parent.verticalCenter
-            }
-        }
+        Rectangle {
+            property int footerHeight: (30 + (rightMargin * 2)) * virtualstudio.uiScale;
+            x: -1; y: parent.height - footerHeight;
+            width: parent.width; height: footerHeight;
+            border.color: "#33979797"
+            color: backgroundColour
 
-        CheckBox {
-            id: showAgainCheckbox
-            checked: virtualstudio.showDeviceSetup
-            visible: audio.backendAvailable
-            text: qsTr("Ask again next time")
-            anchors.right: saveButton.left
-            anchors.rightMargin: 16 * virtualstudio.uiScale
-            anchors.verticalCenter: saveButton.verticalCenter
-            onClicked: { virtualstudio.showDeviceSetup = showAgainCheckbox.checkState == Qt.Checked }
-            indicator: Rectangle {
-                implicitWidth: 16 * virtualstudio.uiScale
-                implicitHeight: 16 * virtualstudio.uiScale
-                x: showAgainCheckbox.leftPadding
-                y: parent.height / 2 - height / 2
-                radius: 3 * virtualstudio.uiScale
-                border.color: showAgainCheckbox.down || showAgainCheckbox.hovered ? checkboxPressedStroke : checkboxStroke
-
-                Rectangle {
-                    width: 10 * virtualstudio.uiScale
-                    height: 10 * virtualstudio.uiScale
-                    x: 3 * virtualstudio.uiScale
-                    y: 3 * virtualstudio.uiScale
-                    radius: 2 * virtualstudio.uiScale
-                    color: showAgainCheckbox.down || showAgainCheckbox.hovered ? checkboxPressedStroke : checkboxStroke
-                    visible: showAgainCheckbox.checked
+            Button {
+                id: backButton
+                background: Rectangle {
+                    radius: 6 * virtualstudio.uiScale
+                    color: backButton.down ? buttonPressedColour : buttonColour
+                    border.width: 1
+                    border.color: backButton.down || backButton.hovered ? buttonPressedStroke : buttonStroke
+                }
+                onClicked: { virtualstudio.windowState = "browse"; virtualstudio.studioToJoin = ""; audio.stopAudio(); }
+                anchors.left: parent.left
+                anchors.leftMargin: 16 * virtualstudio.uiScale
+                anchors.bottomMargin: rightMargin * virtualstudio.uiScale
+                anchors.bottom: parent.bottom
+                width: 150 * virtualstudio.uiScale; height: 30 * virtualstudio.uiScale
+                Text {
+                    text: "Back"
+                    font.family: "Poppins"
+                    font.pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale
+                    color: textColour
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    anchors.verticalCenter: parent.verticalCenter
                 }
             }
 
-            contentItem: Text {
-                text: showAgainCheckbox.text
-                font.family: "Poppins"
-                font.pixelSize: 10 * virtualstudio.fontScale * virtualstudio.uiScale
-                anchors.horizontalCenter: parent.horizontalCenter
-                anchors.verticalCenter: parent.verticalCenter
-                leftPadding: showAgainCheckbox.indicator.width + showAgainCheckbox.spacing
-                color: textColour
+            DeviceWarning {
+                id: deviceWarning
+                anchors.left: backButton.right
+                anchors.leftMargin: 16 * virtualstudio.uiScale
+                anchors.verticalCenter: backButton.verticalCenter
+                visible: Boolean(audio.devicesError) || Boolean(audio.devicesWarning)
+            }
+
+            Button {
+                id: saveButton
+                background: Rectangle {
+                    radius: 6 * virtualstudio.uiScale
+                    color: saveButton.down ? saveButtonPressedColour : saveButtonBackgroundColour
+                    border.width: 1
+                    border.color: saveButton.down || saveButton.hovered ? saveButtonPressedStroke : saveButtonStroke
+                }
+                enabled: !Boolean(audio.devicesError) && audio.backendAvailable && audio.audioReady
+                onClicked: {
+                    audio.stopAudio(true);
+                    virtualstudio.windowState = "connected";
+                    virtualstudio.saveSettings();
+                    virtualstudio.joinStudio();
+                }
+                anchors.right: parent.right
+                anchors.rightMargin: rightMargin * virtualstudio.uiScale
+                anchors.bottomMargin: rightMargin * virtualstudio.uiScale
+                anchors.bottom: parent.bottom
+                width: 150 * virtualstudio.uiScale; height: 30 * virtualstudio.uiScale
+                Text {
+                    text: "Connect to Studio"
+                    font.family: "Poppins"
+                    font.pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale
+                    font.weight: Font.Bold
+                    color: !Boolean(audio.devicesError) && audio.backendAvailable && audio.audioReady ? saveButtonText : disabledButtonText
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+            }
+
+            CheckBox {
+                id: showAgainCheckbox
+                checked: virtualstudio.showDeviceSetup
+                visible: audio.backendAvailable
+                text: qsTr("Ask again next time")
+                anchors.right: saveButton.left
+                anchors.rightMargin: 16 * virtualstudio.uiScale
+                anchors.verticalCenter: saveButton.verticalCenter
+                onClicked: { virtualstudio.showDeviceSetup = showAgainCheckbox.checkState == Qt.Checked }
+                indicator: Rectangle {
+                    implicitWidth: 16 * virtualstudio.uiScale
+                    implicitHeight: 16 * virtualstudio.uiScale
+                    x: showAgainCheckbox.leftPadding
+                    y: parent.height / 2 - height / 2
+                    radius: 3 * virtualstudio.uiScale
+                    border.color: showAgainCheckbox.down || showAgainCheckbox.hovered ? checkboxPressedStroke : checkboxStroke
+
+                    Rectangle {
+                        width: 10 * virtualstudio.uiScale
+                        height: 10 * virtualstudio.uiScale
+                        x: 3 * virtualstudio.uiScale
+                        y: 3 * virtualstudio.uiScale
+                        radius: 2 * virtualstudio.uiScale
+                        color: showAgainCheckbox.down || showAgainCheckbox.hovered ? checkboxPressedStroke : checkboxStroke
+                        visible: showAgainCheckbox.checked
+                    }
+                }
+
+                contentItem: Text {
+                    text: showAgainCheckbox.text
+                    font.family: "Poppins"
+                    font.pixelSize: 10 * virtualstudio.fontScale * virtualstudio.uiScale
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    anchors.verticalCenter: parent.verticalCenter
+                    leftPadding: showAgainCheckbox.indicator.width + showAgainCheckbox.spacing
+                    color: textColour
+                }
             }
         }
     }


### PR DESCRIPTION
ChangeDevice had various bugs that had already been fixed in AudioSettings but not copied over. This resolves the bugs and makes AudioSettings reusable across all the interfaces, to prevent more bugs from appearing in the future.

This also has a bunch of various UI tweaks, in particular with regards to positioning and where the Device Warning messages are displayed.