### PR TITLE
Use 48 kHz sample rate for audio testing interface

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -1,3 +1,7 @@
+- Version: "2.2.1"
+  Date: 2024-01-29
+  Description:
+  - (fixed) Sample rate issues with certain Windows ASIO drivers
 - Version: "2.2.0"
   Date: 2024-01-22
   Description:

--- a/src/gui/vsAudio.cpp
+++ b/src/gui/vsAudio.cpp
@@ -891,7 +891,7 @@ AudioInterface* VsAudio::newJackAudioInterface([[maybe_unused]] JackTrip* jackTr
 #if defined(__unix__)
         AudioInterface::setPipewireLatency(
             getBufferSize(),
-            jackTripPtr == nullptr ? 44100 : jackTripPtr->getSampleRate());
+            jackTripPtr == nullptr ? 48000 : jackTripPtr->getSampleRate());
 #endif
         ifPtr->setup(true);
     }
@@ -919,7 +919,7 @@ AudioInterface* VsAudio::newRtAudioInterface([[maybe_unused]] JackTrip* jackTrip
         inputChans, outputChans,
         static_cast<AudioInterface::inputMixModeT>(getInputMixMode()),
         m_audioBitResolution, jackTripPtr != nullptr, jackTripPtr);
-    ifPtr->setSampleRate(jackTripPtr == nullptr ? 44100 : jackTripPtr->getSampleRate());
+    ifPtr->setSampleRate(jackTripPtr == nullptr ? 48000 : jackTripPtr->getSampleRate());
     ifPtr->setInputDevice(getInputDevice().toStdString());
     ifPtr->setOutputDevice(getOutputDevice().toStdString());
     ifPtr->setBufferSizeInSamples(getBufferSize());

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -40,7 +40,7 @@
 
 #include "AudioInterface.h"
 
-constexpr const char* const gVersion = "2.2.0";  ///< JackTrip version
+constexpr const char* const gVersion = "2.2.1";  ///< JackTrip version
 
 //*******************************************************************************
 /// \name Default Values


### PR DESCRIPTION
I suspect this may be causing sample rate issues with some Windows ASIO drivers, but don't have any way to reproduce or test it.