### PR TITLE
Various qt upgrade related things

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -857,7 +857,7 @@ jobs:
     name: 'deploy container'
     env:
       REGISTRY_IMAGE: jacktrip/jacktrip
-      JACK_VERSION: 1.9.22-20240224
+      JACK_VERSION: 1.9.22-20240505
     steps:
       - uses: actions/checkout@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ COPY . /root
 RUN cd /root \
 	&& export QT_PATH=/opt/qt-${QT_VERSION}-static \
 	&& export PATH=${QT_PATH}/bin:${PATH} \
-	&& export LDFLAGS=-L${QT_PATH}/lib \
+	&& export LDFLAGS="-L${QT_PATH}/lib -L${QT_PATH}/plugins/tls" \
 	&& meson setup -Ddefault_library=static -Dnogui=true --buildtype release builddir \
 	&& meson compile -C builddir
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,20 +17,28 @@ ARG JACK_VERSION=latest
 FROM registry.fedoraproject.org/fedora:${FEDORA_VERSION} AS builder
 
 # install tools require to build jacktrip
-RUN dnf install -y --nodocs gcc gcc-c++ meson python3-pyyaml python3-jinja2 qt5-qtbase-devel jack-audio-connection-kit-devel
+RUN dnf install -y --nodocs gcc gcc-c++ meson git python3-pyyaml python3-jinja2 glib2-devel jack-audio-connection-kit-devel
+
+ENV QT_VERSION=6.5.3
+RUN if [ "$(uname -m)" = "x86_64" ]; then export ARCH=amd64; else export ARCH=arm64; fi \
+	&& curl -L -s -o /root/qt.tar.gz "https://files.jacktrip.org/contrib/qt/qt-${QT_VERSION}-static-linux-${ARCH}.tar.gz" \
+	&& tar -C /opt -xzf /root/qt.tar.gz \
+	&& rm -f /root/qt.tar.gz
 
 # copy files from repository to build container
 COPY . /root
 
 # configure and run the build
 RUN cd /root \
-	&& PKG_CONFIG_PATH=/usr/local/lib/pkgconfig meson setup -Ddefault_library=static -Dnogui=true --buildtype release builddir \
+	&& export QT_PATH=/opt/qt-${QT_VERSION}-static \
+	&& export PATH=${QT_PATH}/bin:${PATH} \
+	&& export LDFLAGS=-L${QT_PATH}/lib \
+	&& meson setup -Ddefault_library=static -Dnogui=true --buildtype release builddir \
 	&& meson compile -C builddir
 
 # stage files in INSTALLDIR
-ENV INSTALLDIR=/opt
-RUN mkdir -p ${INSTALLDIR}/usr/local/bin/ ${INSTALLDIR}/usr/lib64/ ${INSTALLDIR}/etc/systemd/system/ \
-	&& cp /lib64/libQt5Core.so.5 /lib64/libQt5Network.so.5 ${INSTALLDIR}/usr/lib64/ \
+ENV INSTALLDIR=/artifacts
+RUN mkdir -p ${INSTALLDIR}/usr/local/bin/ ${INSTALLDIR}/etc/systemd/system/ \
 	&& cp /root/builddir/jacktrip ${INSTALLDIR}/usr/local/bin/ \
 	&& strip ${INSTALLDIR}/usr/local/bin/jacktrip
 COPY linux/container/jacktrip.service ${INSTALLDIR}/etc/systemd/system/
@@ -41,9 +49,6 @@ COPY linux/container/jacktrip.service ${INSTALLDIR}/etc/systemd/system/
 ########################
 # use the jack ubi-init container
 FROM jacktrip/jack:${JACK_VERSION}
-
-# install libraries that we need for things to run
-RUN dnf install -y --nodocs libicu pcre libstdc++ compat-openssl11 pcre2-utf16
 
 # add jacktrip user, enable service and allow access to jackd
 RUN useradd -r -m -N -G audio -s /usr/sbin/nologin jacktrip \
@@ -56,7 +61,7 @@ RUN useradd -r -m -N -G audio -s /usr/sbin/nologin jacktrip \
 	&& echo 'echo "JACKTRIP_OPTS=\"$JACKTRIP_OPTS\"" > /etc/default/jacktrip' >> /usr/sbin/defaults.sh
 
 # copy the artifacts we built into the final container image
-COPY --from=builder /opt /
+COPY --from=builder /artifacts /
 
 # jacktrip hub server listens on 4464 and uses 61000+ for clients
 EXPOSE 4464/tcp

--- a/meson.build
+++ b/meson.build
@@ -238,7 +238,17 @@ else
 endif
 
 if qt_version == '6' and get_option('default_library') == 'static'
-	deps += dependency('qt6', modules: ['BundledLibpng', 'BundledPcre2', 'BundledHarfbuzz'], include_type: 'system')
+	if (host_machine.system() == 'linux')
+		# BundledZLIB required on linux
+		deps += dependency('qt6', modules: ['BundledLibpng', 'BundledPcre2', 'BundledHarfbuzz', 'BundledZLIB'], include_type: 'system')
+		deps += compiler.find_library('ssl', required : true)
+		deps += compiler.find_library('crypto', required : true)
+		deps += compiler.find_library('dl', required : true)
+		deps += compiler.find_library('glib-2.0', required : true)
+	else
+		# BundledZLIB not found on windows
+		deps += dependency('qt6', modules: ['BundledLibpng', 'BundledPcre2', 'BundledHarfbuzz'], include_type: 'system')
+	endif
 endif
 
 # TODO: QT_OPENSOURCE should only be defined for open source Qt distribution

--- a/meson.build
+++ b/meson.build
@@ -237,19 +237,30 @@ else
 	endif
 endif
 
-if qt_version == '6' and get_option('default_library') == 'static'
+if get_option('default_library') == 'static'
 	if (host_machine.system() == 'linux')
-		# BundledZLIB required on linux
-		deps += dependency('qt6', modules: ['BundledLibpng', 'BundledPcre2', 'BundledHarfbuzz', 'BundledZLIB'], include_type: 'system')
-		deps += compiler.find_library('ssl', required : true)
-		deps += compiler.find_library('crypto', required : true)
-		deps += compiler.find_library('dl', required : true)
-		deps += compiler.find_library('glib-2.0', required : true)
-		deps += compiler.find_library('qopensslbackend', required : true)
-		src += ['src/QtStaticPlugins.cpp']
+		if qt_version == '6'
+			# BundledZLIB required on linux
+			deps += dependency('qt6', modules: ['BundledLibpng', 'BundledPcre2', 'BundledHarfbuzz', 'BundledZLIB'], include_type: 'system')
+			deps += compiler.find_library('ssl', required : true)
+			deps += compiler.find_library('crypto', required : true)
+			deps += compiler.find_library('dl', required : true)
+			deps += compiler.find_library('glib-2.0', required : true)
+			deps += compiler.find_library('qopensslbackend', required : true)
+			src += ['src/QtStaticPlugins.cpp']
+		else
+			# -ldl required on linux
+			deps += compiler.find_library('qtpcre2', required : true)
+			deps += compiler.find_library('ssl', required : true)
+			deps += compiler.find_library('crypto', required : true)
+			deps += compiler.find_library('dl', required : true)
+			deps += compiler.find_library('glib-2.0', required : true)
+		endif
 	else
-		# BundledZLIB not found on windows
-		deps += dependency('qt6', modules: ['BundledLibpng', 'BundledPcre2', 'BundledHarfbuzz'], include_type: 'system')
+		if qt_version == '6'
+			# BundledZLIB not found on windows or osx
+			deps += dependency('qt6', modules: ['BundledLibpng', 'BundledPcre2', 'BundledHarfbuzz'], include_type: 'system')
+		endif
 	endif
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -245,6 +245,8 @@ if qt_version == '6' and get_option('default_library') == 'static'
 		deps += compiler.find_library('crypto', required : true)
 		deps += compiler.find_library('dl', required : true)
 		deps += compiler.find_library('glib-2.0', required : true)
+		deps += compiler.find_library('qopensslbackend', required : true)
+		src += ['src/QtStaticPlugins.cpp']
 	else
 		# BundledZLIB not found on windows
 		deps += dependency('qt6', modules: ['BundledLibpng', 'BundledPcre2', 'BundledHarfbuzz'], include_type: 'system')

--- a/src/QtStaticPlugins.cpp
+++ b/src/QtStaticPlugins.cpp
@@ -1,0 +1,4 @@
+#include <QtPlugin>
+
+// used to load tls backend for linux static builds
+Q_IMPORT_PLUGIN(QTlsBackendOpenSSL)


### PR DESCRIPTION
Make static qt6 builds with meson work on linux

Update base jacktrip/jack container image for CI to 1.9.22-20240505. This includes latest ubi-init base image patches (using 9.4-6)

Update container to use a static build of jacktrip with qt 6.5.3. This shaves about 59MB off the image size and removes unnecessary things that increase vulnerability risk.