### PR TITLE
Fix for audio devices that contain a comma

### DIFF
--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -1017,12 +1017,14 @@ void Settings::setDevicesByString(std::string nameArg)
     if (escapedPositions.size() > 0) {
         // We have to get rid of instances of our escape character.
         position = 0;
-        while ((position = mInputDeviceName.find(escaped, position)) != std::string::npos) {
+        while ((position = mInputDeviceName.find(escaped, position))
+               != std::string::npos) {
             mInputDeviceName.replace(position, escaped.length(), ",");
             position++;
         }
         position = 0;
-        while ((position = mOutputDeviceName.find(escaped, position)) != std::string::npos) {
+        while ((position = mOutputDeviceName.find(escaped, position))
+               != std::string::npos) {
             mOutputDeviceName.replace(position, escaped.length(), ",");
             position++;
         }

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -1031,7 +1031,6 @@ void Settings::setDevicesByString(std::string nameArg)
     }
 }
 
-
 #endif
 
 //*******************************************************************************

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -981,12 +981,32 @@ void Settings::setDevicesByString(std::string nameArg)
 {
     size_t commaPos;
     char delim = ',';
-    if (std::count(nameArg.begin(), nameArg.end(), delim) > 1) {
+
+    // Some audio device names contain commas. Allow these to be escaped with a backslash.
+    int delimCount = std::count(nameArg.begin(), nameArg.end(), delim);
+    std::string escaped = "\\,";
+    std::vector<size_t> escapedPositions;
+
+    size_t position = nameArg.find(escaped, 0);
+    while(position != std::string::npos) {
+        // Store our comma locations for future reference.
+        escapedPositions.push_back(position + 1);
+        cout << position + 1 << endl;
+        position = nameArg.find(escaped, position + escaped.length());
+    }
+
+    if (delimCount - escapedPositions.size() > 1) {
         throw std::invalid_argument(
             "Found multiple commas in the --audiodevice argument, cannot parse "
             "reliably.");
     }
+    int index = escapedPositions.size() - 1;
     commaPos = nameArg.rfind(delim);
+    while (commaPos > 0 && index >= 0 && commaPos == escapedPositions.at(index)) {
+        commaPos = nameArg.rfind(delim, commaPos - 1);
+        index--;
+    }
+
     if (commaPos || nameArg[0] == delim) {
         mInputDeviceName  = nameArg.substr(0, commaPos);
         mOutputDeviceName = nameArg.substr(commaPos + 1);

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -997,7 +997,7 @@ void Settings::setDevicesByString(std::string nameArg)
 
     if (delimCount - escapedPositions.size() > 1) {
         throw std::invalid_argument(
-            "Found multiple commas in the --audiodevice argument, cannot parse "
+            "Found multiple unescaped commas in the --audiodevice argument, cannot parse "
             "reliably.");
     }
     int index = escapedPositions.size() - 1;
@@ -1013,7 +1013,23 @@ void Settings::setDevicesByString(std::string nameArg)
     } else {
         mInputDeviceName = mOutputDeviceName = nameArg;
     }
+
+    if (escapedPositions.size() > 0) {
+        // We have to get rid of instances of our escape character.
+        position = 0;
+        while ((position = mInputDeviceName.find(escaped, position)) != std::string::npos) {
+            mInputDeviceName.replace(position, escaped.length(), ",");
+            position++;
+        }
+        position = 0;
+        while ((position = mOutputDeviceName.find(escaped, position)) != std::string::npos) {
+            mOutputDeviceName.replace(position, escaped.length(), ",");
+            position++;
+        }
+    }
 }
+
+
 #endif
 
 //*******************************************************************************

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -983,12 +983,12 @@ void Settings::setDevicesByString(std::string nameArg)
     char delim = ',';
 
     // Some audio device names contain commas. Allow these to be escaped with a backslash.
-    int delimCount = std::count(nameArg.begin(), nameArg.end(), delim);
+    int delimCount      = std::count(nameArg.begin(), nameArg.end(), delim);
     std::string escaped = "\\,";
     std::vector<size_t> escapedPositions;
 
     size_t position = nameArg.find(escaped, 0);
-    while(position != std::string::npos) {
+    while (position != std::string::npos) {
         // Store our comma locations for future reference.
         escapedPositions.push_back(position + 1);
         cout << position + 1 << endl;
@@ -1001,7 +1001,7 @@ void Settings::setDevicesByString(std::string nameArg)
             "reliably.");
     }
     int index = escapedPositions.size() - 1;
-    commaPos = nameArg.rfind(delim);
+    commaPos  = nameArg.rfind(delim);
     while (commaPos > 0 && index >= 0 && commaPos == escapedPositions.at(index)) {
         commaPos = nameArg.rfind(delim, commaPos - 1);
         index--;

--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -136,11 +136,6 @@ QJackTrip::QJackTrip(UserInterface& interface, QWidget* parent)
         m_ui->credsLabel->setEnabled(m_ui->requireAuthCheckBox->isChecked());
         m_ui->credsEdit->setEnabled(m_ui->requireAuthCheckBox->isChecked());
         m_ui->credsBrowse->setEnabled(m_ui->requireAuthCheckBox->isChecked());
-        /*connect(m_ui->usersButton, &QPushButton::clicked, this, [=]() {
-            AuthDialog authDialog(this, m_credsFile, m_lastPath);
-            connect(&authDialog, &AuthDialog::signalFileChanged, this, &QJackTrip::credsFileChanged);
-            authDialog.exec();
-        });*/
         authFilesChanged();
     });
     connect(m_ui->ioStatsCheckBox, &QCheckBox::stateChanged, this, [=]() {
@@ -560,7 +555,7 @@ void QJackTrip::receivedConnectionFromPeer()
                                                                       Qt::SkipEmptyParts);
 #else
                                                                       QString::
-                                                                          SkipEmptyParts); 
+                                                                          SkipEmptyParts);
 #endif
         if (!arguments.isEmpty()) {
             QProcess connectScript;

--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -559,7 +559,8 @@ void QJackTrip::receivedConnectionFromPeer()
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
                                                                       Qt::SkipEmptyParts);
 #else
-                                                                      QString::SkipEmptyParts); 
+                                                                      QString::
+                                                                          SkipEmptyParts); 
 #endif
         if (!arguments.isEmpty()) {
             QProcess connectScript;
@@ -715,12 +716,6 @@ void QJackTrip::credentialsChanged()
     }
 }
 
-/*void QJackTrip::credsFileChanged(const QString& fileName)
-{
-    m_credsFile = fileName;
-    m_lastPath = QFileInfo(fileName).canonicalPath();
-}*/
-
 void QJackTrip::browseForFile()
 {
     QPushButton* sender = static_cast<QPushButton*>(QObject::sender());
@@ -824,18 +819,6 @@ void QJackTrip::resetOptions()
 
 void QJackTrip::start()
 {
-    // Abort if we're a hub server and still need to set up authentication.
-    /*if (m_ui->typeComboBox->currentIndex() == HUB_SERVER
-        && m_ui->requireAuthCheckBox->isChecked() && m_credsFile.isEmpty()) {
-        QMessageBox msgBox;
-        msgBox.setText(QStringLiteral(
-            "Error: To enable authentication you need to set up a list of users before "
-            "running the server. Click on the \"Manage Users\" button to do this."));
-        msgBox.setWindowTitle(QStringLiteral("Doh!"));
-        msgBox.exec();
-        return;
-    }*/
-
     m_ui->connectButton->setEnabled(false);
     enableUi(false);
     m_jackTripRunning = true;
@@ -1987,13 +1970,12 @@ QString QJackTrip::commandLineFromCurrentOptions()
         if (m_ui->outputDeviceComboBox->currentIndex() > 0) {
             outDevice = m_ui->outputDeviceComboBox->currentText();
         }
-        QString inDeviceEscaped = QString(inDevice).replace(QStringLiteral(","),
-                                                            QStringLiteral("\\,"));
-        QString outDeviceEscaped = QString(outDevice).replace(QStringLiteral(","),
-                                                              QStringLiteral("\\,"));
-        commandLine.append(
-            QStringLiteral(" --audiodevice \"%1\",\"%2\"").arg(inDeviceEscaped,
-                                                               outDeviceEscaped));
+        QString inDeviceEscaped =
+            QString(inDevice).replace(QStringLiteral(","), QStringLiteral("\\,"));
+        QString outDeviceEscaped =
+            QString(outDevice).replace(QStringLiteral(","), QStringLiteral("\\,"));
+        commandLine.append(QStringLiteral(" --audiodevice \"%1\",\"%2\"")
+                               .arg(inDeviceEscaped, outDeviceEscaped));
     }
 #endif
 
@@ -2018,13 +2000,11 @@ void QJackTrip::populateDeviceMenu(QComboBox* menu, bool isInput)
         if (menu->findText(utf8Name) != -1) {
             continue;
         }
-
         if (isInput && info.inputChannels > 0) {
             menu->addItem(utf8Name);
         } else if (!isInput && info.outputChannels > 0) {
             menu->addItem(utf8Name);
         }
-
     }
 
     // set the previous value


### PR DESCRIPTION
Allow for a comma to be escaped with a backslash if it's part of an rtaudio device name. (Should fix #1363.)