### PR TITLE
Refresh Access Token Automatically When Keeping App Open For Long Durations

### DIFF
--- a/src/vs/vsAuth.cpp
+++ b/src/vs/vsAuth.cpp
@@ -41,6 +41,12 @@
 VsAuth::VsAuth(QNetworkAccessManager* networkAccessManager, VsApi* api)
     : m_clientId(AUTH_CLIENT_ID), m_authorizationServerHost(AUTH_SERVER_HOST)
 {
+    qint64 refreshIntervalInMs =
+        1000 * 60 * 60 * 3;  // automatic access token refresh every 3 hours
+    m_refreshTimer.reset(new QTimer());
+    m_refreshTimer->setInterval(refreshIntervalInMs);
+    m_refreshTimer->setSingleShot(false);
+
     m_networkAccessManager = networkAccessManager;
     m_api                  = api;
     m_deviceCodeFlow.reset(new VsDeviceCodeFlow(networkAccessManager));
@@ -53,6 +59,7 @@ VsAuth::VsAuth(QNetworkAccessManager* networkAccessManager, VsApi* api)
             &VsAuth::codeFlowCompleted);
     connect(m_deviceCodeFlow.data(), &VsDeviceCodeFlow::deviceCodeFlowTimedOut, this,
             &VsAuth::codeExpired);
+    connect(m_refreshTimer.data(), &QTimer::timeout, this, &VsAuth::refreshTimerTimedOut);
 
     m_verificationUrl = QStringLiteral("https://auth.jacktrip.org/activate");
 }
@@ -190,6 +197,13 @@ void VsAuth::codeExpired()
     emit deviceCodeExpired();
 }
 
+void VsAuth::refreshTimerTimedOut()
+{
+    if (m_refreshToken != "") {
+        refreshAccessToken(m_refreshToken);
+    }
+}
+
 void VsAuth::handleRefreshSucceeded(QString accessToken)
 {
     qDebug() << "Successfully refreshed access token";
@@ -198,11 +212,19 @@ void VsAuth::handleRefreshSucceeded(QString accessToken)
     m_authenticationStage    = QStringLiteral("success");
     m_errorMessage           = QStringLiteral("");
     m_attemptingRefreshToken = false;
+    m_accessTokenTimestamp   = QDateTime::currentDateTime();
+
+    m_refreshTimer->start();
 
     emit updatedAuthenticationStage(m_authenticationStage);
     emit updatedErrorMessage(m_errorMessage);
     emit updatedVerificationCode(m_verificationCode);
     emit updatedAttemptingRefreshToken(m_attemptingRefreshToken);
+}
+
+void VsAuth::handleRefreshFailed()
+{
+    m_refreshTimer->stop();
 }
 
 void VsAuth::handleAuthSucceeded(QString userId, QString accessToken)
@@ -225,6 +247,9 @@ void VsAuth::handleAuthSucceeded(QString userId, QString accessToken)
     m_errorMessage           = QStringLiteral("");
     m_attemptingRefreshToken = false;
     m_isAuthenticated        = true;
+    m_accessTokenTimestamp   = QDateTime::currentDateTime();
+
+    m_refreshTimer->start();
 
     emit updatedUserId(m_userId);
     emit updatedAuthenticationStage(m_authenticationStage);
@@ -253,6 +278,7 @@ void VsAuth::handleAuthFailed(QString errorMessage)
     m_authenticationMethod   = QStringLiteral("");
     m_attemptingRefreshToken = false;
     m_isAuthenticated        = false;
+    m_accessTokenTimestamp   = QDateTime::fromMSecsSinceEpoch(0);
 
     emit updatedUserId(m_userId);
     emit updatedAuthenticationStage(m_authenticationStage);
@@ -271,12 +297,13 @@ void VsAuth::cancelAuthenticationFlow()
     qDebug() << "Canceling authentication flow";
     m_deviceCodeFlow->cancelCodeFlow();
 
-    m_userId              = QStringLiteral("");
-    m_verificationCode    = QStringLiteral("");
-    m_accessToken         = QStringLiteral("");
-    m_authenticationStage = QStringLiteral("unauthenticated");
-    m_errorMessage        = QStringLiteral("cancelled");
-    m_isAuthenticated     = false;
+    m_userId               = QStringLiteral("");
+    m_verificationCode     = QStringLiteral("");
+    m_accessToken          = QStringLiteral("");
+    m_accessTokenTimestamp = QDateTime::fromMSecsSinceEpoch(0);
+    m_authenticationStage  = QStringLiteral("unauthenticated");
+    m_errorMessage         = QStringLiteral("cancelled");
+    m_isAuthenticated      = false;
 
     emit updatedUserId(m_userId);
     emit updatedAuthenticationStage(m_authenticationStage);
@@ -293,12 +320,13 @@ void VsAuth::logout()
     qDebug() << "Logging out";
 
     // reset auth state
-    m_userId              = QStringLiteral("");
-    m_verificationCode    = QStringLiteral("");
-    m_accessToken         = QStringLiteral("");
-    m_authenticationStage = QStringLiteral("unauthenticated");
-    m_errorMessage        = QStringLiteral("");
-    m_isAuthenticated     = false;
+    m_userId               = QStringLiteral("");
+    m_verificationCode     = QStringLiteral("");
+    m_accessToken          = QStringLiteral("");
+    m_authenticationStage  = QStringLiteral("unauthenticated");
+    m_errorMessage         = QStringLiteral("");
+    m_isAuthenticated      = false;
+    m_accessTokenTimestamp = QDateTime::fromMSecsSinceEpoch(0);
 
     emit updatedUserId(m_userId);
     emit updatedAuthenticationStage(m_authenticationStage);

--- a/src/vs/vsAuth.h
+++ b/src/vs/vsAuth.h
@@ -37,10 +37,12 @@
 #ifndef VSAUTH_H
 #define VSAUTH_H
 
+#include <QDateTime>
 #include <QNetworkAccessManager>
 #include <QQmlContext>
 #include <QQmlEngine>
 #include <QString>
+#include <QTimer>
 #include <iostream>
 
 #include "vsApi.h"
@@ -86,6 +88,7 @@ class VsAuth : public QObject
     QString refreshToken() { return m_refreshToken; };
     QString authenticationMethod() { return m_authenticationMethod; }
     bool attemptingRefreshToken() { return m_attemptingRefreshToken; }
+    QDateTime accessTokenTimestamp() { return m_accessTokenTimestamp; }
 
    signals:
     void updatedAuthenticationStage(QString authenticationStage);
@@ -104,11 +107,13 @@ class VsAuth : public QObject
 
    private slots:
     void handleRefreshSucceeded(QString accessToken);
+    void handleRefreshFailed();
     void handleAuthSucceeded(QString userId, QString accessToken);
     void handleAuthFailed(QString errorMessage);
     void initializedCodeFlow(QString code, QString verificationUrl);
     void codeFlowCompleted(QString accessToken, QString refreshToken);
     void codeExpired();
+    void refreshTimerTimedOut();
 
    private:
     void fetchUserInfo(QString accessToken);
@@ -127,10 +132,12 @@ class VsAuth : public QObject
     QString m_userId;
     QString m_accessToken;
     QString m_refreshToken;
+    QDateTime m_accessTokenTimestamp = QDateTime::fromMSecsSinceEpoch(0);
 
     QNetworkAccessManager* m_networkAccessManager;
     VsApi* m_api;
     QScopedPointer<VsDeviceCodeFlow> m_deviceCodeFlow;
+    QScopedPointer<QTimer> m_refreshTimer;
 };
 
 #endif

--- a/src/vs/vsQuickView.cpp
+++ b/src/vs/vsQuickView.cpp
@@ -54,7 +54,11 @@ VsQuickView::VsQuickView(QWindow* parent) : QQuickView(parent)
 
 bool VsQuickView::event(QEvent* event)
 {
-    if (event->type() == QEvent::Close || event->type() == QEvent::Quit) {
+    if (event->type() == QEvent::FocusIn) {
+        emit focusGained();
+    } else if (event->type() == QEvent::FocusOut) {
+        emit focusLost();
+    } else if (event->type() == QEvent::Close || event->type() == QEvent::Quit) {
         emit windowClose();
         event->ignore();
     }

--- a/src/vs/vsQuickView.h
+++ b/src/vs/vsQuickView.h
@@ -55,6 +55,8 @@ class VsQuickView : public QQuickView
 
    signals:
     void windowClose();
+    void focusGained();
+    void focusLost();
 
    private slots:
     void closeWindow();


### PR DESCRIPTION
Should handle the cases of people leaving their app open for long durations (>24h) more robustly. Currently, we don't continuously refresh our access token (which expires after 24h) after the initial app login, so things may break if you try to use the app after it expires.

This handles a few more cases by adding a 
- periodic access token refresh timer with an interval of 3 hours, and
- an additional access token refresh event when the window is focused and the current token is at least an hour old

This should additionally handle the case where the device goes to sleep for >24hours and wakes up again (though the user would need to click on the window to focus it and refresh the token). Having that done automatically might be useful but can be done in a separate PR if we need it.