### PR TITLE
Blacklisting Generic Low Latency ASIO Driver

### DIFF
--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -919,6 +919,10 @@ void Regulator::readSlotNonBlocking(int8_t* ptrToReadSlot)
 //*******************************************************************************
 bool Regulator::getStats(RingBuffer::IOStat* stat, bool reset)
 {
+    if (!mFPPratioIsSet) {
+        return false;
+    }
+
     if (reset) {  // all are unused, this is copied from superclass
         mUnderruns        = 0;
         mOverflows        = 0;

--- a/src/gui/vsAudio.cpp
+++ b/src/gui/vsAudio.cpp
@@ -1125,6 +1125,7 @@ void VsAudioWorker::getDeviceList(const QVector<RtAudioDevice>& devices,
 #ifdef _WIN32
         // Realtek ASIO: seems to crash any computer that tries to use it
         QString::fromUtf8("Realtek ASIO"),
+        QString::fromUtf8("Generic Low Latency ASIO Driver"),
 #endif
         // JackRouter: crashes if not running; use Jack backend instead
         QString::fromUtf8("JackRouter"),


### PR DESCRIPTION
I added this to the blacklist in https://github.com/jacktrip/jacktrip/pull/1088 but it seems to have gotten lost. Possibly removed by accident during a refactor?

Also fixing a crash when using -I option with PLC when connection fails