### PR TITLE
Don't reset studioToJoin when going to the device settings page

### DIFF
--- a/src/vs/Connected.qml
+++ b/src/vs/Connected.qml
@@ -67,10 +67,7 @@ Item {
         anchors.left: parent.left
         anchors.bottom: deviceControlsGroup.top
 
-        property string accessToken: auth.isAuthenticated && Boolean(auth.accessToken) ? auth.accessToken : ""
-        property string studioId: virtualstudio.currentStudio.id
-
-        source: accessToken && studioId ? "Web.qml" : "WebNull.qml"
+        source: auth.isAuthenticated && Boolean(auth.accessToken) && Boolean(virtualstudio.currentStudio.id) ? "Web.qml" : "WebNull.qml"
     }
 
     DeviceControlsGroup {

--- a/src/vs/DeviceWarningModal.qml
+++ b/src/vs/DeviceWarningModal.qml
@@ -132,7 +132,6 @@ Item {
                     onClicked: () => {
                         deviceWarningPopup.close();
                         audio.stopAudio(true);
-                        virtualstudio.studioToJoin = virtualstudio.currentStudio.id;
                         virtualstudio.windowState = "connected";
                         virtualstudio.saveSettings();
                         virtualstudio.joinStudio();

--- a/src/vs/Setup.qml
+++ b/src/vs/Setup.qml
@@ -140,7 +140,6 @@ Item {
                         deviceWarningModal.open();
                     } else {
                         audio.stopAudio(true);
-                        virtualstudio.studioToJoin = virtualstudio.currentStudio.id;
                         virtualstudio.windowState = "connected";
                         virtualstudio.saveSettings();
                         virtualstudio.joinStudio();

--- a/src/vs/WebEngine.qml
+++ b/src/vs/WebEngine.qml
@@ -52,9 +52,6 @@ Item {
         anchors.fill: parent
         color: backgroundColour
 
-        property string accessToken: auth.isAuthenticated && Boolean(auth.accessToken) ? auth.accessToken : ""
-        property string studioId: virtualstudio.currentStudio.id
-
         WebEngineView {
             id: webEngineView
             anchors.fill: parent
@@ -62,7 +59,7 @@ Item {
             settings.javascriptCanPaste: true
             settings.screenCaptureEnabled: true
             profile.httpUserAgent: `JackTrip/${virtualstudio.versionString}`
-            url: `https://${virtualstudio.apiHost}/studios/${studioId}/live`
+            url: `https://${virtualstudio.apiHost}/studios/${virtualstudio.currentStudio.id}/live`
 
             // useful for debugging
             // onJavaScriptConsoleMessage: function(level, message, lineNumber, sourceID) {


### PR DESCRIPTION
There was some weird back-and-forth between studioToJoin and currentStudio when someone went to device settings page before joining a studio. This leaves studioToJoin alone and defers setting currentStudio until we're switching to the connected page.

Allow additional webengine flags to be set via env, for debugging