### PR TITLE
Defer checks for JACK libraries until opening audio interface

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -2,6 +2,7 @@
   Date: 2024-03-13
   Description:
   - (fixed) Allow software opengl for older windows video drivers
+  - (fixed) VS Mode avoid unnecessary JACK library checks at startup
 - Version: "2.2.3"
   Date: 2024-03-04
   Description:

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -40,7 +40,7 @@
 
 #include "AudioInterface.h"
 
-constexpr const char* const gVersion = "2.2.3";  ///< JackTrip version
+constexpr const char* const gVersion = "2.2.4";  ///< JackTrip version
 
 //*******************************************************************************
 /// \name Default Values

--- a/win/qt6.wxs
+++ b/win/qt6.wxs
@@ -37,7 +37,7 @@
             <Component Id="cmpE2BC49F17425202019B2C48873956253" Directory="INSTALLDIR" Guid="{4F42E138-BC56-4253-8AE7-47D1C92EA803}">
                 <File Id="fil011E2822115DD1D5BD9A9096D1914F51" KeyPath="yes" Source="SourceDir\license.rtf" />
             </Component>
-            <Component Id="cmpC2B5C938CDBD7BD0FAE06ACAABDB3B54" Directory="TARGETDIR" Guid="{E3D42FA3-DD28-4928-AB36-D33EFC3D454E}">
+            <Component Id="cmpC2B5C938CDBD7BD0FAE06ACAABDB3B54" Directory="INSTALLDIR" Guid="{E3D42FA3-DD28-4928-AB36-D33EFC3D454E}">
                 <File Id="fil025966B7C1FB522423ADF8E9CE443022" KeyPath="yes" Source="SourceDir\opengl32sw.dll" />
             </Component>
             <Component Id="cmp7111706DBFB0E180EC7A8BDC93A90139" Directory="INSTALLDIR" Guid="{B19ABB59-5607-4637-93D8-C03CA180767F}">


### PR DESCRIPTION
See https://community.jacktrip.org/t/old-jack-crashes-jacktrip-on-windows/722

Old versions of JACK installed on windows causes crashes in any application that tries to open the client library. This bypasses the problem for the most part by only ever trying to open the JACK client library if it is explicitly selected as a backend (which is not the default, at least for VS mode).

Fix for install directory of opengl32sw.dll on windows

Bumping version to 2.2.4 pending release