### PR TITLE
Ignore devices that look like iPhone microphone

### DIFF
--- a/src/vs/vsAudio.cpp
+++ b/src/vs/vsAudio.cpp
@@ -1113,7 +1113,9 @@ void VsAudioWorker::getDeviceList(const QVector<RtAudioDevice>& devices,
         }
 
         // Skip blacklisted devices
-        if (blacklisted_devices.contains(deviceName)) {
+        const bool iPhoneMic = deviceName.startsWith("Apple Inc.:")
+                               && deviceName.endsWith("Phone Microphone");
+        if (blacklisted_devices.contains(deviceName) || iPhoneMic) {
             std::cout << "RTAudio: blacklisted " << (isInput ? "input" : "output")
                       << " device: " << devices[n].name << std::endl;
             continue;


### PR DESCRIPTION
I thought that we may just be able to add a warning to discourage it, but after implementing and trying it out, it's clearly not enough. Bad things happen when you select iphone microphone that go far beyond latency and audio quality.

See https://discussions.apple.com/thread/254349417?sortBy=rank