### PR TITLE
Replacing buffer strategy with new PLC settings in VS mode

### DIFF
--- a/src/vs/virtualstudio.cpp
+++ b/src/vs/virtualstudio.cpp
@@ -970,18 +970,11 @@ void VirtualStudio::completeConnection()
         }
 #endif
 
-        // increment buffer_strategy by 1 for array-index mapping
-        int buffer_strategy = m_audioConfigPtr->getBufferStrategy() + 1;
-        // adjust buffer_strategy for PLC "auto" mode menu item
-        if (buffer_strategy == 4 || buffer_strategy == 5) {
-            buffer_strategy = 3;
-        }
-
         // create a new JackTrip instance
         JackTrip* jackTrip = m_devicePtr->initJackTrip(
             useRtAudio, input, output, baseInputChannel, numInputChannels,
             baseOutputChannel, numOutputChannels, inputMixMode, buffer_size,
-            buffer_strategy, &m_currentStudio);
+            m_audioConfigPtr->getQueueBuffer(), &m_currentStudio);
         if (jackTrip == 0) {
             processError("Could not bind port");
             return;

--- a/src/vs/vsAudio.cpp
+++ b/src/vs/vsAudio.cpp
@@ -279,12 +279,12 @@ void VsAudio::setBufferSize(int bufSize)
     emit bufferSizeChanged();
 }
 
-void VsAudio::setBufferStrategy(int bufStrategy)
+void VsAudio::setQueueBuffer(int queueBuffer)
 {
-    if (m_bufferStrategy == bufStrategy)
+    if (m_queueBuffer == queueBuffer)
         return;
-    m_bufferStrategy = bufStrategy;
-    emit bufferStrategyChanged();
+    m_queueBuffer = queueBuffer;
+    emit queueBufferChanged();
 }
 
 void VsAudio::setNumInputChannels(int numChannels)
@@ -540,10 +540,7 @@ void VsAudio::loadSettings()
     }
 
     setBufferSize(settings.value(QStringLiteral("BufferSize"), 128).toInt());
-    int buffer_strategy = settings.value(QStringLiteral("BufferStrategy"), 2).toInt();
-    if (buffer_strategy == 3 || buffer_strategy == 4)
-        buffer_strategy = 2;
-    setBufferStrategy(buffer_strategy);
+    setQueueBuffer(settings.value(QStringLiteral("QueueBuffer"), -500).toInt());
     setFeedbackDetectionEnabled(
         settings.value(QStringLiteral("FeedbackDetectionEnabled"), true).toBool());
     settings.endGroup();
@@ -566,7 +563,7 @@ void VsAudio::saveSettings()
     settings.setValue(QStringLiteral("BaseOutputChannel"), m_baseOutputChannel);
     settings.setValue(QStringLiteral("NumOutputChannels"), m_numOutputChannels);
     settings.setValue(QStringLiteral("BufferSize"), m_audioBufferSize);
-    settings.setValue(QStringLiteral("BufferStrategy"), m_bufferStrategy);
+    settings.setValue(QStringLiteral("QueueBuffer"), m_queueBuffer);
     settings.setValue(QStringLiteral("FeedbackDetectionEnabled"),
                       m_feedbackDetectionEnabled);
     settings.endGroup();

--- a/src/vs/vsAudio.h
+++ b/src/vs/vsAudio.h
@@ -81,8 +81,8 @@ class VsAudio : public QObject
         int sampleRate READ getSampleRate WRITE setSampleRate NOTIFY sampleRateChanged)
     Q_PROPERTY(
         int bufferSize READ getBufferSize WRITE setBufferSize NOTIFY bufferSizeChanged)
-    Q_PROPERTY(int bufferStrategy READ getBufferStrategy WRITE setBufferStrategy NOTIFY
-                   bufferStrategyChanged)
+    Q_PROPERTY(int queueBuffer READ getQueueBuffer WRITE setQueueBuffer NOTIFY
+                   queueBufferChanged)
     Q_PROPERTY(int numInputChannels READ getNumInputChannels WRITE setNumInputChannels
                    NOTIFY numInputChannelsChanged)
     Q_PROPERTY(int numOutputChannels READ getNumOutputChannels WRITE setNumOutputChannels
@@ -121,11 +121,8 @@ class VsAudio : public QObject
                    outputChannelsComboModelChanged)
     Q_PROPERTY(QJsonArray inputMixModeComboModel READ getInputMixModeComboModel NOTIFY
                    inputMixModeComboModelChanged)
-    Q_PROPERTY(QStringList feedbackDetectionComboModel READ getFeedbackDetectionComboModel
-                   CONSTANT)
     Q_PROPERTY(QStringList bufferSizeComboModel READ getBufferSizeComboModel CONSTANT)
-    Q_PROPERTY(
-        QStringList bufferStrategyComboModel READ getBufferStrategyComboModel CONSTANT)
+    Q_PROPERTY(QStringList queueTypeComboModel READ getQueueTypeComboModel CONSTANT)
     Q_PROPERTY(QStringList audioBackendComboModel READ getAudioBackendComboModel CONSTANT)
     Q_PROPERTY(
         QString devicesWarning READ getDevicesWarningMsg NOTIFY devicesWarningChanged)
@@ -172,7 +169,7 @@ class VsAudio : public QObject
     }
     int getSampleRate() const { return m_audioSampleRate; }
     int getBufferSize() const { return m_audioBufferSize; }
-    int getBufferStrategy() const { return m_bufferStrategy; }
+    int getQueueBuffer() const { return m_queueBuffer; }
     int getNumInputChannels() const { return getUseRtAudio() ? m_numInputChannels : 2; }
     int getNumOutputChannels() const { return getUseRtAudio() ? m_numOutputChannels : 2; }
     int getBaseInputChannel() const { return getUseRtAudio() ? m_baseInputChannel : 0; }
@@ -202,15 +199,8 @@ class VsAudio : public QObject
     {
         return m_inputMixModeComboModel;
     }
-    const QStringList& getFeedbackDetectionComboModel() const
-    {
-        return m_feedbackDetectionComboModel;
-    }
     const QStringList& getBufferSizeComboModel() const { return m_bufferSizeComboModel; }
-    const QStringList& getBufferStrategyComboModel() const
-    {
-        return m_bufferStrategyComboModel;
-    }
+    const QStringList& getQueueTypeComboModel() const { return m_queueTypeComboModel; }
     const QStringList& getAudioBackendComboModel() const
     {
         return m_audioBackendComboModel;
@@ -227,7 +217,7 @@ class VsAudio : public QObject
     void setAudioBackend(const QString& backend);
     void setSampleRate(int sampleRate);
     void setBufferSize(int bufSize);
-    void setBufferStrategy(int bufStrategy);
+    void setQueueBuffer(int queueBuffer);
     void setNumInputChannels(int numChannels);
     void setNumOutputChannels(int numChannels);
     void setBaseInputChannel(int baseChannel);
@@ -264,7 +254,7 @@ class VsAudio : public QObject
     void audioBackendChanged(bool useRtAudio);
     void sampleRateChanged();
     void bufferSizeChanged();
-    void bufferStrategyChanged();
+    void queueBufferChanged();
     void numInputChannelsChanged(int numChannels);
     void numOutputChannelsChanged(int numChannels);
     void baseInputChannelChanged(int baseChannel);
@@ -338,7 +328,7 @@ class VsAudio : public QObject
     int m_audioSampleRate           = gDefaultSampleRate;
     int m_audioBufferSize =
         gDefaultBufferSizeInSamples;  ///< Audio buffer size to process on each callback
-    int m_bufferStrategy    = 0;
+    int m_queueBuffer       = 0;
     int m_numInputChannels  = gDefaultNumInChannels;
     int m_numOutputChannels = gDefaultNumOutChannels;
     int m_baseInputChannel  = 0;
@@ -383,11 +373,11 @@ class VsAudio : public QObject
     Analyzer* m_outputAnalyzerPluginPtr;
 #endif
 
-    QStringList m_audioBackendComboModel      = {"JACK", "RtAudio"};
-    QStringList m_feedbackDetectionComboModel = {"Enabled", "Disabled"};
+    QStringList m_audioBackendComboModel = {"JACK", "RtAudio"};
     QStringList m_bufferSizeComboModel = {"16", "32", "64", "128", "256", "512", "1024"};
-    QStringList m_bufferStrategyComboModel = {
-        "Adaptable Latency (Old)", "Stable Latency (Old)", "Loss Concealment (Default)"};
+    QStringList m_queueTypeComboModel  = {"Auto Latency (Variable Headroom)",
+                                         "Auto Latency (Fixed Headroom)",
+                                         "Fixed Latency"};
 
     friend class VsAudioWorker;
 };

--- a/src/vs/vsDevice.cpp
+++ b/src/vs/vsDevice.cpp
@@ -277,7 +277,7 @@ JackTrip* VsDevice::initJackTrip(
     [[maybe_unused]] std::string output, [[maybe_unused]] int baseInputChannel,
     [[maybe_unused]] int numChannelsIn, [[maybe_unused]] int baseOutputChannel,
     [[maybe_unused]] int numChannelsOut, [[maybe_unused]] int inputMixMode,
-    [[maybe_unused]] int bufferSize, [[maybe_unused]] int bufferStrategy,
+    [[maybe_unused]] int bufferSize, [[maybe_unused]] int queueBuffer,
     VsServerInfo* studioInfo)
 {
     m_jackTrip.reset(
@@ -304,8 +304,8 @@ JackTrip* VsDevice::initJackTrip(
     }
     m_jackTrip->setBindPorts(bindPort);
     m_jackTrip->setRemoteClientName(m_appID);
-    m_jackTrip->setBufferStrategy(bufferStrategy);
-    m_jackTrip->setBufferQueueLength(-500);  // use -q auto
+    m_jackTrip->setBufferStrategy(3);  // PLC
+    m_jackTrip->setBufferQueueLength(queueBuffer);
     m_jackTrip->setUseRtUdpPriority(
         true);  // rt udp priority reduces glitches on desktops
     m_jackTrip->setPeerAddress(studioInfo->host());

--- a/src/vs/vsDevice.h
+++ b/src/vs/vsDevice.h
@@ -72,7 +72,7 @@ class VsDevice : public QObject
     JackTrip* initJackTrip(bool useRtAudio, std::string input, std::string output,
                            int baseInputChannel, int numChannelsIn, int baseOutputChannel,
                            int numChannelsOut, int inputMixMode, int bufferSize,
-                           int bufferStrategy, VsServerInfo* studioInfo);
+                           int queueBuffer, VsServerInfo* studioInfo);
     void startJackTrip(const VsServerInfo& studioInfo);
     void stopJackTrip(bool isReconnecting = false);
     void reconcileAgentConfig(QJsonDocument newState);


### PR DESCRIPTION
PLC (buffer strategy 3) has matured to the point where it no longer makes sense to support the older buffer strategies. Although they are interesting for testing and research, there no longer is any real world value.

However, it is very useful to allow one to adjust the balance between lower latency and higher quality. PLC provides different mechanisms to do that, but we haven't yet made them available outside of the command line.

Effectively, PLC supports three different modes:

1. Auto latency adjustment based on connection heuristics, with variable headroom added automatically ("-q auto", represented as a queue buffer length of -500) -- this is the default

2. Auto latency adjustment based on connection heuristics, with a fixed amount of headroom ("-q auto#" where # is number of ms, represented as a negative queue buffer length)

3. Fixed latency ("-q #", where # is fixed number of ms, represented as a positive queue buffer length)

This PR removes buffer strategy settings in VS mode, although they remain available via command line and in Classic mode. It also makes it easy to adjust these PLC settings using the Advanced settings menu in VS mode.

This also replaces the "Enabled" / "Disabled" combo for Feedback Detection with a checkbox, so that it's consistent with other settings.