### PR TITLE
Don't send ping data in heartbeats until after vsPinger has started

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -1,3 +1,10 @@
+- Version: "2.2.3"
+  Date: 2024-03-04
+  Description:
+  - (added) New container images for JackTrip hub server
+  - (fixed) Support for audio interfaces on OSX with multiple channels
+  - (fixed) VS Mode blacklisted Generic Low Latency ASIO Driver
+  - (fixed) VS Mode inconsistent initial connection state 
 - Version: "2.2.2"
   Date: 2024-02-09
   Description:

--- a/src/gui/Setup.qml
+++ b/src/gui/Setup.qml
@@ -136,6 +136,7 @@ Item {
                 }
                 enabled: !Boolean(audio.devicesError) && audio.backendAvailable && audio.audioReady
                 onClicked: {
+                    audio.stopAudio(true);
                     virtualstudio.studioToJoin = virtualstudio.currentStudio.id;
                     virtualstudio.windowState = "connected";
                     virtualstudio.saveSettings();

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -40,7 +40,7 @@
 
 #include "AudioInterface.h"
 
-constexpr const char* const gVersion = "2.2.2";  ///< JackTrip version
+constexpr const char* const gVersion = "2.2.3";  ///< JackTrip version
 
 //*******************************************************************************
 /// \name Default Values


### PR DESCRIPTION
I believe this was causing bogus data to be sent at startup, causing strange connection statusus when it should have been "Measuring"

Don't start vsPinger for self hosted studios. This was causing an error about not having an auth token

Stop audio before starting to connect to a studio from setup screen. I'm not sure but this could have been causing the deadlock during window state transitions.

Bumping version and changelog for 2.2.3 release