### PR TITLE
Updating PLC to run using peer instead of local FPP

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -1,3 +1,11 @@
+- Version: "2.3.0-beta1"
+  Date: 2024-04-xx
+  Description:
+  - (fixed) PLC audio degradation when buffer sizes don't match
+  - (fixed) PLC statistics for auto latency adjustments
+  - (updated) VS Mode help links to point to support.jacktrip.com
+  - (updated) Removed worker thread for PLC buffer strategies
+  - (updated) Improved PLC performance and quality
 - Version: "2.2.5"
   Date: 2024-03-28
   Description:

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -423,21 +423,12 @@ void JackTrip::setupRingBuffers()
                 new RingBuffer(audio_output_slot_size, mBufferQueueLength);
             mPacketHeader->setBufferRequiresSameSettings(true);
         } else if ((mBufferStrategy == 3) || (mBufferStrategy == 4)) {
-            bool use_worker_thread = (mBufferStrategy == 3);
             cout << "Using experimental buffer strategy " << mBufferStrategy
-                 << "-- Regulator with PLC (worker="
-                 << (use_worker_thread ? "true" : "false") << ")" << endl;
+                 << "-- Regulator with PLC" << endl;
             Regulator* regulator_ptr =
                 new Regulator(mNumAudioChansOut, mAudioBitResolution, mAudioBufferSize,
                               mBufferQueueLength, mBroadcastQueueLength, mSampleRate);
             mReceiveRingBuffer = regulator_ptr;
-            if (use_worker_thread) {
-#ifdef REGULATOR_SHARED_WORKER_THREAD
-                regulator_ptr->enableWorkerThread(mRegulatorThreadPtr);
-#else
-                regulator_ptr->enableWorkerThread();
-#endif
-            }
             // bufStrategy 3 or 4, mBufferQueueLength is in integer msec not packets
 
             mPacketHeader->setBufferRequiresSameSettings(false);  // = asym is default

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -254,9 +254,11 @@ void Regulator::setFPPratio(int len)
         return;
     }
 
-    mPeerBytes      = len;
-    mPeerFPP        = len / (mNumChannels * mBitResolutionMode);
-    mPeerFPPdurMsec = 1000.0 * mPeerFPP / mSampleRate;
+    mPeerBytes           = len;
+    mPeerFPP             = len / (mNumChannels * mBitResolutionMode);
+    mPeerFPPdurMsec      = 1000.0 * mPeerFPP / mSampleRate;
+    mFPPratioNumerator   = 1;
+    mFPPratioDenominator = 1;
 
     if (mPeerFPP != mFPP) {
         if (mPeerFPP > mFPP)
@@ -378,7 +380,7 @@ void Regulator::updatePushStats(int seq_num)
 //*******************************************************************************
 void Regulator::pushPacket(const int8_t* buf, int seq_num)
 {
-    if (m_b_BroadcastQueueLength)
+    if (m_b_BroadcastRingBuffer != NULL)
         m_b_BroadcastRingBuffer->insertSlotNonBlocking(buf, mPeerBytes, 0, seq_num);
     seq_num %= mNumSlots;
     // if (seq_num==0) return;   // impose regular loss

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -124,7 +124,6 @@ Regulator::Regulator(int rcvChannels, int bit_res, int FPP, int qLen, int bqLen,
     , mBroadcastBuffer(NULL)
     , mBroadcastPullPtr(NULL)
     , mSlotBuf(NULL)
-    , mZeros(NULL)
     , mMsecTolerance((double)qLen)  // handle non-auto mode, expects positive qLen
     , pushStat(NULL)
     , pullStat(NULL)
@@ -164,8 +163,6 @@ Regulator::Regulator(int rcvChannels, int bit_res, int FPP, int qLen, int bqLen,
     }
     mBytes      = mFPP * mNumChannels * mBitResolutionMode;
     mFPPdurMsec = 1000.0 * mFPP / mSampleRate;
-    mZeros      = new int8_t[mBytes];
-    memset(mZeros, 0, mBytes);
     mPhasor.resize(mNumChannels, 0.0);
     mIncomingTiming.resize(NumSlotsMax);
     for (int i = 0; i < NumSlotsMax; i++) {
@@ -199,7 +196,6 @@ Regulator::~Regulator()
     delete[] mXfrBuffer;
     delete[] mBroadcastBuffer;
     delete[] mSlotBuf;
-    delete[] mZeros;
     delete pushStat;
     delete pullStat;
     for (int i = 0; i < mNumChannels; i++)
@@ -460,7 +456,7 @@ UNDERRUN : {
 }
 
 ZERO_OUTPUT:
-    memcpy(mXfrBuffer, mZeros, mPeerBytes);
+    memset(mXfrBuffer, 0, mPeerBytes);
 
 OUTPUT:
     return;
@@ -854,7 +850,7 @@ void Regulator::readSlotNonBlocking(int8_t* ptrToReadSlot)
     if (!mInitialized) {
         // audio callback before receiving first packet from peer
         // nothing is initialized yet, so just return silence
-        memcpy(ptrToReadSlot, mZeros, mBytes);
+        memset(ptrToReadSlot, 0, mBytes);
         return;
     }
 
@@ -891,7 +887,7 @@ void Regulator::readBroadcastSlot(int8_t* ptrToReadSlot)
     if (!mInitialized || m_b_BroadcastRingBuffer == NULL) {
         // audio callback before receiving first packet from peer
         // nothing is initialized yet, so just return silence
-        memcpy(ptrToReadSlot, mZeros, mBytes);
+        memset(ptrToReadSlot, 0, mBytes);
         return;
     }
 

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -851,14 +851,14 @@ bool StdDev::tick(double prevTime, double curTime)
 
 void Regulator::readSlotNonBlocking(int8_t* ptrToReadSlot)
 {
-    pullStat->tick();
-
     if (!mInitialized) {
         // audio callback before receiving first packet from peer
         // nothing is initialized yet, so just return silence
         memcpy(ptrToReadSlot, mZeros, mBytes);
         return;
     }
+
+    pullStat->tick();
 
     if (mFPPratioNumerator == mFPPratioDenominator) {
         // local FPP matches peer

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -114,10 +114,17 @@ constexpr double AutoSmoothingFactor =
 Regulator::Regulator(int rcvChannels, int bit_res, int FPP, int qLen, int bqLen,
                      int sample_rate)
     : RingBuffer(0, 0)
+    , mInitialized(false)
     , mNumChannels(rcvChannels)
     , mAudioBitRes(bit_res)
     , mFPP(FPP)
     , mSampleRate(sample_rate)
+    , mXfrBuffer(NULL)
+    , mXfrPullPtr(NULL)
+    , mBroadcastBuffer(NULL)
+    , mBroadcastPullPtr(NULL)
+    , mSlotBuf(NULL)
+    , mZeros(NULL)
     , mMsecTolerance((double)qLen)  // handle non-auto mode, expects positive qLen
     , pushStat(NULL)
     , pullStat(NULL)
@@ -125,10 +132,8 @@ Regulator::Regulator(int rcvChannels, int bit_res, int FPP, int qLen, int bqLen,
     , mSkipAutoHeadroom(true)
     , mLastGlitches(0)
     , mCurrentHeadroom(0)
-    , mUseWorkerThread(false)
+    , m_b_BroadcastRingBuffer(NULL)
     , m_b_BroadcastQueueLength(bqLen)
-    , mRegulatorThreadPtr(NULL)
-    , mRegulatorWorkerPtr(NULL)
 {
     // catch settings that are compute bound using long HIST
     // hub client rcvChannels is set from client's settings parameters
@@ -157,92 +162,16 @@ Regulator::Regulator(int rcvChannels, int bit_res, int FPP, int qLen, int bqLen,
         mBitResolutionMode = AudioInterface::audioBitResolutionT::BIT32;
         break;
     }
-    mHist = HIST;  //    HIST (default) is 4
-                   //    as FPP decreases the rate of PLC triggers potentially goes up
-                   //    and load increases so don't use an inverse relation
-
-    //    crossfaded prediction is a full packet ahead of predicted
-    //    packet, so the size of mPrediction needs to account for 2 full packets (2*FPP)
-    //    but trainSamps = (HIST * FPP) and mPrediction.resize(trainSamps - 1, 0.0) so if
-    //    hist = 2, then it exceeds the size
-
-    if (((mNumChannels > 1) && (mFPP > 64)) || (mFPP > 128))
-        mHist = 3;  // min packets for prediction, needs at least 3
-
-    if (gVerboseFlag)
-        cout << "mHist = " << mHist << " at " << mFPP << "\n";
-    mBytes     = mFPP * mNumChannels * mBitResolutionMode;
-    mXfrBuffer = new int8_t[mBytes];
-    mPacketCnt = 0;  // burg initialization
-    mFadeUp.resize(mFPP, 0.0);
-    mFadeDown.resize(mFPP, 0.0);
-    for (int i = 0; i < mFPP; i++) {
-        mFadeUp[i]   = (double)i / (double)mFPP;
-        mFadeDown[i] = 1.0 - mFadeUp[i];
-    }
-    mLastWasGlitch = false;
-    mNumSlots      = NumSlotsMax;
-
-    for (int i = 0; i < mNumSlots; i++) {
-        int8_t* tmp = new int8_t[mBytes];
-        mSlots.push_back(tmp);
-    }
-    for (int i = 0; i < mNumChannels; i++) {
-        ChanData* tmp = new ChanData(i, mFPP, mHist);
-        mChanData.push_back(tmp);
-        for (int s = 0; s < mFPP; s++)
-            sampleToBits(0.0, i, s);  // zero all channels in mXfrBuffer
-    }
-    mZeros = new int8_t[mBytes];
-    memcpy(mZeros, mXfrBuffer, mBytes);
-    mAssembledPacket = new int8_t[mBytes];  // for asym
-    memcpy(mAssembledPacket, mXfrBuffer, mBytes);
-    mLastLostCount = 0;  // for stats
-    mIncomingTimer.start();
-    mLastSeqNumIn.store(-1, std::memory_order_relaxed);
-    mLastSeqNumOut = -1;
+    mBytes      = mFPP * mNumChannels * mBitResolutionMode;
+    mFPPdurMsec = 1000.0 * mFPP / mSampleRate;
+    mZeros      = new int8_t[mBytes];
+    memset(mZeros, 0, mBytes);
     mPhasor.resize(mNumChannels, 0.0);
     mIncomingTiming.resize(NumSlotsMax);
-    mAssemblyCounts.resize(NumSlotsMax);
     for (int i = 0; i < NumSlotsMax; i++) {
         mIncomingTiming[i] = 0.0;
-        mAssemblyCounts[i] = 0;
     }
-    mFPPratioNumerator   = 1;
-    mFPPratioDenominator = 1;
-    mFPPratioIsSet       = false;
-    mBytesPeerPacket     = mBytes;
-    mPeerFPP             = mFPP;  // use local until first packet arrives
-    mAutoHeadroom        = 3.0;
-    mFPPdurMsec          = 1000.0 * mFPP / mSampleRate;
     changeGlobal_2(NumSlotsMax);  // need hg if running GUI
-    if (m_b_BroadcastQueueLength) {
-        m_b_BroadcastRingBuffer =
-            new JitterBuffer(mFPP, qLen, mSampleRate, 1, m_b_BroadcastQueueLength,
-                             mNumChannels, mAudioBitRes);
-        qDebug() << "Broadcast started in Regulator with packet queue of"
-                 << m_b_BroadcastQueueLength;
-        // have not implemented the mJackTrip->queueLengthChanged functionality
-    }
-}
-
-void Regulator::enableWorkerThread(QThread* thread_ptr)
-{
-    if (thread_ptr == nullptr) {
-        // create owned regulator thread (client mode)
-        if (mRegulatorThreadPtr == nullptr) {
-            mRegulatorThreadPtr = new QThread();
-            mRegulatorThreadPtr->setObjectName("RegulatorThread");
-            mRegulatorThreadPtr->start();
-        }
-        thread_ptr = mRegulatorThreadPtr;
-    }
-    if (mRegulatorWorkerPtr != nullptr) {
-        delete mRegulatorWorkerPtr;
-    }
-    mRegulatorWorkerPtr = new RegulatorWorker(this);
-    mRegulatorWorkerPtr->moveToThread(thread_ptr);
-    mUseWorkerThread = true;
 }
 
 void Regulator::changeGlobal(double x)
@@ -267,25 +196,15 @@ void Regulator::printParams(){
 
 Regulator::~Regulator()
 {
-    if (mRegulatorThreadPtr != nullptr) {
-        // Stop the Regulator thread before deleting other things
-        mRegulatorThreadPtr->quit();
-        mRegulatorThreadPtr->wait();
-        delete mRegulatorThreadPtr;
-    }
-    if (mRegulatorWorkerPtr != nullptr)
-        delete mRegulatorWorkerPtr;
     delete[] mXfrBuffer;
+    delete[] mBroadcastBuffer;
+    delete[] mSlotBuf;
     delete[] mZeros;
-    delete[] mAssembledPacket;
     delete pushStat;
     delete pullStat;
     for (int i = 0; i < mNumChannels; i++)
         delete mChanData[i];
-    for (auto& slot : mSlots) {
-        delete[] slot;
-    };
-    if (m_b_BroadcastQueueLength)
+    if (m_b_BroadcastRingBuffer)
         delete m_b_BroadcastRingBuffer;
 }
 
@@ -332,113 +251,144 @@ void Regulator::updateTolerance()
 }
 
 //*******************************************************************************
-void Regulator::setFPPratio()
+void Regulator::setFPPratio(int len)
 {
+    // only for first peer packet
+    if (mInitialized) {
+        return;
+    }
+
+    mPeerBytes      = len;
+    mPeerFPP        = len / (mNumChannels * mBitResolutionMode);
+    mPeerFPPdurMsec = 1000.0 * mPeerFPP / mSampleRate;
+
     if (mPeerFPP != mFPP) {
         if (mPeerFPP > mFPP)
             mFPPratioDenominator = mPeerFPP / mFPP;
         else
             mFPPratioNumerator = mFPP / mPeerFPP;
-        //        qDebug() << "peerBuffers / localBuffers" << mFPPratioNumerator << " / "
-        //                 << mFPPratioDenominator;
     }
+
+    // bufstrategy 1 autoq mode overloads qLen with negative val
+    // creates this ugly code
+    if (mMsecTolerance <= 0) {  // handle -q auto or, for example, -q auto10
+        mAuto = true;
+        // default is -500 from bufstrategy 1 autoq mode
+        // use mMsecTolerance to set headroom
+        if (mMsecTolerance == -500.0) {
+            mAutoHeadroom = -1;
+            qDebug() << "PLC is in auto mode and has been set with variable headroom";
+        } else {
+            mAutoHeadroom = -mMsecTolerance;
+            qDebug() << "PLC is in auto mode and has been set with" << mAutoHeadroom
+                     << "ms headroom";
+            if (mAutoHeadroom > 50.0)
+                qDebug() << "That's a very large value and should be less than, "
+                            "for example, 50ms";
+        }
+        // found an interesting relationship between mPeerFPP and initial
+        // mMsecTolerance mPeerFPP*0.5 is pretty good though that's an oddball
+        // conversion of bufsize directly to msec
+        mMsecTolerance = (mPeerFPP * AutoInitValFactor);
+    } else {
+        qDebug() << "PLC is using a fixed tolerance of " << mMsecTolerance << "ms";
+    }
+
+    mHist = HIST;  //    HIST (default) is 4
+                   //    as FPP decreases the rate of PLC triggers potentially goes up
+                   //    and load increases so don't use an inverse relation
+
+    //    crossfaded prediction is a full packet ahead of predicted
+    //    packet, so the size of mPrediction needs to account for 2 full packets (2*FPP)
+    //    but trainSamps = (HIST * FPP) and mPrediction.resize(trainSamps - 1, 0.0) so if
+    //    hist = 2, then it exceeds the size
+
+    if (((mNumChannels > 1) && (mPeerFPP > 64)) || (mPeerFPP > 128))
+        mHist = 3;  // min packets for prediction, needs at least 3
+    if (gVerboseFlag)
+        cout << "mHist = " << mHist << " at " << mPeerFPP << "\n";
+
+    mXfrBuffer       = new int8_t[mPeerBytes];
+    mBroadcastBuffer = new int8_t[mPeerBytes];
+    memset(mXfrBuffer, 0, mPeerBytes);
+    memset(mBroadcastBuffer, 0, mPeerBytes);
+    mPacketCnt = 0;  // burg initialization
+    mFadeUp.resize(mPeerFPP, 0.0);
+    mFadeDown.resize(mPeerFPP, 0.0);
+    for (int i = 0; i < mPeerFPP; i++) {
+        mFadeUp[i]   = (double)i / (double)mPeerFPP;
+        mFadeDown[i] = 1.0 - mFadeUp[i];
+    }
+    mLastWasGlitch = false;
+    mNumSlots      = NumSlotsMax;
+
+    mSlots      = new int8_t*[mNumSlots];
+    mSlotBuf    = new int8_t[mNumSlots * mPeerBytes];
+    int8_t* tmp = mSlotBuf;
+    for (int i = 0; i < mNumSlots; i++) {
+        mSlots[i] = tmp;
+        tmp += mPeerBytes;
+    }
+
+    for (int i = 0; i < mNumChannels; i++) {
+        ChanData* tmp = new ChanData(i, mPeerFPP, mHist);
+        mChanData.push_back(tmp);
+        for (int s = 0; s < mPeerFPP; s++)
+            sampleToBits(0.0, i, s);  // zero all channels in mXfrBuffer
+    }
+    mLastLostCount = 0;  // for stats
+    mIncomingTimer.start();
+    mLastSeqNumIn.store(-1, std::memory_order_relaxed);
+    mLastSeqNumOut = -1;
+    if (m_b_BroadcastQueueLength) {
+        m_b_BroadcastRingBuffer =
+            new JitterBuffer(mPeerFPP, 10, mSampleRate, 1, m_b_BroadcastQueueLength,
+                             mNumChannels, mAudioBitRes);
+        qDebug() << "Broadcast started in Regulator with packet queue of"
+                 << m_b_BroadcastQueueLength;
+        // have not implemented the mJackTrip->queueLengthChanged functionality
+    }
+
+    // number of stats tick calls per sec depends on FPP
+    pushStat =
+        new StdDev(1, &mIncomingTimer, (int)(floor(mSampleRate / (double)mPeerFPP)));
+    pullStat = new StdDev(2, &mIncomingTimer, (int)(floor(mSampleRate / (double)mFPP)));
+
+    mInitialized = true;
 }
 
 //*******************************************************************************
-void Regulator::shimFPP(const int8_t* buf, int len, int seq_num)
+void Regulator::updatePushStats(int seq_num)
 {
-    if (seq_num != -1) {
-        if (!mFPPratioIsSet) {  // first peer packet
-            mBytesPeerPacket = len;
-            mPeerFPP         = len / (mNumChannels * mBitResolutionMode);
-            mPeerFPPdurMsec  = 1000.0 * mPeerFPP / mSampleRate;
-            // bufstrategy 1 autoq mode overloads qLen with negative val
-            // creates this ugly code
-            if (mMsecTolerance <= 0) {  // handle -q auto or, for example, -q auto10
-                mAuto = true;
-                // default is -500 from bufstrategy 1 autoq mode
-                // use mMsecTolerance to set headroom
-                if (mMsecTolerance == -500.0) {
-                    mAutoHeadroom = -1;
-                    qDebug()
-                        << "PLC is in auto mode and has been set with variable headroom";
-                } else {
-                    mAutoHeadroom = -mMsecTolerance;
-                    qDebug() << "PLC is in auto mode and has been set with"
-                             << mAutoHeadroom << "ms headroom";
-                    if (mAutoHeadroom > 50.0)
-                        qDebug() << "That's a very large value and should be less than, "
-                                    "for example, 50ms";
-                }
-                // found an interesting relationship between mPeerFPP and initial
-                // mMsecTolerance mPeerFPP*0.5 is pretty good though that's an oddball
-                // conversion of bufsize directly to msec
-                mMsecTolerance = (mPeerFPP * AutoInitValFactor);
-            };
-            setFPPratio();
-            // number of stats tick calls per sec depends on FPP
-            pushStat = new StdDev(1, &mIncomingTimer,
-                                  (int)(floor(mSampleRate / (double)mPeerFPP)));
-            pullStat =
-                new StdDev(2, &mIncomingTimer, (int)(floor(mSampleRate / (double)mFPP)));
-            mFPPratioIsSet = true;
-        }
-        if (mFPPratioNumerator == mFPPratioDenominator) {
-            // local FPP matches peer
-            pushPacket(buf, seq_num);
-        } else if (mFPPratioNumerator > 1) {
-            // 2/1, 4/1 peer FPP is lower, (local/peer)/1
-            assemblePacket(buf, seq_num);
-        } else {
-            // 1/2, 1/4 peer FPP is higher, 1/(peer/local)
-            seq_num *= mFPPratioDenominator;
-            for (int i = 0; i < mFPPratioDenominator; i++) {
-                memcpy(mAssembledPacket, buf, mBytes);
-                pushPacket(mAssembledPacket, seq_num);
-                buf += mBytes;
-                seq_num++;
-            }
-        }
-        bool pushStatsUpdated = pushStat->tick();
-        if (mAuto && pushStatsUpdated && (pushStat->lastTime > AutoInitDur)
-            && pushStat->longTermCnt % WindowDivisor == 0) {
-            // after AutoInitDur: update auto tolerance once per second
-            updateTolerance();
-        }
+    // use time of last packet pulled as a baseline time for previous packet
+    // this avoids having to search for a previous packet that wasn't missing
+    // pkts is distance of previous packet from mLastSeqNumOut
+    int pkts = seq_num - 1 - mLastSeqNumOut;
+    if (pkts < 0)
+        pkts += mNumSlots;
+    double prev_time = mIncomingTiming[mLastSeqNumOut] + (pkts * mPeerFPPdurMsec);
+    if (prev_time >= mIncomingTiming[seq_num])
+        return;  // skip edge case where mLastSeqNumOut was very late
+
+    // update push stats
+    bool pushStatsUpdated = pushStat->tick(prev_time, mIncomingTiming[seq_num]);
+    if (mAuto && pushStatsUpdated && (pushStat->lastTime > AutoInitDur)
+        && pushStat->longTermCnt % WindowDivisor == 0) {
+        // after AutoInitDur: update auto tolerance once per second
+        updateTolerance();
     }
-};
+}
 
 //*******************************************************************************
 void Regulator::pushPacket(const int8_t* buf, int seq_num)
 {
     if (m_b_BroadcastQueueLength)
-        m_b_BroadcastRingBuffer->insertSlotNonBlocking(buf, mBytes, 0, seq_num);
+        m_b_BroadcastRingBuffer->insertSlotNonBlocking(buf, mPeerBytes, 0, seq_num);
     seq_num %= mNumSlots;
     // if (seq_num==0) return;   // impose regular loss
     mIncomingTiming[seq_num] =
         mMsecTolerance + (double)mIncomingTimer.nsecsElapsed() / 1000000.0;
-    memcpy(mSlots[seq_num], buf, mBytes);
-    mLastSeqNumIn.store(seq_num, std::memory_order_release);
-};
-
-//*******************************************************************************
-void Regulator::assemblePacket(const int8_t* buf, int peer_seq_num)
-{
-    // copy packet fragment into slot
-    int seq_num = (peer_seq_num / mFPPratioNumerator) % mNumSlots;
-    int pkt_pos = (peer_seq_num % mFPPratioNumerator);
-    memcpy(&(mSlots[seq_num][pkt_pos * mBytesPeerPacket]), buf, mBytesPeerPacket);
-
-    // check if done assembling yet
-    if (++mAssemblyCounts[seq_num] < mFPPratioNumerator)
-        return;
-
-    // complete it
-    if (m_b_BroadcastQueueLength)
-        m_b_BroadcastRingBuffer->insertSlotNonBlocking(mSlots[seq_num], mBytes, 0,
-                                                       seq_num);
-    mIncomingTiming[seq_num] =
-        mMsecTolerance + (double)mIncomingTimer.nsecsElapsed() / 1000000.0;
+    memcpy(mSlots[seq_num], buf, mPeerBytes);
     mLastSeqNumIn.store(seq_num, std::memory_order_release);
 };
 
@@ -449,7 +399,7 @@ void Regulator::pullPacket()
     const int lastSeqNumIn = mLastSeqNumIn.load(std::memory_order_acquire);
     mSkip                  = 0;
 
-    if ((lastSeqNumIn == -1) || (!mFPPratioIsSet)) {
+    if ((lastSeqNumIn == -1) || (!mInitialized)) {
         goto ZERO_OUTPUT;
     } else if (lastSeqNumIn == mLastSeqNumOut) {
         goto UNDERRUN;
@@ -465,14 +415,11 @@ void Regulator::pullPacket()
             int next = lastSeqNumIn - i;
             if (next < 0)
                 next += mNumSlots;
-            if (mFPPratioNumerator > 1) {
-                // time for assembly has passed; reset for next time
-                mAssemblyCounts[next] = 0;
-            }
             if (mLastSeqNumOut != -1) {
                 // account for missing packets
                 if (mIncomingTiming[next] < mIncomingTiming[mLastSeqNumOut])
                     continue;
+                updatePushStats(next);
                 // count how many we have skipped
                 mSkip = next - mLastSeqNumOut - 1;
                 if (mSkip < 0)
@@ -483,7 +430,7 @@ void Regulator::pullPacket()
             // if next timestamp < now, it is too old based upon tolerance
             if (mIncomingTiming[mLastSeqNumOut] >= now) {
                 // next is the best candidate
-                memcpy(mXfrBuffer, mSlots[mLastSeqNumOut], mBytes);
+                memcpy(mXfrBuffer, mSlots[mLastSeqNumOut], mPeerBytes);
                 goto PACKETOK;
             }
         }
@@ -513,10 +460,9 @@ UNDERRUN : {
 }
 
 ZERO_OUTPUT:
-    memcpy(mXfrBuffer, mZeros, mBytes);
+    memcpy(mXfrBuffer, mZeros, mPeerBytes);
 
 OUTPUT:
-    pullStat->tick();
     return;
 };
 
@@ -544,13 +490,13 @@ void Regulator::processChannel(int ch, bool glitch, int packetCnt, bool lastWasG
 {
     //    if(glitch) qDebug() << "glitch"; else fprintf(stderr,".");
     ChanData* cd = mChanData[ch];
-    for (int s = 0; s < mFPP; s++)
+    for (int s = 0; s < mPeerFPP; s++)
         cd->mTruth[s] = bitsToSample(ch, s);
     if (packetCnt) {
         // always update mTrain
         for (int i = 0; i < mHist; i++) {
-            for (int s = 0; s < mFPP; s++)
-                cd->mTrain[s + ((mHist - (i + 1)) * mFPP)] = cd->mLastPackets[i][s];
+            for (int s = 0; s < mPeerFPP; s++)
+                cd->mTrain[s + ((mHist - (i + 1)) * mPeerFPP)] = cd->mLastPackets[i][s];
         }
         if (glitch) {
             // GET LINEAR PREDICTION COEFFICIENTS
@@ -567,30 +513,30 @@ void Regulator::processChannel(int ch, bool glitch, int packetCnt, bool lastWasG
         }
         // cross fade last prediction with mTruth
         if (lastWasGlitch)
-            for (int s = 0; s < mFPP; s++)
+            for (int s = 0; s < mPeerFPP; s++)
                 cd->mXfadedPred[s] =
                     cd->mTruth[s] * mFadeUp[s] + cd->mLastPred[s] * mFadeDown[s];
-        for (int s = 0; s < mFPP; s++)
+        for (int s = 0; s < mPeerFPP; s++)
             sampleToBits((glitch)
                              ? cd->mPrediction[s]
                              : ((lastWasGlitch) ? cd->mXfadedPred[s] : cd->mTruth[s]),
                          ch, s);
         if (glitch) {
-            for (int s = 0; s < mFPP; s++)
-                cd->mLastPred[s] = cd->mPrediction[s + mFPP];
+            for (int s = 0; s < mPeerFPP; s++)
+                cd->mLastPred[s] = cd->mPrediction[s + mPeerFPP];
         }
     }
 
     // copy down history
 
     for (int i = mHist - 1; i > 0; i--) {
-        for (int s = 0; s < mFPP; s++)
+        for (int s = 0; s < mPeerFPP; s++)
             cd->mLastPackets[i][s] = cd->mLastPackets[i - 1][s];
     }
 
     // add prediction  or current input to history, the former checking if primed
 
-    for (int s = 0; s < mFPP; s++)
+    for (int s = 0; s < mPeerFPP; s++)
         cd->mLastPackets[0][s] =
             //                ((!glitch) || (packetCnt < mHist)) ? cd->mTruth[s] :
             //                cd->mPrediction[s];
@@ -600,7 +546,7 @@ void Regulator::processChannel(int ch, bool glitch, int packetCnt, bool lastWasG
     // diagnostic output
     /////////////////////
     if (false)
-        for (int s = 0; s < mFPP; s++) {
+        for (int s = 0; s < mPeerFPP; s++) {
             sampleToBits(0.7 * sin(mPhasor[ch]), ch, s);
             mPhasor[ch] += (!ch) ? 0.1 : 0.11;
         }
@@ -818,11 +764,16 @@ double StdDev::smooth(double avg, double current)
     return avg + AutoSmoothingFactor * (current - avg);
 }
 
-bool StdDev::tick()
+bool StdDev::tick(double prevTime, double curTime)
 {
-    double now       = (double)mTimer->nsecsElapsed() / 1000000.0;
-    double msElapsed = now - lastTime;
-    lastTime         = now;
+    double msElapsed = curTime - prevTime;
+    if (msElapsed > 0) {
+        lastTime = curTime;
+    } else {
+        double now = (double)mTimer->nsecsElapsed() / 1000000.0;
+        msElapsed  = now - lastTime;
+        lastTime   = now;
+    }
 
     // discard measurements that exceed the max wait time
     // this prevents temporary outages from skewing jitter metrics
@@ -900,26 +851,79 @@ bool StdDev::tick()
 
 void Regulator::readSlotNonBlocking(int8_t* ptrToReadSlot)
 {
-    if (!mFPPratioIsSet) {
+    pullStat->tick();
+
+    if (!mInitialized) {
         // audio callback before receiving first packet from peer
         // nothing is initialized yet, so just return silence
         memcpy(ptrToReadSlot, mZeros, mBytes);
         return;
     }
-    if (mUseWorkerThread) {
-        // use separate worker thread for PLC
-        mRegulatorWorkerPtr->pop(ptrToReadSlot);
+
+    if (mFPPratioNumerator == mFPPratioDenominator) {
+        // local FPP matches peer
+        pullPacket();
+        memcpy(ptrToReadSlot, mXfrBuffer, mBytes);
         return;
     }
-    // use jack callback thread to perform PLC
-    pullPacket();
-    memcpy(ptrToReadSlot, mXfrBuffer, mBytes);
+
+    if (mFPPratioNumerator > 1) {
+        // 2/1, 4/1 peer FPP is lower, (local/peer)/1
+        for (int i = 0; i < mFPPratioNumerator; i++) {
+            pullPacket();
+            memcpy(ptrToReadSlot, mXfrBuffer, mPeerBytes);
+            ptrToReadSlot += mPeerBytes;
+        }
+        return;
+    }
+
+    // 1/2, 1/4 peer FPP is higher, 1/(peer/local)
+    if (mXfrPullPtr == NULL || mXfrPullPtr >= (mXfrBuffer + mPeerBytes)) {
+        pullPacket();
+        mXfrPullPtr = mXfrBuffer;
+    }
+    memcpy(ptrToReadSlot, mXfrPullPtr, mBytes);
+    mXfrPullPtr += mBytes;
+}
+
+void Regulator::readBroadcastSlot(int8_t* ptrToReadSlot)
+{
+    if (!mInitialized || m_b_BroadcastRingBuffer == NULL) {
+        // audio callback before receiving first packet from peer
+        // nothing is initialized yet, so just return silence
+        memcpy(ptrToReadSlot, mZeros, mBytes);
+        return;
+    }
+
+    if (mFPPratioNumerator == mFPPratioDenominator) {
+        // local FPP matches peer
+        m_b_BroadcastRingBuffer->readBroadcastSlot(ptrToReadSlot);
+        return;
+    }
+
+    if (mFPPratioNumerator > 1) {
+        // 2/1, 4/1 peer FPP is lower, (local/peer)/1
+        for (int i = 0; i < mFPPratioNumerator; i++) {
+            m_b_BroadcastRingBuffer->readBroadcastSlot(ptrToReadSlot);
+            ptrToReadSlot += mPeerBytes;
+        }
+        return;
+    }
+
+    // 1/2, 1/4 peer FPP is higher, 1/(peer/local)
+    if (mBroadcastPullPtr == NULL
+        || mBroadcastPullPtr >= (mBroadcastBuffer + mPeerBytes)) {
+        m_b_BroadcastRingBuffer->readBroadcastSlot(mBroadcastBuffer);
+        mBroadcastPullPtr = mBroadcastBuffer;
+    }
+    memcpy(ptrToReadSlot, mBroadcastPullPtr, mBytes);
+    mBroadcastPullPtr += mBytes;
 }
 
 //*******************************************************************************
 bool Regulator::getStats(RingBuffer::IOStat* stat, bool reset)
 {
-    if (!mFPPratioIsSet) {
+    if (!mInitialized) {
         return false;
     }
 
@@ -933,10 +937,6 @@ bool Regulator::getStats(RingBuffer::IOStat* stat, bool reset)
         mBufIncUnderrun   = 0;
         mBufIncCompensate = 0;
         mBroadcastSkew    = 0;
-    }
-
-    if (mUseWorkerThread && mRegulatorWorkerPtr != nullptr) {
-        mRegulatorWorkerPtr->getStats();
     }
 
     // hijack  of  struct IOStat {

--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -210,7 +210,6 @@ class Regulator : public RingBuffer
     bool mLastWasGlitch;
     int8_t** mSlots;
     int8_t* mSlotBuf;
-    int8_t* mZeros;
     double mMsecTolerance;
     std::vector<ChanData*> mChanData;
     StdDev* pushStat;

--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -42,8 +42,6 @@
 #ifndef __REGULATOR_H__
 #define __REGULATOR_H__
 
-//#define REGULATOR_SHARED_WORKER_THREAD
-
 #include <math.h>
 
 #include <QDebug>
@@ -55,9 +53,6 @@
 #include "RingBuffer.h"
 #include "WaitFreeFrameBuffer.h"
 #include "jacktrip_globals.h"
-
-// forward declaration
-class RegulatorWorker;
 
 class BurgAlgorithm
 {
@@ -96,7 +91,8 @@ class StdDev
 {
    public:
     StdDev(int id, QElapsedTimer* timer, int w);
-    bool tick();  // returns true if stats were updated
+    bool tick(double prevTime = 0,
+              double curTime  = 0);  // returns true if stats were updated
     double calcAuto();
     int mId;
     int plcOverruns;
@@ -138,10 +134,6 @@ class Regulator : public RingBuffer
     // virtual destructor
     virtual ~Regulator();
 
-    /// @brief enables use of a separate worker thread for pulling packets
-    /// @param thread_ptr pointer to shared thread; if null, a unique one will be used
-    void enableWorkerThread(QThread* thread_ptr = nullptr);
-
     // can hijack unused2 to propagate incoming seq num if needed
     // option is in UdpDataProtocol
     // if (!mJackTrip->writeAudioBuffer(src, host_buf_size, last_seq_num))
@@ -150,7 +142,10 @@ class Regulator : public RingBuffer
     virtual bool insertSlotNonBlocking(const int8_t* ptrToSlot, int len,
                                        [[maybe_unused]] int lostLen, int seq_num)
     {
-        shimFPP(ptrToSlot, len, seq_num);
+        if (seq_num == -1)
+            return true;
+        setFPPratio(len);
+        pushPacket(ptrToSlot, seq_num);
         return (true);
     }
 
@@ -160,10 +155,7 @@ class Regulator : public RingBuffer
 
     /// @brief called by broadcast ports to get the next buffer of samples
     /// @param ptrToReadSlot new samples will be copied to this memory block
-    virtual void readBroadcastSlot(int8_t* ptrToReadSlot)
-    {
-        m_b_BroadcastRingBuffer->readBroadcastSlot(ptrToReadSlot);
-    }
+    virtual void readBroadcastSlot(int8_t* ptrToReadSlot);
 
     /// @brief returns sample rate
     inline int getSampleRate() const { return mSampleRate; }
@@ -184,16 +176,16 @@ class Regulator : public RingBuffer
     virtual bool getStats(IOStat* stat, bool reset);
 
    private:
-    void shimFPP(const int8_t* buf, int len, int seq_num);
+    void shimFPP(const int8_t* buf, int seq_num);
     void pushPacket(const int8_t* buf, int seq_num);
-    void assemblePacket(const int8_t* buf, int peer_seq_num);
+    void updatePushStats(int seq_num);
     void pullPacket();
     void updateTolerance();
-    void setFPPratio();
+    void setFPPratio(int len);
     void processPacket(bool glitch);
     void processChannel(int ch, bool glitch, int packetCnt, bool lastWasGlitch);
 
-    bool mFPPratioIsSet;
+    bool mInitialized;
     int mNumChannels;
     int mAudioBitRes;
     int mFPP;
@@ -205,16 +197,19 @@ class Regulator : public RingBuffer
     AudioInterface::audioBitResolutionT mBitResolutionMode;
     BurgAlgorithm ba;
     int mBytes;
-    int mBytesPeerPacket;
+    int mPeerBytes;
     int8_t* mXfrBuffer;
-    int8_t* mAssembledPacket;
+    int8_t* mXfrPullPtr;
+    int8_t* mBroadcastBuffer;
+    int8_t* mBroadcastPullPtr;
     int mPacketCnt;
     sample_t bitsToSample(int ch, int frame);
     void sampleToBits(sample_t sample, int ch, int frame);
     std::vector<sample_t> mFadeUp;
     std::vector<sample_t> mFadeDown;
     bool mLastWasGlitch;
-    std::vector<int8_t*> mSlots;
+    int8_t** mSlots;
+    int8_t* mSlotBuf;
     int8_t* mZeros;
     double mMsecTolerance;
     std::vector<ChanData*> mChanData;
@@ -225,7 +220,6 @@ class Regulator : public RingBuffer
     int mLastSeqNumOut;
     std::vector<double> mPhasor;
     std::vector<double> mIncomingTiming;
-    std::vector<int> mAssemblyCounts;
     int mSkip;
     int mFPPratioNumerator;
     int mFPPratioDenominator;
@@ -236,7 +230,6 @@ class Regulator : public RingBuffer
     double mAutoHeadroom;
     double mFPPdurMsec;
     double mPeerFPPdurMsec;
-    bool mUseWorkerThread;
     void changeGlobal(double);
     void changeGlobal_2(int);
     void changeGlobal_3(int);
@@ -245,143 +238,6 @@ class Regulator : public RingBuffer
     /// Pointer for the Broadcast RingBuffer
     RingBuffer* m_b_BroadcastRingBuffer;
     int m_b_BroadcastQueueLength;
-
-    /// thread used to pull packets from Regulator (if mBufferStrategy==3)
-    QThread* mRegulatorThreadPtr;
-
-    /// worker used to pull packets from Regulator (if mBufferStrategy==3)
-    RegulatorWorker* mRegulatorWorkerPtr;
-
-    friend class RegulatorWorker;
-};
-
-class RegulatorWorker : public QObject
-{
-    Q_OBJECT;
-
-   public:
-    RegulatorWorker(Regulator* rPtr)
-        : mRegulatorPtr(rPtr)
-        , mPacketQueue(rPtr->getPacketSize())
-        , mPacketQueueTarget(1)
-        , mLastUnderrun(0)
-        , mSkipQueueUpdate(true)
-        , mUnderrun(false)
-        , mStarted(false)
-    {
-        // wire up signals
-        QObject::connect(this, &RegulatorWorker::startup, this,
-                         &RegulatorWorker::setRealtimePriority, Qt::QueuedConnection);
-        QObject::connect(this, &RegulatorWorker::signalPullPacket, this,
-                         &RegulatorWorker::pullPacket, Qt::QueuedConnection);
-        // set thread to realtime priority
-        emit startup();
-    }
-
-    virtual ~RegulatorWorker() {}
-
-    bool pop(int8_t* pktPtr)
-    {
-        // start pulling more packets to maintain target
-        emit signalPullPacket();
-
-        if (mPacketQueue.pop(pktPtr))
-            return true;
-
-        // use silence for underruns
-        ::memset(pktPtr, 0, mPacketQueue.getBytesPerFrame());
-
-        // trigger underrun to re-evaluate queue target
-        mUnderrun.store(true, std::memory_order_relaxed);
-
-        return false;
-    }
-
-    void getStats()
-    {
-        std::cout << "PLC worker queue: size=" << mPacketQueue.size()
-                  << " target=" << mPacketQueueTarget
-                  << " underruns=" << mPacketQueue.getUnderruns()
-                  << " overruns=" << mPacketQueue.getOverruns() << std::endl;
-        mPacketQueue.clearStats();
-    }
-
-   signals:
-    void signalPullPacket();
-    void signalMaxQueueSize();
-    void startup();
-
-   public slots:
-    void pullPacket()
-    {
-        if (mUnderrun.load(std::memory_order_relaxed)) {
-            if (mStarted) {
-                double now =
-                    (double)mRegulatorPtr->mIncomingTimer.nsecsElapsed() / 1000000.0;
-                // only adjust target at most once per 1.0 seconds
-                if (now - mLastUnderrun >= 1000.0) {
-                    if (mSkipQueueUpdate) {
-                        // require consecutive underruns periods to bump target
-                        mSkipQueueUpdate = false;
-                    } else if (now - mLastUnderrun < 2000.0) {
-                        // previous period had underruns
-                        updateQueueTarget();
-                        mSkipQueueUpdate = true;
-                    }  // else, skip this period but not the next one
-                    mLastUnderrun = now;
-                }
-                mUnderrun.store(false, std::memory_order_relaxed);
-            } else {
-                mStarted = true;
-            }
-        }
-        std::size_t qSize = mPacketQueue.size();
-        while (qSize < mPacketQueueTarget) {
-            mRegulatorPtr->pullPacket();
-            qSize = mPacketQueue.push(mRegulatorPtr->mXfrBuffer);
-        }
-    }
-    void setRealtimePriority() { setRealtimeProcessPriority(); }
-
-   private:
-    void updateQueueTarget()
-    {
-        // sanity check
-        const std::size_t maxPackets = mPacketQueue.capacity() / 2;
-        if (mPacketQueueTarget > maxPackets)
-            return;
-        // adjust queue target
-        ++mPacketQueueTarget;
-        std::cout << "PLC worker queue: adjusting target=" << mPacketQueueTarget
-                  << " (max=" << maxPackets
-                  << ", lastDspElapsed=" << mRegulatorPtr->getLastDspElapsed() << ")"
-                  << std::endl;
-        if (mPacketQueueTarget == maxPackets) {
-            emit signalMaxQueueSize();
-            std::cout << "PLC worker queue: reached MAX target!" << std::endl;
-        }
-    }
-
-    /// pointer to Regulator for pulling packets
-    Regulator* mRegulatorPtr;
-
-    /// queue of ready packets (if mBufferStrategy==3)
-    WaitFreeFrameBuffer<> mPacketQueue;
-
-    /// target size for the packet queue
-    std::size_t mPacketQueueTarget;
-
-    /// time of last underrun, in milliseconds
-    double mLastUnderrun;
-
-    /// true if the next packet queue update should be skipped
-    bool mSkipQueueUpdate;
-
-    /// last value of packet queue underruns
-    std::atomic<bool> mUnderrun;
-
-    /// will be true after first packet is pushed
-    bool mStarted;
 };
 
 #endif  //__REGULATOR_H__

--- a/src/gui/virtualstudio.cpp
+++ b/src/gui/virtualstudio.cpp
@@ -896,27 +896,8 @@ void VirtualStudio::completeConnection()
         // increment buffer_strategy by 1 for array-index mapping
         int buffer_strategy = m_audioConfigPtr->getBufferStrategy() + 1;
         // adjust buffer_strategy for PLC "auto" mode menu item
-        if (buffer_strategy == 3) {
-            // run PLC without worker (4)
-            buffer_strategy = 4;
-            /*
-            // I don't believe this is still necessary,
-            // after splitting the input and output RtAudio streams
-            // See https://github.com/jacktrip/jacktrip/pull/1235
-            if (useRtAudio) {
-                // if same device for input and output,
-                // run PLC without worker (4)
-                if (input == output)
-                    buffer_strategy = 4;
-                // else run PLC with worker (3)
-                // to reduce crackles
-            } else {
-                // run PLC without worker (4)
-                buffer_strategy = 4;
-            }
-            */
-        } else if (buffer_strategy == 5) {
-            buffer_strategy = 3;  // run PLC with worker (3)
+        if (buffer_strategy == 4 || buffer_strategy == 5) {
+            buffer_strategy = 3;
         }
 
         // create a new JackTrip instance

--- a/src/gui/vsAudio.cpp
+++ b/src/gui/vsAudio.cpp
@@ -532,7 +532,10 @@ void VsAudio::loadSettings()
     }
 
     setBufferSize(settings.value(QStringLiteral("BufferSize"), 128).toInt());
-    setBufferStrategy(settings.value(QStringLiteral("BufferStrategy"), 2).toInt());
+    int buffer_strategy = settings.value(QStringLiteral("BufferStrategy"), 2).toInt();
+    if (buffer_strategy == 3 || buffer_strategy == 4)
+        buffer_strategy = 2;
+    setBufferStrategy(buffer_strategy);
     setFeedbackDetectionEnabled(
         settings.value(QStringLiteral("FeedbackDetectionEnabled"), true).toBool());
     settings.endGroup();

--- a/src/gui/vsAudio.h
+++ b/src/gui/vsAudio.h
@@ -386,9 +386,8 @@ class VsAudio : public QObject
     QStringList m_audioBackendComboModel      = {"JACK", "RtAudio"};
     QStringList m_feedbackDetectionComboModel = {"Enabled", "Disabled"};
     QStringList m_bufferSizeComboModel = {"16", "32", "64", "128", "256", "512", "1024"};
-    QStringList m_bufferStrategyComboModel = {
-        "Minimal Latency", "Stable Latency", "Loss Concealment (Auto)",
-        "Loss Concealment (No Worker)", "Loss Concealment (Use Worker)"};
+    QStringList m_bufferStrategyComboModel = {"Adaptable Latency", "Stable Latency",
+                                              "Loss Concealment"};
 
     friend class VsAudioWorker;
 };

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -40,7 +40,7 @@
 
 #include "AudioInterface.h"
 
-constexpr const char* const gVersion = "2.2.5";  ///< JackTrip version
+constexpr const char* const gVersion = "2.3.0-beta1";  ///< JackTrip version
 
 //*******************************************************************************
 /// \name Default Values


### PR DESCRIPTION
Adjustments for FPP differences are made at pull time rather than when packets are being pushed. This enables us to perform more targetted predictions (using more "truth" and having smaller "glitches") when packets are missing and peer's FPP is larger than our own.

Removing PLC Regulator worker thread. After optimizations made previously, there is no longer any benefits to using this versus running things inside the callback. At this point it was just dead code, not worth updating for these changes.

Updated calculation of pushStats (packets arriving from peer) to be calculated at pull time, and to use previously known timestamps to calculate deltas. The previous approach did not handle out of order packets, which could significantly skew the stats lower than they should be.

Optimized memory usage for mSlots to reduce fragmentation