### PR TITLE
Reverting OSX update to use Qt 6.2.8

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -148,7 +148,8 @@ jobs:
             installer-path: installer
             build-system: meson
             meson-library-type: both
-            qt-version: '6.2.8'
+            qt-version: '6.2.6'
+            qt-download-commit: 'b09fbe4'
             qt-type: 'dynamic'
             macosx-architectures: 'x86_64;arm64'
             macosx-deployment-target: 10.14

--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -1,3 +1,9 @@
+- Version: "2.3.1"
+  Date: 2024-07-26
+  Description:
+  - (updated) VS Mode stronger recommendations for audio devices
+  - (updated) Reverting OSX builds from Qt 6.2.8 back to 6.2.6
+  - (fixed) Screen sharing on OSX freezes when window is hidden
 - Version: "2.3.0"
   Date: 2024-05-15
   Description:

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -40,7 +40,7 @@
 
 #include "AudioInterface.h"
 
-constexpr const char* const gVersion = "2.3.0";  ///< JackTrip version
+constexpr const char* const gVersion = "2.3.1";  ///< JackTrip version
 
 //*******************************************************************************
 /// \name Default Values


### PR DESCRIPTION
Qt 6.2.7 introduced a regression bug in WebEngine that breaks screen sharing. In particular, screen sharing freezes whenever the application window is completely hidden. Unfortunately, none of the latest Qt releases seem to have fixed this yet.

Bumping version to 2.3.1 and updating changelog for release