### PR TITLE
PLC auto headroom tweaks to improve audio quality

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -3,11 +3,13 @@
   Description:
   - (addded) VS Mode warning when speakers selected for output
   - (addded) VS Mode dialog when connecting with audio warning
+  - (updated) PLC auto headroom tweaks to improve audio quality
   - (updated) MIT license for VS mode interface and integration
   - (updated) Removed classic mode from JackTrip Labs builds
   - (updated) ASIO is now only enabled for JackTrip Labs builds
   - (updated) VS Mode removed button click to create first studio
-  - (updated) VS Mode updated to new link to edit user profile
+  - (updated) VS Mode updated to use new studio creation interface
+  - (updated) VS Mode updated to use new user profile interface
   - (updated) VS Mode changed red text color for buttons to black
   - (updated) VS Mode improved error handling for login screen
   - (updated) VS Mode improved messaging while loading studios

--- a/src/vs/vsDevice.cpp
+++ b/src/vs/vsDevice.cpp
@@ -306,6 +306,8 @@ JackTrip* VsDevice::initJackTrip(
     m_jackTrip->setRemoteClientName(m_appID);
     m_jackTrip->setBufferStrategy(bufferStrategy);
     m_jackTrip->setBufferQueueLength(-500);  // use -q auto
+    m_jackTrip->setUseRtUdpPriority(
+        true);  // rt udp priority reduces glitches on desktops
     m_jackTrip->setPeerAddress(studioInfo->host());
     m_jackTrip->setPeerPorts(studioInfo->port());
     m_jackTrip->setPeerHandshakePort(studioInfo->port());


### PR DESCRIPTION
Allow use of most recent packet arrived if it's the best option

Lower skipped packet threshold for increasing headroom from 2% to 1%

Only require two seconds in a row for the skipped packet threshold to be broken if current tolerance is less than packet duration * 2

Use realtime threads for UDP packet processing. I discovered this does help reduce glitches, at least on my MacBook. If the threads don't have high priority, any kind of meaningful CPU activity will cause a material delay on the arrival of packets.