### PR TITLE
Increase PLC auto headroom more aggressively when very low jitter

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -2,6 +2,7 @@
   Date: 2024-09-27
   Description:
   - (fixed) Disabling qWave Quality of Service for Windows users
+  - (fixed) PLC auto headroom optimization for very low jitter
 - Version: "2.4.0"
   Date: 2024-09-13
   Description:

--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -2,6 +2,7 @@
   Date: 2024-09-27
   Description:
   - (fixed) Disabling qWave Quality of Service for Windows users
+  - (fixed) PLC occasional popping sound when you first connect
   - (fixed) PLC auto headroom optimization for very low jitter
 - Version: "2.4.0"
   Date: 2024-09-13

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -481,8 +481,10 @@ void Regulator::updateTolerance(int glitches, int skipped)
         // prevent headroom from growing beyond rolling average of max.
         int skipsAllowed;
         if (mMsecTolerance >= (mPeerFPPdurMsec * 2)) {
-            // calculate skips allowed if tolerance if above or equal to duration of two packets
-            skipsAllowed = static_cast<int>(AutoHeadroomGlitchTolerance * mSampleRate / mPeerFPP);
+            // calculate skips allowed if tolerance if above or equal to duration of two
+            // packets
+            skipsAllowed =
+                static_cast<int>(AutoHeadroomGlitchTolerance * mSampleRate / mPeerFPP);
         } else {
             // zero skips allowed if tolerance is below duration of two packets
             skipsAllowed = 0;


### PR DESCRIPTION
If a connection has really low jitter, the tolerance calculated is usually less than the duration of two audio packets. It's a very small window that doesn't leave much room for out of order packets.

This allows auto headroom to increase more agressively, up until the total tolerance matches or exceeds the duration of two audio packets.

I think this reaches a cleaner balance faster than the previous iteration, and should yield a better overall experience for people with optimized connections.