### PR TITLE
Work-around for ASIO drivers that have trouble changing sample rates

### DIFF
--- a/src/AudioInterface.h
+++ b/src/AudioInterface.h
@@ -40,6 +40,7 @@
 
 #include <QVarLengthArray>
 #include <QVector>
+#include <functional>
 
 #include "AudioTester.h"
 #include "ProcessPlugin.h"
@@ -50,6 +51,9 @@
 class JackTrip;
 
 // using namespace JackTripNamespace;
+
+// callback function for audio interface errors
+typedef std::function<void(const std::string& errorText)> AudioErrorCallback;
 
 /** \brief Base Class that provides an interface with audio
  */
@@ -265,6 +269,7 @@ class AudioInterface
     virtual void setLoopBack(bool b) { mLoopBack = b; }
     virtual void enableBroadcastOutput() {}
     virtual void setAudioTesterP(AudioTester* atp) { mAudioTesterP = atp; }
+    void setErrorCallback(AudioErrorCallback c) { mErrorCallback = c; }
     //------------------------------------------------------------------
 
     //--------------GETTERS---------------------------------------------
@@ -367,6 +372,7 @@ class AudioInterface
     std::string mWarningHelpUrl;
     std::string mErrorHelpUrl;
     bool mHighLatencyFlag;
+    AudioErrorCallback mErrorCallback;
 };
 
 #endif  // __AUDIOINTERFACE_H__

--- a/src/JackAudioInterface.cpp
+++ b/src/JackAudioInterface.cpp
@@ -283,7 +283,11 @@ void JackAudioInterface::jackShutdown(jack_status_t /*code*/, const char* reason
         errorMsg += reason;
     }
     if (arg != nullptr) {
-        static_cast<JackAudioInterface*>(arg)->mErrorMsg = errorMsg;
+        JackAudioInterface* ifPtr = static_cast<JackAudioInterface*>(arg);
+        ifPtr->mErrorMsg          = errorMsg;
+        if (ifPtr->mErrorCallback) {
+            ifPtr->mErrorCallback(errorMsg);
+        }
     }
     std::cerr << errorMsg << std::endl;
     JackTrip::sAudioStopped = true;

--- a/src/RtAudioInterface.cpp
+++ b/src/RtAudioInterface.cpp
@@ -610,7 +610,11 @@ void RtAudioInterface::errorCallback(RtAudioErrorType errorType,
         errorMsg += errorText;
     }
     if (arg != nullptr) {
-        static_cast<RtAudioInterface*>(arg)->mErrorMsg = errorMsg;
+        RtAudioInterface* ifPtr = static_cast<RtAudioInterface*>(arg);
+        ifPtr->mErrorMsg        = errorText;
+        if (ifPtr->mErrorCallback) {
+            ifPtr->mErrorCallback(errorText);
+        }
     }
     std::cerr << errorMsg << std::endl;
     JackTrip::sAudioStopped = true;

--- a/src/gui/vsAudio.h
+++ b/src/gui/vsAudio.h
@@ -314,6 +314,7 @@ class VsAudio : public QObject
     void updateDeviceMessages(AudioInterface& audioInterface);
     AudioInterface* newJackAudioInterface(JackTrip* jackTripPtr = nullptr);
     AudioInterface* newRtAudioInterface(JackTrip* jackTripPtr = nullptr);
+    void errorCallback(const std::string& errorText, JackTrip* jackTripPtr = nullptr);
 
     // range for volume meters
     static constexpr float m_meterMax = 0.0;
@@ -370,6 +371,7 @@ class VsAudio : public QObject
     Volume* m_inputVolumePluginPtr;
     Volume* m_outputVolumePluginPtr;
     Monitor* m_monitorPluginPtr;
+    bool mHasErrors;  ///< true if one or more error callbacks have been triggered
 
 #ifndef NO_FEEDBACK
     Analyzer* m_outputAnalyzerPluginPtr;


### PR DESCRIPTION
Some ASIO drivers seem to have issues when you open a stream using a different sample rate than they are currently using. They will start the stream but then immediately (and unfortunately, asynchronously) trigger an error for the sample rate change. It's unclear if this is a bug in RtAudio, or the driver implementation. An example driver that does this is "Yamaha Steinberg ASIO USB".

The net result is that audio just stops working, with no feedback why or what is happening.

This basically just intercepts the errors and triggers a device refresh when it happens, which works around the issue. It also ensures that an "Audio Error" warning will be triggered in the user interface for any audio interface errors that occur after starting the stream.