### PR TITLE
Adding throttle for UDP waited too long errors

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -4,6 +4,7 @@
   - (updated) VS Mode updated network connection thresholds
   - (updated) VS Mode improved sample rate flexibility for Windows
   - (fixed) VS Mode inconsistent deep link handling on Windows
+  - (fixed) Throttle console errors for UDP waiting too long
 - Version: "2.2.1"
   Date: 2024-01-29
   Description:

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -97,7 +97,6 @@ constexpr double AutoMax  = 250.0;  // msec bounds on insane IPI, like ethernet 
 constexpr double AutoInitDur = 3000.0;  // kick in auto after this many msec
 constexpr double AutoInitValFactor =
     0.5;  // scale for initial mMsecTolerance during init phase if unspecified
-constexpr double MaxWaitTime = 30;  // msec
 
 // tweak
 constexpr int WindowDivisor   = 8;     // for faster auto tracking
@@ -505,7 +504,7 @@ PACKETOK : {
 UNDERRUN : {
     pullStat->plcUnderruns++;  // count late
     if ((mLastSeqNumOut == lastSeqNumIn)
-        && ((now - mIncomingTiming[mLastSeqNumOut]) > MaxWaitTime)) {
+        && ((now - mIncomingTiming[mLastSeqNumOut]) > gUdpWaitTimeout)) {
         goto ZERO_OUTPUT;
     }
     // "good underrun", not a stuck client
@@ -827,7 +826,7 @@ bool StdDev::tick()
 
     // discard measurements that exceed the max wait time
     // this prevents temporary outages from skewing jitter metrics
-    if (msElapsed > MaxWaitTime)
+    if (msElapsed > gUdpWaitTimeout)
         return false;
 
     if (ctr != window) {

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -88,6 +88,7 @@ constexpr const char* gDefaultLocalAddress     = "";
 constexpr int gDefaultRedundancy               = 1;
 constexpr int gTimeOutMultiThreadedServer      = 10000;  // seconds
 constexpr int gWaitCounter                     = 60;
+constexpr int gUdpWaitTimeout                  = 30;  // milliseconds
 //@}
 
 //*******************************************************************************


### PR DESCRIPTION
So that it only logs to console once per gap rather than every 30ms

Also replacing local variables and constants for 30ms with a new global gUdpWaitTimeout