### PR TITLE
Increase UDP wait timeout to 512ms

### DIFF
--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -87,7 +87,7 @@ constexpr uint32_t gDefaultBufferSizeInSamples = 128;
 constexpr const char* gDefaultLocalAddress     = "";
 constexpr int gDefaultRedundancy               = 1;
 constexpr int gTimeOutMultiThreadedServer      = 10000;  // seconds
-constexpr int gUdpWaitTimeout                  = 50;     // milliseconds
+constexpr int gUdpWaitTimeout                  = 512;    // milliseconds
 //@}
 
 //*******************************************************************************


### PR DESCRIPTION
Increase UDP wait timeout to 512ms, since people using 1024 buffer size are still too likely to run into this and experience drop-outs.

Why 1024 buffer size? People using DAWs etc who are collaborating online do not care about latency, and sometimes may need to use a very high buffer size to avoid CPU overload of plugins, etc.