### PR TITLE
Disabling qwave support for Windows

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -1,3 +1,7 @@
+- Version: "2.4.1"
+  Date: 2024-09-27
+  Description:
+  - (fixed) Disabling qWave Quality of Service for Windows users
 - Version: "2.4.0"
   Date: 2024-09-13
   Description:

--- a/src/UdpDataProtocol.cpp
+++ b/src/UdpDataProtocol.cpp
@@ -294,7 +294,7 @@ socket_type UdpDataProtocol::bindSocket()
     ::setsockopt(sock_fd, SOL_SOCKET, SO_REUSEPORT, &one, sizeof(one));
 #endif
 
-    // set qos for windows after flow is established (requires peer address/port)
+    // set quality of service for the UDP socket
     if (setSocketQos(sock_fd)) {
         std::cout << "Set QoS for network socket" << std::endl;
     } else {
@@ -323,6 +323,9 @@ bool UdpDataProtocol::setSocketQos(socket_type& sock_fd)
     // Windows QoS (qWave) for audio traffic flows
     // https://learn.microsoft.com/en-us/windows/win32/api/_qos/
     // https://learn.microsoft.com/en-us/previous-versions/windows/desktop/qos/qwave-api-reference
+
+#if 0
+    // DISABLED SINCE THIS CAUSES GARBLED AUDIO FOR SOME PEOPLE
 
     // Initialize the QoS version parameter.
     QOS_VERSION Version;
@@ -354,6 +357,8 @@ bool UdpDataProtocol::setSocketQos(socket_type& sock_fd)
         std::cerr << WSAGetLastError() << std::endl;
         return false;
     }
+#endif
+
 #elif defined(__APPLE__)
     // set service type "Interactive Voice"
     // TODO: this is supposed to be the right thing to do on OSX, but doesn't seem to do

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -40,7 +40,7 @@
 
 #include "AudioInterface.h"
 
-constexpr const char* const gVersion = "2.4.0";  ///< JackTrip version
+constexpr const char* const gVersion = "2.4.1";  ///< JackTrip version
 
 //*******************************************************************************
 /// \name Default Values

--- a/win/meson.build
+++ b/win/meson.build
@@ -31,7 +31,6 @@ if host_machine.system() == 'windows'
 		link_args += 'Winhttp.lib'
 		link_args += 'Dnsapi.lib'
 		link_args += 'Iphlpapi.lib'
-		link_args += 'Qwave.lib'
 	endif
 
 endif


### PR DESCRIPTION
I confirmed that this causes severe garbled audio problems for some Windows users. Not sure if it's a bug in Windows, or if some home routers simply can't handle QoS, but either way it sadly doesn't work.

Bumping version and changelog to 2.4.1 for bugfix release