### PR TITLE
Show open privacy button when microphone permission denied on mac

### DIFF
--- a/src/vs/AudioSettings.qml
+++ b/src/vs/AudioSettings.qml
@@ -793,10 +793,38 @@ Rectangle {
                 id: scanningDevicesLabel
                 x: 0; y: 0
                 width: parent.width - (16 * virtualstudio.uiScale)
-                text: "Scanning audio devices..."
+                text: (Qt.platform.os == "osx" && permissions.micPermission != "granted") ? "Microphone permissions not permitted" : "Scanning audio devices..."
                 font { family: "Poppins"; pixelSize: fontMedium * virtualstudio.fontScale * virtualstudio.uiScale }
                 wrapMode: Text.WordWrap
                 color: textColour
+            }
+
+            Button {
+                id: openSettingsButton
+                visible: Qt.platform.os == "osx" && permissions.micPermission != "granted"
+                background: Rectangle {
+                    radius: 6 * virtualstudio.uiScale
+                    color: openSettingsButton.down ? buttonPressedColour : buttonColour
+                    border.width: 1
+                    border.color: openSettingsButton.down || openSettingsButton.hovered ? buttonPressedStroke : buttonStroke
+                    layer.enabled: openSettingsButton.hovered && !openSettingsButton.down
+                }
+                onClicked: {
+                    permissions.openSystemPrivacy();
+                }
+                anchors.top: scanningDevicesLabel.bottom
+                anchors.topMargin: 16 * virtualstudio.uiScale
+                anchors.horizontalCenter: parent.horizontalCenter
+                width: 200 * virtualstudio.uiScale; height: 30 * virtualstudio.uiScale
+                Text {
+                    text: "Open Privacy Settings"
+                    font.family: "Poppins"
+                    font.pixelSize: 11 * virtualstudio.fontScale * virtualstudio.uiScale
+                    font.weight: Font.Bold
+                    color: textColour
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    anchors.verticalCenter: parent.verticalCenter
+                }
             }
         }
     }

--- a/src/vs/vsAudio.cpp
+++ b/src/vs/vsAudio.cpp
@@ -176,6 +176,7 @@ VsAudio::VsAudio(QObject* parent)
 #else
     m_permissionsPtr.reset(new VsPermissions());
 #endif
+    qDebug() << "Microphone permissions: " << m_permissionsPtr->micPermission();
 }
 
 VsAudio::~VsAudio()

--- a/src/vs/vsMacPermissions.mm
+++ b/src/vs/vsMacPermissions.mm
@@ -85,11 +85,13 @@ void VsMacPermissions::getMicPermission()
             {
                 // The user has previously denied access.
                 setMicPermission(QStringLiteral("denied"));
+                break;
             }
             case AVAuthorizationStatusRestricted:
             {
                 // The user can't grant access due to restrictions.
                 setMicPermission(QStringLiteral("denied"));
+                break;
             }
         }
     } else {


### PR DESCRIPTION
I can't figure out how to re-prompt, but we can at least change the message + include a link to where to change it. Looks like this:
![Screenshot 2024-10-02 at 9 56 43 AM](https://github.com/user-attachments/assets/67b2f872-078c-45bf-8848-bfa6a22d7a26)
![Screenshot 2024-10-02 at 9 58 38 AM](https://github.com/user-attachments/assets/ed7549e1-8737-4184-af9f-b03d9848abdd)
