### PR TITLE
Improve error logging for cli application

### DIFF
--- a/src/UdpHubListener.cpp
+++ b/src/UdpHubListener.cpp
@@ -147,7 +147,6 @@ void UdpHubListener::start()
         QString error_message = QStringLiteral("TCP Socket Server on Port %1 ERROR: %2")
                                     .arg(mServerPort)
                                     .arg(mTcpServer.errorString());
-        std::cerr << error_message.toStdString() << endl;
         emit signalError(error_message);
         return;
     }
@@ -215,7 +214,6 @@ void UdpHubListener::start()
         }
 
         if (error) {
-            std::cerr << "ERROR: " << error_message.toStdString() << endl;
             emit signalError(error_message);
             return;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -467,12 +467,15 @@ int main(int argc, char* argv[])
     } else {
 #endif  // NO_GUI
         // Otherwise use the non-GUI version, and parse our command line.
-#ifndef PSI
-        QLoggingCategory::setFilterRules(QStringLiteral("*.debug=true"));
-#endif
         try {
             Settings settings;
             settings.parseInput(argc, argv);
+
+#ifndef PSI
+            if (gVerboseFlag) {
+                QLoggingCategory::setFilterRules(QStringLiteral("*.debug=true"));
+            }
+#endif
 
             // Either start our hub server or our jacktrip process as appropriate.
             if (settings.isHubServer()) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -216,6 +216,11 @@ void qtMessageHandler([[maybe_unused]] QtMsgType type,
 #endif  // NO_GUI
 }
 
+void outputError(const QString& msg)
+{
+    std::cerr << "Error: " << msg.toStdString() << std::endl;
+}
+
 #ifndef _WIN32
 static int setupUnixSignalHandler(void (*handler)(int))
 {
@@ -478,6 +483,7 @@ int main(int argc, char* argv[])
                 QObject::connect(udpHub.data(), &UdpHubListener::signalStopped,
                                  app.data(), &QCoreApplication::quit,
                                  Qt::QueuedConnection);
+                QObject::connect(udpHub.data(), &UdpHubListener::signalError, outputError);
                 QObject::connect(udpHub.data(), &UdpHubListener::signalError, app.data(),
                                  &QCoreApplication::quit, Qt::QueuedConnection);
 #ifndef _WIN32
@@ -495,6 +501,7 @@ int main(int argc, char* argv[])
                 QObject::connect(jackTrip.data(), &JackTrip::signalProcessesStopped,
                                  app.data(), &QCoreApplication::quit,
                                  Qt::QueuedConnection);
+                QObject::connect(jackTrip.data(), &JackTrip::signalError, outputError);
                 QObject::connect(jackTrip.data(), &JackTrip::signalError, app.data(),
                                  &QCoreApplication::quit, Qt::QueuedConnection);
 #ifndef _WIN32


### PR DESCRIPTION
This PR is a proposed fix for #1301. It introduces a signal handler that ouputs errors from `JackTrip::signalError` and `UdpHupListener::signalError` to stderr.

It also modifies the "*.debug=true" QLoggingCategory filterRule to only take effect if verbose output has been requested. (Which fixes my problem in #1302).
