### PR TITLE
Upgrading qt versions for various releases

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -169,7 +169,7 @@ jobs:
             build-system: meson
             meson-library-type: static
 
-          - name: Windows-x64-meson-msvc-qt6
+          - name: Windows-x64-meson-msvc-shared
             release-name: Windows-x64
             runs-on: windows-2019
             system-rtaudio: false

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -74,6 +74,7 @@ jobs:
             # static-analysis: true # run clang-tidy static analysis (meson/Linux only)
             qt-version: '5.15.13'
             qt-type: 'static'
+            qt-arch: 'amd64'
 
           - name: Linux-x64-meson-gcc-shared-nortaudio # meson shared build without rtaudio
             runs-on: ubuntu-22.04
@@ -100,6 +101,7 @@ jobs:
             meson-library-type: static
             qt-version: '5.15.13'
             qt-type: 'static'
+            qt-arch: 'amd64'
 
           - name: Linux-x64-meson-gcc-shared
             release-name: Linux-x64 # specify a separate name for all builds that should be included in releases
@@ -327,7 +329,10 @@ jobs:
             if [[ -n "${{ matrix.qt-download-commit }}" ]]; then
               QT_DOWNLOAD_COMMIT="${{ matrix.qt-download-commit }}"
             fi
-            QT_DOWNLOAD_URL="$QT_DOWNLOAD_BASE_URL/qt-${{ matrix.qt-version }}-${{ matrix.qt-type }}-$QT_DOWNLOAD_OS-$QT_DOWNLOAD_COMMIT.$QT_DOWNLOAD_EXT"
+            if [[ -n "${{ matrix.qt-arch }}" ]]; then
+              QT_DOWNLOAD_ARCH="-${{ matrix.qt-arch }}"
+            fi
+            QT_DOWNLOAD_URL="$QT_DOWNLOAD_BASE_URL/qt-${{ matrix.qt-version }}-${{ matrix.qt-type }}-${QT_DOWNLOAD_OS}${QT_DOWNLOAD_ARCH}-$QT_DOWNLOAD_COMMIT.$QT_DOWNLOAD_EXT"
           fi
           mkdir -p $QT_INSTALL_PATH
           cd $QT_INSTALL_PATH
@@ -540,7 +545,7 @@ jobs:
           NAME=JackTrip-${{ steps.set-version.outputs.version }}-${{ steps.set-version.outputs.name }}
           ZIPFILE=$BUILD_PATH/${{ matrix.binary-path }}/$NAME-binary.zip
           mkdir -p $BUILD_PATH/${{ matrix.binary-path }}
-          if [[ "${{ runner.os }}" == "Windows" ]]; then
+          if [[ "${{ runner.os }}" == "Windows" && -n "${{ matrix.installer-path }}" ]]; then
             cd win
             mv deploy $NAME
             7z a $ZIPFILE -tzip $NAME

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -72,24 +72,36 @@ jobs:
             build-system: qmake # qmake, meson, cmake (todo)
             # meson-library-type: shared # shared, static, both
             # static-analysis: true # run clang-tidy static analysis (meson/Linux only)
-            qt-version: '5.15.10'
+            qt-version: '5.15.13'
             qt-type: 'static'
 
-          - name: Linux-x64-qmake-gcc-static-nogui
+          - name: Linux-x64-meson-gcc-shared-nortaudio # meson shared build without rtaudio
+            runs-on: ubuntu-22.04
+            system-rtaudio: false
+            bundled-rtaudio: false
+            nogui: false
+            weakjack: false
+            # jacktrip-path: jacktrip
+            # binary-path: binary
+            build-system: meson
+            meson-library-type: shared
+
+          - name: Linux-x64-meson-gcc-static
             release-name: Linux-x64-nogui
             runs-on: ubuntu-20.04
             system-rtaudio: false
-            bundled-rtaudio: false
+            bundled-rtaudio: true
             nogui: true
             novs: true
             weakjack: false
             jacktrip-path: jacktrip
             binary-path: binary
-            build-system: qmake
-            qt-version: '5.15.10'
+            build-system: meson
+            meson-library-type: static
+            qt-version: '5.15.13'
             qt-type: 'static'
 
-          - name: Linux-x64-meson-gcc-shared-bundled_rtaudio
+          - name: Linux-x64-meson-gcc-shared
             release-name: Linux-x64 # specify a separate name for all builds that should be included in releases
             runs-on: ubuntu-22.04
             system-rtaudio: false
@@ -102,36 +114,25 @@ jobs:
             meson-library-type: shared
             static-analysis: true
 
-          - name: Linux-x64-meson-gcc-shared # meson shared build without rtaudio
-            runs-on: ubuntu-22.04
-            system-rtaudio: false
-            bundled-rtaudio: false
-            nogui: false
-            weakjack: false
-            # jacktrip-path: jacktrip
-            # binary-path: binary
-            build-system: meson
-            meson-library-type: shared
-
-          - name: macOS-x64-qmake-clang-static-bundled_rtaudio
+          - name: macOS-x64-meson-clang-static
+            release-name: macOS-x64-nogui
             runs-on: macos-12
             system-rtaudio: false
             bundled-rtaudio: true
-            nogui: false
+            nogui: true
             novs: true
             weakjack: true
-            macosx-deployment-target: 10.13
-            macosx-architectures: 'x86_64 arm64'
-            xcode-directory: /Applications/Xcode_14.0.1.app # uses SDK macOS 12.3 which is latest supported by qt5
-            # jacktrip-path: jacktrip
-            # binary-path: binary
-            # bundle-path: bundle
-            # installer-path: installer
-            build-system: qmake
-            qt-version: '5.15.10'
+            jacktrip-path: jacktrip
+            binary-path: binary
+            build-system: meson
+            meson-library-type: static
+            qt-version: '5.15.13'
             qt-type: 'static'
+            macosx-architectures: 'x86_64;arm64'
+            macosx-deployment-target: 10.13
+            xcode-directory: /Applications/Xcode_14.2.app
 
-          - name: macOS-x64-meson-clang-shared-bundled_rtaudio
+          - name: macOS-x64-meson-clang-shared
             release-name: macOS-x64
             runs-on: macos-12
             system-rtaudio: false
@@ -145,23 +146,24 @@ jobs:
             installer-path: installer
             build-system: meson
             meson-library-type: both
-            qt-version: '6.2.6'
+            qt-version: '6.2.8'
             qt-type: 'dynamic'
             macosx-architectures: 'x86_64;arm64'
             macosx-deployment-target: 10.14
             xcode-directory: /Applications/Xcode_14.2.app
 
           - name: Windows-x64-meson-msvc-static
+            release-name: Windows-x64-nogui
             runs-on: windows-2019
             system-rtaudio: false
             bundled-rtaudio: true
             nogui: true
             novs: true
             weakjack: true
-            qt-version: '6.2.6'
+            qt-version: '5.15.13'
             qt-type: 'static'
-            # jacktrip-path: jacktrip.exe
-            # binary-path: binary
+            jacktrip-path: jacktrip.exe
+            binary-path: binary
             build-system: meson
             meson-library-type: static
 
@@ -186,7 +188,7 @@ jobs:
       CLANG_TIDY_NAME: clang-tidy-result
       CLANG_TIDY_PATH: ${{ github.workspace }}/clang-tidy-result
       QT_DOWNLOAD_BASE_URL: 'https://files.jacktrip.org/contrib/qt'
-      QT_DOWNLOAD_COMMIT: 'b09fbe4'
+      QT_DOWNLOAD_COMMIT: 'f82eab7'
 
     steps:
       - uses: actions/checkout@v3

--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -1,10 +1,19 @@
+- Version: "2.3.0-beta2"
+  Date: 2024-05-07
+  Description:
+  - (added) Static Qt 5.15.13 nogui (CLI) builds for all platforms
+  - (updated) Builds now use Qt 6.2.8 for OSX and 5.15.13 for Linux
+  - (updated) Linux containers now use static builds with Qt 6.5.3
+  - (updated) Automatically start PLC worker for slower predictions
+  - (updated) Additional PLC quality and latency improvements
+  - (fixed) Classic mode options for PLC strategy consolidation
 - Version: "2.3.0-beta1"
   Date: 2024-05-03
   Description:
   - (added) VS Mode learn more buttons and warning links
-  - (updated) Improved PLC performance and quality
-  - (updated) Improved auto latency adjustments for PLC
-  - (updated) Removed worker thread for PLC buffer strategies
+  - (updated) Significant PLC performance and quality improvements
+  - (updated) Reduced amount of latency added for PLC strategy
+  - (updated) Merged PLC buffer strategies (3 is now identical to 4)
   - (updated) VS Mode help links go to support.jacktrip.com
   - (updated) VS Mode manage button goes to new studio dashboard
   - (fixed) PLC degradation when peer != local buffer sizes

--- a/meson.build
+++ b/meson.build
@@ -257,7 +257,7 @@ if get_option('default_library') == 'static'
 		deps += compiler.find_library('glib-2.0', required : true)
 		if qt_version == '6'
 			# we need a Q_IMPORT_LIBRARY for the openssl backend on linux
-			deps += compiler.find_library('qopensslbackend', required : true, dirs : [qt_plugindir])
+			deps += compiler.find_library('qopensslbackend', required : true, dirs : [qt_plugindir+'/tls'])
 			src += ['src/QtStaticPlugins.cpp']
 		endif
 	else

--- a/meson.build
+++ b/meson.build
@@ -238,28 +238,40 @@ else
 endif
 
 if get_option('default_library') == 'static'
+	# use qmake to get paths for qt libraries and plugins
+	# seems like qt module should have a method for this, but it doesn't
+	qmake = find_program('qmake', required: true)
+	qt_libdir = run_command(qmake, '-query', 'QT_INSTALL_LIBS').stdout().strip()
+	qt_plugindir = run_command(qmake, '-query', 'QT_INSTALL_PLUGINS').stdout().strip()
+	if qt_version == '6'
+		# qt6 requires "Bundled*" modules for linking
+		deps += dependency('qt6', modules: ['BundledLibpng', 'BundledPcre2', 'BundledHarfbuzz', 'BundledZLIB'], include_type: 'system')
+	else
+		deps += compiler.find_library('qtpcre2', required : true, dirs : [qt_libdir])
+	endif
 	if (host_machine.system() == 'linux')
+		# linux static
+		deps += compiler.find_library('ssl', required : true, dirs : [qt_libdir])
+		deps += compiler.find_library('crypto', required : true, dirs : [qt_libdir])
+		deps += compiler.find_library('dl', required : true)
+		deps += compiler.find_library('glib-2.0', required : true)
 		if qt_version == '6'
-			# BundledZLIB required on linux
-			deps += dependency('qt6', modules: ['BundledLibpng', 'BundledPcre2', 'BundledHarfbuzz', 'BundledZLIB'], include_type: 'system')
-			deps += compiler.find_library('ssl', required : true)
-			deps += compiler.find_library('crypto', required : true)
-			deps += compiler.find_library('dl', required : true)
-			deps += compiler.find_library('glib-2.0', required : true)
-			deps += compiler.find_library('qopensslbackend', required : true)
+			# we need a Q_IMPORT_LIBRARY for the openssl backend on linux
+			deps += compiler.find_library('qopensslbackend', required : true, dirs : [qt_plugindir])
 			src += ['src/QtStaticPlugins.cpp']
-		else
-			# -ldl required on linux
-			deps += compiler.find_library('qtpcre2', required : true)
-			deps += compiler.find_library('ssl', required : true)
-			deps += compiler.find_library('crypto', required : true)
-			deps += compiler.find_library('dl', required : true)
-			deps += compiler.find_library('glib-2.0', required : true)
 		endif
 	else
-		if qt_version == '6'
-			# BundledZLIB not found on windows or osx
-			deps += dependency('qt6', modules: ['BundledLibpng', 'BundledPcre2', 'BundledHarfbuzz'], include_type: 'system')
+		if (host_machine.system() == 'windows')
+			# windows static
+			deps += compiler.find_library('bcrypt', required : true)
+			deps += compiler.find_library('winmm', required : true)
+			deps += compiler.find_library('Crypt32', required : true)
+			if qt_version == '6'
+				deps += compiler.find_library('Authz', required : true)
+			endif
+		else
+			# mac static
+			# TODO
 		endif
 	endif
 endif

--- a/meson.build
+++ b/meson.build
@@ -241,8 +241,8 @@ if get_option('default_library') == 'static'
 	# use qmake to get paths for qt libraries and plugins
 	# seems like qt module should have a method for this, but it doesn't
 	qmake = find_program('qmake', required: true)
-	qt_libdir = run_command(qmake, '-query', 'QT_INSTALL_LIBS').stdout().strip()
-	qt_plugindir = run_command(qmake, '-query', 'QT_INSTALL_PLUGINS').stdout().strip()
+	qt_libdir = run_command(qmake, '-query', 'QT_INSTALL_LIBS', check : true).stdout().strip()
+	qt_plugindir = run_command(qmake, '-query', 'QT_INSTALL_PLUGINS', check : true).stdout().strip()
 	if qt_version == '6'
 		# qt6 requires "Bundled*" modules for linking
 		deps += dependency('qt6', modules: ['BundledLibpng', 'BundledPcre2', 'BundledHarfbuzz', 'BundledZLIB'], include_type: 'system')
@@ -271,7 +271,16 @@ if get_option('default_library') == 'static'
 			endif
 		else
 			# mac static
-			# TODO
+			# this approach fails for universal builds, so we have to just append to link_args
+			#deps += dependency('CoreServices', required : true)
+			link_args += ['-framework', 'CoreServices']
+			link_args += ['-framework', 'CFNetwork']
+			link_args += ['-framework', 'AppKit']
+			link_args += ['-framework', 'IOKit']
+			link_args += ['-framework', 'Security']
+			link_args += ['-framework', 'GSS']
+			link_args += ['-framework', 'SystemConfiguration']
+			deps += dependency('zlib', required : true)
 		endif
 	endif
 endif

--- a/src/gui/Recommendations.qml
+++ b/src/gui/Recommendations.qml
@@ -121,7 +121,7 @@ Item {
 
         AppIcon {
             id: ethernetRecommendationLogo
-            y: 120
+            y: 90
             anchors.horizontalCenter: parent.horizontalCenter
             width: 179
             height: 128
@@ -145,7 +145,7 @@ Item {
                 + "WiFi works OK for some people, but generates significantly more latency and audio glitches."
             font { family: "Poppins"; pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale }
             color: textColour
-            width: 560
+            width: 600
             wrapMode: Text.Wrap
             horizontalAlignment: Text.AlignHCenter
             anchors.horizontalCenter: parent.horizontalCenter
@@ -194,7 +194,7 @@ Item {
 
         AppIcon {
             id: fiberRecommendationLogo
-            y: 120
+            y: 90
             anchors.horizontalCenter: parent.horizontalCenter
             width: 179
             height: 128
@@ -218,7 +218,7 @@ Item {
                 + "It's OK to use JackTrip with Cable and DSL, but these types of Internet connections introduce significantly more latency."
             font { family: "Poppins"; pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale }
             color: textColour
-            width: 560
+            width: 600
             wrapMode: Text.Wrap
             horizontalAlignment: Text.AlignHCenter
             anchors.horizontalCenter: parent.horizontalCenter
@@ -267,7 +267,7 @@ Item {
 
         AppIcon {
             id: headphoneWarningLogo
-            y: 120
+            y: 90
             anchors.horizontalCenter: parent.horizontalCenter
             width: 118
             height: 128
@@ -293,7 +293,7 @@ Item {
                 + "Wireless and bluetooth headphones introduce higher latency."
             font { family: "Poppins"; pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale }
             color: textColour
-            width: 560
+            width: 600
             wrapMode: Text.Wrap
             horizontalAlignment: Text.AlignHCenter
             anchors.horizontalCenter: parent.horizontalCenter
@@ -337,7 +337,7 @@ Item {
 
         AppIcon {
             id: audioInterfaceRecommendationLogo
-            y: 120
+            y: 90
             anchors.horizontalCenter: parent.horizontalCenter
             width: 118
             height: 128
@@ -364,7 +364,7 @@ Item {
                 + "Thunderbolt audio interfaces will usually produce better quality and lower latency."
             font { family: "Poppins"; pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale }
             color: textColour
-            width: 560
+            width: 600
             wrapMode: Text.Wrap
             horizontalAlignment: Text.AlignHCenter
             anchors.horizontalCenter: parent.horizontalCenter
@@ -388,14 +388,13 @@ Item {
             visible: onWindows
             text: "Your audio device controls the quality of sound, and can also have a big impact on latency."
                 + "<br/><br/>"
-                + "Additionally, low latency on Windows requires the use of ASIO drivers. "
-                + "Beware that using ASIO drivers which are not made specifically for your device can cause crashes."
+                + "ASIO drivers are required for low latency on Windows. "
                 + "<br/><br/>"
                 + "It's OK to use the audio device that is built into your computer, but external USB and "
-                + "Thunderbolt audio interfaces that provide ASIO drivers will produce better quality and much lower latency."
+                + "Thunderbolt devices will produce better quality and much lower latency."
             font { family: "Poppins"; pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale }
             color: textColour
-            width: 560
+            width: 600
             wrapMode: Text.Wrap
             horizontalAlignment: Text.AlignHCenter
             anchors.horizontalCenter: parent.horizontalCenter
@@ -461,7 +460,7 @@ Item {
             text: "Would you like to review the getting started recommendations again the next time you start JackTrip?"
             font { family: "Poppins"; pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale }
             color: textColour
-            width: 560
+            width: 600
             wrapMode: Text.Wrap
             horizontalAlignment: Text.AlignHCenter
             anchors.horizontalCenter: parent.horizontalCenter
@@ -554,7 +553,7 @@ Item {
             text: "You can change this setting at any time under <b>Settings > Advanced</b>"
             font { family: "Poppins"; pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale }
             color: textColour
-            width: 560
+            width: 600
             wrapMode: Text.Wrap
             horizontalAlignment: Text.AlignHCenter
             anchors.horizontalCenter: parent.horizontalCenter

--- a/src/gui/qjacktrip.ui
+++ b/src/gui/qjacktrip.ui
@@ -1398,22 +1398,22 @@ for better quality at the expense of latency.</string>
           </property>
           <item>
            <property name="text">
-            <string>1</string>
+            <string>1 (adaptable latency)</string>
            </property>
           </item>
           <item>
            <property name="text">
-            <string>2</string>
+            <string>2 (stable latency)</string>
            </property>
           </item>
           <item>
            <property name="text">
-            <string>3 (experimental - in own thread) </string>
+            <string>3 (loss concealment)</string>
            </property>
           </item>
           <item>
            <property name="text">
-            <string>4 (experimental - in callback)</string>
+            <string>4 (same as 3)</string>
            </property>
           </item>
          </widget>

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -40,7 +40,7 @@
 
 #include "AudioInterface.h"
 
-constexpr const char* const gVersion = "2.3.0-beta1";  ///< JackTrip version
+constexpr const char* const gVersion = "2.3.0-beta2";  ///< JackTrip version
 
 //*******************************************************************************
 /// \name Default Values


### PR DESCRIPTION
Updating qt 6.2.6 to 6.2.8 for OSX builds

Added support for static builds of jacktrip using meson across all platforms

Now using qt 5.15.13 to create static "nogui" (CLI) release packages across all platforms, built using meson

Update buffer strategy options in classic mode for PLC buffer strategy consolidation

Various tweaks to vs mode recommendations screens

Updated changelog and bumped version for 2.3.0-beta2 release