### PR TITLE
Use correct number of channels for the selected CoreAudio stream

### DIFF
--- a/src/gui/DeviceControlsGroup.qml
+++ b/src/gui/DeviceControlsGroup.qml
@@ -123,6 +123,7 @@ Rectangle {
                 }
 
                 Item {
+                    visible: isUsingRtAudio
                     Layout.preferredWidth: 40 * virtualstudio.uiScale
                     Layout.preferredHeight: 64 * virtualstudio.uiScale
                     Layout.bottomMargin: 5 * virtualstudio.uiScale
@@ -132,7 +133,6 @@ Rectangle {
 
                     Button {
                         id: changeDevicesButton
-                        visible: isUsingRtAudio
                         width: 36 * virtualstudio.uiScale
                         height: 36 * virtualstudio.uiScale
                         anchors.top: parent.top

--- a/subprojects/packagefiles/rtaudio-coreaudio-stream-channels.patch
+++ b/subprojects/packagefiles/rtaudio-coreaudio-stream-channels.patch
@@ -1,0 +1,11 @@
+--- a/RtAudio.cpp	2024-02-11 15:05:31
++++ b/RtAudio.cpp	2024-02-11 15:07:49
+@@ -1782,7 +1782,7 @@
+   stream_.deviceFormat[mode] = RTAUDIO_FLOAT32;
+ 
+   if ( streamCount == 1 )
+-    stream_.nDeviceChannels[mode] = description.mChannelsPerFrame;
++    stream_.nDeviceChannels[mode] = streamChannels;
+   else // multiple streams
+     stream_.nDeviceChannels[mode] = channels;
+   stream_.nUserChannels[mode] = channels;

--- a/subprojects/rtaudio.wrap
+++ b/subprojects/rtaudio.wrap
@@ -3,7 +3,7 @@ directory = rtaudio-6.0.1
 source_url = https://github.com/thestk/rtaudio/archive/refs/tags/6.0.1.tar.gz
 source_filename = 6.0.1.tar.gz
 source_hash = 7206c8b6cee43b474f43d64988fefaadfdcfc4264ed38d8de5f5d0e6ddb0a123
-diff_files = rtaudio-remove-input-disconnect-listener.patch
+diff_files = rtaudio-remove-input-disconnect-listener.patch,rtaudio-coreaudio-stream-channels.patch
 
 [provide]
 dependency_names = rtaudio


### PR DESCRIPTION
Patching RtAudio bug where OSX users of some audio devices with high channel counts (including RME) could experience garbled audio

Also hiding "Devices" label when Jack audio backend is selected