### PR TITLE
Switching from double to float for PLC coefficients

### DIFF
--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -658,7 +658,7 @@ bool BurgAlgorithm::classify(double d)
     return tmp;
 }
 
-void BurgAlgorithm::train(std::vector<double>& coeffs, const std::vector<double>& x)
+void BurgAlgorithm::train(std::vector<float>& coeffs, const std::vector<double>& x)
 {
     // GET SIZE FROM INPUT VECTORS
     size_t N = x.size() - 1;
@@ -732,7 +732,7 @@ void BurgAlgorithm::train(std::vector<double>& coeffs, const std::vector<double>
     coeffs.assign(++Ak.begin(), Ak.end());
 }
 
-void BurgAlgorithm::predict(std::vector<double>& coeffs, std::vector<double>& tail)
+void BurgAlgorithm::predict(std::vector<float>& coeffs, std::vector<double>& tail)
 {
     size_t m = coeffs.size();
     //    qDebug() << "tail.at(0)" << tail[0]*32768;

--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -63,8 +63,8 @@ class BurgAlgorithm
 {
    public:
     bool classify(double d);
-    void train(std::vector<double>& coeffs, const std::vector<double>& x);
-    void predict(std::vector<double>& coeffs, std::vector<double>& tail);
+    void train(std::vector<float>& coeffs, const std::vector<double>& x);
+    void predict(std::vector<float>& coeffs, std::vector<double>& tail);
 
    private:
     // the following are class members to minimize heap memory allocations
@@ -83,7 +83,7 @@ class ChanData
     std::vector<double> mTrain;
     std::vector<double> mTail;
     std::vector<sample_t> mPrediction;  // ORDER
-    std::vector<double> mCoeffs;
+    std::vector<float> mCoeffs;
     std::vector<sample_t> mXfadedPred;
     std::vector<sample_t> mLastPred;
     std::vector<std::vector<sample_t>> mLastPackets;


### PR DESCRIPTION
I'm not seeing a noticeable difference?

Before (64 buffer size, PLC auto, 1% simulated loss across ethernet, receiving 2 channels)

```
2024-02-04T10:26:17 terra send: 0/0 Glitches: 14
PUSH -- SD avg/last: 0.131 / 0.148 	 mean/min/max: 1.347 / 1.104 / 2.688
PULL -- SD avg/last: 0.083 / 0.073 	 mean/min/max: 1.332 / 0.909 / 1.813 
 tot: 15847 	 tol: 7.404 	 dsp (last): 0.446

2024-02-04T10:26:18 terra send: 0/0 Glitches: 19
PUSH -- SD avg/last: 0.132 / 0.033 	 mean/min/max: 1.333 / 1.243 / 1.422
PULL -- SD avg/last: 0.082 /  0.04 	 mean/min/max: 1.333 / 1.232 / 1.431 
 tot: 16598 	 tol: 7.413 	 dsp (last): 0.411

2024-02-04T10:26:19 terra send: 0/0 Glitches: 15
PUSH -- SD avg/last: 0.131 / 0.142 	 mean/min/max: 1.348 / 1.196 / 2.684
PULL -- SD avg/last: 0.082 / 0.071 	 mean/min/max: 1.332 / 0.881 / 1.747 
 tot: 17348 	 tol: 7.405 	 dsp (last): 0.478
```

After

```
2024-02-04T10:25:20 terra send: 0/0 Glitches: 16
PUSH -- SD avg/last: 0.123 /  0.15 	 mean/min/max: 1.347 / 1.211 / 2.697
PULL -- SD avg/last:  0.09 / 0.107 	 mean/min/max: 1.333 / 0.928 / 1.804 
 tot: 34523 	 tol: 7.336 	 dsp (last): 0.448

2024-02-04T10:25:21 terra send: 0/0 Glitches: 14
PUSH -- SD avg/last: 0.123 / 0.216 	 mean/min/max: 1.362 / 0.969 / 2.794
PULL -- SD avg/last: 0.091 / 0.151 	 mean/min/max: 1.332 / 0.776 / 2.014 
 tot: 35273 	 tol: 7.332 	 dsp (last): 0.575

2024-02-04T10:25:22 terra send: 0/0 Glitches: 16
PUSH -- SD avg/last: 0.123 / 0.051 	 mean/min/max: 1.333 / 1.185 / 1.482
PULL -- SD avg/last: 0.091 / 0.079 	 mean/min/max: 1.333 / 1.155 /  1.53 
 tot: 36023 	 tol:  7.34 	 dsp (last): 0.581
```