### PR TITLE
A few updates for osc server support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,15 +155,6 @@ set(qjacktrip_SRC
   src/Auth.cpp
   src/ProcessPlugin.cpp
   src/OscServer.cpp
-  src/oscpp/client.hpp
-  src/oscpp/detail/endian.hpp
-  src/oscpp/detail/host.hpp
-  src/oscpp/detail/stream.hpp
-  src/oscpp/error.hpp
-  src/oscpp/print.hpp
-  src/oscpp/server.hpp
-  src/oscpp/types.hpp
-  src/oscpp/util.hpp
 )
 
 if (rtaudio)

--- a/meson.build
+++ b/meson.build
@@ -96,16 +96,7 @@ moc_h = ['src/DataProtocol.h',
 	'src/UdpHubListener.h',
 	'src/Auth.h',
 	'src/SslServer.h',
-	'src/OscServer.h',
-	'src/oscpp/client.hpp',
-	'src/oscpp/detail/endian.hpp',
-	'src/oscpp/detail/host.hpp',
-	'src/oscpp/detail/stream.hpp',
-	'src/oscpp/error.hpp',
-	'src/oscpp/print.hpp',
-	'src/oscpp/server.hpp',
-	'src/oscpp/types.hpp',
-	'src/oscpp/util.hpp']
+	'src/OscServer.h']
 
 ui_h = []
 qres = []

--- a/src/OscServer.cpp
+++ b/src/OscServer.cpp
@@ -3,8 +3,7 @@
   JackTrip: A System for High-Quality Audio Network Performance
   over the Internet
 
-  Copyright (c) 2008-2024 Juan-Pablo Caceres, Chris Chafe.
-  SoundWIRE group at CCRMA, Stanford University.
+  Copyright (c) 2024 JackTrip Labs, Inc.
 
   Permission is hereby granted, free of charge, to any person
   obtaining a copy of this software and associated documentation

--- a/src/OscServer.h
+++ b/src/OscServer.h
@@ -3,8 +3,7 @@
   JackTrip: A System for High-Quality Audio Network Performance
   over the Internet
 
-  Copyright (c) 2008-2024 Juan-Pablo Caceres, Chris Chafe.
-  SoundWIRE group at CCRMA, Stanford University.
+  Copyright (c) 2024 JackTrip Labs, Inc.
 
   Permission is hereby granted, free of charge, to any person
   obtaining a copy of this software and associated documentation

--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -297,6 +297,7 @@ class Regulator : public RingBuffer
     int mStatsGlitches            = 0;
     double mStatsMaxPLCdspElapsed = 0;
     double mCurrentHeadroom       = 0;
+    double mAutoHeadroomStartTime = 6000.0;
     double mAutoHeadroom          = -1;
     Time* mTime                   = nullptr;
 

--- a/src/UdpHubListener.cpp
+++ b/src/UdpHubListener.cpp
@@ -368,6 +368,7 @@ void UdpHubListener::stopCheck()
 
 void UdpHubListener::queueBufferChanged(int queueBufferSize)
 {
+    cout << "Updating queueBuffer to " << queueBufferSize << endl;
     QMutexLocker lock(&mMutex);
     mBufferQueueLength = queueBufferSize;
     // Now that we have our actual port, remove any duplicate workers.


### PR DESCRIPTION
Updated logic for Regulator::setQueueBufferLength to handle both fixed and auto headroom.

Moved queue buffer update logging up to once per change versus once per client per change.

Added mAutoHeadroomStartTime to handle headroom calculation being started after initialization.

No need to moc oscpp headers. It just gives warnings since there is nothing to moc.