### PR TITLE
Fix flickering of audio device controls when you reconnect after closing them

### DIFF
--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -845,6 +845,9 @@ void VirtualStudio::completeConnection()
         return;
     }
 
+    // always connect with audio device controls open
+    setCollapseDeviceControls(false);
+
     m_jackTripRunning = true;
     m_connectionState = QStringLiteral("Preparing audio...");
     emit connectionStateChanged();


### PR DESCRIPTION
Ensures that audio device controls are always open when you first connect to a studio