### PR TITLE
Fix for joining virtual studios that are still starting up

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -1,3 +1,8 @@
+- Version: "2.2.5"
+  Date: 2024-03-28
+  Description:
+  - (fixed) VS Mode only admins could join new sessions starting up
+  - (updated) VS Mode updates to support self hosted virtual studios
 - Version: "2.2.4"
   Date: 2024-03-13
   Description:

--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -2,6 +2,7 @@
   Date: 2024-03-28
   Description:
   - (fixed) VS Mode only admins could join new sessions starting up
+  - (fixed) VS Mode only ask for feedback if you've joined a session
   - (updated) VS Mode updates to support self hosted virtual studios
 - Version: "2.2.4"
   Date: 2024-03-13

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -831,7 +831,7 @@ void VirtualStudio::connectToStudio()
     m_studioSocketPtr->openSocket();
 
     // Check if we have an address for our server
-    if (m_currentStudio.status() != "Ready" && m_currentStudio.isAdmin() == true) {
+    if (m_currentStudio.status() != "Ready") {
         m_connectionState = QStringLiteral("Waiting...");
         emit connectionStateChanged();
     } else {
@@ -843,8 +843,20 @@ void VirtualStudio::connectToStudio()
 
 void VirtualStudio::completeConnection()
 {
+    // sanity check
     if (m_currentStudio.id() == ""
         || m_currentStudio.status() == QStringLiteral("Disabled")) {
+        processError("Studio session has ended");
+        return;
+    }
+
+    // these shouldn't happen
+    if (m_currentStudio.status() != "Ready") {
+        processError("Studio session is not ready");
+        return;
+    }
+    if (m_currentStudio.host().isEmpty()) {
+        processError("Studio host is unknown");
         return;
     }
 

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -40,7 +40,7 @@
 
 #include "AudioInterface.h"
 
-constexpr const char* const gVersion = "2.2.4";  ///< JackTrip version
+constexpr const char* const gVersion = "2.2.5";  ///< JackTrip version
 
 //*******************************************************************************
 /// \name Default Values


### PR DESCRIPTION
If you tried joining a studio that was still starting up, and were not an admin of the studio, it would immediately kick you out and ask for feedback. It should now sending you to the waiting room, and automatically connect you once the studio session is ready.

Only ask for feedback if you've joined a session

Immediately refresh studio list when you leave a session

Also bumping version for 2.2.5 release