### PR TITLE
Check UDP packet size

### DIFF
--- a/src/UdpDataProtocol.cpp
+++ b/src/UdpDataProtocol.cpp
@@ -497,13 +497,11 @@ void UdpDataProtocol::run()
     int full_redundant_packet_size = full_packet_size * mUdpRedundancyFactor;
     int8_t* full_redundant_packet  = NULL;
 
-    if (full_redundant_packet_size > 0x10000)
-    {
+    if (full_redundant_packet_size > 0x10000) {
         throw std::runtime_error(
             "Maximum UDP packet size exceed! Either reduce your "
             "Jack period size, the number of send channels or "
-            "the packet redundancy."
-        );
+            "the packet redundancy.");
     }
 
     // Set realtime priority (function in jacktrip_globals.h)

--- a/src/UdpDataProtocol.cpp
+++ b/src/UdpDataProtocol.cpp
@@ -497,6 +497,15 @@ void UdpDataProtocol::run()
     int full_redundant_packet_size = full_packet_size * mUdpRedundancyFactor;
     int8_t* full_redundant_packet  = NULL;
 
+    if (full_redundant_packet_size > 0x10000)
+    {
+        throw std::runtime_error(
+            "Maximum UDP packet size exceed! Either reduce your "
+            "Jack period size, the number of send channels or "
+            "the packet redundancy."
+        );
+    }
+
     // Set realtime priority (function in jacktrip_globals.h)
     if (gVerboseFlag)
         std::cout << "    UdpDataProtocol:run" << mRunMode

--- a/src/UdpDataProtocol.cpp
+++ b/src/UdpDataProtocol.cpp
@@ -499,7 +499,7 @@ void UdpDataProtocol::run()
 
     if (full_redundant_packet_size > 0x10000) {
         throw std::runtime_error(
-            "Maximum UDP packet size exceed! Either reduce your "
+            "Maximum UDP packet size exceeded! Either reduce your "
             "Jack period size, the number of send channels or "
             "the packet redundancy.");
     }


### PR DESCRIPTION
This is a proposed fix for #1310. It checks that the UDP packet size would not exceeded the 2^16 limit.