### PR TITLE
add 100ms sleep to Patcher::registerClient to fix timing race with JACK

### DIFF
--- a/src/Patcher.cpp
+++ b/src/Patcher.cpp
@@ -60,6 +60,13 @@ void Patcher::registerClient(const QString& clientName)
 {
     QMutexLocker locker(&m_connectionMutex);
 
+    // this works around a JACK timing bug found under pipewire
+    // if registerClient is called for a second (or subsequent) hub client
+    // jack_client won't have properly updated its ports
+    // the workaround is to sleep here and let JACK update
+    if (m_jackClient)
+        QThread::msleep(100);
+
     // If our jack client isn't running, start it.
     if (!m_jackClient) {
         m_jackClient = jack_client_open("jthubpatcher", JackNoStartServer, &m_status);


### PR DESCRIPTION
add 100ms sleep to Patcher::registerClient to fix timing race with JACK
this fixes a problem under pipewire
the issue affected hub patching, for example, a server with hub patch modes -p1, -p2 or -p4
when a second (or subsequent) hub client connected, its ports were not yet listed in jack_get_ports
100ms sleep does the trick, maybe it can be even less