### PR TITLE
meson: support libsamplerate as system dependency

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -65,6 +65,7 @@ jobs:
             nogui: false
             novs: true
             weakjack: false
+            libsamplerate: true
             # jacktrip-path: jacktrip # needed for binary upload
             # binary-path: binary # directory relative to build path; triggers artifact upload for jacktrip binary
             # bundle-path: bundle # directory relative to build path; triggers application bundle creation and upload (macOS)
@@ -82,6 +83,7 @@ jobs:
             bundled-rtaudio: false
             nogui: false
             weakjack: false
+            libsamplerate: true
             # jacktrip-path: jacktrip
             # binary-path: binary
             build-system: meson
@@ -322,6 +324,9 @@ jobs:
             sudo apt-get install --yes help2man
             python -m pip install --upgrade pip
             pip install meson pyyaml Jinja2
+          fi
+          if [[ "${{ matrix.libsamplerate }}" == true ]]; then
+            sudo apt-get install --yes libsamplerate-dev
           fi
       - name: install dependencies for macOS
         if: runner.os == 'macOS'

--- a/meson.build
+++ b/meson.build
@@ -343,9 +343,10 @@ if rtaudio_dep.found() == false and jack_dep.found() == false
 	configure.''')
 endif
 
-libsamplerate_dep = []
-found_libsamplerate = false
-if get_option('libsamplerate').allowed()
+libsamplerate_dep = dependency('samplerate', required: get_option('libsamplerate'))
+found_libsamplerate = libsamplerate_dep.found()
+
+if get_option('libsamplerate').allowed() and found_libsamplerate == false
 	opt_var = cmake.subproject_options()
 	if get_option('buildtype') == 'release'
 		opt_var.add_cmake_defines({'CMAKE_BUILD_TYPE': 'Release'})
@@ -359,10 +360,11 @@ if get_option('libsamplerate').allowed()
 	if not found_libsamplerate and not get_option('libsamplerate').auto()
 		error('failed to configure libsamplerate')
 	endif
-	if found_libsamplerate
-		defines += '-DHAVE_LIBSAMPLERATE'
-		deps += libsamplerate_dep
-	endif
+endif
+
+if found_libsamplerate
+	defines += '-DHAVE_LIBSAMPLERATE'
+	deps += libsamplerate_dep
 endif
 
 if host_machine.system() == 'darwin'

--- a/meson.build
+++ b/meson.build
@@ -343,7 +343,7 @@ if rtaudio_dep.found() == false and jack_dep.found() == false
 	configure.''')
 endif
 
-libsamplerate_dep = dependency('samplerate', required: get_option('libsamplerate'))
+libsamplerate_dep = dependency('samplerate', required: false)
 found_libsamplerate = libsamplerate_dep.found()
 
 if get_option('libsamplerate').allowed() and found_libsamplerate == false


### PR DESCRIPTION
This should handle the build with libsamplerate as a system dependency.

WIP: There's still a logic error, because I needed to set required: false.