### PR TITLE
Fix for display of failed message screen during startup on Linux

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -30,8 +30,13 @@ jobs:
         submodules: true
     - name: Add SHORT_SHA environment variable
       run: echo "SHORT_SHA=`echo ${GITHUB_SHA::7}`" >> $GITHUB_ENV
-    - uses: flatpak/flatpak-github-actions/flatpak-builder@v6.3
+    - uses: flatpak/flatpak-github-actions/flatpak-builder@master
       with:
         bundle: JackTrip-${{ env.SHORT_SHA }}.flatpak
         manifest-path: build-aux/flatpak/org.jacktrip.JackTrip.json
         cache-key: flatpak-builder-${{ github.sha }}
+        upload-artifact: false
+    - uses: actions/upload-artifact@v4
+      with:
+        name: JackTrip-${{ env.SHORT_SHA }}-x86_64
+        path: JackTrip-${{ env.SHORT_SHA }}.flatpak

--- a/.github/workflows/mkdocs-preview.yml
+++ b/.github/workflows/mkdocs-preview.yml
@@ -26,7 +26,7 @@ jobs:
           mkdir docs-upload
           mv site docs-upload/JackTrip-docs-${{ github.sha }}
       - name: Upload docs for preview
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: JackTrip-docs-${{ github.sha }}
           path: docs-upload

--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -2,6 +2,8 @@
   Date: 2025-01-30
   Description:
   - (fixed) Updating Qt in Mac builds from 6.2.6 to 6.2.11
+  - (fixed) Strange error message during startup on Linux
+  - (fixed) VS Mode studio padding when browsing on Linux
   - (fixed) VS Mode ensure studio data is fresh before connecting
 - Version: "2.5.0"
   Date: 2025-01-21

--- a/linux/README.md
+++ b/linux/README.md
@@ -13,7 +13,7 @@ dnf install -y qt6-qtbase qt6-qtbase-common qt6-qtbase-gui qt6-qtsvg qt6-qtwebso
 For Debian or Ubuntu:
 
 ```
-apt install -y libqt6core6 libqt6gui6 libqt6network6 libqt6widgets6 libqt6qml6 libqt6qmlcore6 libqt6quick6 libqt6quickcontrols2-6 libqt6svg6  libqt6webchannel6 libqt6webengine6-data libqt6webenginecore6 libqt6webenginecore6-bin libqt6webenginequick6 libqt6websockets6 libqt6shadertools6 qt6-qpa-plugins qml6-module-qtquick-controls qml6-module-qtqml-workerscript qml6-module-qtquick-templates qml6-module-qtquick-layouts qml6-module-qt5compat-graphicaleffects qml6-module-qtwebchannel qml6-module-qtwebengine qml6-module-qtquick-window libjack-jackd2-0 librtaudio6 libgtkmm-3.0-1t64 libxcb-cursor0
+apt install -y libqt6core6 libqt6gui6 libqt6network6 libqt6widgets6 libqt6qml6 libqt6qmlcore6 libqt6quick6 libqt6quickcontrols2-6 libqt6svg6  libqt6webchannel6 libqt6webengine6-data libqt6webenginecore6 libqt6webenginecore6-bin libqt6webenginequick6 libqt6websockets6 libqt6shadertools6 qt6-qpa-plugins qml6-module-qtquick-controls qml6-module-qtqml-workerscript qml6-module-qtquick-templates qml6-module-qtquick-layouts qml6-module-qt5compat-graphicaleffects qml6-module-qtwebchannel qml6-module-qtwebengine qml6-module-qtquick-window libjack-jackd2-0 librtaudio6 libxcb-cursor0
 ```
 
 To install JackTrip as a Linux desktop application:

--- a/src/vs/Browse.qml
+++ b/src/vs/Browse.qml
@@ -52,7 +52,10 @@ Item {
 
     ListView {
         id: studioListView
-        x:0; y: 0; width: parent.width - (2 * x); height: parent.height - 36 * virtualstudio.uiScale
+        x:0;
+        y: 0;
+        width: parent.width
+        height: parent.height - (36 * virtualstudio.uiScale)
         spacing: 16 * virtualstudio.uiScale
         header: footer
         footer: footer
@@ -60,8 +63,9 @@ Item {
         clip: true
         boundsBehavior: Flickable.StopAtBounds
         delegate: Studio {
-            x: 16 * virtualstudio.uiScale
-            width: studioListView.width - (2 * x)
+            anchors.left: parent ? parent.left : undefined
+            anchors.leftMargin: 16 * virtualstudio.uiScale
+            width: studioListView.width - (32 * virtualstudio.uiScale)
             serverLocation: virtualstudio.regions[modelData.location] ? "in " + virtualstudio.regions[modelData.location].label : ""
             flagImage: modelData.bannerURL ? modelData.bannerURL : modelData.flag
             studioName: modelData.name

--- a/src/vs/vs.qml
+++ b/src/vs/vs.qml
@@ -226,13 +226,13 @@ Rectangle {
         x: window.width
     }
 
-    CreateStudio {
-        id: createStudioScreen
+    Failed {
+        id: failedScreen
         x: window.width
     }
 
-    Failed {
-        id: failedScreen
+    CreateStudio {
+        id: createStudioScreen
         x: window.width
     }
 


### PR DESCRIPTION
Fix studio padding (or lack thereof) when browsing on Linux

I think these are more related to the use of newer Qt releases versus Linux, but since we pin to older releases on other platforms I'm only mentioning that in the changelog

I honestly don't understand why rearranging things in vs.qml fixes the display of the failed screen, but it seems to work..