### PR TITLE
Fixing longTermMax stats corruption in Regulator

### DIFF
--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -855,11 +855,16 @@ bool StdDev::tick(double prevTime, double curTime)
         return false;
 
     data[ctr] = msElapsed;
-    if (msElapsed < min)
-        min = msElapsed;
-    else if (msElapsed > max)
-        max = msElapsed;
     acc += msElapsed;
+    if (ctr == 0) {
+        min = msElapsed;
+        max = msElapsed;
+    } else {
+        if (msElapsed < min)
+            min = msElapsed;
+        if (msElapsed > max)
+            max = msElapsed;
+    }
     if (ctr == 0 && longTermCnt % WindowDivisor == 0) {
         lastMin = msElapsed;
         lastMax = msElapsed;


### PR DESCRIPTION
When auto headroom is updated dynamically, it could cause a race condition where calcAuto() was called before any measurements were made (ctr == 0). This would cause a recording of "max" with a negative value (the reset() value of -999999.0). This is such a large (or small?) value that it corrupted the longTermMax rolling average for a long duration of time.

The result of longTermMax corruption is that tolerance would be reset to a minimum value equal to the duration of a single audio buffer. This resulted in audio received from the participant being very garbled until longTermMax was finally able to recover.

It's a pretty nasty bug. A bit hard to find and unwind, but the fix is pretty clear and obvious. I just added some extra sanity checks to calcAuto to ensure that max (and min) are only used with sane values.

The "good" news is that I think this was only recently introduced by adding the ability to adjust headroom dynamically (via OSC). The "bad" news is that we currently have this running in production and I'm pretty sure vs-agent is calling that method at least once on startup for all studio sessions.