### PR TITLE
Getting rid of the 5-second studio refresh timer

### DIFF
--- a/src/vs/Browse.qml
+++ b/src/vs/Browse.qml
@@ -10,8 +10,6 @@ Item {
         color: backgroundColour
     }
 
-    property bool refreshing: false
-
     property int buttonHeight: 25
     property int buttonWidth: 103
     property int extraSettingsButtonWidth: 16
@@ -40,19 +38,6 @@ Item {
             currentIndex = studioListView.indexAt(16 * virtualstudio.uiScale, studioListView.contentY + (16 * virtualstudio.uiScale));
         }
         virtualstudio.refreshStudios(currentIndex, true)
-    }
-
-    Rectangle {
-        z: 1
-        width: parent.width; height: parent.height
-        color: "#40000000"
-        visible: refreshing
-        MouseArea {
-            anchors.fill: parent
-            propagateComposedEvents: false
-            hoverEnabled: true
-            preventStealing: true
-        }
     }
 
     Component {
@@ -102,7 +87,7 @@ Item {
         Text {
             id: emptyListMessage
             visible: parent.count == 0
-            text: virtualstudio.isRefreshingStudios ? "Loading Studios..." : "No studios found that match your filter criteria."
+            text: virtualstudio.refreshInProgress ? "Loading Studios..." : "No studios found that match your filter criteria."
             font { family: "Poppins"; pixelSize: fontMedium * virtualstudio.fontScale * virtualstudio.uiScale }
             color: textColour
             width: emptyListMessageWidth
@@ -124,7 +109,6 @@ Item {
             onClicked: {
                 virtualstudio.showSelfHosted = true;
                 virtualstudio.showInactive = true;
-                refreshing = true;
                 refresh();
             }
             anchors.top: emptyListMessage.bottom
@@ -178,7 +162,7 @@ Item {
                 border.width: 1
                 border.color: refreshButton.down ? buttonPressedStroke : (refreshButton.hovered ? buttonHoverStroke : buttonStroke)
             }
-            onClicked: { refreshing = true; refresh() }
+            onClicked: { refresh() }
             anchors.verticalCenter: parent.verticalCenter
             x: 16 * virtualstudio.uiScale
             width: buttonWidth * virtualstudio.uiScale; height: buttonHeight * virtualstudio.uiScale
@@ -254,13 +238,11 @@ Item {
             scrollY = studioListView.contentY;
         }
         function onRefreshFinished(index) {
-            refreshing = false;
             if (index == -1) {
                 studioListView.contentY = scrollY
             } else {
                 studioListView.positionViewAtIndex(index, ListView.Beginning);
             }
         }
-        function onPeriodicRefresh() { refresh() }
     }
 }

--- a/src/vs/virtualstudio.h
+++ b/src/vs/virtualstudio.h
@@ -108,8 +108,8 @@ class VirtualStudio : public QObject
     Q_PROPERTY(bool showWarnings READ showWarnings WRITE setShowWarnings NOTIFY
                    showWarningsChanged)
     Q_PROPERTY(bool isExiting READ isExiting NOTIFY isExitingChanged)
-    Q_PROPERTY(bool isRefreshingStudios READ isRefreshingStudios NOTIFY
-                   isRefreshingStudiosChanged)
+    Q_PROPERTY(
+        bool refreshInProgress READ refreshInProgress NOTIFY refreshInProgressChanged)
     Q_PROPERTY(bool noUpdater READ noUpdater CONSTANT)
     Q_PROPERTY(bool psiBuild READ psiBuild CONSTANT)
     Q_PROPERTY(QString failedMessage READ failedMessage NOTIFY failedMessageChanged)
@@ -175,7 +175,8 @@ class VirtualStudio : public QObject
     bool vsFtux();
     bool hasClassicMode();
     bool isExiting();
-    bool isRefreshingStudios();
+    bool refreshInProgress();
+    void setRefreshInProgress(bool b);
 
     static QApplication* createApplication(int& argc, char* argv[]);
 
@@ -229,13 +230,13 @@ class VirtualStudio : public QObject
     void darkModeChanged();
     void testModeChanged();
     void signalExit();
-    void periodicRefresh();
     void failedMessageChanged();
     void studioToJoinChanged();
     void updatedNetworkOutage(bool outage);
     void windowStateUpdated();
     void isExitingChanged();
-    void isRefreshingStudiosChanged();
+    void scheduleStudioRefresh(int index, bool signalRefresh);
+    void refreshInProgressChanged();
     void apiHostChanged();
     void feedbackDetected();
     void openFeedbackSurveyModal(QString serverId);
@@ -289,7 +290,6 @@ class VirtualStudio : public QObject
     QJsonObject m_userMetadata;
     QJsonObject m_networkStats;
     QTimer m_startTimer;
-    QTimer m_refreshTimer;
     QTimer m_heartbeatTimer;
     QTimer m_networkOutageTimer;
     QMutex m_refreshMutex;


### PR DESCRIPTION
It makes for a poor user experience when the list keeps jumping around, and we already have a button to manually perform a refresh (in which case it isn't so annoying).

Before it not only would refresh when not desired, it failed to refresh when you wanted it to (or you had to wait for it, which made things confusing with status changes). Now it should ensure a refresh happens immediately, whenever you navigate to the "browse" window.