### PR TITLE
Start P2P server on system without IPv6 support

### DIFF
--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -1582,8 +1582,9 @@ bool JackTrip::checkIfPortIsBinded(int port)
     std::map<std::string, QHostAddress::SpecialAddress>::iterator it;
     for (it = interfaces.begin(); it != interfaces.end(); it++) {
         bool binded = UdpSockTemp.bind(it->second, port, QUdpSocket::DontShareAddress);
+        QUdpSocket::SocketError err = UdpSockTemp.error();
         UdpSockTemp.close();
-        if (!binded) {
+        if (!binded && err != QUdpSocket::UnsupportedSocketOperationError) {
             return true;
         }
     }

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -1582,11 +1582,10 @@ bool JackTrip::checkIfPortIsBinded(int port)
     std::map<std::string, QHostAddress::SpecialAddress>::iterator it;
     for (it = interfaces.begin(); it != interfaces.end(); it++) {
         bool binded = UdpSockTemp.bind(it->second, port, QUdpSocket::DontShareAddress);
+        UdpSockTemp.close();
         if (!binded) {
-            UdpSockTemp.close();  // close the socket
             return true;
         }
-        UdpSockTemp.close();
     }
     return false;
 }


### PR DESCRIPTION
When I start jacktrip in P2P server mode on a Linux system without IPv6 support, jacktrip exits without any apparent error:
```
# jacktrip -s -V
Verbose mode
Settings:startJackTrip before new JackTrip
Settings:startJackTrip before mJackTrip->startProcess
step 1
  JackTrip:startProcess before checkIfPortIsBinded(mReceiverBindPort)
Stopping JackTrip...
JackTrip Processes STOPPED!
---------------------------------------------------------
step 6
jmain before app->exec()
```

The reason is that `JackTrip::checkIfPortIsBinded` tries to bind the UDP port for IPv4 and IPv6. It fails for IPv6, because the Linux system has no `ipv6` module loaded.

This patch adds a check for `UnsupportedOperation` errors into that method, so that failures to bind to an IPv6 port is ignored.

P.S.: That I don't see the proper "Could not bind ... UDP socket..." error message is another problem that I will open a separate issue for.