### PR TITLE
Use studio's sample rate when testing audio before joining

### DIFF
--- a/src/AudioInterface.cpp
+++ b/src/AudioInterface.cpp
@@ -95,15 +95,15 @@ AudioInterface::~AudioInterface()
         delete[] mAPInBuffer[i];
     }
 #endif  // endwhere
-    for (auto* i : qAsConst(mProcessPluginsFromNetwork)) {
+    for (auto* i : std::as_const(mProcessPluginsFromNetwork)) {
         i->disconnect();
         delete i;
     }
-    for (auto* i : qAsConst(mProcessPluginsToNetwork)) {
+    for (auto* i : std::as_const(mProcessPluginsToNetwork)) {
         i->disconnect();
         delete i;
     }
-    for (auto* i : qAsConst(mProcessPluginsToMonitor)) {
+    for (auto* i : std::as_const(mProcessPluginsToMonitor)) {
         i->disconnect();
         delete i;
     }
@@ -206,7 +206,7 @@ void AudioInterface::audioInputCallback(QVarLengthArray<sample_t*>& in_buffer,
 #endif  // not WAIR
 
     // process incoming signal from audio interface using process plugins
-    for (auto* p : qAsConst(mProcessPluginsToNetwork)) {
+    for (auto* p : std::as_const(mProcessPluginsToNetwork)) {
         if (p->getInited()) {
             p->compute(n_frames, in_buffer.data(), in_buffer.data());
         }
@@ -268,7 +268,7 @@ void AudioInterface::audioOutputCallback(QVarLengthArray<sample_t*>& out_buffer,
     /// with one. do it chaining outputs to inputs in the buffers. May need a tempo buffer
 
 #ifndef WAIR  // NOT WAIR:
-    for (auto* p : qAsConst(mProcessPluginsFromNetwork)) {
+    for (auto* p : std::as_const(mProcessPluginsFromNetwork)) {
         if (p->getInited()) {
             p->compute(n_frames, out_buffer.data(), out_buffer.data());
         }
@@ -728,17 +728,17 @@ void AudioInterface::initPlugins(bool verbose)
                       << ") at sampling rate " << mSampleRate << "\n";
         }
 
-        for (ProcessPlugin* plugin : qAsConst(mProcessPluginsFromNetwork)) {
+        for (ProcessPlugin* plugin : std::as_const(mProcessPluginsFromNetwork)) {
             plugin->setOutgoingToNetwork(false);
             plugin->updateNumChannels(nChansIn, nChansOut);
             plugin->init(mSampleRate, mBufferSizeInSamples);
         }
-        for (ProcessPlugin* plugin : qAsConst(mProcessPluginsToNetwork)) {
+        for (ProcessPlugin* plugin : std::as_const(mProcessPluginsToNetwork)) {
             plugin->setOutgoingToNetwork(true);
             plugin->updateNumChannels(nChansIn, nChansOut);
             plugin->init(mSampleRate, mBufferSizeInSamples);
         }
-        for (ProcessPlugin* plugin : qAsConst(mProcessPluginsToMonitor)) {
+        for (ProcessPlugin* plugin : std::as_const(mProcessPluginsToMonitor)) {
             plugin->setOutgoingToNetwork(false);
             plugin->updateNumChannels(nChansMon, nChansMon);
             plugin->init(mSampleRate, mBufferSizeInSamples);

--- a/src/gui/Browse.qml
+++ b/src/gui/Browse.qml
@@ -86,6 +86,7 @@ Item {
             connected: false
             studioId: modelData.id ? modelData.id : ""
             inviteKeyString: modelData.inviteKey ? modelData.inviteKey : ""
+            sampleRate: modelData.sampleRate
         }
 
         section { property: "modelData.type"; criteria: ViewSection.FullString; delegate: SectionHeading {} }

--- a/src/gui/Permissions.qml
+++ b/src/gui/Permissions.qml
@@ -189,13 +189,10 @@ Item {
 
         function onMicPermissionUpdated() {
             if (permissions.micPermission === "granted") {
-                if (virtualstudio.studioToJoin.toString() === "") {
+                if (virtualstudio.studioToJoin === "") {
                     virtualstudio.windowState = "browse";
-                } else if (virtualstudio.showDeviceSetup) {
-                    virtualstudio.windowState = "setup";
-                    audio.startAudio();
                 } else {
-                    virtualstudio.windowState = "connected";
+                    virtualstudio.windowState = virtualstudio.showDeviceSetup ? "setup" : "connected";
                     virtualstudio.joinStudio();
                 }
             }

--- a/src/gui/Recommendations.qml
+++ b/src/gui/Recommendations.qml
@@ -471,13 +471,10 @@ Item {
                     virtualstudio.saveSettings();
                     if (permissions.micPermission !== "granted") {
                         virtualstudio.windowState = "permissions";
-                    } else if (virtualstudio.studioToJoin.toString() === "") {
+                    } else if (virtualstudio.studioToJoin === "") {
                         virtualstudio.windowState = "browse";
-                    } else if (virtualstudio.showDeviceSetup) {
-                        virtualstudio.windowState = "setup";
-                        audio.startAudio();
                     } else {
-                        virtualstudio.windowState = "connected";
+                        virtualstudio.windowState = virtualstudio.showDeviceSetup ? "setup" : "connected";
                         virtualstudio.joinStudio();
                     }
                 }
@@ -509,13 +506,10 @@ Item {
                     virtualstudio.saveSettings();
                     if (permissions.micPermission !== "granted") {
                         virtualstudio.windowState = "permissions";
-                    } else if (virtualstudio.studioToJoin.toString() === "") {
+                    } else if (virtualstudio.studioToJoin === "") {
                         virtualstudio.windowState = "browse";
-                    } else if (virtualstudio.showDeviceSetup) {
-                        virtualstudio.windowState = "setup";
-                        audio.startAudio();
                     } else {
-                        virtualstudio.windowState = "connected";
+                        virtualstudio.windowState = virtualstudio.showDeviceSetup ? "setup" : "connected";
                         virtualstudio.joinStudio();
                     }
                 }

--- a/src/gui/Setup.qml
+++ b/src/gui/Setup.qml
@@ -136,7 +136,7 @@ Item {
                 }
                 enabled: !Boolean(audio.devicesError) && audio.backendAvailable && audio.audioReady
                 onClicked: {
-                    audio.stopAudio(true);
+                    virtualstudio.studioToJoin = virtualstudio.currentStudio.id;
                     virtualstudio.windowState = "connected";
                     virtualstudio.saveSettings();
                     virtualstudio.joinStudio();

--- a/src/gui/Studio.qml
+++ b/src/gui/Studio.qml
@@ -14,6 +14,7 @@ Rectangle {
     property string studioName: "Test Studio"
     property string studioId: ""
     property string inviteKeyString: ""
+    property int sampleRate: 48000
     property bool publicStudio: false
     property bool admin: false
     property bool available: true
@@ -197,14 +198,9 @@ Rectangle {
         }
         visible: !connected
         onClicked: {
-            virtualstudio.studioToJoin = `jacktrip://join/${studioId}`
-            if (virtualstudio.showDeviceSetup) {
-                virtualstudio.windowState = "setup";
-                audio.startAudio();
-            } else {
-                virtualstudio.windowState = "connected";
-                virtualstudio.joinStudio();
-            }
+            virtualstudio.studioToJoin = studioId;
+            virtualstudio.windowState = virtualstudio.showDeviceSetup ? "setup" : "connected";
+            virtualstudio.joinStudio();
         }
         Image {
             id: join

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -621,7 +621,7 @@ QString VirtualStudio::failedMessage()
 void VirtualStudio::joinStudio()
 {
     // nothing to do unless on setup or connected windows with studio to join
-    if (m_windowState != "setup" && m_windowState != "connected"
+    if ((m_windowState != "setup" && m_windowState != "connected")
         || !m_auth->isAuthenticated() || m_studioToJoin.isEmpty())
         return;
 

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -582,16 +582,16 @@ void VirtualStudio::setTestMode(bool test)
     emit testModeChanged();
 }
 
-QUrl VirtualStudio::studioToJoin()
+QString VirtualStudio::studioToJoin()
 {
     return m_studioToJoin;
 }
 
-void VirtualStudio::setStudioToJoin(const QUrl& url)
+void VirtualStudio::setStudioToJoin(const QString& id)
 {
-    if (m_studioToJoin == url)
+    if (m_studioToJoin == id)
         return;
-    m_studioToJoin = url;
+    m_studioToJoin = id;
     emit studioToJoinChanged();
 }
 
@@ -620,36 +620,31 @@ QString VirtualStudio::failedMessage()
 
 void VirtualStudio::joinStudio()
 {
+    // nothing to do unless on setup or connected windows with studio to join
+    if (m_windowState != "setup" && m_windowState != "connected"
+        || !m_auth->isAuthenticated() || m_studioToJoin.isEmpty())
+        return;
+
+    // make sure we've retrieved a list of servers
     QMutexLocker locker(&m_refreshMutex);
-    bool authenticated = m_auth->isAuthenticated();
-    if (!authenticated || m_studioToJoin.isEmpty() || m_servers.isEmpty()) {
+    if (m_servers.isEmpty()) {
         // No servers yet. Making sure we have them.
         // getServerList emits refreshFinished which
         // will come back to this function.
-        if (authenticated && !m_studioToJoin.isEmpty() && m_servers.isEmpty()) {
-            locker.unlock();
-            getServerList(true);
-        }
+        locker.unlock();
+        getServerList(true);
         return;
     }
-    if (m_windowState != "connected") {
-        return;  // on audio setup screen before joining the studio
-    }
 
-    QString scheme = m_studioToJoin.scheme();
-    QString path   = m_studioToJoin.path();
-    QString url    = m_studioToJoin.toString();
-    setStudioToJoin(QUrl(""));
+    // pop studioToJoin
+    const QString targetId = m_studioToJoin;
+    setStudioToJoin("");
+    emit studioToJoinChanged();
 
-    m_failedMessage = "";
-    if (scheme != "jacktrip" || path.length() <= 1) {
-        m_failedMessage = "Invalid join request received: " + url;
-        emit failedMessageChanged();
-        emit failed();
-        return;
-    }
-    QString targetId = path.remove(0, 1);
+    // stop audio if already running (settings or setup windows)
+    m_audioConfigPtr->stopAudio(true);
 
+    // find and populate data for current studio
     VsServerInfoPointer sPtr;
     for (const VsServerInfoPointer& s : m_servers) {
         if (s->id() == targetId) {
@@ -659,14 +654,24 @@ void VirtualStudio::joinStudio()
     }
     locker.unlock();
 
-    if (!sPtr.isNull()) {
-        connectToStudio(*sPtr);
+    if (sPtr.isNull()) {
+        m_failedMessage = "Unable to find studio " + targetId;
+        emit failedMessageChanged();
+        emit failed();
         return;
     }
 
-    m_failedMessage = "Unable to find studio " + targetId;
-    emit failedMessageChanged();
-    emit failed();
+    m_currentStudio = *sPtr;
+    emit currentStudioChanged();
+
+    if (m_windowState == "setup") {
+        m_audioConfigPtr->setSampleRate(m_currentStudio.sampleRate());
+        m_audioConfigPtr->startAudio();
+        return;
+    }
+
+    // m_windowState == "connected"
+    connectToStudio();
 }
 
 void VirtualStudio::toStandard()
@@ -806,15 +811,13 @@ void VirtualStudio::saveSettings()
     m_audioConfigPtr->saveSettings();
 }
 
-void VirtualStudio::connectToStudio(VsServerInfo& studio)
+void VirtualStudio::connectToStudio()
 {
     m_refreshTimer.stop();
 
     m_networkStats = QJsonObject();
     emit networkStatsChanged();
 
-    m_currentStudio = studio;
-    emit currentStudioChanged();
     m_onConnectedScreen = true;
 
     m_studioSocketPtr.reset(new VsWebSocket(
@@ -914,6 +917,7 @@ void VirtualStudio::completeConnection()
             return;
         }
         jackTrip->setIOStatTimeout(m_cliSettings->getIOStatTimeout());
+        m_audioConfigPtr->setSampleRate(jackTrip->getSampleRate());
 
         // this passes ownership to JackTrip
         jackTrip->setAudioInterface(m_audioConfigPtr->newAudioInterface(jackTrip));
@@ -1104,8 +1108,8 @@ void VirtualStudio::openLink(const QString& link)
 void VirtualStudio::handleDeeplinkRequest(const QUrl& link)
 {
     // check link is valid
-    if (link.scheme() != QLatin1String("jacktrip")
-        || link.host() != QLatin1String("join")) {
+    if (link.scheme() != QLatin1String("jacktrip") || link.host() != QLatin1String("join")
+        || link.path().length() <= 1) {
         qDebug() << "Ignoring invalid deeplink to " << link;
         return;
     }
@@ -1117,7 +1121,7 @@ void VirtualStudio::handleDeeplinkRequest(const QUrl& link)
     }
 
     qDebug() << "Handling deeplink to " << link;
-    setStudioToJoin(link);
+    setStudioToJoin(link.path().remove(0, 1));
     raiseToTop();
 
     // Switch to virtual studio mode, if necessary
@@ -1132,21 +1136,7 @@ void VirtualStudio::handleDeeplinkRequest(const QUrl& link)
         }
     }
 
-    // special case if on settings screen
-    if (m_windowState == "settings") {
-        if (showDeviceSetup()) {
-            // audio is already active, so we can just flip screens
-            setWindowState("setup");
-        } else {
-            // we need to stop audio before connecting
-            setWindowState("connected");
-            m_audioConfigPtr->stopAudio(true);
-            joinStudio();
-        }
-        return;
-    }
-
-    // special case if on create_studio screen:
+    // automatically navigate if on certain window screens
     // note that the studio creation happens inside of the web view,
     // and the app doesn't really know anything about it. we depend
     // on the web app triggering a deep link join event, which is
@@ -1154,27 +1144,15 @@ void VirtualStudio::handleDeeplinkRequest(const QUrl& link)
     // noticed yet, so we don't join right away; otherwise we'd just
     // get an unknown studio error. instead, we trigger a refresh and
     // rely on it to kick off the join afterwards.
-    if (m_windowState == "create_studio") {
+    if (m_windowState == "browse" || m_windowState == "create_studio"
+        || m_windowState == "settings" || m_windowState == "setup"
+        || m_windowState == "failed") {
+        if (showDeviceSetup()) {
+            setWindowState("setup");
+        } else {
+            setWindowState("connected");
+        }
         refreshStudios(0, true);
-        if (showDeviceSetup()) {
-            setWindowState("setup");
-            m_audioConfigPtr->startAudio();
-        } else {
-            setWindowState("connected");
-        }
-        return;
-    }
-
-    // special case if on browsing and failed screens
-    if (m_windowState == "browse" || m_windowState == "failed") {
-        if (showDeviceSetup()) {
-            setWindowState("setup");
-            m_audioConfigPtr->startAudio();
-        } else {
-            setWindowState("connected");
-            joinStudio();
-        }
-        return;
     }
 
     // otherwise, assume we are on setup screens and can let the normal flow handle it
@@ -1267,7 +1245,7 @@ void VirtualStudio::connectionFinished()
             } else {
                 m_audioConfigPtr->validateDevices(true);
             }
-            connectToStudio(m_currentStudio);
+            connectToStudio();
         }
         return;
     }
@@ -1710,24 +1688,6 @@ void VirtualStudio::getUserMetadata()
 
         m_userMetadata = QJsonDocument::fromJson(reply->readAll()).object();
         emit userMetadataChanged();
-        reply->deleteLater();
-    });
-}
-
-void VirtualStudio::stopStudio()
-{
-    if (m_currentStudio.id() == "") {
-        return;
-    }
-
-    QJsonObject json      = {{QLatin1String("enabled"), false}};
-    QJsonDocument request = QJsonDocument(json);
-    m_currentStudio.setHost(QLatin1String(""));
-    QNetworkReply* reply = m_api->updateServer(m_currentStudio.id(), request.toJson());
-    connect(reply, &QNetworkReply::finished, this, [=]() {
-        if (m_isExiting && !m_jackTripRunning) {
-            emit signalExit();
-        }
         reply->deleteLater();
     });
 }

--- a/src/gui/virtualstudio.h
+++ b/src/gui/virtualstudio.h
@@ -86,7 +86,7 @@ class VirtualStudio : public QObject
     Q_PROPERTY(
         QVector<VsServerInfo*> serverModel READ getServerModel NOTIFY serverModelChanged)
     Q_PROPERTY(VsServerInfo* currentStudio READ currentStudio NOTIFY currentStudioChanged)
-    Q_PROPERTY(QUrl studioToJoin READ studioToJoin WRITE setStudioToJoin NOTIFY
+    Q_PROPERTY(QString studioToJoin READ studioToJoin WRITE setStudioToJoin NOTIFY
                    studioToJoinChanged)
     Q_PROPERTY(QJsonObject regions READ regions NOTIFY regionsChanged)
     Q_PROPERTY(QJsonObject userMetadata READ userMetadata NOTIFY userMetadataChanged)
@@ -163,8 +163,8 @@ class VirtualStudio : public QObject
     void setCollapseDeviceControls(bool collapseDeviceControls);
     bool testMode();
     void setTestMode(bool test);
-    QUrl studioToJoin();
-    void setStudioToJoin(const QUrl& url);
+    QString studioToJoin();
+    void setStudioToJoin(const QString& id);
     bool showDeviceSetup();
     void setShowDeviceSetup(bool show);
     bool showWarnings();
@@ -264,9 +264,8 @@ class VirtualStudio : public QObject
     void getSubscriptions();
     void getRegions();
     void getUserMetadata();
-    void stopStudio();
     bool readyToJoin();
-    void connectToStudio(VsServerInfo& studio);
+    void connectToStudio();
     void completeConnection();
 
    private:
@@ -299,7 +298,7 @@ class VirtualStudio : public QObject
     QTimer m_heartbeatTimer;
     QTimer m_networkOutageTimer;
     QMutex m_refreshMutex;
-    QUrl m_studioToJoin;
+    QString m_studioToJoin;
     QString m_updateChannel;
     QString m_refreshToken;
     QString m_userId;

--- a/src/gui/vs.qml
+++ b/src/gui/vs.qml
@@ -286,13 +286,10 @@ Rectangle {
             }
             if (virtualstudio.showWarnings) {
                 virtualstudio.windowState = "recommendations";
-            } else if (virtualstudio.studioToJoin.toString() === "") {
+            } else if (virtualstudio.studioToJoin === "") {
                 virtualstudio.windowState = "browse";
-            } else if (virtualstudio.showDeviceSetup) {
-                virtualstudio.windowState = "setup";
-                audio.startAudio();
             } else {
-                virtualstudio.windowState = "connected";
+                virtualstudio.windowState = virtualstudio.showDeviceSetup ? "setup" : "connected";
                 virtualstudio.joinStudio();
             }
         }

--- a/src/gui/vsAudio.cpp
+++ b/src/gui/vsAudio.cpp
@@ -268,6 +268,14 @@ void VsAudio::setFeedbackDetectionEnabled(bool enabled)
     emit feedbackDetectionEnabledChanged();
 }
 
+void VsAudio::setSampleRate(int sampleRate)
+{
+    if (m_audioSampleRate == sampleRate)
+        return;
+    m_audioSampleRate = sampleRate;
+    emit sampleRateChanged();
+}
+
 void VsAudio::setBufferSize(int bufSize)
 {
     if (m_audioBufferSize == bufSize)
@@ -901,9 +909,7 @@ AudioInterface* VsAudio::newJackAudioInterface([[maybe_unused]] JackTrip* jackTr
                                        jackTripPtr != nullptr, jackTripPtr);
         ifPtr->setClientName(QStringLiteral("JackTrip"));
 #if defined(__unix__)
-        AudioInterface::setPipewireLatency(
-            getBufferSize(),
-            jackTripPtr == nullptr ? 48000 : jackTripPtr->getSampleRate());
+        AudioInterface::setPipewireLatency(getBufferSize(), getSampleRate());
 #endif
         ifPtr->setup(true);
     }
@@ -931,7 +937,7 @@ AudioInterface* VsAudio::newRtAudioInterface([[maybe_unused]] JackTrip* jackTrip
         inputChans, outputChans,
         static_cast<AudioInterface::inputMixModeT>(getInputMixMode()),
         m_audioBitResolution, jackTripPtr != nullptr, jackTripPtr);
-    ifPtr->setSampleRate(jackTripPtr == nullptr ? 48000 : jackTripPtr->getSampleRate());
+    ifPtr->setSampleRate(getSampleRate());
     ifPtr->setInputDevice(getInputDevice().toStdString());
     ifPtr->setOutputDevice(getOutputDevice().toStdString());
     ifPtr->setBufferSizeInSamples(getBufferSize());

--- a/src/gui/vsAudio.h
+++ b/src/gui/vsAudio.h
@@ -79,6 +79,8 @@ class VsAudio : public QObject
     Q_PROPERTY(QString audioBackend READ getAudioBackend WRITE setAudioBackend NOTIFY
                    audioBackendChanged)
     Q_PROPERTY(
+        int sampleRate READ getSampleRate WRITE setSampleRate NOTIFY sampleRateChanged)
+    Q_PROPERTY(
         int bufferSize READ getBufferSize WRITE setBufferSize NOTIFY bufferSizeChanged)
     Q_PROPERTY(int bufferStrategy READ getBufferStrategy WRITE setBufferStrategy NOTIFY
                    bufferStrategyChanged)
@@ -168,6 +170,7 @@ class VsAudio : public QObject
     {
         return getUseRtAudio() ? QStringLiteral("RtAudio") : QStringLiteral("JACK");
     }
+    int getSampleRate() const { return m_audioSampleRate; }
     int getBufferSize() const { return m_audioBufferSize; }
     int getBufferStrategy() const { return m_bufferStrategy; }
     int getNumInputChannels() const { return getUseRtAudio() ? m_numInputChannels : 2; }
@@ -222,6 +225,7 @@ class VsAudio : public QObject
     // setters for state shared with QML
     void setFeedbackDetectionEnabled(bool enabled);
     void setAudioBackend(const QString& backend);
+    void setSampleRate(int sampleRate);
     void setBufferSize(int bufSize);
     void setBufferStrategy(int bufStrategy);
     void setNumInputChannels(int numChannels);
@@ -258,6 +262,7 @@ class VsAudio : public QObject
     void signalScanningDevicesChanged();
     void deviceModelsInitializedChanged(bool initialized);
     void audioBackendChanged(bool useRtAudio);
+    void sampleRateChanged();
     void bufferSizeChanged();
     void bufferStrategyChanged();
     void numInputChannelsChanged(int numChannels);
@@ -330,6 +335,7 @@ class VsAudio : public QObject
     bool m_scanningDevices          = false;
     bool m_feedbackDetectionEnabled = true;
     bool m_deviceModelsInitialized  = false;
+    int m_audioSampleRate           = gDefaultSampleRate;
     int m_audioBufferSize =
         gDefaultBufferSizeInSamples;  ///< Audio buffer size to process on each callback
     int m_bufferStrategy    = 0;
@@ -432,6 +438,7 @@ class VsAudioWorker : public QObject
     int getNumOutputChannels() const { return m_parentPtr->getNumOutputChannels(); }
     int getBaseInputChannel() const { return m_parentPtr->getBaseInputChannel(); }
     int getBaseOutputChannel() const { return m_parentPtr->getBaseOutputChannel(); }
+    int getSampleRate() const { return m_parentPtr->getSampleRate(); }
     int getBufferSize() const { return m_parentPtr->getBufferSize(); }
     int getInputMixMode() const { return m_parentPtr->getInputMixMode(); }
     const QString& getInputDevice() const { return m_parentPtr->getInputDevice(); }


### PR DESCRIPTION
Change virtualstudio.studioToJoin from a URL into a string, and parse all deeplink urls within handleDeepLinks.

Audio start for setup window is moved into joinStudio(), which waits until a studio is found. This has the added advantage of not found studios triggering an error right away, versus only after you click "Connect to Studio" from the setup window.

All deeplinks are now handled by joinStudio() signal fired after refreshing studios, versus just when on create studio page. This is just safer all around, and cleans things up a bit.

Made sampleRate a proper property of vsAudio

Removed dead code VirtualStudio::stopStudio()