### PR TITLE
Fix bug preventing logout from virtual studio mode

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -1,3 +1,8 @@
+- Version: "2.5.0-beta2"
+  Date: 2025-01-16
+  Description:
+  - (added) Sample rate conversion in Audio Bridge VST3 Plugin
+  - (fixed) VS mode logout was immediately triggering re-login
 - Version: "2.5.0-beta1"
   Date: 2025-01-13
   Description:

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -40,7 +40,7 @@
 
 #include "jacktrip_types.h"
 
-constexpr const char* const gVersion = "2.5.0-beta1";  ///< JackTrip version
+constexpr const char* const gVersion = "2.5.0-beta2";  ///< JackTrip version
 
 //*******************************************************************************
 /// \name Default Values

--- a/src/vs/vsAuth.cpp
+++ b/src/vs/vsAuth.cpp
@@ -327,10 +327,14 @@ void VsAuth::logout()
     }
     qDebug() << "Logging out";
 
+    // stop timer to refresh token
+    m_refreshTimer->stop();
+
     // reset auth state
     m_userId               = QStringLiteral("");
     m_verificationCode     = QStringLiteral("");
     m_accessToken          = QStringLiteral("");
+    m_refreshToken         = QStringLiteral("");
     m_authenticationStage  = QStringLiteral("unauthenticated");
     m_errorMessage         = QStringLiteral("");
     m_isAuthenticated      = false;


### PR DESCRIPTION
It actually was logging out by clearing the access token, but we were failing to also clear the new refresh token. So it would just immediately trigger the cycle to use the refresh token to get a new access token, effectively logging in again right away.

Clearing the refresh token on logout fixes the problem, but also best to stop the refresh timer (it will get started again after successful login).

Also bumping version and changelog for beta2 release