### PR TITLE
Attempting to make the user feedback form easier to dismiss

### DIFF
--- a/src/gui/FeedbackSurvey.qml
+++ b/src/gui/FeedbackSurvey.qml
@@ -292,39 +292,18 @@ Item {
                     anchors.topMargin: 24 * virtualstudio.uiScale
 
                     Button {
-                        id: noUserFeedbackButton
-                        anchors.left: buttonsArea.left
-                        anchors.verticalCenter: parent.buttonsArea
-                        width: 150 * virtualstudio.uiScale; height: 30 * virtualstudio.uiScale
-                        onClicked: () => {
-                            userFeedbackModal.close();
-                            rating = 0;
-                            serverId = "";
-                            messageBox.clear();
-                        }
-
-                        background: Rectangle {
-                            radius: 6 * virtualstudio.uiScale
-                            color: noUserFeedbackButton.down ? buttonPressedColour : (noUserFeedbackButton.hovered ? buttonHoverColour : buttonColour)
-                            border.width: 1
-                            border.color: noUserFeedbackButton.down ? buttonPressedStroke : (noUserFeedbackButton.hovered ? buttonHoverStroke : buttonStroke)
-                        }
-
-                        Text {
-                            text: "No thanks"
-                            font.family: "Poppins"
-                            font.pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale
-                            anchors.horizontalCenter: parent.horizontalCenter
-                            anchors.verticalCenter: parent.verticalCenter
-                        }
-                    }
-
-                    Button {
-                        id: submitUserFeedbackButton
+                        id: userFeedbackButton
                         anchors.right: buttonsArea.right
+                        anchors.horizontalCenter: buttonsArea.horizontalCenter
                         anchors.verticalCenter: parent.buttonsArea
                         width: 150 * virtualstudio.uiScale; height: 30 * virtualstudio.uiScale
                         onClicked: () => {
+                            if (rating === 0 && messageBox.text === "") {
+                                userFeedbackModal.close();
+                                serverId = "";
+                                messageBox.clear();
+                                return;
+                            }
                             virtualstudio.collectFeedbackSurvey(serverId, rating, messageBox.text);
                             submitted = true;
                             rating = 0;
@@ -336,13 +315,13 @@ Item {
 
                         background: Rectangle {
                             radius: 6 * virtualstudio.uiScale
-                            color: submitUserFeedbackButton.down ? buttonPressedColour : (submitUserFeedbackButton.hovered ? buttonHoverColour : buttonColour)
+                            color: userFeedbackButton.down ? buttonPressedColour : (userFeedbackButton.hovered ? buttonHoverColour : buttonColour)
                             border.width: 1
-                            border.color: submitUserFeedbackButton.down ? buttonPressedStroke : (submitUserFeedbackButton.hovered ? buttonHoverStroke : buttonStroke)
+                            border.color: userFeedbackButton.down ? buttonPressedStroke : (userFeedbackButton.hovered ? buttonHoverStroke : buttonStroke)
                         }
 
                         Text {
-                            text: "Submit"
+                            text: (rating === 0 && messageBox.text === "") ? "Dismiss" : "Submit"
                             font.family: "Poppins"
                             font.pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale
                             font.weight: Font.Bold


### PR DESCRIPTION
Attempting to make the user feedback form easier to dismiss after leaving a virtual studio

We've noticed that people often send "empty feedback" by clicking on the "Submit" button when no stars are selected and no comments are written. I believe the "No Thanks" button was being confused with the "Submit" button when people just wanted to quickly dismiss it. This should prevent that from being possible by having only one button, which submits if there is feedback and discards if there is none.

Hopefully having just one big button will also make it easier for people to quickly dismiss the dialog.

Nothing to submit:

<img width="597" alt="Screenshot 2024-01-16 at 9 54 41 AM" src="https://github.com/jacktrip/jacktrip/assets/1159596/ef582d2e-32f8-4dd2-9115-f7df6ac79f2d">

Either a star selected or text in message box:

<img width="538" alt="Screenshot 2024-01-16 at 9 54 50 AM" src="https://github.com/jacktrip/jacktrip/assets/1159596/ba9f0d4b-f199-48ce-9bab-f8866dc5e7e2">