### PR TITLE
Adding support to build for Linux using a Docker container

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -86,25 +86,10 @@ jobs:
             # binary-path: binary
             build-system: meson
             meson-library-type: shared
+            static-analysis: true
 
-          - name: Linux-x64-meson-gcc-static
-            release-name: Linux-x64-nogui
-            runs-on: ubuntu-20.04
-            system-rtaudio: false
-            bundled-rtaudio: true
-            nogui: true
-            novs: true
-            weakjack: false
-            jacktrip-path: jacktrip
-            binary-path: binary
-            build-system: meson
-            meson-library-type: static
-            qt-version: '5.15.13'
-            qt-type: 'static'
-            qt-arch: 'amd64'
-
-          - name: Linux-x64-meson-gcc-shared
-            release-name: Linux-x64 # specify a separate name for all builds that should be included in releases
+          - name: Linux-x64-docker-shared
+            release-name: Linux-x64
             runs-on: ubuntu-22.04
             system-rtaudio: false
             bundled-rtaudio: true
@@ -112,9 +97,78 @@ jobs:
             weakjack: false
             jacktrip-path: jacktrip # needed for binary upload
             binary-path: binary # directory relative to build path; triggers artifact upload for jacktrip binary
-            build-system: meson
+            build-system: docker
+            docker-image: ubuntu:jammy-20240911.1
+            docker-platform: linux/amd64
             meson-library-type: shared
-            static-analysis: true
+
+          - name: Linux-arm64-docker-shared
+            release-name: Linux-arm64
+            runs-on: ubuntu-22.04
+            system-rtaudio: false
+            bundled-rtaudio: true
+            nogui: false
+            weakjack: false
+            jacktrip-path: jacktrip
+            binary-path: binary
+            build-system: docker
+            docker-image: ubuntu:jammy-20240911.1
+            docker-platform: linux/arm64
+            meson-library-type: shared
+
+          - name: Linux-x64-docker-nogui
+            release-name: Linux-x64-nogui
+            runs-on: ubuntu-22.04
+            system-rtaudio: false
+            bundled-rtaudio: true
+            nogui: true
+            novs: true
+            weakjack: false
+            jacktrip-path: jacktrip
+            binary-path: binary
+            build-system: docker
+            docker-image: ubuntu:focal-20241011
+            docker-platform: linux/amd64
+            meson-library-type: static
+            qt-version: '6.5.3'
+            qt-type: 'static'
+            qt-arch: 'amd64'
+
+          - name: Linux-arm64-docker-nogui
+            release-name: Linux-arm64-nogui
+            runs-on: ubuntu-22.04
+            system-rtaudio: false
+            bundled-rtaudio: true
+            nogui: true
+            novs: true
+            weakjack: false
+            jacktrip-path: jacktrip
+            binary-path: binary
+            build-system: docker
+            docker-image: ubuntu:focal-20241011
+            docker-platform: linux/arm64
+            meson-library-type: static
+            qt-version: '6.5.3'
+            qt-type: 'static'
+            qt-arch: 'arm64'
+
+          - name: Linux-arm32-docker-nogui
+            release-name: Linux-arm32-nogui
+            runs-on: ubuntu-22.04
+            system-rtaudio: false
+            bundled-rtaudio: true
+            nogui: true
+            novs: true
+            weakjack: false
+            jacktrip-path: jacktrip
+            binary-path: binary
+            build-system: docker
+            docker-image: debian:buster-20240612-slim
+            docker-platform: linux/arm/v7
+            meson-library-type: static
+            qt-version: '5.15.13'
+            qt-type: 'static'
+            qt-arch: 'arm32'
 
           - name: macOS-x64-meson-clang-static
             release-name: macOS-x64-nogui
@@ -223,7 +277,7 @@ jobs:
         if: runner.os == 'macOS' && matrix.xcode-directory
         run: sudo xcode-select -s ${{ matrix.xcode-directory }}
       - name: install dependencies for Linux
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && matrix.build-system != 'docker'
         run: |
           sudo chmod a+rwx /opt
           sudo apt-get update
@@ -249,12 +303,9 @@ jobs:
             sudo apt-get install --yes libasound2-dev libpulse-dev
           fi
           if [[ "${{ matrix.build-system }}" == "meson" ]]; then
-            sudo apt-get install --yes help2man clang-tidy
+            sudo apt-get install --yes help2man
             python -m pip install --upgrade pip
             pip install meson pyyaml Jinja2
-          fi
-          if [[ "${{ matrix.nogui }}" == false ]]; then 
-            sudo apt-get install --yes desktop-file-utils
           fi
       - name: install dependencies for macOS
         if: runner.os == 'macOS'
@@ -335,19 +386,23 @@ jobs:
             fi
             QT_DOWNLOAD_URL="$QT_DOWNLOAD_BASE_URL/qt-${{ matrix.qt-version }}-${{ matrix.qt-type }}-${QT_DOWNLOAD_OS}${QT_DOWNLOAD_ARCH}-$QT_DOWNLOAD_COMMIT.$QT_DOWNLOAD_EXT"
           fi
-          mkdir -p $QT_INSTALL_PATH
-          cd $QT_INSTALL_PATH
-          echo "Downloading $QT_DOWNLOAD_URL"
-          curl -L $QT_DOWNLOAD_URL -o qt.$QT_DOWNLOAD_EXT
-          if [[ "${{ runner.os }}" == 'Windows' ]]; then
-            unzip qt.$QT_DOWNLOAD_EXT
+          if [[ "${{ matrix.build-system }}" == "docker" ]]; then
+            echo "QT_DOWNLOAD_URL=$QT_DOWNLOAD_URL" >> $GITHUB_ENV
           else
-            tar -xzf qt.$QT_DOWNLOAD_EXT
+            mkdir -p $QT_INSTALL_PATH
+            cd $QT_INSTALL_PATH
+            echo "Downloading $QT_DOWNLOAD_URL"
+            curl -L $QT_DOWNLOAD_URL -o qt.$QT_DOWNLOAD_EXT
+            if [[ "${{ runner.os }}" == 'Windows' ]]; then
+              unzip qt.$QT_DOWNLOAD_EXT
+            else
+              tar -xzf qt.$QT_DOWNLOAD_EXT
+            fi
+            rm qt.$QT_DOWNLOAD_EXT
           fi
-          rm qt.$QT_DOWNLOAD_EXT
       - name: Set Qt environment variables # needed to find qmake depending on the way qt was installed
         shell: bash
-        if: matrix.qt-version && matrix.qt-type
+        if: matrix.qt-version && matrix.qt-type && matrix.build-system != 'docker'
         run: |
           if [[ "${{ runner.os }}" == 'Windows' ]]; then
             QT_PATH="c:\qt\qt-${{ matrix.qt-version }}-${{ matrix.qt-type }}"
@@ -365,6 +420,19 @@ jobs:
               echo "DYLD_FRAMEWORK_PATH=$QT_PATH/lib" >> $GITHUB_ENV
             fi
           fi
+      - name: Set up QEMU dependency
+        if: matrix.build-system == 'docker' && needs.check-secrets.outputs.should_run == 'false'
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx (Local)
+        if: matrix.build-system == 'docker' && needs.check-secrets.outputs.should_run == 'false'
+        uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx (Build Cloud)
+        if: matrix.build-system == 'docker' && needs.check-secrets.outputs.should_run == 'true'
+        uses: docker/setup-buildx-action@v3
+        with:
+          version: "lab:latest"
+          driver: cloud
+          endpoint: "jacktrip/test"
       - name: build JackTrip with QMake
         if: matrix.build-system == 'qmake'
         shell: bash
@@ -409,7 +477,7 @@ jobs:
             ./build $CONFIG_STRING
           fi
       - name: build JackTrip with Meson
-        if: matrix.build-system == 'meson'
+        if: matrix.build-system == 'meson' || matrix.build-system == 'docker'
         shell: bash
         run: |
           CONFIG_STRING="-Ddefault_library=${{ matrix.meson-library-type }}"
@@ -427,7 +495,13 @@ jobs:
                 CONFIG_STRING="-Drtaudio:asio=disabled $CONFIG_STRING"
               fi
             elif [[ "${{ runner.os }}" == 'Linux' ]]; then
-              CONFIG_STRING="-Drtaudio:alsa=enabled -Drtaudio:pulse=enabled -Drtaudio:werror=false $CONFIG_STRING"
+              CONFIG_STRING="-Drtaudio:alsa=enabled -Drtaudio:werror=false $CONFIG_STRING"
+              if [[ "${{ matrix.meson-library-type }}" == "static" ]]; then
+                # PulseAudio is SLOW and brings in a lot of extra deps, so exclude it from static builds
+                CONFIG_STRING="-Drtaudio:pulse=disabled $CONFIG_STRING"
+              else
+                CONFIG_STRING="-Drtaudio:pulse=enabled $CONFIG_STRING"
+              fi
             fi
           fi
           if [[ "${{ matrix.nojack }}" == true ]]; then 
@@ -451,9 +525,6 @@ jobs:
           if [[ "${{ matrix.weakjack }}" == true ]]; then 
             CONFIG_STRING="-Dweakjack=true $CONFIG_STRING"
           fi
-          if [[ "${{ runner.os }}" == 'Linux' ]]; then
-            CONFIG_STRING="-Dwerror=true $CONFIG_STRING"
-          fi
           if [[ -n "${{ matrix.macosx-architectures }}" ]]; then
             # TODO: for now, just assume that we want universal if it is not empty
             if [[ -n "${{ matrix.macosx-deployment-target }}" ]]; then
@@ -467,8 +538,23 @@ jobs:
           if [[ "${{ runner.os }}" == 'Windows' && "${{ matrix.qt-type }}" == "static" ]]; then
             CONFIG_STRING="-Db_vscrt=mt $CONFIG_STRING"
           fi
-          meson setup --buildtype release $CONFIG_STRING $BUILD_PATH
-          meson compile -C $BUILD_PATH -v
+          echo "Meson config: ${CONFIG_STRING}"
+          if [[ "${{ matrix.build-system }}" == "docker" ]]; then
+            mkdir -p $BUILD_PATH
+            if [[ "${{ matrix.docker-platform }}" == "linux/arm/v7" ]]; then
+              # should be implied, but this is necessary for broken compiler on arm32
+              CONFIG_STRING="-Dcpp_link_args='-no-pie' $CONFIG_STRING"
+            else
+              CONFIG_STRING="-Dwerror=true $CONFIG_STRING"
+            fi
+            docker buildx build --target=artifact --progress=plain -f linux/Dockerfile.build --output type=local,dest=$BUILD_PATH \
+              --platform "${{ matrix.docker-platform }}" --build-arg BUILD_CONTAINER="${{ matrix.docker-image }}" \
+              --build-arg MESON_ARGS="$CONFIG_STRING" \
+              --build-arg QT_DOWNLOAD_URL="$QT_DOWNLOAD_URL" .
+          else
+            meson setup --buildtype release $CONFIG_STRING $BUILD_PATH
+            meson compile -C $BUILD_PATH -v
+          fi
       - name: validate desktop file
         if: runner.os == 'Linux' && !matrix.nogui
         shell: bash
@@ -478,6 +564,7 @@ jobs:
             DESKTOP_FILE_PATH=$BUILD_PATH/linux/org.jacktrip.JackTrip.desktop
           fi
           echo "DESKTOP_FILE_PATH=$DESKTOP_FILE_PATH" >> $GITHUB_ENV
+          sudo apt-get install --yes desktop-file-utils
           desktop-file-validate $DESKTOP_FILE_PATH
       - name: set signing secrets for macOS
         if: runner.os == 'macOS' && (matrix.bundle-path || matrix.installer-path) && needs.check-secrets.outputs.should_run == 'true'
@@ -563,9 +650,11 @@ jobs:
             mv deploy $NAME
             7z a $ZIPFILE -tzip $NAME
           else
-            strip $BINFILE
+            if [[ "${{ matrix.build-system }}" != "docker" ]]; then
+              strip $BINFILE
+            fi
             zip -j $ZIPFILE $BINFILE
-            if [[ "${{ matrix.name }}" == "Linux-x64-meson-gcc-shared" ]]; then
+            if [[ "${{ matrix.name }}" == "Linux-x64-docker-shared" || "${{ matrix.name }}" == "Linux-arm64-docker-shared" ]]; then
               cp $GITHUB_WORKSPACE/linux/icons/jacktrip.svg $BUILD_PATH/org.jacktrip.JackTrip.svg
               cp $GITHUB_WORKSPACE/linux/icons/jacktrip_48x48.png $BUILD_PATH/org.jacktrip.JackTrip.png
               zip -j $ZIPFILE $DESKTOP_FILE_PATH $BUILD_PATH/jacktrip.1.gz $BUILD_PATH/org.jacktrip.JackTrip.svg $BUILD_PATH/org.jacktrip.JackTrip.png $GITHUB_WORKSPACE/linux/README.md
@@ -607,6 +696,7 @@ jobs:
         if: github.event_name == 'pull_request' && matrix.static-analysis == true
         shell: bash
         run: |
+          sudo apt-get install --yes clang-tidy
           mkdir $CLANG_TIDY_PATH
           git diff -U0 origin/${{ github.base_ref }} | clang-tidy-diff -p1 -path $BUILD_PATH -export-fixes $CLANG_TIDY_PATH/fixes.yml
       - name: save PR metadata for static analysis
@@ -741,7 +831,7 @@ jobs:
             if: needs.check-secrets.outputs.should_run == 'true'
             platform-name: linux
             release-name: Linux-x64
-            build-job-name: Linux-x64-meson-gcc-shared
+            build-job-name: Linux-x64-docker-shared
             runs-on: ubuntu-latest
     permissions:
       contents: "read"

--- a/docs/Build/Linux.md
+++ b/docs/Build/Linux.md
@@ -124,6 +124,56 @@ $ meson install -C builddir
 # enter your password when prompted
 ```
 
+### Building with Docker
+
+You can also build JackTrip using Docker, which especially makes it easier
+to build for alternative architectures. The following build arguments are
+available:
+
+* BUILD_CONTAINER - Debian based container image to build with
+* MESON_ARGS - arguments to build using meson
+* QT_DOWNLOAD_URL - path to qt6 download (optional)
+
+For example:
+
+amd64 dynamic
+```
+docker buildx build --target=artifact -f linux/Dockerfile.build --output type=local,dest=./ \
+  --platform linux/amd64 --build-arg BUILD_CONTAINER=ubuntu:22.04 \
+  --build-arg MESON_ARGS="-Ddefault_library=shared -Drtaudio=enabled -Drtaudio:jack=disabled -Drtaudio:default_library=static -Drtaudio:alsa=enabled -Drtaudio:pulse=enabled -Drtaudio:werror=false" .
+```
+
+amd64 static
+```
+docker buildx build --target=artifact -f linux/Dockerfile.build --output type=local,dest=./ \
+  --platform linux/amd64 --build-arg BUILD_CONTAINER=ubuntu:20.04 \
+  --build-arg MESON_ARGS="-Ddefault_library=static -Drtaudio=enabled -Drtaudio:jack=disabled -Drtaudio:default_library=static -Drtaudio:alsa=enabled -Drtaudio:pulse=disabled -Drtaudio:werror=false -Dnogui=true" \
+  --build-arg QT_DOWNLOAD_URL=https://files.jacktrip.org/contrib/qt/qt-6.5.3-static-linux-amd64.tar.gz .
+```
+
+arm64 dynamic
+```
+docker buildx build --target=artifact -f linux/Dockerfile.build --output type=local,dest=./ \
+  --platform linux/arm64 --build-arg BUILD_CONTAINER=ubuntu:22.04 \
+  --build-arg MESON_ARGS="-Ddefault_library=shared -Drtaudio=enabled -Drtaudio:jack=disabled -Drtaudio:default_library=static -Drtaudio:alsa=enabled -Drtaudio:pulse=enabled -Drtaudio:werror=false" .
+```
+
+arm64 static
+```
+docker buildx build --target=artifact -f linux/Dockerfile.build --output type=local,dest=./ \
+  --platform linux/arm64 --build-arg BUILD_CONTAINER=ubuntu:20.04 \
+  --build-arg MESON_ARGS="-Ddefault_library=static -Drtaudio=enabled -Drtaudio:jack=disabled -Drtaudio:default_library=static -Drtaudio:alsa=enabled -Drtaudio:pulse=disabled -Drtaudio:werror=false -Dnogui=true" \
+  --build-arg QT_DOWNLOAD_URL=https://files.jacktrip.org/contrib/qt/qt-6.5.3-static-linux-arm64.tar.gz .
+```
+
+arm32 static
+```
+docker buildx build --target=artifact -f linux/Dockerfile.build --output type=local,dest=./ \
+  --platform linux/arm/v7 --build-arg BUILD_CONTAINER=debian:buster \
+  --build-arg MESON_ARGS="-Ddefault_library=static -Drtaudio=enabled -Drtaudio:jack=disabled -Drtaudio:default_library=static -Drtaudio:alsa=enabled -Drtaudio:pulse=disabled -Drtaudio:werror=false -Dnogui=true -Dcpp_link_args='-no-pie'" \
+  --build-arg QT_DOWNLOAD_URL=https://files.jacktrip.org/contrib/qt/qt-5.15.13-static-linux-arm32.tar.gz .
+```
+
 ### Verification
 
 If you have installed jacktrip, from anywhere in the Terminal, type:

--- a/linux/Dockerfile.build
+++ b/linux/Dockerfile.build
@@ -1,0 +1,63 @@
+# JackTrip build container for Linux
+#
+# this Dockerfile is used by GitHub CI to create linux builds
+# it requires these environment variables:
+#
+# BUILD_CONTAINER - Debian based container image to build with
+# MESON_ARGS      - arguments to build using meson
+# QT_DOWNLOAD_URL - path to qt download (optional)
+
+# container image versions
+ARG BUILD_CONTAINER=ubuntu:20.04
+
+FROM ${BUILD_CONTAINER} AS builder
+
+# install required packages
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+  && apt-get install -yq --no-install-recommends curl python3-pip build-essential git libclang-dev libdbus-1-dev cmake ninja-build libjack-dev \
+  && apt-get install -yq --no-install-recommends libfreetype6-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libx11-xcb-dev libdrm-dev libglu1-mesa-dev libwayland-dev libwayland-egl1-mesa libgles2-mesa-dev libwayland-server0 libwayland-egl-backend-dev libxcb1-dev libxext-dev libfontconfig1-dev libxrender-dev libxcb-keysyms1-dev libxcb-image0-dev libxcb-shm0-dev libxcb-icccm4-dev '^libxcb.*-dev' libxcb-render-util0-dev libxcomposite-dev libgtk-3-dev \
+  && apt-get install -yq --no-install-recommends libasound2-dev libpulse-dev \
+  && apt-get install -yq --no-install-recommends help2man clang-tidy desktop-file-utils
+RUN python3 -m pip install --upgrade pip \
+  && python3 -m pip install --upgrade certifi \
+  && python3 -m pip install meson pyyaml Jinja2
+
+WORKDIR /opt/jacktrip
+
+# install qt
+ARG QT_DOWNLOAD_URL=""
+ENV QT_DOWNLOAD_URL=$QT_DOWNLOAD_URL
+ENV QT_INSTALL_PATH="/opt"
+RUN if [ -n "$QT_DOWNLOAD_URL" ]; then \
+  mkdir -p $QT_INSTALL_PATH; \
+  chmod a+rwx $QT_INSTALL_PATH; \
+  curl -k -L $QT_DOWNLOAD_URL -o qt.tar.gz; \
+  tar -C $QT_INSTALL_PATH -xzf qt.tar.gz; \
+  rm qt.tar.gz; \
+  else \
+  add-apt-repository universe; \
+  apt-get update; \
+  apt-get install -yq --no-install-recommends qt6-base-dev qt6-base-dev-tools qmake6 qt6-tools-dev qt6-declarative-dev qt6-webengine-dev qt6-webview-dev qt6-webview-plugins libqt6svg6-dev libqt6websockets6-dev libgl1-mesa-dev libqt6core5compat6-dev libqt6shadertools6-dev; \
+  qtchooser -install qt6 $(which qmake6); \
+  fi
+
+# build jacktrip using meson
+COPY . ./
+ARG MESON_ARGS=""
+ENV MESON_ARGS=$MESON_ARGS
+ENV BUILD_PATH="/opt/jacktrip/builddir"
+RUN if [ -n "$QT_DOWNLOAD_URL" ]; then \
+  export QT_PATH="/opt/$(echo $QT_DOWNLOAD_URL | sed -e 's,.*/qt/\(qt-[.0-9]*\-[a-z]*\).*,\1,')"; \
+  export PATH="$PATH:$QT_PATH/bin"; \
+  export PKG_CONFIG_PATH="$QT_PATH/lib/pkgconfig"; \
+  export CMAKE_PREFIX_PATH="$QT_PATH"; fi \
+  && export SSL_CERT_FILE=$(python3 -m certifi) \
+  && meson setup --buildtype release $MESON_ARGS $BUILD_PATH \
+  && meson compile -C $BUILD_PATH -v \
+  && strip $BUILD_PATH/jacktrip
+
+
+FROM scratch AS artifact
+
+COPY --from=builder /opt/jacktrip/builddir/jacktrip /opt/jacktrip/builddir/linux/org.jacktrip.JackTrip.desktop /

--- a/linux/README.md
+++ b/linux/README.md
@@ -7,13 +7,13 @@ JackTrip requires that Qt6 is installed on your machine.
 For Fedora or RedHat:
 
 ```
-dnf install -y qt6-qtbase qt6-qtbase-common qt6-qtbase-gui qt6-qtsvg qt6-qtwebsockets qt6-qtwebengine qt6-qtwebchannel qt6-qt5compat
+dnf install -y qt6-qtbase qt6-qtbase-common qt6-qtbase-gui qt6-qtsvg qt6-qtwebsockets qt6-qtwebengine qt6-qtwebchannel qt6-qt5compat rtaudio-devel
 ```
 
 For Debian or Ubuntu:
 
 ```
-apt install -y libqt6core6 libqt6gui6 libqt6network6 libqt6widgets6 libqt6qml6 libqt6qmlcore6 libqt6quick6 libqt6quickcontrols2-6 libqt6svg6  libqt6webchannel6 libqt6webengine6-data libqt6webenginecore6 libqt6webenginecore6-bin libqt6webenginequick6 libqt6websockets6 libqt6shadertools6 qt6-qpa-plugins qml6-module-qtquick-controls qml6-module-qtqml-workerscript qml6-module-qtquick-templates qml6-module-qtquick-layouts qml6-module-qt5compat-graphicaleffects qml6-module-qtwebchannel qml6-module-qtwebengine qml6-module-qtquick-window
+apt install -y libqt6core6 libqt6gui6 libqt6network6 libqt6widgets6 libqt6qml6 libqt6qmlcore6 libqt6quick6 libqt6quickcontrols2-6 libqt6svg6  libqt6webchannel6 libqt6webengine6-data libqt6webenginecore6 libqt6webenginecore6-bin libqt6webenginequick6 libqt6websockets6 libqt6shadertools6 qt6-qpa-plugins qml6-module-qtquick-controls qml6-module-qtqml-workerscript qml6-module-qtquick-templates qml6-module-qtquick-layouts qml6-module-qt5compat-graphicaleffects qml6-module-qtwebchannel qml6-module-qtwebengine qml6-module-qtquick-window libjack-jackd2-0 librtaudio6
 ```
 
 To install JackTrip as a Linux desktop application:

--- a/meson.build
+++ b/meson.build
@@ -268,7 +268,7 @@ if get_option('default_library') == 'static'
 	qt_plugindir = run_command(qmake, '-query', 'QT_INSTALL_PLUGINS', check : true).stdout().strip()
 	if qt_version == '6'
 		# qt6 requires "Bundled*" modules for linking
-		deps += dependency('qt6', modules: ['BundledLibpng', 'BundledPcre2', 'BundledHarfbuzz', 'BundledZLIB'], include_type: 'system')
+		deps += dependency('qt6', modules: ['DBus', 'BundledLibpng', 'BundledPcre2', 'BundledHarfbuzz', 'BundledZLIB'], include_type: 'system')
 	else
 		deps += compiler.find_library('qtpcre2', required : true, dirs : [qt_libdir])
 	endif
@@ -280,6 +280,7 @@ if get_option('default_library') == 'static'
 		deps += compiler.find_library('glib-2.0', required : true)
 		if qt_version == '6'
 			# we need a Q_IMPORT_LIBRARY for the openssl backend on linux
+			deps += compiler.find_library('dbus-1', required : true)
 			deps += compiler.find_library('qopensslbackend', required : true, dirs : [qt_plugindir+'/tls'])
 			src += ['src/QtStaticPlugins.cpp']
 		endif

--- a/src/AudioInterface.cpp
+++ b/src/AudioInterface.cpp
@@ -95,15 +95,15 @@ AudioInterface::~AudioInterface()
         delete[] mAPInBuffer[i];
     }
 #endif  // endwhere
-    for (auto* i : std::as_const(mProcessPluginsFromNetwork)) {
+    for (auto* i : qAsConst(mProcessPluginsFromNetwork)) {
         i->disconnect();
         delete i;
     }
-    for (auto* i : std::as_const(mProcessPluginsToNetwork)) {
+    for (auto* i : qAsConst(mProcessPluginsToNetwork)) {
         i->disconnect();
         delete i;
     }
-    for (auto* i : std::as_const(mProcessPluginsToMonitor)) {
+    for (auto* i : qAsConst(mProcessPluginsToMonitor)) {
         i->disconnect();
         delete i;
     }
@@ -206,7 +206,7 @@ void AudioInterface::audioInputCallback(QVarLengthArray<sample_t*>& in_buffer,
 #endif  // not WAIR
 
     // process incoming signal from audio interface using process plugins
-    for (auto* p : std::as_const(mProcessPluginsToNetwork)) {
+    for (auto* p : qAsConst(mProcessPluginsToNetwork)) {
         if (p->getInited()) {
             p->compute(n_frames, in_buffer.data(), in_buffer.data());
         }
@@ -268,7 +268,7 @@ void AudioInterface::audioOutputCallback(QVarLengthArray<sample_t*>& out_buffer,
     /// with one. do it chaining outputs to inputs in the buffers. May need a tempo buffer
 
 #ifndef WAIR  // NOT WAIR:
-    for (auto* p : std::as_const(mProcessPluginsFromNetwork)) {
+    for (auto* p : qAsConst(mProcessPluginsFromNetwork)) {
         if (p->getInited()) {
             p->compute(n_frames, out_buffer.data(), out_buffer.data());
         }
@@ -728,17 +728,17 @@ void AudioInterface::initPlugins(bool verbose)
                       << ") at sampling rate " << mSampleRate << "\n";
         }
 
-        for (ProcessPlugin* plugin : std::as_const(mProcessPluginsFromNetwork)) {
+        for (ProcessPlugin* plugin : qAsConst(mProcessPluginsFromNetwork)) {
             plugin->setOutgoingToNetwork(false);
             plugin->updateNumChannels(nChansIn, nChansOut);
             plugin->init(mSampleRate, mBufferSizeInSamples);
         }
-        for (ProcessPlugin* plugin : std::as_const(mProcessPluginsToNetwork)) {
+        for (ProcessPlugin* plugin : qAsConst(mProcessPluginsToNetwork)) {
             plugin->setOutgoingToNetwork(true);
             plugin->updateNumChannels(nChansIn, nChansOut);
             plugin->init(mSampleRate, mBufferSizeInSamples);
         }
-        for (ProcessPlugin* plugin : std::as_const(mProcessPluginsToMonitor)) {
+        for (ProcessPlugin* plugin : qAsConst(mProcessPluginsToMonitor)) {
             plugin->setOutgoingToNetwork(false);
             plugin->updateNumChannels(nChansMon, nChansMon);
             plugin->init(mSampleRate, mBufferSizeInSamples);


### PR DESCRIPTION
Using docker container to create all Linux release builds. Added new Linux arm64 static and dynamic builds, and a Linux arm32 static build for old Raspberry Pi bridge devices.

Switching qAsConst instead of std::as_const since older compilers that we are still using do not support it

Disabling PulseAudio in Linux static builds since it brings in a bunch of extra dependencies and is very SLOW