### PR TITLE
Include opengl32sw.dll in the windows installer

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -1,3 +1,7 @@
+- Version: "2.2.4"
+  Date: 2024-03-13
+  Description:
+  - (fixed) Allow software opengl for older windows video drivers
 - Version: "2.2.3"
   Date: 2024-03-04
   Description:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -182,7 +182,7 @@ QCoreApplication* createApplication(int& argc, char* argv[])
 #if !defined(NO_VS) && QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
         // Enables resource sharing between the OpenGL contexts
         QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
-        QCoreApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
+        // QCoreApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
         // QCoreApplication::setAttribute(Qt::AA_UseOpenGLES);
 
         // QQuickWindow::setGraphicsApi(QSGRendererInterface::Direct3D11);

--- a/win/build_installer.bat
+++ b/win/build_installer.bat
@@ -11,6 +11,12 @@ del deploy /s /q
 rmdir deploy /s /q
 mkdir deploy
 
+REM get opengl32sw.dll mesa3d llvm build, required by opengl software backend
+curl -L -s -o opengl32sw.zip https://files.jacktrip.org/contrib/opengl32sw.zip
+unzip opengl32sw.zip
+del opengl32sw.zip
+move opengl32sw.dll deploy
+
 copy ..\LICENSE.md deploy\
 xcopy ..\LICENSES deploy\LICENSES\
 

--- a/win/qt6-noguids.wxs
+++ b/win/qt6-noguids.wxs
@@ -30,8 +30,14 @@
             <Component Id="cmp61BABE677B13AE7A25F57865DD2CB150" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
                 <File Id="filD0B8E5384B7EB5609D1B2A67A98FF334" KeyPath="yes" Source="SourceDir\jacktrip.exe" />
             </Component>
+            <Component Id="cmp5C97B37BB3181F77EDC11261A4463285" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
+                <File Id="fil46101D0C43E1BEF1BE4C5475DA0B2837" KeyPath="yes" Source="SourceDir\JackTrip.msi" />
+            </Component>
             <Component Id="cmpCD23A5CC7196B582D23DF7AC7DFE061F" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
                 <File Id="fil00C2A327ECCB1D33F7BBF313ADEEFD43" KeyPath="yes" Source="SourceDir\jacktrip.wixobj" />
+            </Component>
+            <Component Id="cmpEF56078548B21E7891727FDE729B864B" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
+                <File Id="fil01A07DE9CBC162E11AA3C8EFB4A4D4B9" KeyPath="yes" Source="SourceDir\JackTrip.wixpdb" />
             </Component>
             <Component Id="cmp63BFF65F319CB52D38DBB3FE6B8DE6F6" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
                 <File Id="fil886DC1D217D62357ED536BCFF93E7C0F" KeyPath="yes" Source="SourceDir\jacktrip.wxs" />
@@ -41,6 +47,9 @@
             </Component>
             <Component Id="cmpE2BC49F17425202019B2C48873956253" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
                 <File Id="fil011E2822115DD1D5BD9A9096D1914F51" KeyPath="yes" Source="SourceDir\license.rtf" />
+            </Component>
+            <Component Id="cmpC2B5C938CDBD7BD0FAE06ACAABDB3B54" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
+                <File Id="fil025966B7C1FB522423ADF8E9CE443022" KeyPath="yes" Source="SourceDir\opengl32sw.dll" />
             </Component>
             <Component Id="cmpD16A82FC04DA86995B222E5199ABF99B" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
                 <File Id="fil03546A9C6805C45BEB0A60D29FFC5D22" KeyPath="yes" Source="SourceDir\qt6.wixobj" />

--- a/win/qt6.wxs
+++ b/win/qt6.wxs
@@ -37,6 +37,9 @@
             <Component Id="cmpE2BC49F17425202019B2C48873956253" Directory="INSTALLDIR" Guid="{4F42E138-BC56-4253-8AE7-47D1C92EA803}">
                 <File Id="fil011E2822115DD1D5BD9A9096D1914F51" KeyPath="yes" Source="SourceDir\license.rtf" />
             </Component>
+            <Component Id="cmpC2B5C938CDBD7BD0FAE06ACAABDB3B54" Directory="TARGETDIR" Guid="{E3D42FA3-DD28-4928-AB36-D33EFC3D454E}">
+                <File Id="fil025966B7C1FB522423ADF8E9CE443022" KeyPath="yes" Source="SourceDir\opengl32sw.dll" />
+            </Component>
             <Component Id="cmp7111706DBFB0E180EC7A8BDC93A90139" Directory="INSTALLDIR" Guid="{B19ABB59-5607-4637-93D8-C03CA180767F}">
                 <File Id="fil1A08189509DCFE1E185AEC6B499929BA" KeyPath="yes" Source="SourceDir\Qt6Core.dll" />
             </Component>


### PR DESCRIPTION
This is build of Mesa with llvmpipe. It is required by Qt when using the software OpenGL backend, which is used if OpenGL support on the system is missing or otherwise insufficient.

https://doc.qt.io/qt-6/windows-graphics.html

https://docs.mesa3d.org/drivers/llvmpipe.html