### PR TITLE
Prefer glitch count to skipped for increasing headroom

### DIFF
--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -769,7 +769,9 @@ void JackTrip::onStatTimer()
             //                     pkt_stat.lost << "/"
             //                     << pkt_stat.outOfOrder << "/" << pkt_stat.revived
             << " \n tot: " << pkt_stat.tot << " \t tol: " << setw(5)
-            << INVFLOATFACTOR * recv_io_stat.autoq_corr << " \t dsp (max): " << setw(5)
+            << INVFLOATFACTOR * recv_io_stat.autoq_corr
+            << " \t latency (max): " << setw(5) << std::setprecision(3)
+            << mReceiveRingBuffer->getLatency() << " \t dsp (max): " << setw(5)
             << INVFLOATFACTOR * recv_io_stat.autoq_rate
             //                     << " sync: " << recv_io_stat.level << "/"
             //                     << recv_io_stat.buf_inc_underrun << "/"

--- a/src/JackTrip.h
+++ b/src/JackTrip.h
@@ -221,11 +221,12 @@ class JackTrip : public QObject
     /// \brief Sets (override) Buffer Queue Length Mode after construction
     virtual void setBufferQueueLength(int queueBuffer)
     {
-        if (mBufferQueueLength == queueBuffer || mReceiveRingBuffer == nullptr) {
+        if (mBufferQueueLength == queueBuffer) {
             return;
         }
         mBufferQueueLength = queueBuffer;
-        if ((mBufferStrategy == 3) || (mBufferStrategy == 4)) {
+        if (mReceiveRingBuffer != nullptr
+            && (mBufferStrategy == 3 || mBufferStrategy == 4)) {
             // mReceiveRingBuffer should be an instance of Regulator when mBufferStrategy
             // is 3 or 4
             mReceiveRingBuffer->setQueueBufferLength(mBufferQueueLength);
@@ -549,6 +550,10 @@ class JackTrip : public QObject
     {
         return (mAudioInterface == nullptr) ? false
                                             : mAudioInterface->getHighLatencyFlag();
+    }
+    double getLatency() const
+    {
+        return mReceiveRingBuffer == nullptr ? -1 : mReceiveRingBuffer->getLatency();
     }
     //@}
     //------------------------------------------------------------------------------------

--- a/src/JitterBuffer.h
+++ b/src/JitterBuffer.h
@@ -55,6 +55,9 @@ class JitterBuffer : public RingBuffer
 
     virtual bool getStats(IOStat* stat, bool reset);
 
+    /// @brief returns max latency during previous interval, in milliseconds
+    virtual double getLatency() const { return mMaxLatency; }
+
     void setJackTrip(JackTrip* jackTrip) { mJackTrip = jackTrip; }
 
    protected:

--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -225,9 +225,14 @@ class Regulator : public RingBuffer
     /// @brief returns true if worker thread & queue is enabled
     inline bool isWorkerEnabled() const { return mWorkerEnabled; }
 
-    //    virtual QString getStats(uint32_t statCount, uint32_t lostCount);
+    /// @brief returns statistics for -I command line option
     virtual bool getStats(IOStat* stat, bool reset);
+
+    /// @brief sets length of queue buffer
     virtual void setQueueBufferLength([[maybe_unused]] int queueBuffer);
+
+    /// @brief returns max latency during previous interval, in milliseconds
+    virtual double getLatency() const { return mLastMaxLatency; }
 
    private:
     void pushPacket(const int8_t* buf, int seq_num);
@@ -295,6 +300,8 @@ class Regulator : public RingBuffer
     int mLastSkipped              = 0;
     int mLastGlitches             = 0;
     int mStatsGlitches            = 0;
+    double mLastMaxLatency        = 0;
+    double mStatsMaxLatency       = 0;
     double mStatsMaxPLCdspElapsed = 0;
     double mCurrentHeadroom       = 0;
     double mAutoHeadroomStartTime = 6000.0;

--- a/src/RingBuffer.cpp
+++ b/src/RingBuffer.cpp
@@ -326,3 +326,10 @@ void RingBuffer::updateReadStats()
     mUnderrunsNew = 0;
     mLevel        = std::ceil(mLevelCur);
 }
+
+//*******************************************************************************
+// Not supported in RingBuffer
+double RingBuffer::getLatency() const
+{
+    return -1;
+}

--- a/src/RingBuffer.h
+++ b/src/RingBuffer.h
@@ -100,6 +100,8 @@ class RingBuffer
      */
     virtual void readSlotNonBlocking(int8_t* ptrToReadSlot);
     virtual void readBroadcastSlot(int8_t* ptrToReadSlot);
+
+    /// @brief sets length of queue buffer
     virtual void setQueueBufferLength([[maybe_unused]] int queueBuffer);
 
     struct IOStat {
@@ -118,7 +120,12 @@ class RingBuffer
         int32_t autoq_corr;
         int32_t autoq_rate;
     };
+
+    /// @brief returns statistics for -I command line option
     virtual bool getStats(IOStat* stat, bool reset);
+
+    /// @brief returns max latency during previous interval, in milliseconds
+    virtual double getLatency() const;
 
    protected:
     /** \brief Sets the memory in the Read Slot when uderrun occurs. By default,

--- a/src/vs/vsDevice.cpp
+++ b/src/vs/vsDevice.cpp
@@ -189,6 +189,8 @@ void VsDevice::sendHeartbeat()
         json.insert(QLatin1String("high_latency"),
                     m_audioConfigPtr->getHighLatencyFlag());
         json.insert(QLatin1String("network_outage"), m_networkOutage);
+        json.insert(QLatin1String("recv_latency"),
+                    m_jackTrip.isNull() ? -1 : m_jackTrip->getLatency());
 
         // For the internal application UI, ms will suffice. No conversion needed
         QJsonObject pingStats = {};
@@ -201,6 +203,8 @@ void VsDevice::sendHeartbeat()
                          ((int)(10 * stats.stdDevRtt)) / 10.0);
         pingStats.insert(QLatin1String("highLatency"),
                          m_audioConfigPtr->getHighLatencyFlag());
+        pingStats.insert(QLatin1String("recvLatency"),
+                         m_jackTrip.isNull() ? -1 : m_jackTrip->getLatency());
         emit updateNetworkStats(pingStats);
     }
 


### PR DESCRIPTION
This seems to be a better indicator which allows it grow and adjust faster for bad connections, without having an adverse impact on good connections.

Adding latency stat for Regulator (use "-I 1" to see it). This is helpful because tolerance is a maximum, and not necessarily indicative of true latency.

Adding receive latency to vs device heartbeat