### PR TITLE
Skip create studio button if you are member of 0 studios

### DIFF
--- a/src/vs/Browse.qml
+++ b/src/vs/Browse.qml
@@ -96,13 +96,13 @@ Item {
         SectionHeading {
             id: emptyListSectionHeading
             listIsEmpty: true
-            visible: parent.count == 0 && !virtualstudio.showCreateStudio
+            visible: parent.count == 0
         }
 
         Text {
             id: emptyListMessage
-            visible: parent.count == 0 && !virtualstudio.showCreateStudio
-            text: "No studios found that match your filter criteria."
+            visible: parent.count == 0
+            text: virtualstudio.isRefreshingStudios ? "Loading Studios..." : "No studios found that match your filter criteria."
             font { family: "Poppins"; pixelSize: fontMedium * virtualstudio.fontScale * virtualstudio.uiScale }
             color: textColour
             width: emptyListMessageWidth
@@ -120,9 +120,9 @@ Item {
                 border.width: 1
                 border.color: resetFiltersButton.down ? buttonPressedStroke : (resetFiltersButton.hovered ? buttonHoverStroke : buttonStroke)
             }
-            visible: parent.count == 0 && !virtualstudio.showCreateStudio
+            visible: parent.count == 0
             onClicked: {
-                virtualstudio.showSelfHosted = false;
+                virtualstudio.showSelfHosted = true;
                 virtualstudio.showInactive = true;
                 refreshing = true;
                 refresh();
@@ -136,71 +136,6 @@ Item {
                 font { family: "Poppins"; pixelSize: fontMedium * virtualstudio.fontScale * virtualstudio.uiScale }
                 anchors {horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter }
                 color: textColour
-            }
-        }
-
-        Rectangle {
-            id: newUserEmptyList
-            anchors.fill: parent
-            color: "transparent"
-            visible: parent.count == 0 && virtualstudio.showCreateStudio
-
-            Rectangle {
-                color: "transparent"
-                width: emptyListMessageWidth
-                height: createButton.height + createStudioMessage.height + welcomeMessage.height + createButtonTopMargin + createMessageTopMargin
-                anchors.horizontalCenter: parent.horizontalCenter
-                anchors.verticalCenter: parent.verticalCenter
-
-                Text {
-                    id: welcomeMessage
-                    text: "Welcome"
-                    font { family: "Poppins"; pixelSize: fontBig * virtualstudio.fontScale * virtualstudio.uiScale; weight: Font.Bold }
-                    color: textColour
-                    width: emptyListMessageWidth
-                    wrapMode: Text.Wrap
-                    horizontalAlignment: Text.AlignHCenter
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    anchors.top: parent.top
-                }
-
-                Text {
-                    id: createStudioMessage
-                    text: "Looks like you're not a member of any studios!\nHave the studio owner send you an invite link, or create your own studio to invite others."
-                    font { family: "Poppins"; pixelSize: fontMedium * virtualstudio.fontScale * virtualstudio.uiScale }
-                    color: textColour
-                    width: emptyListMessageWidth
-                    wrapMode: Text.Wrap
-                    horizontalAlignment: Text.AlignHCenter
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    anchors.top: welcomeMessage.bottom
-                    anchors.topMargin: createMessageTopMargin
-                }
-
-                Button {
-                    id: createButton
-                    background: Rectangle {
-                        radius: 6 * virtualstudio.uiScale
-                        color: createButton.down ? "#E7E8E8" : "#F2F3F3"
-                        border.width: 1
-                        border.color: createButton.down ? "#B0B5B5" : createButtonStroke
-                        layer.enabled: createButton.hovered && !createButton.down
-                    }
-                    onClicked: { virtualstudio.createStudio(); }
-                    anchors.top: createStudioMessage.bottom
-                    anchors.topMargin: createButtonTopMargin
-                    anchors.horizontalCenter: createStudioMessage.horizontalCenter
-                    width: 210 * virtualstudio.uiScale; height: 45 * virtualstudio.uiScale
-                    Text {
-                        text: "Create a Studio"
-                        font.family: "Poppins"
-                        font.pixelSize: 18 * virtualstudio.fontScale * virtualstudio.uiScale
-                        font.weight: Font.Bold
-                        color: "#000000"
-                        anchors.horizontalCenter: parent.horizontalCenter
-                        anchors.verticalCenter: parent.verticalCenter
-                    }
-                }
             }
         }
 

--- a/src/vs/CreateStudio.qml
+++ b/src/vs/CreateStudio.qml
@@ -87,6 +87,7 @@ Item {
         RowLayout {
             id: layout
             anchors.fill: parent
+            visible: virtualstudio.serverModel.length > 0
 
             Item {
                 Layout.fillHeight: true

--- a/src/vs/SectionHeading.qml
+++ b/src/vs/SectionHeading.qml
@@ -32,7 +32,7 @@ Rectangle {
           border.color: createButton.down ? "#B0B5B5" : "#EAEBEB"
           layer.enabled: createButton.hovered && !createButton.down
       }
-      onClicked: { virtualstudio.createStudio(); }
+      onClicked: { virtualstudio.windowState = "create_studio"; }
       anchors.right: filterButton.left
       anchors.rightMargin: 16
       anchors.verticalCenter: sectionText.verticalCenter

--- a/src/vs/virtualstudio.h
+++ b/src/vs/virtualstudio.h
@@ -91,8 +91,6 @@ class VirtualStudio : public QObject
                    showInactiveChanged)
     Q_PROPERTY(bool showSelfHosted READ showSelfHosted WRITE setShowSelfHosted NOTIFY
                    showSelfHostedChanged)
-    Q_PROPERTY(bool showCreateStudio READ showCreateStudio WRITE setShowCreateStudio
-                   NOTIFY showCreateStudioChanged)
     Q_PROPERTY(QString connectionState READ connectionState NOTIFY connectionStateChanged)
     Q_PROPERTY(QJsonObject networkStats READ networkStats NOTIFY networkStatsChanged)
     Q_PROPERTY(bool networkOutage READ networkOutage NOTIFY updatedNetworkOutage)
@@ -110,6 +108,8 @@ class VirtualStudio : public QObject
     Q_PROPERTY(bool showWarnings READ showWarnings WRITE setShowWarnings NOTIFY
                    showWarningsChanged)
     Q_PROPERTY(bool isExiting READ isExiting NOTIFY isExitingChanged)
+    Q_PROPERTY(bool isRefreshingStudios READ isRefreshingStudios NOTIFY
+                   isRefreshingStudiosChanged)
     Q_PROPERTY(bool noUpdater READ noUpdater CONSTANT)
     Q_PROPERTY(bool psiBuild READ psiBuild CONSTANT)
     Q_PROPERTY(QString failedMessage READ failedMessage NOTIFY failedMessageChanged)
@@ -149,8 +149,6 @@ class VirtualStudio : public QObject
     void setShowInactive(bool inactive);
     bool showSelfHosted();
     void setShowSelfHosted(bool selfHosted);
-    bool showCreateStudio();
-    void setShowCreateStudio(bool createStudio);
     float fontScale();
     float uiScale();
     void setUiScale(float scale);
@@ -177,6 +175,7 @@ class VirtualStudio : public QObject
     bool vsFtux();
     bool hasClassicMode();
     bool isExiting();
+    bool isRefreshingStudios();
 
     static QApplication* createApplication(int& argc, char* argv[]);
 
@@ -194,7 +193,6 @@ class VirtualStudio : public QObject
     void loadSettings();
     void saveSettings();
     void triggerReconnect(bool refresh);
-    void createStudio();
     void editProfile();
     void showAbout();
     void openLink(const QString& url);
@@ -220,7 +218,6 @@ class VirtualStudio : public QObject
     void userMetadataChanged();
     void showInactiveChanged();
     void showSelfHostedChanged();
-    void showCreateStudioChanged();
     void connectionStateChanged();
     void networkStatsChanged();
     void updateChannelChanged();
@@ -238,6 +235,7 @@ class VirtualStudio : public QObject
     void updatedNetworkOutage(bool outage);
     void windowStateUpdated();
     void isExitingChanged();
+    void isRefreshingStudiosChanged();
     void apiHostChanged();
     void feedbackDetected();
     void openFeedbackSurveyModal(QString serverId);
@@ -257,9 +255,8 @@ class VirtualStudio : public QObject
 
    private:
     void resetState();
-    void getServerList(bool signalRefresh = false, int index = -1);
+    void handleServerUpdate(QNetworkReply* reply, bool signalRefresh, int index);
     bool filterStudio(const VsServerInfo& serverInfo) const;
-    void getSubscriptions();
     void getRegions();
     void getUserMetadata();
     bool readyToJoin();
@@ -310,8 +307,7 @@ class VirtualStudio : public QObject
     bool m_onConnectedScreen      = false;
     bool m_isExiting              = false;
     bool m_showInactive           = true;
-    bool m_showSelfHosted         = false;
-    bool m_showCreateStudio       = false;
+    bool m_showSelfHosted         = true;
     bool m_showDeviceSetup        = true;
     bool m_showWarnings           = true;
     bool m_darkMode               = false;


### PR DESCRIPTION
No reason to require an extra button click during the getting started process. About 30% of new users are dropping off on this, likely because we show them too many other things to do before creating their first studio.

Merging getServerList() and getSubscriptions() into refreshStudios() and updating getUserMetadata() to call refreshStudios() after it gets user meta data. We had a bug where we were sending all these requests asynchronously and:

* getServerList relied on the results of getSubscriptions
* getSubscriptions relied on the results of getUserMetadata

If they didn't all finish in the desired order, bad things would happen. This ensures that they all run in order to properly enforce their dependencies.

Don't show message that you have no studios when it's loading.

Default filters to include unmanaged studios (update terminology).

Filter out public studios that are inactive.