### PR TITLE
Fix regression with reconnecting JackTrip audio during live session

### DIFF
--- a/src/vs/virtualstudio.cpp
+++ b/src/vs/virtualstudio.cpp
@@ -1039,9 +1039,13 @@ void VirtualStudio::connectToStudio()
             &VirtualStudio::restartStudioSocket);
     m_studioSocketPtr->openSocket();
 
-    // Wait for websocket to respond with studio data before connecting
-    m_connectionState = QStringLiteral("Waiting...");
-    emit connectionStateChanged();
+    // Check if we have an address for our server
+    if (m_currentStudio.status() != "Ready" || m_currentStudio.host().isEmpty()) {
+        m_connectionState = QStringLiteral("Waiting...");
+        emit connectionStateChanged();
+    } else {
+        completeConnection();
+    }
 
     m_reconnectState = ReconnectState::NOT_RECONNECTING;
 }


### PR DESCRIPTION
this reverts the logic in VirtualStudio::connectToStudio except that it adds an extra check for the server host being empty. The first time you connect, this should always be empty, forcing it to wait for the websocket response. But it will not be empty for subsequent reconnects to the same studio, enabling it to not have to wait for a new websocket message.