### PR TITLE
More fixes related to collapsed device controls when connected

### DIFF
--- a/src/gui/Connected.qml
+++ b/src/gui/Connected.qml
@@ -75,21 +75,11 @@ Item {
 
     DeviceControlsGroup {
         id: deviceControlsGroup
-        showMinified: false
         anchors.bottom: footer.top
     }
 
     Footer {
         id: footer
         anchors.bottom: parent.bottom
-    }
-
-    Connections {
-        target: virtualstudio
-
-        // self-managed servers do not support minified controls so keep it full size
-        function onCollapseDeviceControlsChanged(collapseDeviceControls) {
-            deviceControlsGroup.showMinified = virtualstudio.currentStudio.isManaged && collapseDeviceControls;
-        }
     }
 }


### PR DESCRIPTION
Fixes issues with feedback detection

Don't show close button for self-hosted studios

Show close button when using Jack audio backend (managed studios)

Syncs height of area for "Back to Studios" button with create studio