### PR TITLE
Make stronger recommendations about audio devices

### DIFF
--- a/macos/meson_native_minversion_11.ini
+++ b/macos/meson_native_minversion_11.ini
@@ -1,0 +1,10 @@
+[constants]
+minversion_args = ['-mmacosx-version-min=11']
+
+[built-in options]
+c_args = minversion_args
+cpp_args = minversion_args
+objcpp_args = minversion_args
+c_link_args = minversion_args
+cpp_link_args = minversion_args
+objcpp_link_args = minversion_args

--- a/macos/meson_native_universal_11.ini
+++ b/macos/meson_native_universal_11.ini
@@ -1,0 +1,11 @@
+[constants]
+minversion_args = ['-mmacosx-version-min=11']
+universal_args = ['-arch', 'x86_64', '-arch', 'arm64']
+
+[built-in options]
+c_args = universal_args + minversion_args
+cpp_args = universal_args + minversion_args
+objcpp_args = universal_args + minversion_args
+c_link_args = universal_args + minversion_args
+cpp_link_args = universal_args + minversion_args
+objcpp_link_args = universal_args + minversion_args

--- a/src/gui/Recommendations.qml
+++ b/src/gui/Recommendations.qml
@@ -347,7 +347,7 @@ Item {
         Text {
             id: audioInterfaceRecommendationHeaderNonWindows
             visible: !onWindows
-            text: "External Audio Device Recommended"
+            text: "Use Recommended Audio Devices"
             font { family: "Poppins"; weight: Font.Bold; pixelSize: fontMedium * virtualstudio.fontScale * virtualstudio.uiScale }
             color: textColour
             anchors.horizontalCenter: parent.horizontalCenter
@@ -358,10 +358,10 @@ Item {
         Text {
             id: audioInterfaceRecommendationSubheaderNonWindows
             visible: !onWindows
-            text: "Your audio device controls the quality of sound, and can also have a big impact on latency."
+            text: "Many audio devices are too slow to work well with JackTrip."
                 + "<br/><br/>"
-                + "It's OK to use the audio device that is built into your computer, but external USB and "
-                + "Thunderbolt audio interfaces will usually produce better quality and lower latency."
+                + "We recommend external USB or Thunderbolt interfaces released within the past "
+                + "few years for the best quality, low latency and glitch-free sound."
             font { family: "Poppins"; pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale }
             color: textColour
             width: 600
@@ -375,7 +375,7 @@ Item {
         Text {
             id: audioInterfaceRecommendationHeaderWindows
             visible: onWindows
-            text: "External Audio Device Recommended"
+            text: "Use Recommended Audio Devices"
             font { family: "Poppins"; weight: Font.Bold; pixelSize: fontMedium * virtualstudio.fontScale * virtualstudio.uiScale }
             color: textColour
             anchors.horizontalCenter: parent.horizontalCenter
@@ -386,12 +386,12 @@ Item {
         Text {
             id: audioInterfaceRecommendationSubheaderWindows
             visible: onWindows
-            text: "Your audio device controls the quality of sound, and can also have a big impact on latency."
-                + "<br/><br/>"
+            text: "Many audio devices are too slow to work well with JackTrip."
+                + "<br/>"
                 + "ASIO drivers are required for low latency on Windows. "
                 + "<br/><br/>"
-                + "It's OK to use the audio device that is built into your computer, but external USB and "
-                + "Thunderbolt devices will produce better quality and much lower latency."
+                + "We recommend external USB or Thunderbolt interfaces released within the past "
+                + "few years for the best quality, low latency and glitch-free sound."
             font { family: "Poppins"; pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale }
             color: textColour
             width: 600


### PR DESCRIPTION
As we grow, we've seen people trying to use lots of audio devices that are old and/or very poor quality. This causes lots of audio problems that are hard to diagnose and understand. Making stronger recommendations about devices that we have properly vetted will lead to more successful outcomes.

Also adding native files for OSX 11, which is required by Qt 6.5 and later.

Windows has extra message about ASIO
<img width="799" alt="Screenshot 2024-07-26 at 8 50 02 AM" src="https://github.com/user-attachments/assets/9194c1e3-11e1-4b16-9eda-947931449c69">

Other platforms
<img width="798" alt="Screenshot 2024-07-26 at 8 50 57 AM" src="https://github.com/user-attachments/assets/b903bbdb-ac61-4569-8dc7-3d6e153f860e">
