### PR TITLE
Bumping builds to start using qt 6.8.2

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -380,6 +380,7 @@ jobs:
           fi
           choco install jack --version=1.9.17 --no-progress
           choco install pkgconfiglite --no-progress
+          choco install zip --no-progress
       - name: setup MSVC
         uses: ilammy/msvc-dev-cmd@v1
         if: runner.os == 'Windows'
@@ -620,9 +621,6 @@ jobs:
           fi
           if [[ -n "${{ matrix.vst3sdk-version }}" && "${{ matrix.build-system }}" != "docker" && "${{ runner.os }}" != 'Windows' ]]; then
             CONFIG_STRING="-Dvst-sdkdir=$VST3SDK_INSTALL_PATH $CONFIG_STRING"
-          fi
-          if [[ "${{ runner.os }}" == 'Windows' && "${{ matrix.qt-type }}" == "static" ]]; then
-            CONFIG_STRING="-Db_vscrt=mt $CONFIG_STRING"
           fi
           if [[ "${{ matrix.build-system }}" == "docker" ]]; then
             mkdir -p $BUILD_PATH

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -138,7 +138,7 @@ jobs:
             docker-image: ubuntu:jammy-20240911.1
             docker-platform: linux/amd64
             meson-library-type: static
-            qt-version: '6.8.1'
+            qt-version: '6.8.2'
             qt-type: 'static'
             qt-arch: 'amd64'
 
@@ -157,7 +157,7 @@ jobs:
             docker-image: ubuntu:jammy-20240911.1
             docker-platform: linux/arm64
             meson-library-type: static
-            qt-version: '6.8.1'
+            qt-version: '6.8.2'
             qt-type: 'static'
             qt-arch: 'arm64'
 
@@ -194,7 +194,7 @@ jobs:
             binary-path: binary
             build-system: meson
             meson-library-type: static
-            qt-version: '6.8.1'
+            qt-version: '6.8.2'
             qt-type: 'static'
             macosx-architectures: 'x86_64;arm64'
             macosx-deployment-target: 12
@@ -215,7 +215,7 @@ jobs:
             installer-path: installer
             build-system: meson
             meson-library-type: both
-            qt-version: '6.8.1'
+            qt-version: '6.8.2'
             qt-type: 'dynamic'
             vst3sdk-version: '3.7.12'
             macosx-architectures: 'x86_64;arm64'
@@ -231,7 +231,7 @@ jobs:
             novs: true
             weakjack: true
             libsamplerate: true
-            qt-version: '6.8.1'
+            qt-version: '6.8.2'
             qt-type: 'static'
             jacktrip-path: jacktrip.exe
             binary-path: binary
@@ -247,7 +247,7 @@ jobs:
             novs: false
             weakjack: true
             libsamplerate: true
-            qt-version: '6.8.1'
+            qt-version: '6.8.2'
             qt-type: 'dynamic'
             jacktrip-path: jacktrip.exe
             installer-path: installer
@@ -262,7 +262,7 @@ jobs:
       CLANG_TIDY_PATH: ${{ github.workspace }}/clang-tidy-result
       VST3SDK_DOWNLOAD_BASE_URL: 'https://files.jacktrip.org/contrib/vst3sdk'
       QT_DOWNLOAD_BASE_URL: 'https://files.jacktrip.org/contrib/qt'
-      QT_DOWNLOAD_COMMIT: '3e1fab2'
+      QT_DOWNLOAD_COMMIT: '7934713'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -73,6 +73,7 @@ jobs:
             # meson-library-type: shared # shared, static, both
             # static-analysis: true # run clang-tidy static analysis (meson/Linux only)
             qt-version: '5.15.13'
+            qt-download-commit: 'f82eab7'
             qt-type: 'static'
             qt-arch: 'amd64'
 
@@ -134,10 +135,10 @@ jobs:
             jacktrip-path: jacktrip
             binary-path: binary
             build-system: docker
-            docker-image: ubuntu:focal-20241011
+            docker-image: ubuntu:jammy-20240911.1
             docker-platform: linux/amd64
             meson-library-type: static
-            qt-version: '6.5.3'
+            qt-version: '6.8.1'
             qt-type: 'static'
             qt-arch: 'amd64'
 
@@ -153,10 +154,10 @@ jobs:
             jacktrip-path: jacktrip
             binary-path: binary
             build-system: docker
-            docker-image: ubuntu:focal-20241011
+            docker-image: ubuntu:jammy-20240911.1
             docker-platform: linux/arm64
             meson-library-type: static
-            qt-version: '6.5.3'
+            qt-version: '6.8.1'
             qt-type: 'static'
             qt-arch: 'arm64'
 
@@ -176,12 +177,13 @@ jobs:
             docker-platform: linux/arm/v7
             meson-library-type: static
             qt-version: '5.15.13'
+            qt-download-commit: 'f82eab7'
             qt-type: 'static'
             qt-arch: 'arm32'
 
           - name: macOS-x64-meson-clang-static
             release-name: macOS-x64-nogui
-            runs-on: macos-13
+            runs-on: macos-14
             system-rtaudio: false
             bundled-rtaudio: true
             nogui: true
@@ -192,15 +194,15 @@ jobs:
             binary-path: binary
             build-system: meson
             meson-library-type: static
-            qt-version: '5.15.13'
+            qt-version: '6.8.1'
             qt-type: 'static'
             macosx-architectures: 'x86_64;arm64'
-            macosx-deployment-target: 10.13
-            xcode-directory: /Applications/Xcode_14.2.app
+            macosx-deployment-target: 12
+            xcode-directory: /Applications/Xcode_16.2.app
 
           - name: macOS-x64-meson-clang-shared
             release-name: macOS-x64
-            runs-on: macos-13
+            runs-on: macos-14
             system-rtaudio: false
             bundled-rtaudio: true
             nogui: false
@@ -213,24 +215,23 @@ jobs:
             installer-path: installer
             build-system: meson
             meson-library-type: both
-            qt-version: '6.2.11'
-            qt-download-commit: '50d9952'
+            qt-version: '6.8.1'
             qt-type: 'dynamic'
             vst3sdk-version: '3.7.12'
             macosx-architectures: 'x86_64;arm64'
-            macosx-deployment-target: 10.14
-            xcode-directory: /Applications/Xcode_14.2.app
+            macosx-deployment-target: 12
+            xcode-directory: /Applications/Xcode_16.2.app
 
           - name: Windows-x64-meson-msvc-static
             release-name: Windows-x64-nogui
-            runs-on: windows-2019
+            runs-on: windows-2022
             system-rtaudio: false
             bundled-rtaudio: true
             nogui: true
             novs: true
             weakjack: true
             libsamplerate: true
-            qt-version: '5.15.13'
+            qt-version: '6.8.1'
             qt-type: 'static'
             jacktrip-path: jacktrip.exe
             binary-path: binary
@@ -246,7 +247,7 @@ jobs:
             novs: false
             weakjack: true
             libsamplerate: true
-            qt-version: '6.5.3'
+            qt-version: '6.8.1'
             qt-type: 'dynamic'
             jacktrip-path: jacktrip.exe
             installer-path: installer
@@ -261,7 +262,7 @@ jobs:
       CLANG_TIDY_PATH: ${{ github.workspace }}/clang-tidy-result
       VST3SDK_DOWNLOAD_BASE_URL: 'https://files.jacktrip.org/contrib/vst3sdk'
       QT_DOWNLOAD_BASE_URL: 'https://files.jacktrip.org/contrib/qt'
-      QT_DOWNLOAD_COMMIT: 'f82eab7'
+      QT_DOWNLOAD_COMMIT: '3e1fab2'
 
     steps:
       - uses: actions/checkout@v3
@@ -628,7 +629,7 @@ jobs:
             if [[ "${{ matrix.docker-platform }}" == "linux/arm/v7" ]]; then
               # should be implied, but this is necessary for broken compiler on arm32
               CONFIG_STRING="-Dcpp_link_args='-no-pie' $CONFIG_STRING"
-            elif [[ -z "${{ matrix.vst3sdk-version }}" ]]; then
+            elif [[ -z "${{ matrix.vst3sdk-version }}" && "${{ matrix.qt-version}}" == "5.15.13" ]]; then
               # vst3 sdk has a lot of header warnings
               CONFIG_STRING="-Dwerror=true $CONFIG_STRING"
             fi

--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -1,3 +1,7 @@
+- Version: "2.6.0"
+  Date: 2025-xx-xx
+  Description:
+  - (updated) Updating to Qt 6.8.1 for most builds
 - Version: "2.5.1"
   Date: 2025-01-30
   Description:

--- a/macos/meson_native_minversion_12.ini
+++ b/macos/meson_native_minversion_12.ini
@@ -1,5 +1,5 @@
 [constants]
-minversion_args = ['-mmacosx-version-min=11']
+minversion_args = ['-mmacosx-version-min=12']
 
 [built-in options]
 c_args = minversion_args

--- a/macos/meson_native_universal_12.ini
+++ b/macos/meson_native_universal_12.ini
@@ -1,5 +1,5 @@
 [constants]
-minversion_args = ['-mmacosx-version-min=11']
+minversion_args = ['-mmacosx-version-min=12']
 universal_args = ['-arch', 'x86_64', '-arch', 'arm64']
 
 [built-in options]

--- a/meson.build
+++ b/meson.build
@@ -281,7 +281,17 @@ if get_option('default_library') == 'static'
 	qt_plugindir = run_command(qmake, '-query', 'QT_INSTALL_PLUGINS', check : true).stdout().strip()
 	if qt_version == '6'
 		# qt6 requires "Bundled*" modules for linking
-		static_deps += dependency('qt6', modules: ['DBus', 'BundledLibpng', 'BundledPcre2', 'BundledHarfbuzz', 'BundledZLIB'], include_type: 'system')
+		static_deps += compiler.find_library('Qt6BundledLibpng', required : true, dirs : [qt_libdir])
+		static_deps += compiler.find_library('Qt6BundledPcre2', required : true, dirs : [qt_libdir])
+		static_deps += compiler.find_library('Qt6BundledHarfbuzz', required : true, dirs : [qt_libdir])
+		zlib_dep = compiler.find_library('Qt6BundledZLIB', required : false, dirs : [qt_libdir])
+		if zlib_dep.found()
+			static_deps += zlib_dep
+		endif
+		dbus_dep = compiler.find_library('Qt6DBus', required : false, dirs : [qt_libdir])
+		if dbus_dep.found()
+			static_deps += dbus_dep
+		endif
 	else
 		static_deps += compiler.find_library('qtpcre2', required : true, dirs : [qt_libdir])
 	endif
@@ -317,6 +327,8 @@ if get_option('default_library') == 'static'
 			static_link_args += ['-framework', 'Security']
 			static_link_args += ['-framework', 'GSS']
 			static_link_args += ['-framework', 'SystemConfiguration']
+			static_link_args += ['-framework', 'UniformTypeIdentifiers']
+			static_link_args += '-lresolv'
 			static_deps += dependency('zlib', required : true)
 		endif
 	endif

--- a/src/AudioInterface.cpp
+++ b/src/AudioInterface.cpp
@@ -45,6 +45,12 @@
 #include "JackTrip.h"
 #include "ProcessPlugin.h"
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 8, 0)
+#define STD_AS_CONST qAsConst
+#else
+#define STD_AS_CONST std::as_const
+#endif
+
 using std::cout;
 using std::endl;
 
@@ -189,7 +195,7 @@ void AudioInterface::audioInputCallback(QVarLengthArray<sample_t*>& in_buffer,
     }
 
 #ifndef WAIR
-    for (auto& s : qAsConst(mAudioSockets)) {
+    for (auto& s : STD_AS_CONST(mAudioSockets)) {
         s->getFromAudioSocketPlugin()->compute(n_frames, in_buffer.data(),
                                                in_buffer.data());
     }
@@ -204,7 +210,7 @@ void AudioInterface::audioInputCallback(QVarLengthArray<sample_t*>& in_buffer,
 #endif  // not WAIR
 
     // process incoming signal from audio interface using process plugins
-    for (auto& p : qAsConst(mProcessPluginsToNetwork)) {
+    for (auto& p : STD_AS_CONST(mProcessPluginsToNetwork)) {
         if (p->getInited()) {
             p->compute(n_frames, in_buffer.data(), in_buffer.data());
         }
@@ -266,7 +272,7 @@ void AudioInterface::audioOutputCallback(QVarLengthArray<sample_t*>& out_buffer,
     /// with one. do it chaining outputs to inputs in the buffers. May need a tempo buffer
 
 #ifndef WAIR  // NOT WAIR:
-    for (auto& p : qAsConst(mProcessPluginsFromNetwork)) {
+    for (auto& p : STD_AS_CONST(mProcessPluginsFromNetwork)) {
         if (p->getInited()) {
             p->compute(n_frames, out_buffer.data(), out_buffer.data());
         }
@@ -308,7 +314,7 @@ void AudioInterface::audioOutputCallback(QVarLengthArray<sample_t*>& out_buffer,
         }
     }
 
-    for (auto& s : qAsConst(mAudioSockets)) {
+    for (auto& s : STD_AS_CONST(mAudioSockets)) {
         s->getToAudioSocketPlugin()->compute(n_frames, out_buffer.data(),
                                              out_buffer.data());
     }
@@ -740,22 +746,22 @@ void AudioInterface::initPlugins(bool verbose)
                       << ") at sampling rate " << mSampleRate << "\n";
         }
 
-        for (auto& plugin : qAsConst(mProcessPluginsFromNetwork)) {
+        for (auto& plugin : STD_AS_CONST(mProcessPluginsFromNetwork)) {
             plugin->setOutgoingToNetwork(false);
             plugin->updateNumChannels(nChansIn, nChansOut);
             plugin->init(mSampleRate, mBufferSizeInSamples);
         }
-        for (auto& plugin : qAsConst(mProcessPluginsToNetwork)) {
+        for (auto& plugin : STD_AS_CONST(mProcessPluginsToNetwork)) {
             plugin->setOutgoingToNetwork(true);
             plugin->updateNumChannels(nChansIn, nChansOut);
             plugin->init(mSampleRate, mBufferSizeInSamples);
         }
-        for (auto& plugin : qAsConst(mProcessPluginsToMonitor)) {
+        for (auto& plugin : STD_AS_CONST(mProcessPluginsToMonitor)) {
             plugin->setOutgoingToNetwork(false);
             plugin->updateNumChannels(nChansMon, nChansMon);
             plugin->init(mSampleRate, mBufferSizeInSamples);
         }
-        for (auto& s : qAsConst(mAudioSockets)) {
+        for (auto& s : STD_AS_CONST(mAudioSockets)) {
             auto* plugin = s->getFromAudioSocketPlugin().get();
             plugin->setOutgoingToNetwork(true);
             plugin->updateNumChannels(nChansIn, nChansOut);

--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -45,6 +45,12 @@
 #include "RtAudio.h"
 #endif
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
+#define QCHECKBOX_STATE_CHANGED QCheckBox::stateChanged
+#else
+#define QCHECKBOX_STATE_CHANGED QCheckBox::checkStateChanged
+#endif
+
 #include "../Compressor.h"
 #include "../CompressorPresets.h"
 #include "../Limiter.h"
@@ -119,14 +125,14 @@ QJackTrip::QJackTrip(UserInterface& interface, QWidget* parent)
                     m_ui->patchServerCheckBox->setEnabled(false);
                 }
             });
-    connect(m_ui->authCheckBox, &QCheckBox::stateChanged, this, [=]() {
+    connect(m_ui->authCheckBox, &QCHECKBOX_STATE_CHANGED, this, [=]() {
         m_ui->usernameLabel->setEnabled(m_ui->authCheckBox->isChecked());
         m_ui->usernameEdit->setEnabled(m_ui->authCheckBox->isChecked());
         m_ui->passwordLabel->setEnabled(m_ui->authCheckBox->isChecked());
         m_ui->passwordEdit->setEnabled(m_ui->authCheckBox->isChecked());
         credentialsChanged();
     });
-    connect(m_ui->requireAuthCheckBox, &QCheckBox::stateChanged, this, [=]() {
+    connect(m_ui->requireAuthCheckBox, &QCHECKBOX_STATE_CHANGED, this, [=]() {
         m_ui->certLabel->setEnabled(m_ui->requireAuthCheckBox->isChecked());
         m_ui->certEdit->setEnabled(m_ui->requireAuthCheckBox->isChecked());
         m_ui->certBrowse->setEnabled(m_ui->requireAuthCheckBox->isChecked());
@@ -138,21 +144,21 @@ QJackTrip::QJackTrip(UserInterface& interface, QWidget* parent)
         m_ui->credsBrowse->setEnabled(m_ui->requireAuthCheckBox->isChecked());
         authFilesChanged();
     });
-    connect(m_ui->ioStatsCheckBox, &QCheckBox::stateChanged, this, [=]() {
+    connect(m_ui->ioStatsCheckBox, &QCHECKBOX_STATE_CHANGED, this, [=]() {
         m_ui->ioStatsLabel->setEnabled(m_ui->ioStatsCheckBox->isChecked());
         m_ui->ioStatsSpinBox->setEnabled(m_ui->ioStatsCheckBox->isChecked());
         if (!m_ui->ioStatsCheckBox->isChecked()) {
             m_statsDialog->hide();
         }
     });
-    connect(m_ui->verboseCheckBox, &QCheckBox::stateChanged, this, [=]() {
+    connect(m_ui->verboseCheckBox, &QCHECKBOX_STATE_CHANGED, this, [=]() {
         gVerboseFlag = m_ui->verboseCheckBox->isChecked();
         if (!gVerboseFlag) {
             m_debugDialog->hide();
             m_debugDialog->clearOutput();
         }
     });
-    connect(m_ui->jitterCheckBox, &QCheckBox::stateChanged, this, [=]() {
+    connect(m_ui->jitterCheckBox, &QCHECKBOX_STATE_CHANGED, this, [=]() {
         m_ui->broadcastCheckBox->setEnabled(m_ui->jitterCheckBox->isChecked());
         m_ui->broadcastQueueLabel->setEnabled(m_ui->jitterCheckBox->isChecked()
                                               && m_ui->broadcastCheckBox->isChecked());
@@ -177,13 +183,13 @@ QJackTrip::QJackTrip(UserInterface& interface, QWidget* parent)
             m_autoQueueIndicator.setText(QStringLiteral("Auto queue: disabled"));
         }
     });
-    connect(m_ui->broadcastCheckBox, &QCheckBox::stateChanged, this, [=]() {
+    connect(m_ui->broadcastCheckBox, &QCHECKBOX_STATE_CHANGED, this, [=]() {
         m_ui->broadcastQueueLabel->setEnabled(m_ui->jitterCheckBox->isChecked()
                                               && m_ui->broadcastCheckBox->isChecked());
         m_ui->broadcastQueueSpinBox->setEnabled(m_ui->jitterCheckBox->isChecked()
                                                 && m_ui->broadcastCheckBox->isChecked());
     });
-    connect(m_ui->autoQueueCheckBox, &QCheckBox::stateChanged, this, [=]() {
+    connect(m_ui->autoQueueCheckBox, &QCHECKBOX_STATE_CHANGED, this, [=]() {
         m_ui->autoQueueLabel->setEnabled(m_ui->jitterCheckBox->isChecked()
                                          && m_ui->autoQueueCheckBox->isChecked());
         m_ui->autoQueueSpinBox->setEnabled(m_ui->jitterCheckBox->isChecked()
@@ -199,34 +205,34 @@ QJackTrip::QJackTrip(UserInterface& interface, QWidget* parent)
         }
     });
 
-    connect(m_ui->inFreeverbCheckBox, &QCheckBox::stateChanged, this, [=]() {
+    connect(m_ui->inFreeverbCheckBox, &QCHECKBOX_STATE_CHANGED, this, [=]() {
         m_ui->inFreeverbLabel->setEnabled(m_ui->inFreeverbCheckBox->isChecked());
         m_ui->inFreeverbWetnessSlider->setEnabled(m_ui->inFreeverbCheckBox->isChecked());
     });
-    connect(m_ui->inZitarevCheckBox, &QCheckBox::stateChanged, this, [=]() {
+    connect(m_ui->inZitarevCheckBox, &QCHECKBOX_STATE_CHANGED, this, [=]() {
         m_ui->inZitarevLabel->setEnabled(m_ui->inZitarevCheckBox->isChecked());
         m_ui->inZitarevWetnessSlider->setEnabled(m_ui->inZitarevCheckBox->isChecked());
     });
 
-    connect(m_ui->outFreeverbCheckBox, &QCheckBox::stateChanged, this, [=]() {
+    connect(m_ui->outFreeverbCheckBox, &QCHECKBOX_STATE_CHANGED, this, [=]() {
         m_ui->outFreeverbLabel->setEnabled(m_ui->outFreeverbCheckBox->isChecked());
         m_ui->outFreeverbWetnessSlider->setEnabled(
             m_ui->outFreeverbCheckBox->isChecked());
     });
-    connect(m_ui->outZitarevCheckBox, &QCheckBox::stateChanged, this, [=]() {
+    connect(m_ui->outZitarevCheckBox, &QCHECKBOX_STATE_CHANGED, this, [=]() {
         m_ui->outZitarevLabel->setEnabled(m_ui->outZitarevCheckBox->isChecked());
         m_ui->outZitarevWetnessSlider->setEnabled(m_ui->outZitarevCheckBox->isChecked());
     });
-    connect(m_ui->outLimiterCheckBox, &QCheckBox::stateChanged, this, [=]() {
+    connect(m_ui->outLimiterCheckBox, &QCHECKBOX_STATE_CHANGED, this, [=]() {
         m_ui->outLimiterLabel->setEnabled(m_ui->outLimiterCheckBox->isChecked());
         m_ui->outClientsSpinBox->setEnabled(m_ui->outLimiterCheckBox->isChecked());
     });
 
-    connect(m_ui->connectScriptCheckBox, &QCheckBox::stateChanged, this, [=]() {
+    connect(m_ui->connectScriptCheckBox, &QCHECKBOX_STATE_CHANGED, this, [=]() {
         m_ui->connectScriptEdit->setEnabled(m_ui->connectScriptCheckBox->isChecked());
         m_ui->connectScriptBrowse->setEnabled(m_ui->connectScriptCheckBox->isChecked());
     });
-    connect(m_ui->disconnectScriptCheckBox, &QCheckBox::stateChanged, this, [=]() {
+    connect(m_ui->disconnectScriptCheckBox, &QCHECKBOX_STATE_CHANGED, this, [=]() {
         m_ui->disconnectScriptEdit->setEnabled(
             m_ui->disconnectScriptCheckBox->isChecked());
         m_ui->disconnectScriptBrowse->setEnabled(
@@ -426,7 +432,7 @@ void QJackTrip::showEvent(QShowEvent* event)
                     "will automatically be re-enabled.)");
                 msgBox.setWindowTitle(QStringLiteral("JACK Not Available"));
                 msgBox.setCheckBox(dontBugMe);
-                QObject::connect(dontBugMe, &QCheckBox::stateChanged, this, [=]() {
+                QObject::connect(dontBugMe, &QCHECKBOX_STATE_CHANGED, this, [=]() {
                     m_hideWarning = dontBugMe->isChecked();
                 });
                 msgBox.exec();

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -40,7 +40,7 @@
 
 #include "jacktrip_types.h"
 
-constexpr const char* const gVersion = "2.5.1";  ///< JackTrip version
+constexpr const char* const gVersion = "2.6.0";  ///< JackTrip version
 
 //*******************************************************************************
 /// \name Default Values

--- a/src/vs/virtualstudio.cpp
+++ b/src/vs/virtualstudio.cpp
@@ -1873,6 +1873,7 @@ VirtualStudio::~VirtualStudio()
 QApplication* VirtualStudio::createApplication(int& argc, char* argv[])
 {
 #if defined(Q_OS_WIN)
+#if QT_VERSION < QT_VERSION_CHECK(6, 6, 0)
     // Fix for display scaling like 125% or 150% on Windows
     QGuiApplication::setHighDpiScaleFactorRoundingPolicy(
         Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
@@ -1882,8 +1883,12 @@ QApplication* VirtualStudio::createApplication(int& argc, char* argv[])
     // QCoreApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
     // QCoreApplication::setAttribute(Qt::AA_UseOpenGLES);
 
+    // Direct3D11 is still broken as of Qt 6.8.1
     // QQuickWindow::setGraphicsApi(QSGRendererInterface::Direct3D11);
     QQuickWindow::setGraphicsApi(QSGRendererInterface::OpenGL);
+#else  // Qt 6.6.0 or later supports Direct3D 12, which works well
+    QQuickWindow::setGraphicsApi(QSGRendererInterface::Direct3D12);
+#endif
 #endif
 
     QQuickStyle::setStyle("Basic");

--- a/win/qt6-noguids.wxs
+++ b/win/qt6-noguids.wxs
@@ -12,7 +12,6 @@
             <Directory Id="dirC5F8EA44B55B774D108D66814D18D4D1" Name="qml" />
             <Directory Id="dir9331125B8BF1F459D0AC9F91A6A2F779" Name="qmltooling" />
             <Directory Id="dir08941CEA6046320FCCF158F759AF80F2" Name="resources" />
-            <Directory Id="dirD0D2BD28387A827DDF373DED43543ABA" Name="sqldrivers" />
             <Directory Id="dir3BC41331752E78D0C2719C277915294F" Name="styles" />
             <Directory Id="dir509C75F94B9AF6C35CA00410005C14EE" Name="tls" />
             <Directory Id="dir1F7AD7AA9B228AED2E74CDD7C3088B5C" Name="translations" />
@@ -30,17 +29,8 @@
             <Component Id="cmp61BABE677B13AE7A25F57865DD2CB150" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
                 <File Id="filD0B8E5384B7EB5609D1B2A67A98FF334" KeyPath="yes" Source="SourceDir\jacktrip.exe" />
             </Component>
-            <Component Id="cmp5C97B37BB3181F77EDC11261A4463285" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
-                <File Id="fil46101D0C43E1BEF1BE4C5475DA0B2837" KeyPath="yes" Source="SourceDir\JackTrip.msi" />
-            </Component>
             <Component Id="cmpCD23A5CC7196B582D23DF7AC7DFE061F" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
                 <File Id="fil00C2A327ECCB1D33F7BBF313ADEEFD43" KeyPath="yes" Source="SourceDir\jacktrip.wixobj" />
-            </Component>
-            <Component Id="cmpEF56078548B21E7891727FDE729B864B" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
-                <File Id="fil01A07DE9CBC162E11AA3C8EFB4A4D4B9" KeyPath="yes" Source="SourceDir\JackTrip.wixpdb" />
-            </Component>
-            <Component Id="cmp63BFF65F319CB52D38DBB3FE6B8DE6F6" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
-                <File Id="fil886DC1D217D62357ED536BCFF93E7C0F" KeyPath="yes" Source="SourceDir\jacktrip.wxs" />
             </Component>
             <Component Id="cmp64BB59E0E19E219D4D4D5C775D71731F" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
                 <File Id="fil7D228BFB31A8A99EE307AF8BFC2E1841" KeyPath="yes" Source="SourceDir\LICENSE.md" />
@@ -53,9 +43,6 @@
             </Component>
             <Component Id="cmpD16A82FC04DA86995B222E5199ABF99B" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
                 <File Id="fil03546A9C6805C45BEB0A60D29FFC5D22" KeyPath="yes" Source="SourceDir\qt6.wixobj" />
-            </Component>
-            <Component Id="cmp2A0D7AC2E166178EE2B0C41EB50258BA" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
-                <File Id="fil2E03208E0826B1237D2BAB19634F2DC3" KeyPath="yes" Source="SourceDir\qt6.wxs" />
             </Component>
             <Component Id="cmp7111706DBFB0E180EC7A8BDC93A90139" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
                 <File Id="fil1A08189509DCFE1E185AEC6B499929BA" KeyPath="yes" Source="SourceDir\Qt6Core.dll" />
@@ -75,8 +62,8 @@
             <Component Id="cmpB6D50DE19D6ADD781A08727F7F6266E8" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
                 <File Id="filCF6DBEF1D6A13C80715404D32B934AD5" KeyPath="yes" Source="SourceDir\Qt6Qml.dll" />
             </Component>
-            <Component Id="cmp4E9BFD75DF26062E9937847116425997" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
-                <File Id="filAE1BF7A9D9BF060761C9FAAB52C1582A" KeyPath="yes" Source="SourceDir\Qt6QmlLocalStorage.dll" />
+            <Component Id="cmpAF683EE0207F56E683FD073A3F2D2006" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
+                <File Id="fil6331F3687384F1AB7BEF24F2A8B4AA20" KeyPath="yes" Source="SourceDir\Qt6QmlMeta.dll" />
             </Component>
             <Component Id="cmp65C2886373B0C96AD79BAD6B11F4BCEC" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
                 <File Id="fil1A464A34B69E38E90B0748094F580925" KeyPath="yes" Source="SourceDir\Qt6QmlModels.dll" />
@@ -84,35 +71,56 @@
             <Component Id="cmp609AE9C23E17BA20AC06AEA3F3551DAE" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
                 <File Id="fil70941CA86B91BA9374327AE51424DF95" KeyPath="yes" Source="SourceDir\Qt6QmlWorkerScript.dll" />
             </Component>
-            <Component Id="cmpF560A3BA9C9935A03A5C37CBAFF8321F" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
-                <File Id="fil123F08A484F5DF5CC72BFCCDC197DBF9" KeyPath="yes" Source="SourceDir\Qt6QmlXmlListModel.dll" />
-            </Component>
             <Component Id="cmpED65C4A3E125070BC17313D1A32F9C76" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
                 <File Id="filFDA17D38CD6D73072EBAF9E430B8DCD4" KeyPath="yes" Source="SourceDir\Qt6Quick.dll" />
             </Component>
             <Component Id="cmpA463F9E3D9E20729888D635B58292550" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
                 <File Id="filDF57D75497458D7E64C07BB9AD1456C9" KeyPath="yes" Source="SourceDir\Qt6QuickControls2.dll" />
             </Component>
+            <Component Id="cmp233846C2BEE2F647CFB8678979D9FE2A" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
+                <File Id="fil9025E81D1684343EC39A0488A289C2AA" KeyPath="yes" Source="SourceDir\Qt6QuickControls2Basic.dll" />
+            </Component>
+            <Component Id="cmp539A635B8282736FFE569271963EB9BA" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
+                <File Id="filEC8BF7880F9C9499740FB738802F7453" KeyPath="yes" Source="SourceDir\Qt6QuickControls2BasicStyleImpl.dll" />
+            </Component>
+            <Component Id="cmp1F67893FFAFCE5107295A466BC3B3313" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
+                <File Id="fil470A1FCB196D2864F277A8780846C1F1" KeyPath="yes" Source="SourceDir\Qt6QuickControls2FluentWinUI3StyleImpl.dll" />
+            </Component>
+            <Component Id="cmp8CFA3AD051A37FEEA263EFE73A8BA8BD" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
+                <File Id="fil9244247757CBE6E1F72810713C4EECBC" KeyPath="yes" Source="SourceDir\Qt6QuickControls2Fusion.dll" />
+            </Component>
+            <Component Id="cmp65209AC7EBC7E60989C4807CDACDCC09" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
+                <File Id="fil80A990BFE09B00A495C207224ADB5BDB" KeyPath="yes" Source="SourceDir\Qt6QuickControls2FusionStyleImpl.dll" />
+            </Component>
+            <Component Id="cmpDB52D9B1FD2BCE9B579FF9BBE5B0204F" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
+                <File Id="fil8F15B827E2E835F92443FC28E2531D08" KeyPath="yes" Source="SourceDir\Qt6QuickControls2Imagine.dll" />
+            </Component>
+            <Component Id="cmpAE751F6A0569A5ACC0F12E5E91E9EA64" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
+                <File Id="fil14B9D585B7BF9DEA12D02B5DD13F8BE2" KeyPath="yes" Source="SourceDir\Qt6QuickControls2ImagineStyleImpl.dll" />
+            </Component>
             <Component Id="cmp0571EF0C5FB8E314588A9065CF74AE35" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
                 <File Id="filDC1C47A2ADA5BD76E86CE6CE8EC4F5B4" KeyPath="yes" Source="SourceDir\Qt6QuickControls2Impl.dll" />
             </Component>
-            <Component Id="cmp2BB41ECBA565E0A0B4EDF020A49025F9" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
-                <File Id="fil57860EF8422A74A3CE88A88BAD0CABB7" KeyPath="yes" Source="SourceDir\Qt6QuickDialogs2.dll" />
+            <Component Id="cmp52F90B0CC4C64CD7297DABAA32382B1A" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
+                <File Id="filBB3DB98EB685B0DA80E7D949397ADAD0" KeyPath="yes" Source="SourceDir\Qt6QuickControls2Material.dll" />
             </Component>
-            <Component Id="cmp73D256572698B6DB61D05CCD551BEF9A" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
-                <File Id="filC9FA5D0D485CF88CB948BE06870C3B8A" KeyPath="yes" Source="SourceDir\Qt6QuickDialogs2QuickImpl.dll" />
+            <Component Id="cmp60EB7CBF8EAC53D5AED329B93B6D47C2" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
+                <File Id="fil4882D38AC1397034ED3F2303FC5DAACA" KeyPath="yes" Source="SourceDir\Qt6QuickControls2MaterialStyleImpl.dll" />
             </Component>
-            <Component Id="cmpC26015BC765576311A63C5B026DB71FF" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
-                <File Id="fil2911EE010D604A656A176E72D572CCAC" KeyPath="yes" Source="SourceDir\Qt6QuickDialogs2Utils.dll" />
+            <Component Id="cmpA7A0CBD344B074F175E448ABC0BFDE58" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
+                <File Id="filD97D25AF582D747D0239EB5A50746D35" KeyPath="yes" Source="SourceDir\Qt6QuickControls2Universal.dll" />
+            </Component>
+            <Component Id="cmpA2589BC5C5022DE7265258EE8F15FC3E" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
+                <File Id="filCC14AFBEEA05EA8721B3375EFB3A35DC" KeyPath="yes" Source="SourceDir\Qt6QuickControls2UniversalStyleImpl.dll" />
+            </Component>
+            <Component Id="cmp54DF42DCE2675E57F9EAAD85CC8641F2" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
+                <File Id="fil6CB329504ED279D670301CD15966AA7B" KeyPath="yes" Source="SourceDir\Qt6QuickControls2WindowsStyleImpl.dll" />
             </Component>
             <Component Id="cmp2ABC8A6031A24B9F3C70C18AE40B4CC3" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
                 <File Id="fil0C6C0D67878BFB0A4BD30E472A40969B" KeyPath="yes" Source="SourceDir\Qt6QuickEffects.dll" />
             </Component>
             <Component Id="cmpD246CE6E593DB826C58A42EFAB8AC176" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
                 <File Id="fil89BECDEB84C26F37AC111B6D300D2835" KeyPath="yes" Source="SourceDir\Qt6QuickLayouts.dll" />
-            </Component>
-            <Component Id="cmp05C682DFA26731F5F96864E240BB9367" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
-                <File Id="filF00A542F2EB321619F0825C65334A7F5" KeyPath="yes" Source="SourceDir\Qt6QuickParticles.dll" />
             </Component>
             <Component Id="cmpB2448C4481D00046098304AC1C230B93" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
                 <File Id="fil359D410486F61CCCDFEFE2410735AC75" KeyPath="yes" Source="SourceDir\Qt6QuickShapes.dll" />
@@ -123,23 +131,20 @@
             <Component Id="cmpD5FD28F099F28B38A8C5C6C43481E545" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
                 <File Id="fil1A12F96CDBED6EDBD83A1228E643DFE1" KeyPath="yes" Source="SourceDir\Qt6ShaderTools.dll" />
             </Component>
-            <Component Id="cmpDAA5AE12CA74181FE29953002CC830A3" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
-                <File Id="filEF75955C67A60E62CD86B26117C750AE" KeyPath="yes" Source="SourceDir\Qt6Sql.dll" />
-            </Component>
             <Component Id="cmp2BFDE38E15CC8879E8B911A7A296477A" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
                 <File Id="fil08B70D0B09545B2C830255009EF93341" KeyPath="yes" Source="SourceDir\Qt6Svg.dll" />
             </Component>
             <Component Id="cmp501A53153FAB3908951DADAE039AB865" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
                 <File Id="filDAAFC08AB32ED0F61D6C56EA5B665627" KeyPath="yes" Source="SourceDir\Qt6WebChannel.dll" />
             </Component>
+            <Component Id="cmp5D67931A769831745EAA389FCBE18DB4" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
+                <File Id="fil527B55E277F58ECE350A9D331EC489F4" KeyPath="yes" Source="SourceDir\Qt6WebChannelQuick.dll" />
+            </Component>
             <Component Id="cmp5046A1A989E72DACE21F8D481D0D71C5" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
                 <File Id="fil4DF01BF67F8DD9C408204A2F5BD56FF9" KeyPath="yes" Source="SourceDir\Qt6WebEngineCore.dll" />
             </Component>
             <Component Id="cmp8015426E62DE3ED33343DB50BE0A9A0D" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
                 <File Id="fil58988C3D49189FE2287F68174F6944A2" KeyPath="yes" Source="SourceDir\Qt6WebEngineQuick.dll" />
-            </Component>
-            <Component Id="cmp268C15DC40B82F983C534C9C3DAABD1B" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
-                <File Id="filA069DC2EC3525A8E547CF9EFC89A25E6" KeyPath="yes" Source="SourceDir\Qt6WebEngineQuickDelegatesQml.dll" />
             </Component>
             <Component Id="cmp7B3BE582AD25B07FE55DD249E6D5C333" Directory="TARGETDIR" Guid="PUT-GUID-HERE">
                 <File Id="filF8FC62A4978258AB67C456CC256AAA8B" KeyPath="yes" Source="SourceDir\Qt6WebSockets.dll" />
@@ -200,6 +205,12 @@
             </Component>
             <Component Id="cmp8539D5D6C3427F1F4C82034569A0F132" Directory="dirC15EA267FAD4FC447E84FB3A32CBDB68" Guid="PUT-GUID-HERE">
                 <File Id="filEF2EB40CA1790B7BDC4320E6F7638744" KeyPath="yes" Source="SourceDir\position\qtposition_winrt.dll" />
+            </Component>
+            <Component Id="cmp461F0596AA5F86FE89448A8ECC13E885" Directory="dir831F2329F0F3ACEA4CAA1C1913D06297" Guid="PUT-GUID-HERE">
+                <File Id="filBA6172E9C08F8F6EAA6EBEB7C72E3EF5" KeyPath="yes" Source="SourceDir\qml\QML\plugins.qmltypes" />
+            </Component>
+            <Component Id="cmp780E68E2C2E0DEE8BA15C9717A6569FC" Directory="dir831F2329F0F3ACEA4CAA1C1913D06297" Guid="PUT-GUID-HERE">
+                <File Id="fil2E6126A89886BE286E566A28753D81F4" KeyPath="yes" Source="SourceDir\qml\QML\qmldir" />
             </Component>
             <Component Id="cmp0BF1B39B0DF9604C417C59F0C26849DB" Directory="dir2FA83874D84EB850CB9EC2829B8A3243" Guid="PUT-GUID-HERE">
                 <File Id="fil886A06C8346FCEDB309427F45C47C7A2" KeyPath="yes" Source="SourceDir\qml\Qt5Compat\GraphicalEffects\Blend.qml" />
@@ -315,20 +326,14 @@
             <Component Id="cmp2AE301345F7F9CB39B6986A6FE1B7770" Directory="dir7B12C3FC704EE1F6A1CBC6ECA590217F" Guid="PUT-GUID-HERE">
                 <File Id="filFEA2206E424A82D72528F1EA358D0B69" KeyPath="yes" Source="SourceDir\qml\Qt5Compat\GraphicalEffects\private\qtgraphicaleffectsprivateplugin.dll" />
             </Component>
+            <Component Id="cmpFC1B21C84B8D28BAD32C0AD91ED15B61" Directory="dir92990262DE0ED5508C44523003A4B360" Guid="PUT-GUID-HERE">
+                <File Id="fil2A5F168842EFE199DA0A8B5FD525BA3A" KeyPath="yes" Source="SourceDir\qml\QtQml\plugins.qmltypes" />
+            </Component>
             <Component Id="cmp8EABE0B8AEB6B59BBA116FC21CB7E5F2" Directory="dir92990262DE0ED5508C44523003A4B360" Guid="PUT-GUID-HERE">
                 <File Id="fil0117CF5445EF1792DFCE8ED7540F81CA" KeyPath="yes" Source="SourceDir\qml\QtQml\qmldir" />
             </Component>
-            <Component Id="cmp0C776837FB1ACA4E4665746624A1F66D" Directory="dir92990262DE0ED5508C44523003A4B360" Guid="PUT-GUID-HERE">
-                <File Id="fil4003B93F14AAC88E53C18C94ACEB86B8" KeyPath="yes" Source="SourceDir\qml\QtQml\qmlmetaplugin.dll" />
-            </Component>
-            <Component Id="cmp276C50F9766B97EB467160CC10A6A356" Directory="dirD3E9E07666E50DD0B119271684422637" Guid="PUT-GUID-HERE">
-                <File Id="fil0F05D62E45DA4E9EFA2FBFC0D3553F36" KeyPath="yes" Source="SourceDir\qml\QtQml\Base\plugins.qmltypes" />
-            </Component>
-            <Component Id="cmp517B71582230A4698CBF9E3F6048550D" Directory="dirD3E9E07666E50DD0B119271684422637" Guid="PUT-GUID-HERE">
-                <File Id="filEEB49B8A5C313E798DCB3FC5DE04D86F" KeyPath="yes" Source="SourceDir\qml\QtQml\Base\qmldir" />
-            </Component>
-            <Component Id="cmp870C95E4B9F919D6A3987C4F468D8305" Directory="dirD3E9E07666E50DD0B119271684422637" Guid="PUT-GUID-HERE">
-                <File Id="filEED866F0018D6A66CAAAC4D5E08D6EAA" KeyPath="yes" Source="SourceDir\qml\QtQml\Base\qmlplugin.dll" />
+            <Component Id="cmp4C0332CE67535B43634DCB1FDD8FEE6C" Directory="dir92990262DE0ED5508C44523003A4B360" Guid="PUT-GUID-HERE">
+                <File Id="filEB541820C36F6F6FB28C37EA81F4BAE0" KeyPath="yes" Source="SourceDir\qml\QtQml\qmlplugin.dll" />
             </Component>
             <Component Id="cmpA1F1D19580CB3E153905BE6B71792592" Directory="dirAA6B0932D46A7D6E35A8D1E06E10B2B7" Guid="PUT-GUID-HERE">
                 <File Id="filF67E33CF8E5416727B865F3F9EA9A8E7" KeyPath="yes" Source="SourceDir\qml\QtQml\Models\modelsplugin.dll" />
@@ -347,15 +352,6 @@
             </Component>
             <Component Id="cmp08D9C9933EFB91871225B53380202A87" Directory="dir92A51CED876E1F4286E6663FD7D54CDA" Guid="PUT-GUID-HERE">
                 <File Id="filAEEE5B727783E6621123551D42A7F31B" KeyPath="yes" Source="SourceDir\qml\QtQml\WorkerScript\workerscriptplugin.dll" />
-            </Component>
-            <Component Id="cmp30CA6BFC8F040C1F22D888FD79DC9B1B" Directory="dirD48123A7B6E2CFB660EC94F0CBE0276D" Guid="PUT-GUID-HERE">
-                <File Id="fil49ED9A9A100F4B7848AF9A02B69490F3" KeyPath="yes" Source="SourceDir\qml\QtQml\XmlListModel\plugins.qmltypes" />
-            </Component>
-            <Component Id="cmp50357C4AABC622F51AD737AB1256FE31" Directory="dirD48123A7B6E2CFB660EC94F0CBE0276D" Guid="PUT-GUID-HERE">
-                <File Id="filFBD23B1E55B401CA6C9778F361D5EC66" KeyPath="yes" Source="SourceDir\qml\QtQml\XmlListModel\qmldir" />
-            </Component>
-            <Component Id="cmp86A326EFCF0E1704C41D4A3BE3B2B50C" Directory="dirD48123A7B6E2CFB660EC94F0CBE0276D" Guid="PUT-GUID-HERE">
-                <File Id="fil52EA3E4F82010DABF3A854BA9390EEAC" KeyPath="yes" Source="SourceDir\qml\QtQml\XmlListModel\qmlxmllistmodelplugin.dll" />
             </Component>
             <Component Id="cmpE4E1A33E38557FB60B3F45555FD20ECE" Directory="dir4B7D2A19DD0D33E235AA7BD43615A87E" Guid="PUT-GUID-HERE">
                 <File Id="fil1C0EEC7BC400302C41630BA92C1C307F" KeyPath="yes" Source="SourceDir\qml\QtQuick\plugins.qmltypes" />
@@ -584,6 +580,2514 @@
             </Component>
             <Component Id="cmp191CA6324FBD06A3B02B1B7F18C11E96" Directory="dir78C3D911E47BC1C88AC3A9AC7D40EEC3" Guid="PUT-GUID-HERE">
                 <File Id="fil94069F412C19B914E634255D82E89B35" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Basic\impl\qtquickcontrols2basicstyleimplplugin.dll" />
+            </Component>
+            <Component Id="cmpBEC5CEBC6AFF05B265496A46A98831EC" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="filE7454071DB283322A310481DC72151A1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\ApplicationWindow.qml" />
+            </Component>
+            <Component Id="cmpD407CB8459C1B1B530CF49F3757A7628" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="fil247FD47495EE34D5F907961789C413EE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\BusyIndicator.qml" />
+            </Component>
+            <Component Id="cmpAC7BB06BB817F8E44458D576FA35F1F5" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="fil8171E082BA4EEC420369C8F484B43E3C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\Button.qml" />
+            </Component>
+            <Component Id="cmp7423540D4E30B0CBB803418ADE99F49F" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="fil9B39D1CEB6B6E6CD5889ADC8417CD908" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\CheckBox.qml" />
+            </Component>
+            <Component Id="cmpD1E6B1570A3D1E1357C04E496A1D3F36" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="filFF4E8602EB8C4D7947EC1852DBCEEC22" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\CheckDelegate.qml" />
+            </Component>
+            <Component Id="cmp7A9FCF5DFFC41C252BE968D8701A14C6" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="filDA556695542CEA579EDE7F8A778B31FA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\ComboBox.qml" />
+            </Component>
+            <Component Id="cmpBF2783833711046DE6FD6BD58A09D1D9" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="filC92972D564BBEAD3A8C5E0FF69E34F8D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\Config.qml" />
+            </Component>
+            <Component Id="cmpCAF4B0FAF03D579A728F1926FACA2017" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="filF410D60B2E8C7D4176B638E08701305C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\DelayButton.qml" />
+            </Component>
+            <Component Id="cmp24E6E2D6014C11C0237774E3D24439EC" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="fil3D644ABBA54437F87AF43D33013808DC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\Dialog.qml" />
+            </Component>
+            <Component Id="cmpD87559774E2DE214C8877A4BD32565EE" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="fil1498D2D321E9D106DEFF5BA94E6659C2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\DialogButtonBox.qml" />
+            </Component>
+            <Component Id="cmp66ACC3897EF8B5F1667FD8303AA95A52" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="filF8F8521DB76409C9309A33A6E37E8EA4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\FocusFrame.qml" />
+            </Component>
+            <Component Id="cmpDAA15B7E105F0CFFF27139E95A68395E" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="fil89E25C836EACEE23C8C43F159201E806" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\Frame.qml" />
+            </Component>
+            <Component Id="cmpCC9678D26FEEC236D88C06A8B10F9B31" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="fil983738FCC975A797235595E4AA6480B1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\GroupBox.qml" />
+            </Component>
+            <Component Id="cmpF22434C74A89D374E2390BAD597DDCEB" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="filB695D4B23CAEA6DC02EAF06F2687824C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\ItemDelegate.qml" />
+            </Component>
+            <Component Id="cmpBE6C9D000F09B344019353A05DB3D90E" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="fil28301E6E0A63A887E79F32749D64300F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\Menu.qml" />
+            </Component>
+            <Component Id="cmp81688D192412A7AF329943685DF43850" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="filC2E3A3FDB8C9E37A03D277F828AF2367" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\MenuBar.qml" />
+            </Component>
+            <Component Id="cmpFDA409BE444B8FB89F40323EFA636518" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="fil5EECBF4C03AF0B35B07F6F7DEC893304" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\MenuBarItem.qml" />
+            </Component>
+            <Component Id="cmp9BF9F75C4F6648157F918AEB02FB987B" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="fil12C025630051A0346B995320C179AD83" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\MenuItem.qml" />
+            </Component>
+            <Component Id="cmp594AE21ED3FA4E76E6022887C091DEDA" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="fil89B6A5312333DEB62D6095E577414F92" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\MenuSeparator.qml" />
+            </Component>
+            <Component Id="cmpD26245D682D8A4FF6A923F3A04FCD6CC" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="fil0DB14E44C2350422338A264F7292E0F6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\PageIndicator.qml" />
+            </Component>
+            <Component Id="cmp070DCD11EBE4CB6801FD25FF3D88FB0E" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="filA2AFBFD9E681DD2BE83341BBDA852B97" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\plugins.qmltypes" />
+            </Component>
+            <Component Id="cmp0C025F6409BE9855A779EDB6FBB10331" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="fil68F925FB01F1767C39ABFEF2EA43975C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\Popup.qml" />
+            </Component>
+            <Component Id="cmp3763924DB647B4450CD56B89437DB415" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="filE35C4631ABBDB3A15B9E1B39E87005E8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\ProgressBar.qml" />
+            </Component>
+            <Component Id="cmpCF0A8D6670C1D2BE9D013D1B323CF863" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="fil91307AEEED3351AEA98B937676FDC6B2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\qmldir" />
+            </Component>
+            <Component Id="cmp5513795A63453D025823BB61C9AF1083" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="fil018D6A09AAEEAC155E038A153E0FD562" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\qtquickcontrols2fluentwinui3styleplugin.dll" />
+            </Component>
+            <Component Id="cmp237DD73DAAF688C3789D30EB4F83E61A" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="fil6E1B678E5895330BC27F4D8F97EA68BB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\RadioButton.qml" />
+            </Component>
+            <Component Id="cmp3B5BFD085840E59DBF97450274C370CF" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="fil7CADA6BC067805C69987778106187ABF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\RadioDelegate.qml" />
+            </Component>
+            <Component Id="cmp26DABBF1ECA876E1AA9166C76AC878D6" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="filCBD2B6971CACDB39BD25B10ABB5DD67D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\RangeSlider.qml" />
+            </Component>
+            <Component Id="cmp1F10E0F63A15E80DC6CAE758AFDF5E61" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="fil2336F9078803E2F3B72D153DAA32C65E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\RoundButton.qml" />
+            </Component>
+            <Component Id="cmpA780D5753E011037CFDCAA49E34164D3" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="filE9EC9D01C476A0DB8826F197CF1AB5A0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\Slider.qml" />
+            </Component>
+            <Component Id="cmp0192ABAC199B2E6EB7FD7A67DACFC728" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="fil1CFFB2FAA2B61D9DA6A7C03D1D5ACDFA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\SpinBox.qml" />
+            </Component>
+            <Component Id="cmpB4939353B0641105713876427B30B8BB" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="fil2188D7A3F182193CEFD6079813F76709" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\StyleImage.qml" />
+            </Component>
+            <Component Id="cmpFA0E535D853C42573DBC949E9C73C85E" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="fil080E2EFC77A649C3500BD832BE76FA1F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\SwipeDelegate.qml" />
+            </Component>
+            <Component Id="cmp6DE2DD6F4EAFF2F2CB17C721528F8F06" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="fil9191A185B439D4E3A3A21F1A3199A720" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\Switch.qml" />
+            </Component>
+            <Component Id="cmp691179C823A8384446B95600F9F89091" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="fil71CA5C85B955A7979D623B08C7B3B4EC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\SwitchDelegate.qml" />
+            </Component>
+            <Component Id="cmpD932D3550D9DC5679565FE8E1DC1AB02" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="fil433C97022DAD73E4437AAA698F15B46B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\TabBar.qml" />
+            </Component>
+            <Component Id="cmp5E7EE5E0AA9DDEE0F618772164AFB017" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="fil0AACF02B5AF82702342427CA207DE0C9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\TabButton.qml" />
+            </Component>
+            <Component Id="cmp1BCDEAF28681BC9747BEB147D8D1BFC4" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="filC064725AB88FDA36F5CCB7BE1ECCE34D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\TextArea.qml" />
+            </Component>
+            <Component Id="cmpF4C2D103D24403966706363FD911796E" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="filF74D2CCCBDE90C647967AD060B185E96" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\TextField.qml" />
+            </Component>
+            <Component Id="cmp4421BAFC7077735B15D735DB3D77F331" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="filCEE749F4708B9DC4FCD681F897F8495A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\ToolBar.qml" />
+            </Component>
+            <Component Id="cmp60DC82E68BC2274F0D7E4F2C4D9F4692" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="fil83E359A369182400875C264C18E9A046" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\ToolButton.qml" />
+            </Component>
+            <Component Id="cmp2C488F1C4FB310AE376A3E902E018393" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="filAB53F4F085C8C819E61207A594ECFF27" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\ToolSeparator.qml" />
+            </Component>
+            <Component Id="cmpC1F25A3E55398B55DB1D46D557930BB0" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="PUT-GUID-HERE">
+                <File Id="fil2C5184A1ED5B2230D526D0F25DEDAA56" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\ToolTip.qml" />
+            </Component>
+            <Component Id="cmp8721796279895CF4D1D789ACF3707314" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filB8D7FC78E030D8AD1D9C95A9F99664BC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-checked-disabled.png" />
+            </Component>
+            <Component Id="cmp3EB3229D74B00F835E6EAC2D589890EC" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil460CECE935406A184B8CA6F264009A5F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-checked-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp93EDD2E7297C6A01836530B0281DB955" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filA978E633FB793E4BB9F23FF555168C12" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-checked-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp363D4745A94CC1930672D4AA475EF7C2" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil7FECFAE69B2AE76BC27EF5AB06890BEA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-checked-hovered.png" />
+            </Component>
+            <Component Id="cmpA8B438CBAA6D751191A9C4A0C9265E07" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil60FE31A01E468BAD58C7AB6D4E3B59E6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-checked-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpD49A29F9A5F32AE3241C86BA7EDAE788" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filA45652A5E2A0BC36C072BA103B029A1F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-checked-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp4346F725060AA2C337D2C385D05C75CE" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil59D9560F6EAAA23B5D3B180749C64854" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-checked-pressed.png" />
+            </Component>
+            <Component Id="cmp3B482CC47BB24E35C592A5CC67AC89C1" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil03211802764C8F8B66DDCB83C4322934" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-checked-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpCB07CD2377448CD36D84D9C909E4D780" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filF0DA0FFF491C4A9EFBA403E6417D926F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-checked-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpED83B0B18DFEBD7335BE581CE73BAE0D" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil2EE1F694FE500FF9B1F88478D6514CBA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-checked.png" />
+            </Component>
+            <Component Id="cmpB2530EE7175268CE014B09C628DD201D" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filF5F6FBB6C283D84248780BEB67C692B0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-checked@2x.png" />
+            </Component>
+            <Component Id="cmp466755033794D475259AD9D32395C7E1" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filE50E0E1B22A611FB221DB760C25C148A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-checked@3x.png" />
+            </Component>
+            <Component Id="cmp6FAB0E150883D6A86B3EFBFE677E6288" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil7F9CFDCF6F55B88526F3CA6C9051E6DA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-disabled-partiallyChecked.png" />
+            </Component>
+            <Component Id="cmp76EEFAF6992C3563B4D3ED149B93048C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil5C77C87DE710FF80CFD7C0CFEED4908B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-disabled-partiallyChecked@2x.png" />
+            </Component>
+            <Component Id="cmp30D9DB59A69BC6D8E99D4E386FA5E68B" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filAB6B4EA8E1FDC320C3A225DED4AA1130" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-disabled-partiallyChecked@3x.png" />
+            </Component>
+            <Component Id="cmpD674292FCCAFDDAF0E64F0076CA09D36" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil652912FB156748E3ECE21EED54732B18" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-disabled.png" />
+            </Component>
+            <Component Id="cmpBDB59A04B151122059D8762806F2DBDB" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filDDEE1029AEA324EC33258FE00DBBF2D7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp9CFF8A63C995F3E9C44B2B7AECA1895F" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filE5C07CAE97E8C507D9DC1CB5DDFAB44E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp46983BE079B3E9308C3DB4611FCAF9E1" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil61C0C97FEA0DBF551D045F83C7A23134" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-hovered-partiallyChecked.png" />
+            </Component>
+            <Component Id="cmp3B3ED8778B661EAFAF3750A7ABC66215" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil4E8DAC2BE3A7F557446892D447868279" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-hovered-partiallyChecked@2x.png" />
+            </Component>
+            <Component Id="cmpD254236BF232A54FC978B3E50F0A2429" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil00B3EA131CB6611EDD99EA7F5D1AB6EB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-hovered-partiallyChecked@3x.png" />
+            </Component>
+            <Component Id="cmp7D05F18D4777C434EF5080581253D033" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil9FFA1167A32A9827B53B18BBE9D27E21" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-hovered.png" />
+            </Component>
+            <Component Id="cmpB4E58D6077A19A3A957E7EF006E29245" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filE430377303A931FD4F64F2999C398DF2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp5DAF5C97D3744903481B1BEB29F0E714" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil4BADCE47092E481E45DCE158B259A0CB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpBA959D82589453C1284CADA7CEC09906" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil34CDF5F477271F0C927BFD25565729E6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-partiallyChecked-pressed.png" />
+            </Component>
+            <Component Id="cmp091C767D045B7748C353E0FF5BDF0F0E" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filD235BB415F7B2A55E92F1E7873A1BDA0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-partiallyChecked-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpA394ED27A8DBA527D9DDC428880F30C5" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filBB9B7AB2AFEF824972868F9C7391D594" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-partiallyChecked-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpD26B5BF7E2DBFC2513CEFEC8255676F6" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil48136B9FE38DB86D0DD8346F3C29AD02" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-partiallyChecked.png" />
+            </Component>
+            <Component Id="cmpFF4B734C1513CCC7028BA3D7D8F94B8F" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil40C9CFAB35F3F35AC109B0C3CF28634B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-partiallyChecked@2x.png" />
+            </Component>
+            <Component Id="cmpF47C36A96B5BAD5CEE5E6F8BBBCC2FBD" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filCAAA8542E7FDACD84FBF97978E900157" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-partiallyChecked@3x.png" />
+            </Component>
+            <Component Id="cmp398E8C480D998E40A0828D7FC93AD66A" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil49C347F1FCBB34F45F1F231B02288223" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-pressed.png" />
+            </Component>
+            <Component Id="cmpE06625474542ECE5DFFCE6BAC36D9C6D" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil1CDBE03F70EE032095C2B2E8EC5A3DD7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpC6B752DE6F94A1BA12FBBBE8DBDE8054" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filDFDC7F96299A0A1A2B207B0AC117FBE3" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp153DC955035DF8906B31D61252A84DA8" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil18BE92A4CFFDAA2A1C97F0B96DDCB7D8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator.png" />
+            </Component>
+            <Component Id="cmp3D9321C333BAD8590582C14D042FA99B" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filECF4355653CCB4AAF36DD6F3C54836D8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator@2x.png" />
+            </Component>
+            <Component Id="cmp9457EBBA75FF4345C0177F6DD7DCC839" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil3B5698D155D5014EDE9663A2B1722F5C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator@3x.png" />
+            </Component>
+            <Component Id="cmpD5724FDCEB3DB2F82B59EFFB92E3C491" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil00E62B42B51379F892FA5435772EF6E9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-disabled.png" />
+            </Component>
+            <Component Id="cmp404533A260B5E873A8F4A77BDF0AE4F0" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filEF6299DB3C73D4911631E602B74D4730" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-disabled@2x.png" />
+            </Component>
+            <Component Id="cmpFF210C8877A6A5F455E40A5841E43C86" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filC41CF27BF72521F5C3969881F7E865F8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp637A177DBBAD3C84647EAC895BF40DB8" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filD07BAC4DC972036E9B943A9EB20532AC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-focused.png" />
+            </Component>
+            <Component Id="cmp99B5BDCF6EA3D0DEAB453B16520B7832" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filE51C62D665F97F83DE1722BFB1716CFB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-focused@2x.png" />
+            </Component>
+            <Component Id="cmp5BEA3329794AE34920BAD72C60D65301" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil52FA620E27CAE876292FFC62A3B5FF0C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-focused@3x.png" />
+            </Component>
+            <Component Id="cmpDC38329D8E8677658A5F9C78A6560ABE" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil819189B6B89176F56843C646B11490C0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-hovered-open.png" />
+            </Component>
+            <Component Id="cmp4F3557142E08073AEAF69AB968DD39EE" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil3B5DD9B981584F3E8E1B479D4C555F5F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-hovered-open@2x.png" />
+            </Component>
+            <Component Id="cmp07605ADE55553EF48D9B2EB66F56957A" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filA8DE5DA834697930EF36DB09F1FDBC62" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-hovered-open@3x.png" />
+            </Component>
+            <Component Id="cmpC4F6E5732A118E9CE7A08A09090BC8CF" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil94DA1F4F04DD30D393A13C6E400EED45" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-hovered.png" />
+            </Component>
+            <Component Id="cmpFA60F4E2AFE91F057B533A38E2D38920" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil2992C5F540CB03105338A4A6FF8AEBC1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp037E90877A40E75B9DF9648D38A9D756" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filCF9E27EAFA53C075092243E54B482B92" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp1722C79067C39F257930B79C1F904A48" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filDAC75E65C2CD1736562B937066C12693" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-open-pressed.png" />
+            </Component>
+            <Component Id="cmpDE5BAABA243FE4D5FBBA4A83DBB97378" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filE6A428254613FB18A207C9CBDE6AB68D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-open-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp3A4A6D25D838C4281D148B7C61FBE67F" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil36D2CD75536C4B9DA1FD5BD47961F925" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-open-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp751C01DF0979E4ABC3F4E0856B99071C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filBA6AFA66E46050B76F1F9BF6BC584861" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-open.png" />
+            </Component>
+            <Component Id="cmp53A40CBC4686A321FB4976281E67A235" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil0342CE6954D0A17336F4574F62B0E958" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-open@2x.png" />
+            </Component>
+            <Component Id="cmp60FB6917A2AF5FF992C0FF5224A6CCD4" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filEF524348CC7FA0F9527F3F9B86294EDB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-open@3x.png" />
+            </Component>
+            <Component Id="cmp2F848B85A5701233A0DCA63EB412DD16" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filE18F607BEF6841741E22F8EAF772023B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-pressed.png" />
+            </Component>
+            <Component Id="cmp49A52D7C85CE6BD98E32A54B29F062BA" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filF4CA05B8CE8D8F4C360A6724FD1A897A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp8B928A820DE4E7817BBD118C4569DDD8" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil5ED0404F4A14FA5C2F52FBF146B2BDAC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpF08D9421B64A90FAC63AB17ADDF31305" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filD724A7247C57E645E105856D43A535D6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background.png" />
+            </Component>
+            <Component Id="cmpD45645C908016D47C0954E939DE45B92" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filF9293A38FF869F08131E06F4D8EC2A67" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background@2x.png" />
+            </Component>
+            <Component Id="cmp3299C583164886EEE164318A71CEF78E" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil1B3817A61B54887122215046AC66EC5E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background@3x.png" />
+            </Component>
+            <Component Id="cmp0593D3B46572B88352B98EFA253FC13A" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil7850D1EA75D1878ADB09E8268D29614C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-disabled.png" />
+            </Component>
+            <Component Id="cmp2A075CB4E094FF2B1FCA9295ECF2EC95" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil8B021E3C391A87B54B02E4E743BE2B24" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-disabled@2x.png" />
+            </Component>
+            <Component Id="cmpC8264EF9C4CE0DBBF43542E802D85A6B" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filBA238DCEE3396627A1B62915A1A6BB46" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp3A333D5AD99BCF94F0C651F4557B5082" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil41A56E6C704D9E41D8D3B175D5119DD5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-focused.png" />
+            </Component>
+            <Component Id="cmp1205F8DDE72F06FD391CCA208ADE4704" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil610F8B4A9065665ED3C61F4920390F4C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-focused@2x.png" />
+            </Component>
+            <Component Id="cmp0622C5AF7200E0678F65ED82C578720B" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil9960C7A6E241A53BD92D82AAEADDA8CA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-focused@3x.png" />
+            </Component>
+            <Component Id="cmp729E48799E3EE3CCA67F65180F904955" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil118D137837457D67FE0329F447F2AD5C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-hovered-open.png" />
+            </Component>
+            <Component Id="cmp1E9DA0AD9E148810A2A38C6DE8681A71" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filF4B854609FF560336D1F292B48797AED" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-hovered-open@2x.png" />
+            </Component>
+            <Component Id="cmp868DB35629607051330788879F9B1D4A" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filCA48C0E2BED16E83032ADC87A30DF99F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-hovered-open@3x.png" />
+            </Component>
+            <Component Id="cmpE9270F4926B7D4CD21694A74A79CD3AF" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil944B2F855F58D7E8BA1EEB05046A6E87" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-hovered.png" />
+            </Component>
+            <Component Id="cmp37266D9682666E5A1C07ED3F7198F10C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filC3845A1D7EB8FAA8603B336138176CAD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpDDC2E00A8EA457CF7B507FA3B776929A" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil2FCB2D2DD7786E943CDD39F6F7C2EE64" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpD9F74ED075E99BDDACE46BC4E4CC93F8" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filE04D8B4FE6D562E687312A33BDDE68DD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-open-pressed.png" />
+            </Component>
+            <Component Id="cmpA17C6D2780258AECBA53127A66733A26" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filD1CCEF162ECF6C5ED809CE09726DFF3F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-open-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp9F6B196964A7C380139AA0A2CFFEB187" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil2AACC27FE9C55EC805F808D6E1B86A2A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-open-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp0A9F426B3925047FD9DCD6C3BB134E15" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil4E765F11C4AD218BC6B77A0BAEE9D16A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-open.png" />
+            </Component>
+            <Component Id="cmp82D915804AC2FDB4E851C070FC5D0017" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil286D823FE73F9EE715752A5CEB44D893" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-open@2x.png" />
+            </Component>
+            <Component Id="cmpEB9DD804ED37524A9C34F6BC22C0FF96" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil0E2853143E56341031E1304794F186A1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-open@3x.png" />
+            </Component>
+            <Component Id="cmpE7615C9200750E08CFF9913884C331B5" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil367E8F4E1B56E8152FFDF3E8C80C542E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-pressed.png" />
+            </Component>
+            <Component Id="cmp459A5E97350322D0FBFA6B9BE1B360EA" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil562A03CAAB1C7B8338F3D0D41E6BCF81" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpD8E57F7535034D40732562FD3BE661E1" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filC426DE88BD133BC28AF99B0CC32F1BA7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp913DCE0ADD1A07E3C49B9A8100B772CC" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil321D25A6540F7B3483F55F8ABC9D61E6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator.png" />
+            </Component>
+            <Component Id="cmpEB80488DC1A2A33E73C5FC664087E51A" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil8660BE7976966BD5128B910ABAF5F45B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator@2x.png" />
+            </Component>
+            <Component Id="cmp6C01059487DCB308E196D8452FA03B01" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filD169A846F68D6D64631AF805340AA178" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator@3x.png" />
+            </Component>
+            <Component Id="cmpBF330BC7C4C7EBA6EA4D0D363F82AC77" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil2FDE03BE837A297D17A956BE18E804CA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-background-hovered-open.png" />
+            </Component>
+            <Component Id="cmp26C4499F0BC29041206F042AEDD619B7" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil7AF0D9EAB67A05EC6CF690C033251FF3" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-background-hovered-open@2x.png" />
+            </Component>
+            <Component Id="cmp0BD25EDF358CB6428DF04DA7874684EA" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil5EA85133115EBAE548BE119ECCDABBA4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-background-hovered-open@3x.png" />
+            </Component>
+            <Component Id="cmp5AA3030468E022A16112DBB053E75E61" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil3638901EF46B4E84434A7F5E29D26A00" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-background-open-pressed.png" />
+            </Component>
+            <Component Id="cmp8D2559BF3782018E5DDE1DF0D6F38E87" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filF4FD64E911CC1D584074A15BDBE689DA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-background-open-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp2F2E213D87BA9B5F234C339393BB9196" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil4A25E27EF51D350653EC11B66BE5AD4B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-background-open-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpA403A1D842C40990F7DD729718CF01F1" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil1D38D01243E800AA4F5510DDC6086B32" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-background-open.png" />
+            </Component>
+            <Component Id="cmp619C340E39B021C2398DD759BB2F2750" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filDAB8623E900D4182BD33FC0AA345A6E2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-background-open@2x.png" />
+            </Component>
+            <Component Id="cmpE92F8E0ABA9F17499958C14BF05117DB" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil2AB9AF27788F1E39300F49D32C3D93CD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-background-open@3x.png" />
+            </Component>
+            <Component Id="cmpEDBB1ED7F29AD591FE7A8A3E9B4A7EA5" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filF28AA6E94FFCBB999D84717308BF7237" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-indicator-hovered-open.png" />
+            </Component>
+            <Component Id="cmpD1E234688002465C1D2506BBF3E48C19" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filC88B9B13831E25238B73C135F8F724D1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-indicator-hovered-open@2x.png" />
+            </Component>
+            <Component Id="cmp5114FA69EF39D88163782B2622E3ED39" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil0226BAF7E545DD45F078341D1DAF1CD7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-indicator-hovered-open@3x.png" />
+            </Component>
+            <Component Id="cmp5DE96F626119F38514F0EFF7C587F139" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil245FCA40A0D718B470EB0B2C71E9076E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-indicator-open-pressed.png" />
+            </Component>
+            <Component Id="cmp725287BC85FCE71C32A8A0EA3BF603E7" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filF4E7448A989B47DE746394DDC9385417" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-indicator-open-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpD4ED98F862E2AE14A0DD05F547D2D193" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil734CF477BC59101E30BF9060E6273654" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-indicator-open-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp40C6DC2EEB369F26C22650385885D94D" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filFFB773F276EC619A6FE352BE595F83C6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-indicator-open.png" />
+            </Component>
+            <Component Id="cmp258EBBC9B8204D2502D2E5BFCB7A0441" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil35B67742BA696F678D5EAAF842C68D33" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-indicator-open@2x.png" />
+            </Component>
+            <Component Id="cmpC7E76E2716C48DA3647B198433A671FF" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil4F7F0C20D3F28916962641FF89B6B94A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-indicator-open@3x.png" />
+            </Component>
+            <Component Id="cmpABAEB5D51011EF92AFD1F57E10721B9C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil9AAD491F40EBC5A6B84F8DC1E5D7EC53" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-popup-background-hovered-open.png" />
+            </Component>
+            <Component Id="cmpE58F9627D4190EE5C4DEF899BC21CA0B" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil9D63176B09E2C6224DAD3ABC4988DC94" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-popup-background-hovered-open@2x.png" />
+            </Component>
+            <Component Id="cmp4CE477F271A6C6126DEF0694FE339C4B" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil62E25869C06F055A87C0E8DA7F2923D7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-popup-background-hovered-open@3x.png" />
+            </Component>
+            <Component Id="cmpBAD12E3C00C7F20D54D9837C38321556" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil9E781AB959FA2322537EBA5F8C556684" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-popup-background-open-pressed.png" />
+            </Component>
+            <Component Id="cmp9AF0146A75A179E66A24F71E709732C8" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil32D93A717A9E00536FA3452AE072A35A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-popup-background-open-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp927FD1FB5D00AAD622F68285E9D69362" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil6ADBABB576B1C7C62596DCF77FA5B802" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-popup-background-open-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpE7AB64C1F5CE92B9B5CA3D1B8F7CF7B3" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filFED4351F2970120F8918AD8DF1A5828D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-popup-background-open.png" />
+            </Component>
+            <Component Id="cmp93B3A0E52FD73C6365FE39875121AAD8" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil43D7E83914D9B710B6B460A8B8B42901" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-popup-background-open@2x.png" />
+            </Component>
+            <Component Id="cmpE257C54DCCE460E400BDC1388FB88716" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil2F65AF9A238AC6945A1E927E533E19E0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-popup-background-open@3x.png" />
+            </Component>
+            <Component Id="cmpB1C8BB0FB8D9147EA6E6CF2713C0B584" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil7F4F20CFD343C83861BC17C4E6E91865" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\frame-background-disabled.png" />
+            </Component>
+            <Component Id="cmpD9E4D6D41A575D9EEDF0D2F19A03E76A" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filB3670C170E42C83EF33DD1110B3C7B9F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\frame-background-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp4BC3FF1D46FCF61C1555B946042E0F46" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filF223F6B036E87C8E42519F7DEB183654" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\frame-background-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp09E153F289E1ADAA85B195AAECAB37C0" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filF560697DE374DE85373D1CBF660E4FB0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\frame-background.png" />
+            </Component>
+            <Component Id="cmp04E41BD49FBD31FC395FE98DB87D724F" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil78D4256288C7758C333E230895083859" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\frame-background@2x.png" />
+            </Component>
+            <Component Id="cmpCE347089DE3D5C1B091B7DBB20A8AAED" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil38FCCF8AA384675AF181CCE88F6DA576" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\frame-background@3x.png" />
+            </Component>
+            <Component Id="cmp9C3CE30F80DADAB1BDEFD8CCD99FB142" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil2D6F98C87086F0B3A43BB60F2718F12C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\itemdelegate-background-highlighted-hovered.png" />
+            </Component>
+            <Component Id="cmpA7AEB77768210E8D20F3BBDD9A767C13" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filCB197B4C7DB450426F7D7455A5D803CA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\itemdelegate-background-highlighted-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp2496B0A2F62DC28DB9BECA8CB5946EB6" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil87D67892E22E0CAD2D6BE4373AABB761" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\itemdelegate-background-highlighted-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp7878E8E4A175C90CB2D0D0460E25F408" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil3E5F1945FBB22D26A737D63A34C3139C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\itemdelegate-background-highlighted-pressed.png" />
+            </Component>
+            <Component Id="cmp9F48287DDE734DE7DC71BF94A85BF94A" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil1F419EB33D50CF6BFC975D2861816E1B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\itemdelegate-background-highlighted-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpF56E72E13EBDC2A97CF379241B39BB6D" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil7230EF87E97449CD1A128938A0344FE2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\itemdelegate-background-highlighted-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpBC93705947568B80815CBAC29BFF395B" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil5E11A3D6FB02244111FE639A6EA10A7B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\itemdelegate-background-highlighted.png" />
+            </Component>
+            <Component Id="cmpE28DAC97C5F65C3202C5F3AFEFE6470B" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil3BCA6C768842672AD7F16CED36AA1E94" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\itemdelegate-background-highlighted@2x.png" />
+            </Component>
+            <Component Id="cmp4C4637F92F2902455A264AEFEF922124" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil946B7A7BCE26274CA11FB14F5207DF14" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\itemdelegate-background-highlighted@3x.png" />
+            </Component>
+            <Component Id="cmp64082128100A9C6047787BE5B74AAD60" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filEB93F7B4B28698934B231228D5DA1EC3" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\itemdelegate-background-hovered.png" />
+            </Component>
+            <Component Id="cmpB8623BF5BB1D8EB59B473A3784B1594D" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil392061DFABCA55D8C49538CDD48B7726" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\itemdelegate-background-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpC8A68688A765ADB70CA87E7D663CA3DE" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filBE83C6539190001450209F1FCE0256C1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\itemdelegate-background-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpB34CBFCFBE662BECDC2EAFBEE2ECD579" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filAEB34EE24B77C2BF01F3723296A9D000" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\itemdelegate-background-pressed.png" />
+            </Component>
+            <Component Id="cmp260EEB22A29C1C9C25186F91E1DF3E06" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil04F85B004848C35F39EB444E6DB5B564" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\itemdelegate-background-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp0E365E479FCE4980884CB0BCC81ECE92" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filDB7C0006F957AB34F7C029E4D731E07A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\itemdelegate-background-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpFC6A95B011647882B4B1EE7E2B1EDC01" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filA9153DBB25D9E5D9E730E6D5EDF8817B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-delegate-current-hovered.png" />
+            </Component>
+            <Component Id="cmp227D0013242AEECB4B9F5E616B923185" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil8DADDE3F02446EABCFB6583C28B471EE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-delegate-current-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp3625F2CC21BD626C02FD818F98FE8629" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil3A9120EEC87C73BF10E0620F0F5BE751" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-delegate-current-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpFF58355B5BCA0B83C7A4EFE74062C308" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil9D48CF3F741AB34AEBAB965435561C5E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-delegate-current-pressed.png" />
+            </Component>
+            <Component Id="cmpBAC2AA109568BEC9D9085FC08C620AAE" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filA8A7FCE6CC1CCBFD79C71ADB72CFCC18" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-delegate-current-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp7A3CF3E124BD5DD9B39C827AE372FF11" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filD21B336A6171D1CAEDFDEA23C995D1CD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-delegate-current-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp0EAE9C15BEE119316F969577F025EFD7" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil1842ADB5F323B9AD0792D4B015CCE370" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-delegate-current.png" />
+            </Component>
+            <Component Id="cmpEEC527BDD5D10F0AA61D7F5D52102134" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filAD7CDCA7069373AE8BD1963278BA8E8F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-delegate-current@2x.png" />
+            </Component>
+            <Component Id="cmp13588E3370C460C14FE52E7163B9451B" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filE6023FB36F17DDC8CA26E43E83F29FD9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-delegate-current@3x.png" />
+            </Component>
+            <Component Id="cmp75E4749166E25E2CB401CE538E4EAE0C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filE9DB57A061C2828AFD9C12EEB167B651" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-delegate-pressed.png" />
+            </Component>
+            <Component Id="cmp08F42DBFECDDD10264D060550E5CCB2C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil9181127572C188AA959EB3815FEA1A48" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-delegate-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp88BAF8F710E829D01AB8A061765C4853" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filE1208A2693EE480B26B9D70744F0649B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-delegate-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpA0216E783D01D4ADF9D854AA1352121C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filA4B0D1EA57689847FA480E6451DBE94C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-disabled.png" />
+            </Component>
+            <Component Id="cmp369A5BCFC78989321ECCF2F23A367591" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filE620B0CC8C5809428AE00BE5C60DDAFC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-disabled@2x.png" />
+            </Component>
+            <Component Id="cmpE923659A939143B8FC1F0FBB2D82F604" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil1FEE0663247763E7DD569D0069224A4D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp7F8DCA313F4E66AAB8EE70AE48196E8B" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil1AC384A006D1072B50BA4575CF71A795" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-hovered.png" />
+            </Component>
+            <Component Id="cmp540F8F86999A9DFCC87679FC5AFEF39C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filDEDBA380D3EC285932F1CD4E242F3D6B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpDED1BE30FF1696E927D92DEC68F3D4FB" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil8C0A3133F844AD9C51965D1610E96CBC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpF974BA2D6FC85200C094183DC7EF8089" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil4CC6EFF8219BB98FE72562B8007C3435" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator.png" />
+            </Component>
+            <Component Id="cmp90FC9D73BCFBF4F9D2DA3D38AE2BC7D5" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil678E3BE216FC0069F8DBDF7D2B7F9198" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator@2x.png" />
+            </Component>
+            <Component Id="cmpFD16216FDF70BDA2F7819DD43E8C5421" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil8345CC2CFECD9F2C70A21DD7D4E954E2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator@3x.png" />
+            </Component>
+            <Component Id="cmp001DB5977A6EA2849A1325E1EA3A3D66" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil8A678AE34C028669487A045B1D3577F5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\popup-background.png" />
+            </Component>
+            <Component Id="cmp6595F8D997244ECF20D62418FB6A2A1A" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil4D4D3ADDEBCB883AB502AC21065DD014" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\popup-background@2x.png" />
+            </Component>
+            <Component Id="cmp206413D1227964ACDA532BF47F664FFD" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filE8968A560CF165CA1B418394386E5696" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\popup-background@3x.png" />
+            </Component>
+            <Component Id="cmp575FA2D7C6F79A5363B5BD96E0BF8004" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil9367497245E7A73CAF1E47390A59CFF0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\progressbar-groove-disabled.png" />
+            </Component>
+            <Component Id="cmpD2949F75AC106406CA4DCFE513F50608" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil3D0471389BE1382ECD82405B01734DFD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\progressbar-groove-disabled@2x.png" />
+            </Component>
+            <Component Id="cmpBBCEEC0195A2CFC8C2EAF1B31541FF4B" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil3DF78E2C50C24FD224D3BC35C869F8E8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\progressbar-groove-disabled@3x.png" />
+            </Component>
+            <Component Id="cmpDAE2BBE6EC2ABECBA2A7BEC34ED4EC40" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil8C3040A3A9A6BA5CC4B57AC62984FA85" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\progressbar-groove.png" />
+            </Component>
+            <Component Id="cmpE7DE9EA284C1FDE59A12CF4F9FDB61F7" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil99F1DCDE69D9D20DFB7D8997E1DAAD32" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\progressbar-groove@2x.png" />
+            </Component>
+            <Component Id="cmpDF69E7F5AD4452C90C95C385226366B6" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil7B5227F8EBDCBB244003390EB230AA44" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\progressbar-groove@3x.png" />
+            </Component>
+            <Component Id="cmpAF75F14808A91927EFE293927496F387" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil352452EA615BB05FB634D822631686AF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-checked-disabled.png" />
+            </Component>
+            <Component Id="cmp2E327D258876C78D4150154BDF87A676" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil0283057D99F12FEEFB691604D16038C0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-checked-disabled@2x.png" />
+            </Component>
+            <Component Id="cmpF737C43193D6EE60289227B7B062BDFF" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filB74ED56C0234CCC104573271CC2BDB9C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-checked-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp7DD31E40D0191E5752C0A71CC0979C0D" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil28A74E7ED13973D3CA9D499A7F8969A7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-checked-hovered.png" />
+            </Component>
+            <Component Id="cmpA0CFA29C162D405F48E7C3FC70E79CAA" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil823575DBBF6C87B6554EEA0F9DFF331A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-checked-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp31A98701662F6F983AC28A12C93458FE" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filC8C7F77EEDB5B7DBD343D2133C5CA1DC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-checked-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp3D6264E93A17CBA3E83B85816F31D1E7" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil3CDDCDA60FC39E2064A767E02AF5F206" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-checked-pressed.png" />
+            </Component>
+            <Component Id="cmpF011BE96DB49F35E593C0783717BE649" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filD06EBE4A7716E481BA3B137269F5EAAF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-checked-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp70E45CD253E41635BC89577D4B7EEF14" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil83F2DCBC4C20A469ACD58AE29C941A83" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-checked-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp81D11858E0A46F954E26840C35FCF4B2" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil133CD3034B97E7AC41F2106BE0E95810" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-checked.png" />
+            </Component>
+            <Component Id="cmp020459DC9F172B712DF46551635EFBEB" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil66E35B4E301A20982988E7CA7DE71227" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-checked@2x.png" />
+            </Component>
+            <Component Id="cmp3C7F061300D0105DCE1E85A2EE0071CE" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil6117B3488DE0B0D82FBD4FE089FBEF0F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-checked@3x.png" />
+            </Component>
+            <Component Id="cmp8041E94D11E3ADE69CD60250C1EB59A0" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filF6ABA5F853576429361A2A08BA5F9459" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-disabled.png" />
+            </Component>
+            <Component Id="cmp78586C7DA16DF4EC858EC2C6AD99499F" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filC05EAFC57BADFF50674256B76E5891E8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp6A1398AA9DA1BDE52DEBB0E76ECA216B" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil5FDA1843EC99EBDACBC028501BF72B3D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-disabled@3x.png" />
+            </Component>
+            <Component Id="cmpFBC3B4145488B853B71AA1B21E9D0C84" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil3AD9AB10D22D796F175A1129A70CC2D1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-hovered.png" />
+            </Component>
+            <Component Id="cmp491933FE81E20DBF96D69E4F167264D7" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil0409C9D4663DA8C570B552C41FCCEAF9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp30170248A115AFAC7636171A46D6883E" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil4147F6E86B47D6EA55723D17D557AC63" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp56AFC3FE219BC5F3A1CBFB66CB93E4A2" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil8810A70B08830DFF5621E8CC35C45F1A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-pressed.png" />
+            </Component>
+            <Component Id="cmpAA582E12307A49C8997B20ACB3BF068A" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil3A41E61CEA1D7E7AC5CFADBCFEF5D343" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp868615A60CBF5F507DFEEAFD169698E5" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil31A434A7993A2A651E21FC96B7EF8825" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp98D7A72C338F2590E488C79823AEE7F5" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil5D8CAD075481F7844AD0575656D0FE2D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator.png" />
+            </Component>
+            <Component Id="cmpB9D7E7515B24CE13D53F3D800A532D47" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil18D026FB38F7C3F1EF6E66FA54AD8196" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator@2x.png" />
+            </Component>
+            <Component Id="cmpF0E7023E13CB8A3DD471884262F94EB7" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil5C91E6AD9A8CEC0436774D750A06AB5B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator@3x.png" />
+            </Component>
+            <Component Id="cmp31D16236755D3481138FB1DCC32FC55C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil28728BA7F62F346B1A254A616B104AA4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-first-handle-disabled.png" />
+            </Component>
+            <Component Id="cmp7AE4459D6A462BEC3089E5CC30518DBD" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filC6918D6EF618AF9B610E8C2927E04128" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-first-handle-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp462024A3A6649BE3638D13642A987D7A" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil06E2A95460AB8984F40CA918D57C3AE6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-first-handle-disabled@3x.png" />
+            </Component>
+            <Component Id="cmpAB40AC48C357F11E445566A0728ED146" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil43786224182A968EF2A3659DE17D5580" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-first-handle-handle-pressed.png" />
+            </Component>
+            <Component Id="cmp4821D18F3AE74DC318DC3C4D81D8F6C5" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil7ACD527FEFAEFA8059CB701B122AFE62" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-first-handle-handle-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp9E2A18258F09C7BF4A6F257600395AFB" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil11099990CB60535BDCECC51CB2387403" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-first-handle-handle-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp32DBD4892B52F016727611D8AFF36746" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil6C5366B5D08EE4396D0361EADBC28E2B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-first-handle-hovered.png" />
+            </Component>
+            <Component Id="cmpAFDDAD51597AC7BC4B53868FFC97B87D" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil04A6E37FA3F60752F1349D72E1499D50" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-first-handle-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp67B230EB638ABD809F2CD7A4E803C7A3" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil78CDA1695A16C63D641C3FC079273024" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-first-handle-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpA5F130DDE5E529DB5BF1DD94700B5956" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filBD8FB6600E313AB41ED0B2DDEE82C301" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-first-handle.png" />
+            </Component>
+            <Component Id="cmp85B4113E018FEB67EE5BC894E54085F1" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil4C62A4CA9C60749EB27B9341BCED522D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-first-handle@2x.png" />
+            </Component>
+            <Component Id="cmp69EC3CF9DCEFB354697289B168DF06EA" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil878C45863896D8A411048638408795BF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-first-handle@3x.png" />
+            </Component>
+            <Component Id="cmpF16931AC36B22E6AAC0353CE5901EC98" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil04EF0B63A31AE275D51B7C473BA2AA44" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-groove-disabled.png" />
+            </Component>
+            <Component Id="cmp944558BFD3DB285D65E040A4009289E6" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filE3A584B5E1886013848C20B3E611DEFB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-groove-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp6BD37BCABA23D8D8F4D19DE845CBAC87" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filB14B7C5AB1F928EAACE4F0435B076550" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-groove-disabled@3x.png" />
+            </Component>
+            <Component Id="cmpF43AEA17995A8145B992BBD375E65D10" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil2D28BBC5F0F7776708681D50C72D33B5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-groove-handle-pressed.png" />
+            </Component>
+            <Component Id="cmp684ACC1C9AEA99B8E482440F0960D120" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filD752660D36C7BABB38F1A90C75CF5EE8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-groove-handle-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp74EC66511E9A9450DAF5FDAF1323B97D" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filD2C5773F147B0E0875004EEB83D4B021" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-groove-handle-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp90A8709795FC31907E11CC892C932F4C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil935FD6C58E613E66D9E95156CFF56198" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-groove-hovered.png" />
+            </Component>
+            <Component Id="cmp7D5987B97B94C090C2A62AA81EEE7378" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filEEA68A54CEB04A65A4589610C38A2794" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-groove-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpE57ED60C72FC98EAFEEA29515656065D" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil2719A234DE909FB2C47F89CC9AFB1191" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-groove-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp4E45C2F2FE5C904879A0BC4D59EE3870" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil925CDE0805EFEDD0C2CAF9BFEFF38229" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-groove.png" />
+            </Component>
+            <Component Id="cmp249096D8B4822A5905BF952A26226033" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil3EA19A8A33D8BEF3A9A7C17AF27E693B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-groove@2x.png" />
+            </Component>
+            <Component Id="cmp42480DDF2C3A9CC607443C816256DEF5" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil9E8C31012D905FA943DFC4E33A6FF4A0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-groove@3x.png" />
+            </Component>
+            <Component Id="cmp894A07D119D15D875B72FA80DCE9BC8A" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil268CBC76BF5F7006C53A49292B1E47CD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-second-handle-disabled.png" />
+            </Component>
+            <Component Id="cmp9DA5F03CE617AA096299FB4EA561DBBA" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filA025E1982A3EE541C07248A761D635FC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-second-handle-disabled@2x.png" />
+            </Component>
+            <Component Id="cmpDE6932CDEDD61B2159ABC0B1EBDD509E" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil560BAFC3BF512DB28FBE4D2AEA1B936F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-second-handle-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp79C758817490C355C80181F5C5B8C2B2" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filBB74A6A34CE8AA8CFF782E28C7BA3ED5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-second-handle-handle-pressed.png" />
+            </Component>
+            <Component Id="cmp694C70990A5ED0AEDB45939F6BE07A46" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil0804BCD1416C77AE948EFC6C69737AB9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-second-handle-handle-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp128A76944D3B53BEA70D414FF9D699F7" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filE7A89A2925F7DCF83C7189DB50CD9EC1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-second-handle-handle-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpFB2E2B38EE61D26B0E0B5FD63C592F98" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil46A70C002C893842C3ED4BD6A9B42C2D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-second-handle-hovered.png" />
+            </Component>
+            <Component Id="cmpB1EC6AB5B981F2D2CA47379B8B3673C1" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filB063C2D40BDD09729426F125F47353A4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-second-handle-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp34C669EDC43C036A1CD078953263FA9C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil85AAF6F764A790E6CC119067196B4DDA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-second-handle-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp2077C7CFDA4E92083B0410A37E78FC87" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil57414B139956E3BC8D6B58CE57EC6CBC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-second-handle.png" />
+            </Component>
+            <Component Id="cmpB67C5034282C61543B6085FAA1F3D904" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filF65D55A20CBB12188B9B100C2F6C5C7D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-second-handle@2x.png" />
+            </Component>
+            <Component Id="cmp715B236FE0FDCC7E4EC38C12CC98BB47" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filFFCE33D488C5BCEF9F3B81CA4B69A97A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-second-handle@3x.png" />
+            </Component>
+            <Component Id="cmp89BE99E4F93ED8E733A069E7C4DAF06C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil25C102DC48CF9E07F6A7B00AB8BAB932" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-groove-disabled.png" />
+            </Component>
+            <Component Id="cmp0D2069C8023687B93039C87FDDECBFB1" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filAF9C508DCE5551C509C085FB05B3E397" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-groove-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp5BE9DA91C787D49EEDA003CB07AC4B01" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filB69A872340937932BE568A935F6E3189" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-groove-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp931210B12E72E9B817C7EDF3303C5AAA" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil328B95FD1FF378564C871CAB7548E67E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-groove-hovered.png" />
+            </Component>
+            <Component Id="cmpC0DBE56492C4592A0288C016BDFEE643" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil1A8D73FFA737DC15FF0ED6A27ED4785A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-groove-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp39D5388278DF655CD1A628086EABF5EC" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filE03CA4221DA483C31136855CC4E3F227" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-groove-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp9FE8883A52E5E916757100EB83EBDA29" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filE48D23A3A11F823AC28C48711525C8D9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-groove-pressed.png" />
+            </Component>
+            <Component Id="cmp38C8D2FA2E8A3A077C0DE03A8038D011" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil55C6CA176ADDA58A838544E809FC71C7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-groove-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp94F86EEDF5B701DE19FF2C684E0D5CBD" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filE688D9F33A02778656247EA43650909F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-groove-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpC7B6BF83EC9C94451A579DB1EB43AF24" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil98FD341467647967D681D7067CE26B8A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-groove.png" />
+            </Component>
+            <Component Id="cmp59EBCBE027762165F7792AD6F3979ED8" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil4F475144A0E963A7F51854A3AFA10364" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-groove@2x.png" />
+            </Component>
+            <Component Id="cmpAB3CE7C3D325E3CE51D2E095302BA5B7" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filED79AEBE8A728DC48381D9CCC408D731" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-groove@3x.png" />
+            </Component>
+            <Component Id="cmp2624E79830EBE64BD227D0E8F34AE327" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil598CACCC6E9DF7A644864FE8247E3109" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-handle-disabled.png" />
+            </Component>
+            <Component Id="cmp470C5F5A463FA9D5131A230F2893CB90" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil050043F8894CF5A0863FC754BA5CD71E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-handle-disabled@2x.png" />
+            </Component>
+            <Component Id="cmpAD015BE2B5E41452C610537683DC3D56" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil687DDB2A7262495D919A857AB626E082" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-handle-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp85B87786B28D9199DDC9110C43C95E23" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil3FF11996B13E7F8C235F45C05A842488" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-handle-hovered.png" />
+            </Component>
+            <Component Id="cmpCECAA5B506E53845F9D93497E871A241" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filBFB1ED3865AB9F3BA89CBD6C85746E41" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-handle-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp957A0A2ECB8E90448D1729CC19680B3C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filCF2D1F451FA495DAA821A0A3593D49BE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-handle-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpA8C2C7794837A0C38F9987CBA7D22778" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filF735325DDE8E98CF69EB7F13756BACC6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-handle-pressed.png" />
+            </Component>
+            <Component Id="cmp103A85441D77FC983DBEFFA53946FC6E" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filE30CEDF558E7EBFC78AEC01C207FC626" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-handle-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp05D28D9F519027D1D6E56E43DDCC1C45" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil22A8AB250DB83965395427BCE64E9122" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-handle-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpE75CE6D6D526C513692B7FE8031DEE0F" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil99CC9FCB8496C83EF58F45CE2DD4FBE6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-handle.png" />
+            </Component>
+            <Component Id="cmp3395AE3028B20D10AD97198AFECED416" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filD7CD9674AB6001E8D8C31723847D87A2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-handle@2x.png" />
+            </Component>
+            <Component Id="cmp15EDCA58CBA3F0578EE5A810F9E65049" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil38836EAA113B4B7C4EDC3623041C0020" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-handle@3x.png" />
+            </Component>
+            <Component Id="cmp580B2042B2D2B7A1157A86BC80724A07" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil0566D42C1C7049FAFF4183F1DA73FAF0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-atlimit.png" />
+            </Component>
+            <Component Id="cmp46FC792AA4F5F06253D4FC17AF08566D" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil46447F1C8FE79BBFBA6E28EF6A600FDD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-atlimit@2x.png" />
+            </Component>
+            <Component Id="cmpF15DBD5D96999E95F18EE9FB887FAC97" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil31E1DFAC8F3909FB4646D1A50C03F670" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-atlimit@3x.png" />
+            </Component>
+            <Component Id="cmp31939FF84A3D1074A26A57E13869FC08" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filFDD630C2B0AAD55B6275AF4E9E295D92" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-disabled.png" />
+            </Component>
+            <Component Id="cmp8038611DF66AE331D32B116B34D7B2F1" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil27C63C9F663B03BDB3973E5A00EB7326" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp92D2A312614D046D8D84DC920850D86F" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil384980E59DEEFDE58174385835E09370" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp64E044A30A78419190DDDB88DA3E47C1" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil0712CEEFB2D9C726AD1B7BCC97818B02" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-down-hovered.png" />
+            </Component>
+            <Component Id="cmp8D7D85AC41CBA47FDFB38BFE7B45E3E8" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filC3475F77F6F68324FF076481AC7AA2CA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-down-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp7A3CB534202DFCCC64AC3B86BF96EDD6" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil38CA12AB43415EE8DBD965554C0C04C7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-down-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp43A0024A39C34277C9984F2465AA3A24" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filE1D382DF6FDEF29C0467283BD242B522" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-down-pressed.png" />
+            </Component>
+            <Component Id="cmpD5207F5D25B4D06AB574AE9C3AEF422E" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filD270F391AC986AD2B1221C1B71F3713C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-down-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp71009641112135DC51745EDBAF94485C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil131D68247FFB724A9C1E43F651A0BB25" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-down-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp5FD8D2D9543F0203CA29437E495BF810" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil9E0CA400FC2FA99ED24AF5E192C570EB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-hovered.png" />
+            </Component>
+            <Component Id="cmp59A065A31A87EC513CF9F7FE68D6778A" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filBEDAFCDCFE1B0CED153B59F93A52DEA2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpF627FEF9CFC0ACED23043640733DC60C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filA53DF37AF5ADB0096BE60962CE13B394" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp18E89ACF3BCE5FFD2A2C4C8A9FD5507B" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil4BDCF09ECA17AC3129BE9FB6CA8C7737" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-up-hovered.png" />
+            </Component>
+            <Component Id="cmpF9A4163AD308EB9C6F9E92B287A50875" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filE9539C45F775C6F412EDCF8B976D8D94" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-up-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpF00E234E9FF7ADBE99787D4BD3ECF616" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil516FAEE61E31CA566A9E607097207C83" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-up-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp56C6A926983785B2644A3794F03FED4B" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil5DD4A137C42ACAFE852A20B1D08B10F9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-up-pressed.png" />
+            </Component>
+            <Component Id="cmp91A54B44689191B9FC084D58CE9F5917" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil3003AF8A3ABF953B961E853CA12B70F5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-up-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpD771B5077765A55E7BDB04079AD95D6B" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filF44BAABBBC6602A7C21DDE11C92BC970" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-up-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp38D8EBE377F143BF61CF9133D9815297" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filA7619277339F1B712D70B93CB1DC12B7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background.png" />
+            </Component>
+            <Component Id="cmp21CFF6C956A457718B06A0C6715D3B39" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filA726558E8D877AF49A2529DBBE8F7EEE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background@2x.png" />
+            </Component>
+            <Component Id="cmp63D3A3AC458C62B1DC44C17B54ECACD8" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil6F2947F7E857D73DBDFE1C9AE5805039" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background@3x.png" />
+            </Component>
+            <Component Id="cmpAA83D144077DF996E3C0FE4B2009A24A" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil52DD1C61CA2797407C5FC6F5CA905524" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-atlimit.png" />
+            </Component>
+            <Component Id="cmp27500576ACCCCAF88965B6E19C3B827C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filBB5230FC9E6BDF789EE48D0A15DD4885" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-atlimit@2x.png" />
+            </Component>
+            <Component Id="cmpCBAEEA4D0615F8775B9C48DE64C9B706" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil7A2856CFDEC823FABACE39204AD398FF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-atlimit@3x.png" />
+            </Component>
+            <Component Id="cmp2251B71B1A4159D777F865ABF683CBB9" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil11BD3DADF6D487EE4BF55928A3D4F65C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-disabled.png" />
+            </Component>
+            <Component Id="cmp931F895F425C977FC1C763FA70104EB6" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filE3A2C410B2DD22E5231CF3FCC9083A9B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp713DF617A6203D258F2A8AD385CBFDF4" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil0CBBAB2C580BD332BFD3FE7D738DE3F5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp6AD2D3057FCB1662E1C2EFB4665B8B18" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil18FE7480A5FFD2590A8E8F857773D735" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-down-hovered.png" />
+            </Component>
+            <Component Id="cmpDD74131968A0BA699B01B7ACAA8724A3" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil1A549CDBADDA0D44CC40B0BE44352479" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-down-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp7D021D42498A1788B42F140C8D330150" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filA251DE482707E7DDDD158FF4BEF5F7F3" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-down-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpBD977AE6B41935E1EA6F4AB7C5426C78" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil44B98A579E45636B33C35279E389B13C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-down-pressed.png" />
+            </Component>
+            <Component Id="cmpFD802F22D33F674BC7008327D442A7A0" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filCDD3D4AC2205B8CC63ECAD705F2D6B49" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-down-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp64B9CC422D5E17F5A8EF2541B85C8194" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filA74447502ABD4593B58B8533AFF7B57C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-down-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp839A094865AB3C49CF1145A305C7359C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filDCCDFDD5DB72D5794C2EE949E6F04A7F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-hovered.png" />
+            </Component>
+            <Component Id="cmp3A65DB960E085F6D210F7546DA03039E" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil92943531FC7551540CEA96C1A9F24053" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp45AAB85C958F99494205B435E84ED9A4" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil7FAFD9EEC5D1F6333874588134C0E3E2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpDAF6F7E4C6B5B9C305410ECF05025091" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filAAA6C16A4A40A5462BCC1BC0A216CDBB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-up-hovered.png" />
+            </Component>
+            <Component Id="cmp809D41F829240067C0072806C065602B" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filF44812094F2817E41369CF24D89AA6EF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-up-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp0FCEA69ADE2C5D6A980BD9814209C3C2" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filDCF6B80AA92DEDDA5966A8D86A1DF903" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-up-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpDF38EAF1B92E74BD75D5C81E13A8C1E0" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filA76397784CA8E4B1464DA7E2840259EB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-up-pressed.png" />
+            </Component>
+            <Component Id="cmpCD2C0A85C5506FF30F10F78EA79AD56C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil820BF74C3E39ABE53B24114B39BE6A1F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-up-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp7A2ECBBC616E8AE9B59C52CEED331677" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil9F4AB13807735A723304235AECE485A4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-up-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp2E39FE10693B20CC837240FABCBBFEEC" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil95208D3113AF3C6FA12ABEF8A129774D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background.png" />
+            </Component>
+            <Component Id="cmpE7FABB53128059956962916CF8036868" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filB9BE9740F511405C93A2B44287815B32" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background@2x.png" />
+            </Component>
+            <Component Id="cmp0D5A40BE8354122A0642D2350D94715A" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil1F1E68248D8801E0A1645F77E9F3707C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background@3x.png" />
+            </Component>
+            <Component Id="cmp8494804C08B2DC45FC6A06E978A1FE42" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil9E5BC8A13B45BC37EA44691241AF637F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-atlimit.png" />
+            </Component>
+            <Component Id="cmpE5EC8C4E3965F3E653882C52CC0FEA33" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil2FF2544B0BD0CC4007CA568E3507AD80" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-atlimit@2x.png" />
+            </Component>
+            <Component Id="cmp180A4D008E50DE69F34BC044AB305C6C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil9429B590CFE0ED45DE776AB29D40ED83" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-atlimit@3x.png" />
+            </Component>
+            <Component Id="cmpE6875FBEA1DD36B58503D32B74B661D9" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil0ED6E52596AB5C648531EC2B354D7FEE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-disabled.png" />
+            </Component>
+            <Component Id="cmpCB564C8F4690215AF3757BB196922317" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filDEE0762A7340603E9BA9749D795897CA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp566F225833567198C54ED9F7DC5DC96C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filD8E144A070A620CFBEAB85BF155CC51B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-disabled@3x.png" />
+            </Component>
+            <Component Id="cmpD58105818529285177D24B8A892CA492" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil624015DDD0BC6B548FD6CBB4B4FA19CF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-down-hovered.png" />
+            </Component>
+            <Component Id="cmpB643D3CCF417FD0C4239573732D627BF" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil3B93E30DB42ACAB25DB6A86B998D2AAC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-down-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpEE5FD24684DB5CBA6EB095E6A64C3E3F" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filD028B0DA779080607636CAE4E38C00C8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-down-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp5AC8AA0FE71E66340A38C40FF5426024" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil5AEB63E9FFB7F9096AB11F7E9B960A1B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-down-pressed.png" />
+            </Component>
+            <Component Id="cmp1E747C8EB12449FEA7641C445E3DABF7" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil15E2794FA3D30E66B9AC1067DAB3C7BC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-down-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp35FF670182A5B8F1F70C89F6E1AE7DC8" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filBAD556A99734A7EB946ACD6263F6429E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-down-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp119D8CC1C8F46606BA347AF4043B5593" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil929316507EB21D59E42A64ED57560CA1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-hovered.png" />
+            </Component>
+            <Component Id="cmp5641BBA428729933C705A04A10FA3740" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filE13339E93D7FED2E8D38175E46BD1A99" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp64609DD24EB1B0F499E3C061637CD8B1" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filE24DBBE23E07E06A738D0BFD6945F8E1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp7035C477A755DDAEECB531322CCA4507" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filF3A33010CAEDCC811E3AFED231F5917A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-up-hovered.png" />
+            </Component>
+            <Component Id="cmp7C9A2BCC74C7041B5A1F199007A52C7D" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil8EDA186BFE5F7E5CB6202BF680FEB092" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-up-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp48406F10AD16323F06CD554F0AFF0AF8" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil9726C5FA7A25ABECE5973B0A54E37D7F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-up-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpFFE3375BCAD45951269312579012A1BD" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filE5F3B0311A4FF7FF9DD3F0BADF2661C8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-up-pressed.png" />
+            </Component>
+            <Component Id="cmp0D0B065EFCAEB8436568F7BD1B7A5548" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil23156F1E8330F7DFEFB13E3056E49764" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-up-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpFB98BCBCB2CB6D7E27C0A486D9CE67CA" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil6F1B036DE50C5A59C34864E48EE249F9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-up-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp8985F4BD491DAE58BA7A78CA8B2FFF76" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil6A8903F8CABB07E6B0B74F3C2493207E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon.png" />
+            </Component>
+            <Component Id="cmpB048DDCDED98A032D7AEE3A295D85F87" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil6F99B277E3E652FC624B0739AEF05F54" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon@2x.png" />
+            </Component>
+            <Component Id="cmp926EC0028F4EFF2DBFDCD67BB8856A50" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil60179D821875579AB15E6927B0A10EED" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon@3x.png" />
+            </Component>
+            <Component Id="cmpF54B5999A3BBC1074B9307D7A05DE551" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filEA615C7DFF529927A21DE57FA1C2B949" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-atlimit.png" />
+            </Component>
+            <Component Id="cmp949BCF97D92DB79AC7C97D70B72CA808" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil11E40116068F8C160C2C6391437643C9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-atlimit@2x.png" />
+            </Component>
+            <Component Id="cmp883485F9E7A1F7A41279AEBD5656941E" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil7616676C36FC769139B64F86C0659BFC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-atlimit@3x.png" />
+            </Component>
+            <Component Id="cmpBA6688007706A0C9B9F6C5904D0DF877" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil58D1F1C5BA4205479758EE4E43A7C04F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-disabled.png" />
+            </Component>
+            <Component Id="cmpA62EE0E3912CB072EF416920F11C4611" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil875A8325167AE37677BCA87A67C9B299" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-disabled@2x.png" />
+            </Component>
+            <Component Id="cmpFA3E083D850447C068E5E2032F3D00EE" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filE6D2390C1BBE9D2A6AAFB40CAAA5E2A2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp7D71D29D14C6ADD06094C7CC87790278" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil6DCB493652A8DEE4911126269BBD7F00" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-down-hovered.png" />
+            </Component>
+            <Component Id="cmp628AFD0BC2075C2FE679BB3F43881162" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil1F223BCB1DFC4E7650313207C7F05D7B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-down-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp28EB13FCCA7961195024DD1BAAFE9BBA" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil114AD191504883D1EDBE5867FA7FD91A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-down-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp0025085E3CA9ECC9C99142252ECE5CE9" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil20D6AEF1F2391146983B0E48D1FAC8F0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-down-pressed.png" />
+            </Component>
+            <Component Id="cmp487AD00109DF23884288CFAAA05E2F48" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filCC5248167AD0CEB59D96438C10D2946E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-down-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp8A3062B28C9F61824DAAEAD1A72DDB08" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filA685B92DCF4E9CAA929EF59EE43D5874" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-down-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpEBC9488CCA5418BB31FF3D04FB4B6026" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil398F4C71ADB4372885D6C7B27D72311D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-hovered.png" />
+            </Component>
+            <Component Id="cmp0DB529084B9FCC38C416A3F743C11614" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil86F520B473658E517A17DD58BA5F6549" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp695A2A0695007E9C3EF476B045161D3D" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filA54B02227B17555E01A4610629BD2BF7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp38C884D07467C23B20B299A9018343D0" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil7475673FCD4501315E417D6B753B12ED" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-up-hovered.png" />
+            </Component>
+            <Component Id="cmp857381C9E7B065948CA596466536D1E8" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filB836E617902FBE94E0BD5044BEC4819F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-up-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpD5E53D9EC18F8EFA2C8923248FD4AF90" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil6CBE2F28DC48EF1B25245C5DD1C34C95" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-up-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpC4006E152307B688202E3BC27309B0C9" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil8E81FBD32A5D74082E14919BCCBA9328" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-up-pressed.png" />
+            </Component>
+            <Component Id="cmp8E3C9675C52600E1DD3914A6D1D7B583" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filCC130D927875542B59E0382C75CD6D52" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-up-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpC1C172A8FD9664E27B990D9080DFC2F2" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filA2F985BEAC694FE76C2BA3236EBB5D36" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-up-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpB69EAC27131C4E52252ABC03BB070721" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filF593EEDAAC5A22FAAEA31A49354CBFD5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background.png" />
+            </Component>
+            <Component Id="cmp442109289DF469F0DB3376C99C244F46" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filD6B6149A3A62B3AF288FA021F486A5B2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background@2x.png" />
+            </Component>
+            <Component Id="cmpAC2C93A69483A403DF88971B3A896FAD" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil278FDDC2DEB1496329518E2A1E3390F9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background@3x.png" />
+            </Component>
+            <Component Id="cmp07A4F7ABF87276DC13134D7B2CA43DBD" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filF4EEC381458DE0271F871012268D80DF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-atlimit.png" />
+            </Component>
+            <Component Id="cmp69D0CCCC5C7CB7D6B08D2CD622550A01" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil8C1CB6103AFF82DE48DFCD7ED2152D54" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-atlimit@2x.png" />
+            </Component>
+            <Component Id="cmpE64A0E96F93D1F1CE425724DF12802A2" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil48A9C101BC30517A8116BA0918660B2B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-atlimit@3x.png" />
+            </Component>
+            <Component Id="cmpE2E6B82B944E87F1F2635F3B28186EFF" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filB8C3960581FE3E9CA752369DC824CC12" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-disabled.png" />
+            </Component>
+            <Component Id="cmpBCA57E3530E82DE7CE0D0F22ED9B7956" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filD92A4E0A67FA9C630642F822AD28A5BB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp84C99A67DC353AD4FDD969D348C549F0" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filC2FE86DA99BA2B6C670F10E0D1968B09" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp24BAC3D70B886B6CD81F34B9010CCAF7" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil5BCDF50920AE567BD191431ABB65972A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-down-hovered.png" />
+            </Component>
+            <Component Id="cmp989D67F88238BB7091A7E343755F77A4" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil3B8F0B2455A430EC5243226449D50316" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-down-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp6BC3872C85B160901A863B497270B2C3" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filCC17D7BB9988D14D30D06D721E6BF8A0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-down-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp8D5095B0793E246C594615B6334F0838" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil80870DB9ADFBBCA03DB69022EBE1CA85" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-down-pressed.png" />
+            </Component>
+            <Component Id="cmpCB8EA7805AAC14BDB4D25ECF51430DA8" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil8A2AFC77981E061F3D94B8CE27BF2CE2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-down-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp982C7786060C0D312E10DFE85F50E139" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filB8FF15856FBCE9475D15DABC1C8724F4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-down-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpB5EFDE1E07C85AA2EB40EF47383B09D8" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil86E1D1B57B051853770C97EEF73CAB6F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-hovered.png" />
+            </Component>
+            <Component Id="cmpAE21B56C1F6A53D75336ECCA7D692279" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil97C8B516FE4B91F333AFB1AE941EBDAD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp1D30A0ABD3B6F2575FAB3139D2AECB78" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filF2F8D94D499AC02AACB56E5C1991F150" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp2B74CDE1AD43D39AE1D2661DA67778C4" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil0731555B95646B20A3707BD2DA37A751" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-up-hovered.png" />
+            </Component>
+            <Component Id="cmpB2721C2BD8DCBD146B94C3F0EBA42D90" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filA432ED3B8F7634BC08A2C267E4411DD4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-up-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp6C09A34191357EACF7F84DF133BA7BCD" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filBB349EFD51C4A00A57DAC62122BD2D8B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-up-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp4D7E8A7D25B4C2BC58FD04DA2A816450" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil960D016A1876179887DFC3F02930245C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-up-pressed.png" />
+            </Component>
+            <Component Id="cmp075E41972FCAED1661EFD0CA4B75C1D9" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filC2DC7D92E68591C7A13861E1E4D4251B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-up-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp24A69C41CCAEA94E0B244D93E660AD1E" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil77AE8A3535902329196EA1CAB826E09E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-up-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp050869D698975F75807A25801FFEF2E8" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filBC3CD24F3864B828C8DB87F59F2F355C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon.png" />
+            </Component>
+            <Component Id="cmp18B86D48721B7DC0BB1EEA826C8696C9" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil31021A2FB8C9BAC35B2316CFAABB743A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon@2x.png" />
+            </Component>
+            <Component Id="cmpF236F632127D51F025A7A0B3BC89CDAA" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filF34904BBA34BC3DDCD057F6563A717C4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon@3x.png" />
+            </Component>
+            <Component Id="cmp6A41BF30FDBF24748B89842A47E4909B" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filA235E94A1B86B7540112A1263B46B3D2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textarea-background-disabled.png" />
+            </Component>
+            <Component Id="cmp7C8242EA27097EB39C43A9671ED0DD60" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filC5128F2A3C7CF820828C780439B804FD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textarea-background-disabled@2x.png" />
+            </Component>
+            <Component Id="cmpAC18F3987F56132B75DFBDBDDC439735" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil212748FFD86FAD5ED84DFFEFF2CE220F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textarea-background-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp7FF3AC8A8A66CF47DD9C1B243D1D5019" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil8A4578F9C414CA98562A0D27361283BE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textarea-background-focused.png" />
+            </Component>
+            <Component Id="cmpEF556CFE50A48B46A3F947D7979E5CCC" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil6EA21948D16BEEFA44725610EEB6F5D2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textarea-background-focused@2x.png" />
+            </Component>
+            <Component Id="cmpA27A6F8CAA34C34380A05F4D08BEF0A2" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil1B999C438889038B6B7B7A2DA6B035CD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textarea-background-focused@3x.png" />
+            </Component>
+            <Component Id="cmpC31F819ABD883EFB948198ED9B953FB8" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil51DD033CC3CF966E1EE88BA367478811" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textarea-background-hovered.png" />
+            </Component>
+            <Component Id="cmpBDD7AE4017C56C02949D3190F848CEF9" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filC5763F751CF46F4B7CC42E4423AF844E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textarea-background-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp0CE8DE92F0E6D8AB21DA91480245C2C7" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil5CC688B1B35E8CF99E3135FB919072D9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textarea-background-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp8230384C5DA7378C7013A3EF5862279F" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filD222B952EDD11B69848DA4FFC03AB687" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textarea-background.png" />
+            </Component>
+            <Component Id="cmp92CE6FA5657A1C81A268C87D20D11979" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil3C5CCC275AF4D431E5717561738B1DE3" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textarea-background@2x.png" />
+            </Component>
+            <Component Id="cmpE5EC84F256EFC334394720F13DAE4268" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil1D9BD13E048698E487417364F193A5FD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textarea-background@3x.png" />
+            </Component>
+            <Component Id="cmp6F32A6C8A9CDCE24CB07EA681BB7A493" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil627E8BED02EEC1593E0C58C417F72358" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textfield-background-disabled.png" />
+            </Component>
+            <Component Id="cmpB1B3F16E0AF55B07C5E11A210E1DC108" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil87A7DE6E002D2C760CAE151304B6BBC1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textfield-background-disabled@2x.png" />
+            </Component>
+            <Component Id="cmpAEC017AD179AF373848F033753383438" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filA3DE96334BA9DD72F36ED7AC55247505" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textfield-background-disabled@3x.png" />
+            </Component>
+            <Component Id="cmpF79600AF463E89F964B790E75E776217" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filC90E759B733C99C942D7B59CBAC3B081" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textfield-background-focused.png" />
+            </Component>
+            <Component Id="cmp84F60C8194EE46EA4C2587C572CEA93D" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filC494C4C860630ABF9FE5FD9FDBC535B4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textfield-background-focused@2x.png" />
+            </Component>
+            <Component Id="cmp7C224EF05736BD307B0906B7F270561A" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil1538C27744E7FDB238D446C0D41F7734" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textfield-background-focused@3x.png" />
+            </Component>
+            <Component Id="cmpD3D8129DB97C95CBFC014BC23BFF5E63" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil80F10F9E14C7C1CEF28946013419E377" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textfield-background-hovered.png" />
+            </Component>
+            <Component Id="cmp29F0F55DABD11E0A4AEA5C33864A4F61" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil65A6FD4CFB338C912D042A0FFEF6E86B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textfield-background-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp54968C02AA2107F19070233CC13CB102" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil86085411D62F8A0C07778BE583499D26" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textfield-background-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpF29B459C9E7E3E214CEBC564C6D2FE68" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="filA14E928E61AFA5B6BC62F0E40293BC17" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textfield-background.png" />
+            </Component>
+            <Component Id="cmp07F2BCA46B177EADE0F42AED05534B3F" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil02878927DBF9284C032AA5D7E1DB6627" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textfield-background@2x.png" />
+            </Component>
+            <Component Id="cmp40019F8E324DE798614ECF01FBA1F748" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="PUT-GUID-HERE">
+                <File Id="fil08E8A626D30AC8ABA1E6DD0D470CAD28" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textfield-background@3x.png" />
+            </Component>
+            <Component Id="cmpFA4B9985AD60504DA4E760DEF1A74D92" Directory="dir0986B5CAD2460321886B51FD51019567" Guid="PUT-GUID-HERE">
+                <File Id="fil2E1755F77B25CC5EAEBB81C861D41A8C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\icons\checkmark.png" />
+            </Component>
+            <Component Id="cmpD630A83D7FE5FC40C8D44998950D713A" Directory="dir0986B5CAD2460321886B51FD51019567" Guid="PUT-GUID-HERE">
+                <File Id="fil8E045D228CAA8C8B7E13482D6A1AA115" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\icons\checkmark@2x.png" />
+            </Component>
+            <Component Id="cmp620945788E96073B6EE0E9BF6381DCF3" Directory="dir0986B5CAD2460321886B51FD51019567" Guid="PUT-GUID-HERE">
+                <File Id="filE5C92BAF0C75D5F13FE0181EF73048AE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\icons\checkmark@3x.png" />
+            </Component>
+            <Component Id="cmp49F18407161A99E21CBAD428844D2FD1" Directory="dir0986B5CAD2460321886B51FD51019567" Guid="PUT-GUID-HERE">
+                <File Id="filA429C3E686558435048D14AFD6DD7D5D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\icons\menuarrow.png" />
+            </Component>
+            <Component Id="cmp7FEDBE0CB3797A3933023C9D07FB183E" Directory="dir0986B5CAD2460321886B51FD51019567" Guid="PUT-GUID-HERE">
+                <File Id="fil7407011DF9AC11AC3110BEA846C39B4E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\icons\menuarrow@2x.png" />
+            </Component>
+            <Component Id="cmp962D9C3F8451B480FD9EABA95DF4AE60" Directory="dir0986B5CAD2460321886B51FD51019567" Guid="PUT-GUID-HERE">
+                <File Id="fil2256DAFC0C07F140E1990C99400171E1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\icons\menuarrow@3x.png" />
+            </Component>
+            <Component Id="cmp82F3521CF064FABD14FFE2AAEDD34D89" Directory="dir6760147796A3D8FCCEBCE06251BB6DC9" Guid="PUT-GUID-HERE">
+                <File Id="fil73D72DE30FEB90E8AEFB8FB603A5ED3C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\impl\ButtonBackground.qml" />
+            </Component>
+            <Component Id="cmp2BB2F93E24472D3B6332E7A46B8FE6B9" Directory="dir6760147796A3D8FCCEBCE06251BB6DC9" Guid="PUT-GUID-HERE">
+                <File Id="filF040BE832AD7F9182AB13A852046E278" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\impl\CheckIndicator.qml" />
+            </Component>
+            <Component Id="cmp7FE7670BAE1C5A91148421E35A018814" Directory="dir6760147796A3D8FCCEBCE06251BB6DC9" Guid="PUT-GUID-HERE">
+                <File Id="fil92EE971F8C3D3219444D8F3481F9A74A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\impl\plugins.qmltypes" />
+            </Component>
+            <Component Id="cmp4E32E41E189BB6A13DB7C1EFF120F462" Directory="dir6760147796A3D8FCCEBCE06251BB6DC9" Guid="PUT-GUID-HERE">
+                <File Id="filE696FA4D7C96095E906DB2AA630FBEF9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\impl\qmldir" />
+            </Component>
+            <Component Id="cmp81071CB2D663F93F765BC9495D3E8459" Directory="dir6760147796A3D8FCCEBCE06251BB6DC9" Guid="PUT-GUID-HERE">
+                <File Id="fil7E51880DF16E3C4F6D1E212AAE068210" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\impl\qtquickcontrols2fluentwinui3styleimplplugin.dll" />
+            </Component>
+            <Component Id="cmp0CFE29A505F6D9BA2C3636F27B6716E3" Directory="dir6760147796A3D8FCCEBCE06251BB6DC9" Guid="PUT-GUID-HERE">
+                <File Id="fil48FCAE1AD347F6CD88785402ED1CBDFC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\impl\RadioIndicator.qml" />
+            </Component>
+            <Component Id="cmpFD5FCBCA01EE57A13DE2BB44F2F10160" Directory="dir6760147796A3D8FCCEBCE06251BB6DC9" Guid="PUT-GUID-HERE">
+                <File Id="fil2F25B9994B2EA0A602D63EE705A0E13C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\impl\SwitchIndicator.qml" />
+            </Component>
+            <Component Id="cmp9AF60978003A61A67308A051310E14F7" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filDC6A021BC573FCAC4FBD67F800A6C7A9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-checked-disabled.png" />
+            </Component>
+            <Component Id="cmp47C0B7336586C8F30FDDF2292B6B2903" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil861F6C34155FCC84B024834B219437AD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-checked-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp12598B6AFE978595B8EF43C104BDBAE5" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil7F9ECF72406764960BD4BA970157937F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-checked-disabled@3x.png" />
+            </Component>
+            <Component Id="cmpE22123D2176A4EFF58393FFDDD705CD5" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil9621D2FC552742D9EEBBEC33D295E2BA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-checked-hovered.png" />
+            </Component>
+            <Component Id="cmpED424D6C75BBDFEA2E53F63449A2EB37" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil4AA41A216D20412CB398E43CD73E941C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-checked-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpAE63BC9F355C4E75439413FBEC855781" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil7DC7FB5D1DDB3DDFA609753D4743E01A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-checked-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpA34676C2DDF9187E37ED22B26808098D" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filDBA1CFC40B5E75CE69A40610C0CA5617" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-checked-pressed.png" />
+            </Component>
+            <Component Id="cmp4EE2FAFCB4D55EC1B34DD9A5BDD1E427" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filD0C527CAA361BFAB436EC2C83FD550ED" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-checked-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp0D0ABC3C0B2BBDB64C9194161F55C764" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil15CE78417262F62F1123741E7F310A9A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-checked-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpC4C8B84D931051D155F1A45147CDADE5" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil641BEF42C71229373C6201A7C31191B1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-checked.png" />
+            </Component>
+            <Component Id="cmp0C67C78CB09167B208264674552B7911" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil661B6C2FE7CE4CA4D31BBA769578991F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-checked@2x.png" />
+            </Component>
+            <Component Id="cmp1CA460DF5A1BDA107FAC2AAA2559EAAF" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil1BE334DD8281039A5FE4964EEB8370C5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-checked@3x.png" />
+            </Component>
+            <Component Id="cmpCB77D0C05E5311F90BF48A679ABA1420" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil95FD148E8415C5496D6A7E9173B56223" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-disabled-partiallyChecked.png" />
+            </Component>
+            <Component Id="cmp098000011F69787488D052F17920EEB9" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil87C59D805A8CEE5C04CF35C65534D9B9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-disabled-partiallyChecked@2x.png" />
+            </Component>
+            <Component Id="cmp4F5204F6133E6249A3032F041ACF7D7C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filA27889E8EF944DF2CA6DC7CA040CA47B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-disabled-partiallyChecked@3x.png" />
+            </Component>
+            <Component Id="cmpA89777871A5F01E81CD9115D8B9D9B10" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil7CCAC3172D16CF3DF5ABC4BD6CF8EFB3" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-disabled.png" />
+            </Component>
+            <Component Id="cmp8F2D54F99D01E086D59673B37DA35418" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil7B8FBECD4E7951E116D55A34FD164BE5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-disabled@2x.png" />
+            </Component>
+            <Component Id="cmpFC7874C40B6F8C203ED18BE1276F9BA4" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil47A5F7CB27F1BEA865F86F56470C4FF5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-disabled@3x.png" />
+            </Component>
+            <Component Id="cmpF9AF43E0D0C8C4E5A07BF0E3FFB016A5" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil6196F60A617432E2A022B312A254F3C5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-hovered-partiallyChecked.png" />
+            </Component>
+            <Component Id="cmp4E8B5EF8DD90DA097F607511B7D32EFA" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filE2B70B75EACE54C50A7E591BAAC7ED43" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-hovered-partiallyChecked@2x.png" />
+            </Component>
+            <Component Id="cmp24CA1B3F0EE431F59A81E17C1B670486" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filC91400C1B02D6D931BEAD185C4AC91E6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-hovered-partiallyChecked@3x.png" />
+            </Component>
+            <Component Id="cmpE9A34918E1AE1A4840BAD164456326A9" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil608F66180DB62CD05CFEF4E66F39F682" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-hovered.png" />
+            </Component>
+            <Component Id="cmpEB0A04A9194F9DDF1FBA5A30F14F8954" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil517E87E094D94408E64DA531C1538D4A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpBFA97B684982FADA35A0DC71739E4376" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil534D7905B31DBB3B3EF2F395641FB1AF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp78066EC3200C1ADB5610DD7FD88AFE40" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil86078C6673D86083176ED93FC727EAD1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-partiallyChecked-pressed.png" />
+            </Component>
+            <Component Id="cmpCEE3F5A3112C69AD8BD25931F9578480" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filE8C749B0D4BBE042016D2FAB4E04D196" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-partiallyChecked-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp49136828A93743710CE0F510081FE733" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil869FEE4D865649A0A314118DC95047B6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-partiallyChecked-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp14A47C7C7870279D51EFD92A7A230867" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil2EA6DE86F2D7950A5E195A5A46DC50DA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-partiallyChecked.png" />
+            </Component>
+            <Component Id="cmp1D766E55F46BC236790CF24F3B3AEED4" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filD2C83C8EF5E27F81D2CEC2FEADC7B94C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-partiallyChecked@2x.png" />
+            </Component>
+            <Component Id="cmp02A583DE7008B9AD27D5E2D31DE9C3ED" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filF5D1809038FC81664C2C380AD0DFCC25" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-partiallyChecked@3x.png" />
+            </Component>
+            <Component Id="cmpF19D8489507CCAE8EE83B2BB7D6E0BC1" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filDBE9B08D0F63BD2FECBD05369BE30873" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-pressed.png" />
+            </Component>
+            <Component Id="cmp35B6785DC5C74134D40F66546202D5E5" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil4F5F13575040B722FF49B4C169E2BC57" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpB15F9BF7E07C69D5E2C580EEA1277091" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil8A63BA81346001734E560577757AF8A4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpB5F4B0385E23098DD53FA1F2EE9CA787" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil6CCAEAB01F7F8D0A31B867676B542FFE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator.png" />
+            </Component>
+            <Component Id="cmpE52B74421A62A37BBBEBEA0A49A9A4DF" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil4C5B0B628EF5FC75BBDC1F7731F58B3F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator@2x.png" />
+            </Component>
+            <Component Id="cmp2913087CA54D088AE5F61552E77C9CA8" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filEB7AAB30E92B14EB88401103E4FDD8CF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator@3x.png" />
+            </Component>
+            <Component Id="cmp8AFF84A628E065B8E63FEAD7D8E78CB9" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil8614BD1DD4165E0705D00ADFFC16DFBA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-disabled.png" />
+            </Component>
+            <Component Id="cmpCA8C1B14EE6E0BEF1BE8532B7A92FE07" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil3223A4BAF5FF8D736F2D70CC093C0A13" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp0B2D070DAE458DE664864AF883FE23C9" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil036C6E39FDF9CF31F8E50014645A3A2C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp53D1E43331FC578E53717DEA2E886ED7" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil41DF782A7D72075CEB4065A97012E2D1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-focused.png" />
+            </Component>
+            <Component Id="cmpB828856E6D46E3DBAB0EA7222109025C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filE01C3F9723A28028EEFA29E32CC1308E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-focused@2x.png" />
+            </Component>
+            <Component Id="cmp0A53762348B686F2C9D455BE66994A4B" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filC30437409F11B87FD415EB412C4C7212" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-focused@3x.png" />
+            </Component>
+            <Component Id="cmpA4FD4475A32CB68D21EACDBB95CB5153" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil6934C0D684ECA80435E4FC182EF23857" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-hovered-open.png" />
+            </Component>
+            <Component Id="cmp2F06C5E995467B762EB27189A368EBC8" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil1527F8BB3D78A2E01F982C58A1CC58FA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-hovered-open@2x.png" />
+            </Component>
+            <Component Id="cmp8870470BDFC4E0CABDCCEE8FB4F3EF57" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil08EE8F03134D1055276C69708057209F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-hovered-open@3x.png" />
+            </Component>
+            <Component Id="cmp89B59AA7AC0E949401356663ED1112C6" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filFDFDE41231AB274C952FB95AF41E64ED" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-hovered.png" />
+            </Component>
+            <Component Id="cmpDC7CDF7F168DAEE92E5EB942DE5D6DC9" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil4F2845964E990015109A59ADFA30AF29" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp290632D87DC0778D3FBD57F5B0F58FE9" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filECA632A9905D2E73D448845E599C770B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpDAD3B08F7B95A8D6DF1FFCB46DD732ED" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filA820DA0C79106E185778C352822FFFF3" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-open-pressed.png" />
+            </Component>
+            <Component Id="cmp80F0BB391C7EB44844FA3844E4C084A4" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil1727DFB3372D1E4B0A2AD9A9D6FD5C5D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-open-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpDDB4AA820024C33BD89303448BDDACB3" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil5A195750B74C3D5311B17A28C13B9B7C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-open-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp4572F101E15C9FBF5013C1AE8B63BB95" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filA945DB2836231EA0B0727F5BDE91E502" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-open.png" />
+            </Component>
+            <Component Id="cmp33819AB51A6A14396E6ABF92D930BDF9" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filB251C26B75EA2CADEB9CE460C70F2E5F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-open@2x.png" />
+            </Component>
+            <Component Id="cmpEFD027837D0CDA89598C8B12256D780D" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil88EBB41350855968F0D33F5BCF74F64F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-open@3x.png" />
+            </Component>
+            <Component Id="cmp8FA1B5C24D430203C31FD37C7E824D5E" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filD1C9B9351F3F4D436101DDA1CD742E1F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-pressed.png" />
+            </Component>
+            <Component Id="cmp4B6D581E08F8F3D16E50B09B3940BDB8" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil2FD1274548B88312C27752C8497F1B31" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpC1D7F35904471A327DA4D6DB9D28EE0A" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filF0638C8410DE1C69722A4864336666F7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp5ABCFBDE0D384A722285E09331A6D55C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filB42F542FB912B675BB33E5DFAE843A72" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background.png" />
+            </Component>
+            <Component Id="cmpD4011DA99D59808AE2630740276F33FC" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil55A959C0F00B15C1196FA57CEB37EDA5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background@2x.png" />
+            </Component>
+            <Component Id="cmpF845119E2FBC6A8DE665A4193445F971" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filEC3479D99AC84D753E848E232D9C26D5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background@3x.png" />
+            </Component>
+            <Component Id="cmp203BAC4ACC8F207D60E4FB10F6F7D62D" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil966AFFA62C238DB200788F04F9BDD9BC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-disabled.png" />
+            </Component>
+            <Component Id="cmp491816AF0FACEE8B1A9B0BE858768EA7" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filD544D808806618D8B040CE7B02B6D87E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp98BC93BA65FA126109AE213BEA711CD3" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filAF0BA958DBC6867FC6D464EB5115E92A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-disabled@3x.png" />
+            </Component>
+            <Component Id="cmpDC004F75497A17C850BA45590A4EF3CB" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filCCC6E009894F2AFED5394C406C61A25A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-focused.png" />
+            </Component>
+            <Component Id="cmpCFCE6A6CA42B5BDBC495AFC88D7DB8E6" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filCD4E8B7FE1427AF5C4FFAC9752E32AEB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-focused@2x.png" />
+            </Component>
+            <Component Id="cmpDBBF33531C7E49BD06366F4F693705A5" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filD5CEFF86E39C4EA9F600EFCB95D6AEB8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-focused@3x.png" />
+            </Component>
+            <Component Id="cmp730DC46FBCB5B19A5A0BB9A28F257617" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil65AF893844FBD4D59DE319A0D0CDADCE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-hovered-open.png" />
+            </Component>
+            <Component Id="cmpF03FACA3DAD96D374B7C1DCF9F350C91" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filF46C10E5D02095E9C646B8C58C40EFB0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-hovered-open@2x.png" />
+            </Component>
+            <Component Id="cmpA2E171F4C2BE868C0FF454F971A14776" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil55CD38E7DB4AAD96D650178205F56465" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-hovered-open@3x.png" />
+            </Component>
+            <Component Id="cmp08B234EEBBCA3EE12784B9ADB1B7E02D" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil0FE1BFFE4C9427C47BE3536C9DE8E537" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-hovered.png" />
+            </Component>
+            <Component Id="cmpF7E61DD097EB60FE89A556BC6F80C041" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil31F88065E31A472D00CAD2B62A143FC6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpB05F4CEB225F91B0FF35B909C023786D" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil2D40C186282A39458BCA4D936807ADB5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpB06A34467D96269CB2734DFC8FD5C801" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filBD293335C7F3D3F91C0BB7304284D6BE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-open-pressed.png" />
+            </Component>
+            <Component Id="cmpF07D7B5AEA83F03C3DA51D31F5D4EE30" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filBB8B2159F50290857FE75B14DC9DBC16" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-open-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp6A551D32C22CF30C8DBC69DB28FC65AE" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filDA531C6F27BFF56E472707D2A11AD328" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-open-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp6D93F93FD621961D7C6284F7A8A006C9" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil3E8CB4C6DC34DD732DA058E6543FC61B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-open.png" />
+            </Component>
+            <Component Id="cmpC95E0FF3C4D2C7141CDD13F43D86D87B" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil04ED812A500790F0B885CD42AC0A3A5F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-open@2x.png" />
+            </Component>
+            <Component Id="cmpFA3D23FB4A09B4E96562BC23A5E83AFF" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil637E6875A6424C9265784479C3F8F072" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-open@3x.png" />
+            </Component>
+            <Component Id="cmp57DA9B4079C1C9519D09E30B38E9523A" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil3C1C12A84DF74D0A3B7052A5165D3310" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-pressed.png" />
+            </Component>
+            <Component Id="cmp176F6F306E6AD288915DA1AEED2A75D0" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil9952685C16F3C14A2C367DEC5B3A7C7D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp4A2CDBF078BF75A57F616CCC0819E0A9" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil0535E7051133FD105AD928B45FB32AFD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp79A70D68566AF162204586C439BD1F07" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filC984AC2AE9DD845A0FD11A9AF87F34FA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator.png" />
+            </Component>
+            <Component Id="cmp585E1AD92C18E5B3E64599FA43F85687" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil04BF6F7D53F3451186899FDFEACC63C4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator@2x.png" />
+            </Component>
+            <Component Id="cmp6B7BB62F24D1A5B2F41DFA95BC483E6B" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil76452EF01BB4192FA0284A528D22049F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator@3x.png" />
+            </Component>
+            <Component Id="cmp7645CFD74D6B830800085813AC680852" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil1A1B001221EFA7A6D0A0D805AB5CFC55" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-background-hovered-open.png" />
+            </Component>
+            <Component Id="cmpF7E81A68C097E6EA4BE7C2135ABF6E1B" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil9EE66CE1C1000AF49B19F2631687A16C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-background-hovered-open@2x.png" />
+            </Component>
+            <Component Id="cmpA10F20CF7B5FA2A5810FD216BDB87A3B" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil3A556E57CBC321CBC722F2DD27DB59F4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-background-hovered-open@3x.png" />
+            </Component>
+            <Component Id="cmpB7773AB65040394B1ED24FBC83666D96" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filB48CB4DF540F44FA2A1659AAB2448CF4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-background-open-pressed.png" />
+            </Component>
+            <Component Id="cmp6C06A57C41BE23F108659DA83A0E43D7" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil7698B7573444F2A61F252194558A0209" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-background-open-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp3A1A8566BCA820C8DE4D693284480080" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil71BEB392B3972E7A776EFB8A52853F49" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-background-open-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp6A264543B9EF1F205CA0E3315A67323E" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filD62A58C36D5A0FAE2965C5900F071628" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-background-open.png" />
+            </Component>
+            <Component Id="cmp70E64C6B3F82327F15D8A3193C27C057" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil173BEC18653FBA80EB9B64D1D5B65E08" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-background-open@2x.png" />
+            </Component>
+            <Component Id="cmp0AAFB7AF134AFAD1CAE1B14E6D693C4E" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil458A43A16E7C2DCE3D8A7F5EB7CE7139" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-background-open@3x.png" />
+            </Component>
+            <Component Id="cmpBFBA41B502A56B76CBB1C532F93877D5" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil5BF95D24A1F75451205716A92B8427B5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-indicator-hovered-open.png" />
+            </Component>
+            <Component Id="cmp207831F910C3ED735C98F78B43129E1D" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil0F1ED3DEA0663D80F592B38B04E841AB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-indicator-hovered-open@2x.png" />
+            </Component>
+            <Component Id="cmpC5EC103A8E3B91A3BDBD258407FC2813" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil11245E35AE4EF7F9F710CEE404C478E7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-indicator-hovered-open@3x.png" />
+            </Component>
+            <Component Id="cmp31817EDAD3B390203A4633FEA0A45F12" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil466F0B165E9E404FBDECEE622C83C9A7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-indicator-open-pressed.png" />
+            </Component>
+            <Component Id="cmpE8BC1FDAE39C500B3956FF311434D45D" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil44308388C928DC43EF19A126BD2BCA4A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-indicator-open-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp2BA87DF268DB213B989449193C33E9EA" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil38E2FC70747B8119CDA34AB61ACE8AC8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-indicator-open-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpFC9E835919B6F5EB765B3D582F2DDC8E" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filC764D67B03EEC76EB641C7D602B26FAA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-indicator-open.png" />
+            </Component>
+            <Component Id="cmp99F97B1C0A2003E9E6583426246E570F" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil2FF3D8D500BBA7C4EA3B83EF5797860E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-indicator-open@2x.png" />
+            </Component>
+            <Component Id="cmp87ACA27A630356BEDFFC89A3C6EE2FD3" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filB3779BAB6A4FF31346C282FD521CB612" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-indicator-open@3x.png" />
+            </Component>
+            <Component Id="cmp07BEC5AD21EC759A90A9288728F47C7B" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil9BC3CB7F87C7B379C0C73A12CEEEE451" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-popup-background-hovered-open.png" />
+            </Component>
+            <Component Id="cmp4C91AEF888247A8D488BF0DB7AB42D6A" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil3FF343D406263CC261205BD45F25D31B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-popup-background-hovered-open@2x.png" />
+            </Component>
+            <Component Id="cmp1A640590BDD2A6E46277E87071BB846B" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil49613E57896D8D0EC47735EEF07CD79E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-popup-background-hovered-open@3x.png" />
+            </Component>
+            <Component Id="cmp014E71D1AA7A86EBA0D79C3C33601C0B" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filC118284BE8A39366EAD665FECD73B9B6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-popup-background-open-pressed.png" />
+            </Component>
+            <Component Id="cmp6C34A2DEFD311DE6C26AEA9157C27A58" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil831626EE047C1DBD9C890D5D2BCD7083" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-popup-background-open-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpD4A712BCDCC13288FFBECF192CF4EC21" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil86ADD78F3BDD83BDCBB2E1C758CF20D0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-popup-background-open-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp5424A8A6BE80342ABB00CAA2A44546B5" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil941CAEA57D54ABBECEFBB41C4DA68F70" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-popup-background-open.png" />
+            </Component>
+            <Component Id="cmpE6028B5BCC0FFE8A7F238A5329C3007C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil6F692E6639F6A09672A9F836017F9DA1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-popup-background-open@2x.png" />
+            </Component>
+            <Component Id="cmp1242AB5D742B0AC59FFA678728B83BEC" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil1B05D7BE3B6591515896E2B4823307A9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-popup-background-open@3x.png" />
+            </Component>
+            <Component Id="cmp9F1E5F8FB05D6C07451822C827A083AE" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filC662CF40C2F477C8E5D4A4EACADD2624" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\frame-background-disabled.png" />
+            </Component>
+            <Component Id="cmp317E99BFE7C3FF17FDDE649A5CF5B295" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filA052D58045BF9FC928B306DF5894E706" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\frame-background-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp35EA83D781C3225C9612055AFAE838E4" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filCDBDAE46A4F5261EC293F58B5AE5D8FA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\frame-background-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp4295C6CD7F997BD2F923E9264B9102C8" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil894B0D13A444B5425D393BDCDDD6249D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\frame-background.png" />
+            </Component>
+            <Component Id="cmp32B0F227833DE99A3E07B58CBA31D578" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filDA51F3F8C30B3924D693DF53D8328764" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\frame-background@2x.png" />
+            </Component>
+            <Component Id="cmpEFBB112AB4A47ECE3393A3C8E6FA4037" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filD385F036585A19E0F5D84AC6BA181478" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\frame-background@3x.png" />
+            </Component>
+            <Component Id="cmp8531ED596AF05A0B52992364251F2219" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil221B971138C5FFD1D1C66BABB2961B5B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\itemdelegate-background-highlighted-hovered.png" />
+            </Component>
+            <Component Id="cmp750B896193B1BFBC61B93C4119FB16C9" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil25EEAD492A6C7A772D62135E72425EBC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\itemdelegate-background-highlighted-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp3DFEF28996626CF69AB2129AFCCCC3D3" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil5D65483F078DDDC6F704488B52033AF9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\itemdelegate-background-highlighted-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpC14ADCBE9DECABB78ED4EBEED1352415" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filD7F5E46E6D82DE9B76016545D9024475" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\itemdelegate-background-highlighted-pressed.png" />
+            </Component>
+            <Component Id="cmpCAD9E60E33C32851C4608ACDDFE90228" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filDC0B9927554089235260A2855AC5AC64" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\itemdelegate-background-highlighted-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpD1804C1E42993C4F41EE659DAB4F90D3" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil60F662DB31C3F5075A9AE785B37E676B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\itemdelegate-background-highlighted-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpB3401C345822C965030D92D9EF3FB5DF" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil8387A8CE19056846AD461505ED874E02" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\itemdelegate-background-highlighted.png" />
+            </Component>
+            <Component Id="cmp1035FAB8B87C63DE53F71263EA7A38D8" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil5CE7D164E7207CEC33D8B3DABA1CC070" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\itemdelegate-background-highlighted@2x.png" />
+            </Component>
+            <Component Id="cmp8281B1FF4DC555CD75FD86C3747E1744" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil6C2D138930E4CD786712E3BD383620A8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\itemdelegate-background-highlighted@3x.png" />
+            </Component>
+            <Component Id="cmpAB142705AF1EE8B29FF8C922D020B0C0" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil53AF4F805D0DE17CA49EBDA97FC6B583" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\itemdelegate-background-hovered.png" />
+            </Component>
+            <Component Id="cmpCBB8A0FD2FD66DF2E4FEA2A1541A2D50" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filAC3296F9EAEA6590DDEFA475D73AAA47" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\itemdelegate-background-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp973E1D87117F09B14B4839A990BD5322" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filD2E9158D77C3B796783BF157F3A2A8D8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\itemdelegate-background-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp2051627253877700ED27ADF098BB7C63" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil1289200224161BBD27B215296536AD14" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\itemdelegate-background-pressed.png" />
+            </Component>
+            <Component Id="cmpA9406C8BE6186CCED97A939576199677" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil1D8630701EC27B3D8376EEA0FB01C687" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\itemdelegate-background-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp725E4B62AABD8943C886F7FC5460B0F7" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filB9DCE900308ABAABA56954278A3EC8C6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\itemdelegate-background-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp03391101A892351A3AA3A7E204BCE52D" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filB308FCB3E76BC695F05435EBFBD281CB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-delegate-current-hovered.png" />
+            </Component>
+            <Component Id="cmpDB28079F3DA192E2A778A7F20073F679" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filDB248A8CD1866948CC8A90FA5B621DD8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-delegate-current-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp03523304DCCB23E59F61DC6C5F47781D" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filC882FDBDF0362A640EAC16331BC40E2C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-delegate-current-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp024CCEB95F137838A04FBF308FF49125" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filF61FF76920AAF28713B8F8D5C51C40C4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-delegate-current-pressed.png" />
+            </Component>
+            <Component Id="cmpBBBBC4AD594978F7FE76F32C98A8A9B7" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil68978A338FCBA7B09D5F80A6BFE31198" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-delegate-current-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpA97FA8F8EB3AB91D965D66ABA86CD437" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filDDD3F2FAF63E6A27267BC9AA282A101A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-delegate-current-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpF0259A115C868E7E21EA1C130806BC8C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil3FEC67845A36643FB72C68764D66B82F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-delegate-current.png" />
+            </Component>
+            <Component Id="cmp3FC74C2616AEA12ADCC4EC8C1C3B43A9" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filAEF4F492779DB8FFBD631365342CB436" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-delegate-current@2x.png" />
+            </Component>
+            <Component Id="cmpF82B8254F364D1BCB89761F5296CAEA7" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil10C67B2B83205821E566329FF151E4EA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-delegate-current@3x.png" />
+            </Component>
+            <Component Id="cmpAFF68A7496539D9862885C0C28067135" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil16F85EE6531C3F902426B279C578D5E7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-delegate-pressed.png" />
+            </Component>
+            <Component Id="cmp87A76E7E1A282A96BF8678AC10ED9D52" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filAD6A4D3D6535E9E03110F60E9AF98E1B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-delegate-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp9B9DD3D26119C878CAFC927258CEE77F" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil14FF28116105E2BA3FE6B2C6CCD90A42" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-delegate-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp4FE147108E1ADB030CE76AE75AA2441D" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil8F46E77AB82AC3D1F94E4E4151B32C89" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-disabled.png" />
+            </Component>
+            <Component Id="cmp617B8E071F6BFE57247FD0638C9E1011" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil075360C13CD783692342FC1457E9DBEE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-disabled@2x.png" />
+            </Component>
+            <Component Id="cmpA8E8531D5F7493B7603CCA1C7993637F" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil2E971E6958D7E11C96DCFB4E3974A2B5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp1FC66270AB328AA855F8630F06B43C40" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil9F00B9FEEA3828060E978B5D8B409D79" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-hovered.png" />
+            </Component>
+            <Component Id="cmp0195741567E2A7D69979EC9BA893B15F" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filA894BE789D6308A36977685702B000C5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp57E679994997915584905FC6DC27E704" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filBA7056DCF2595B563E375DAAACAC7CAF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp3E7DA5F97D72A870F930764744C1070F" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filA5201B8C9501C6F9B12A48A498C2CBB0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator.png" />
+            </Component>
+            <Component Id="cmp0EF52DC7D4FBFA70C9A734E133E36098" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil12853B6CC0FC82B8160014F6420136A9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator@2x.png" />
+            </Component>
+            <Component Id="cmp822B1D3F6C0C5EE22018248C8DFCADB5" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filC02D4C511234091CF78B198E6354A8FD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator@3x.png" />
+            </Component>
+            <Component Id="cmpD52E4CB10C7228F41BFA5FA93EE7BD36" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil61AA75F34C9306951B422FDCE2769DCC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\popup-background.png" />
+            </Component>
+            <Component Id="cmp01276998E094E8C03638E3647F776786" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filA521EE7750CA8BE3697F1751F41C5C19" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\popup-background@2x.png" />
+            </Component>
+            <Component Id="cmp6B7C57B85745633B7DCA395E5329702E" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil0DA1E45B4A2BCE7735427AA503D76EDA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\popup-background@3x.png" />
+            </Component>
+            <Component Id="cmp3310A3C651D732D48419DDBFE47B0A3F" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filCCF975D7C5FBB44C7CCD5A647145CB94" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\progressbar-groove-disabled.png" />
+            </Component>
+            <Component Id="cmpFA81AC5A5CF5A2913A929747C49DD4D4" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filB6AE6888EBC28C4A17D971F2D906DB75" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\progressbar-groove-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp6C567EAA259227553D124204FCF9B569" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil9EA083467DDCEDC2FAE3362F8D4C3772" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\progressbar-groove-disabled@3x.png" />
+            </Component>
+            <Component Id="cmpACEE6EBBE68D85216B2E52FF9E35055C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filC6E326AF9E149C226612762B2FDB70FA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\progressbar-groove.png" />
+            </Component>
+            <Component Id="cmp9C787B79EFC3BEFC66F38BF653087786" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil53AA2CED6652C732E48B50FD174EC75A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\progressbar-groove@2x.png" />
+            </Component>
+            <Component Id="cmp3DB8FD7FED80F57D0493DA2EB2CF4F79" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil4ACD9D35C5DB216856548FCF66551A64" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\progressbar-groove@3x.png" />
+            </Component>
+            <Component Id="cmpE3714750C0991EB75FE5CDCA0D4CB8C2" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filCEFA7CA4BF24C128F41E37474704C53B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-checked-disabled.png" />
+            </Component>
+            <Component Id="cmp5630F79816F62D9457CE8E8D22800467" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filFDC1F4E9A6D62223E86384D03B3144CB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-checked-disabled@2x.png" />
+            </Component>
+            <Component Id="cmpEE784F4AF8D2F392C1FB1C919A05CBA8" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil45936727B960C7C96CF4A53DE35E28EE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-checked-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp33E2F3F087DD1A345254A290B2850659" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filBC94B6E8E048FADE1AA000B66B30F143" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-checked-hovered.png" />
+            </Component>
+            <Component Id="cmpA300CCE0BB3920FD29D049FA68A490E4" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil9B49D3D0901DE31AB8F3540EC778F22A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-checked-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp36BA95B12F30ACF7634E0C660C237CF1" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filEA1F401E59BB1EFE37D952F907F406D4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-checked-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp91D053043462B452D078996D822A3DA5" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filDA304D21B596E3FDEF98E10D43E4EF4D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-checked-pressed.png" />
+            </Component>
+            <Component Id="cmp5D16F5E6DEAB88CC23A1B79C4CFFD09C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filBD305E2583BF4CB841B34DA652E36257" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-checked-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp973B81A7CC01861A735CFDB4D6D1A086" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil187540D81174D7F88C4B4EA8F445834E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-checked-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp97092B396D34890A73A7D6A4870995B4" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filFBEE1F5C44D6342BB4C357B39FCF3EFB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-checked.png" />
+            </Component>
+            <Component Id="cmp28E802312B6A7223D3ED9942900BC3E4" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filB0F62444A9E1F9ACA3077788330B2935" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-checked@2x.png" />
+            </Component>
+            <Component Id="cmp4D50306F849835974F5729B1F785D47C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filB409116644982AB950677EFA30CC122A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-checked@3x.png" />
+            </Component>
+            <Component Id="cmp67DD605C7E7BAD158DD5032272D6F9A7" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filC59304985A88FA05DC217FCBDCADCA10" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-disabled.png" />
+            </Component>
+            <Component Id="cmpAD57C016C48F657486C5C3600A0FF7BA" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil074BCEB29E99A91C764F7262158DE995" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp3369740539652CFDD8609288A374BA13" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil8285692AFA3569043F2E676C064DC863" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp06B958C0DF21028CD59598362A56E1D1" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil03AF216FFFFF2D717D1554899F5E5BEA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-hovered.png" />
+            </Component>
+            <Component Id="cmpC4D419736D40F1D1840AA63160B755F3" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil86A6E64EC4A7ECBBBC4D8F27CD39D7A5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp155652F86ED0AD67B64B410D2C9D3331" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filC722BFCBA2103D933258448E8D9AD6FD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp0FABAF5CB59914A66FD351F3571679B7" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil38CEB0562B877B342C344109513F0E09" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-pressed.png" />
+            </Component>
+            <Component Id="cmp1217271319171A9D82281D5D797657E0" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil0C157E6B0AAC892A0EBE49AFB6F81E86" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpA36878F2F46F0CCEC5693E4BD6885A1C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil86C2DE8DD32A781369C12F2405FCD598" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp2A707DC7A147C40DBF13C3FDE4623062" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filD58A20C2A6F6D350C70B2C629E7BC540" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator.png" />
+            </Component>
+            <Component Id="cmp9411363060AF0E050527F43C58875AE8" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil4E3C717CD75C65296124950A9FE2F294" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator@2x.png" />
+            </Component>
+            <Component Id="cmp35E38B7D838E8A861EA579164AF59F37" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil3727EB308F72D329AEFE531526D1396B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator@3x.png" />
+            </Component>
+            <Component Id="cmp65F2A6CA473FFF182B1A911B08420A08" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil24E37E85FFDD6FDB0BBF1055EC5A826E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-first-handle-disabled.png" />
+            </Component>
+            <Component Id="cmpB6976A52E6C93904F3D5CC211F2AD6F1" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil71185CC04BA55B71F263F8253702DCED" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-first-handle-disabled@2x.png" />
+            </Component>
+            <Component Id="cmpE6D379812AF8976AC39F0D976DB8A61C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filE4860053C7FB7820FEC5530C0F5FF715" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-first-handle-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp26552F97951E2813FA9B250FC14E27CC" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil7F99A9753980EBA2A7DEC8F04056AEBB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-first-handle-handle-pressed.png" />
+            </Component>
+            <Component Id="cmp23F8885CDDC70AD71D211641F3E35D02" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filC389041CCAEC1CF09BD710FB5E4AA68A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-first-handle-handle-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp35536054D5A18C4EAB378060409DCA1E" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil37D810E450B6C755D2A40E8AEECACAFF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-first-handle-handle-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp26D91F59A01F8CB1E036B290E3C26A74" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filA6BE1AE7E55EAA3993836AD57B73C03C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-first-handle-hovered.png" />
+            </Component>
+            <Component Id="cmp3F8F346B0372783FCF27018D20BEB908" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil68BC62A6067B994045F57FA49A797564" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-first-handle-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp8A18F2A4A8A2A0B510DFD4AC495DCC1B" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil81E6743256F4DE9A2761C1715DD3DC16" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-first-handle-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp3DE37AAFA65EEAA6C6AB4EF5034CB469" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filEA40F50EA15FD844F7C837EDAA10155F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-first-handle.png" />
+            </Component>
+            <Component Id="cmp30616D951DB8C35094924BC5F6AF036F" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil30CA79E867A82D88FD4F88AFD0D21EAE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-first-handle@2x.png" />
+            </Component>
+            <Component Id="cmp7018902C5C27299FA98E4752879BF589" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil4C48B47E27A3161F8166FD2F0A49736F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-first-handle@3x.png" />
+            </Component>
+            <Component Id="cmp4C2F9822D0A66A2D46A66F2C438F8DF2" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filAEB675B3A7CF2F52C2F0B1A3F6B3B9C5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-groove-disabled.png" />
+            </Component>
+            <Component Id="cmpE9AFBBD482EB14119D30909B77A2BC2C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil0171BDFBC7E1429C972A343ECEA2CE7E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-groove-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp71B151129189766D9F93F8DAA3D4907F" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil29EFB4AF6664D19527EB23D1045B6967" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-groove-disabled@3x.png" />
+            </Component>
+            <Component Id="cmpC9E761CDEB612668B6F38CA5C1E4261F" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil311917549971A7FAAF2B165895ED1810" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-groove-handle-pressed.png" />
+            </Component>
+            <Component Id="cmpA8290640A655C0AA32A9F4225DB7E21F" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil88B765286F4952AA06F55A474A3B0986" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-groove-handle-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp1170F01D9557AAD74B0C014B136A7C8E" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filA80F85AD6F8FF2F93BE7FA407C621D5F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-groove-handle-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp37333B50ECDE098B356A1777AC12A360" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil9DD3278352BA6764E5FED2FA1B3EBA0B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-groove-hovered.png" />
+            </Component>
+            <Component Id="cmp43002BC5641435FC3B6CC77EB238F792" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil7A804F10757E78F584F503B23B076C33" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-groove-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpDA19790DAEDA0EC6E03D31D30EF96C1F" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filA6E3E16F0395C70B3D2BF5C4B5DF8EF2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-groove-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp02432ED987E9AADE96237944527FBF2F" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filD524F9D101B634DA9FA6B1B864482758" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-groove.png" />
+            </Component>
+            <Component Id="cmp624C646F79623FFB94152ECABBE8106A" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filFAD13A71D3F6427BFF2453616A18C298" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-groove@2x.png" />
+            </Component>
+            <Component Id="cmpF55A1B82BB85294EA3829B72C07C4162" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil28C2F4BCA04FAF636DF18DABB74ABB28" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-groove@3x.png" />
+            </Component>
+            <Component Id="cmp842EEC47744D166BE26F4C96378D7613" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil4A7BE9AAEA21F3E6EE8193328E9368AA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-second-handle-disabled.png" />
+            </Component>
+            <Component Id="cmp2EA25D3465C7D49952C5216AE463FFE1" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil952C987431AC696C1F7061879FC2F978" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-second-handle-disabled@2x.png" />
+            </Component>
+            <Component Id="cmpD9E6E949613027BD7772EDAF5D9128D3" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filFC89F79ED8F89C4E3EBFB6089BEAFD42" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-second-handle-disabled@3x.png" />
+            </Component>
+            <Component Id="cmpFD421045565CA6FB907464ACA73D7DE9" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil5B9F1F4E64DD18051806EDAEF3B04333" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-second-handle-handle-pressed.png" />
+            </Component>
+            <Component Id="cmp32292D547E4DFA54934E2C11A970ACD8" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filF6687A52C04E3C802D6C7DDF6966D9A0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-second-handle-handle-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp21E8F11F6462ED62C61247206CAF9A80" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil93223CD8F85AF26357A98D5275520848" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-second-handle-handle-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpEA35D7396B0CCF94534123320F1BC9DD" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil3EAD31F82DED0027CA6B8A5D91F73BD1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-second-handle-hovered.png" />
+            </Component>
+            <Component Id="cmpE2564D0FDA3CE196A95A11F0EBA291CA" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil31E02DDD3224BCB8E6076C8A6A4001D8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-second-handle-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpA4738E7F2B7FA76136DD9305ED36DA44" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil875F7C71661B8AC833DDC44D5F68D4D0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-second-handle-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp44243D8DE0AEA7F22DA860D20CFE64FC" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil6BF2546284FF491C11B9D5901BFE803F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-second-handle.png" />
+            </Component>
+            <Component Id="cmpD96CB4E88B970481CE8401FC445187DB" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filDEB3A591920E9E81F8A7B4DBF31E7D19" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-second-handle@2x.png" />
+            </Component>
+            <Component Id="cmp852E4726A7179F7E87280CD418159848" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filCE008394FFA1428A86BEE5BD7C602E18" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-second-handle@3x.png" />
+            </Component>
+            <Component Id="cmpF2FA0DC18671B96E256E8BC6D6BE9748" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filD0DAC4E495072460AF5F2168A748B557" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-groove-disabled.png" />
+            </Component>
+            <Component Id="cmp5A2DF6473FCC81F633F4108042C45584" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filE561D53AA66261586C435788B1F49D33" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-groove-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp8B5A5EA590A73DFA2E05F4731166D962" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil4D11793771746A6C9EBCDCAF748852A9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-groove-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp1EEF14145C2D588352AED7E5E28230C3" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil5ED5A7031AAA55593EA93F3BB43DB5F4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-groove-hovered.png" />
+            </Component>
+            <Component Id="cmpD3413054AB0C1E4DC6EF480B9A29F017" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil7EF8A0B070FFE1599D493609EC7890D9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-groove-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp206EFCF901B718F0C3EC7331E32A51AB" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil0B1CAEC328022286BD3F1F6559067A63" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-groove-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp3DDEF11ADD37A99482A15968B2E96B62" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filEC6D28872EAB631FAD154AE7626E551F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-groove-pressed.png" />
+            </Component>
+            <Component Id="cmp73AE3FFB00747A87BC38057C85C14B66" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil4C9B0D62846FA121CEDEF691BC6209D1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-groove-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp060325DCAA18506A306435BC2B912706" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil323235584295AE77FC2F6F95C6EF8559" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-groove-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpFC2B4C2A274A60A8A491988C9CC40E31" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filCA4B412D970CE19053A1D25A8653A4D3" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-groove.png" />
+            </Component>
+            <Component Id="cmp1DA8135F70CC5C468C820DB7C088804A" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil4840FA09428392936A74B978B3630E13" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-groove@2x.png" />
+            </Component>
+            <Component Id="cmp6FA6EDDFBA9DF716CD7216E4D19FD51B" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filEA0596FC1D28EA3BA283A20993F550B6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-groove@3x.png" />
+            </Component>
+            <Component Id="cmpF3F8861321960B16C39797EF1865D1F5" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil294C43C1D3EC8AE89C26CF6CED04C37F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-handle-disabled.png" />
+            </Component>
+            <Component Id="cmp71AB0D518E6824EEB2E8DFBF611B2A8D" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil7F0F28F40BEA7FF9CFF2F389B9EBFB6A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-handle-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp0D48C3935D4A337BEACAD21696C75018" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil9F5601C3CF8B2272005F0F8B44C599A4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-handle-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp33ADFD26671BA9128F71A4A84E41E89C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filDE5AA5700094EEDCAAC45085EBE5EBB5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-handle-hovered.png" />
+            </Component>
+            <Component Id="cmpB5AC46A9315F1177234D44D8EF9161C5" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil15F09C33ED9E250EE5B5A8D4BCBF1FCC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-handle-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpF6C269C9780A2A473542719EB40E9390" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filD3C72C3A5EF3ECC4D501606D3DAD4AC4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-handle-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpCDF760A0494A2FE0FD17553E0B218946" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil42D8B23F4010F98B13C71F4D7B204259" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-handle-pressed.png" />
+            </Component>
+            <Component Id="cmp2596991E71AB422DF96844D8898669DF" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil9DDF5CBEC56EA0083352B675BEF957A6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-handle-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp7CFD3FB7444787E7A3C2C0C70175CB8B" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil8121B1E4B4016AD49B2B7E8DC9AAB835" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-handle-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp07BB8DC9B5158C2CEBE1883C78D0ABD6" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil31F9AB723A179D6BEB669D20B0086204" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-handle.png" />
+            </Component>
+            <Component Id="cmp5E61CDC94DD910FACFAECEC9A79EB922" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil05316951DE19A19958B7652A6BD740F5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-handle@2x.png" />
+            </Component>
+            <Component Id="cmp48CC1434DDE3A45882D800CD42589210" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filDB388FD4FE7F58AB09DB7ED6FF2B2285" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-handle@3x.png" />
+            </Component>
+            <Component Id="cmpBDE94B614F7A4F31EA8A3E9F2CB4830A" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filCDD1F4FBC896F8371D02134CE504ACD3" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-atlimit.png" />
+            </Component>
+            <Component Id="cmpF6DBA134DC342AD8633E3BD6E14D8048" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil6A7843C9D0F9E8D352EE5A5B01800227" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-atlimit@2x.png" />
+            </Component>
+            <Component Id="cmpE84FF1562E5F74550A6F2667F764F017" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil0037821B682C591BE1912F60317F58AF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-atlimit@3x.png" />
+            </Component>
+            <Component Id="cmp24EB8E873FFAD2B827D0F37C255888EA" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil7E55ABA0E38D56A3C045C75212EF837D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-disabled.png" />
+            </Component>
+            <Component Id="cmpCD930EADC03A9F3949FF946371B6B8FA" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil441DD5ECCA68E639A63E038C8257DCC3" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp5864A7A3D3E0145DA0544A3C7E307D25" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil36A65381622B4C36DADB75CF33F20113" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp166E26309B63F62C1BB3AC06650BF629" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil8EF7DC1519A3732EBBC6D65391B7F972" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-down-hovered.png" />
+            </Component>
+            <Component Id="cmpB6CD3DD1B6FA02D89E92708F9C180B72" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filDEC894604D8ADDE42DCA62F47BC7569A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-down-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpD2388F038C9D89635A6D14537093935E" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil1379A034068A30DD73BCB3071C757B09" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-down-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp9563B2D3D7F8AF356B0F906A6F77CF56" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filB2E794AD331D7F7B5E9BB239665C2395" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-down-pressed.png" />
+            </Component>
+            <Component Id="cmp20857FE4BE77EED914FE426F0BA11933" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil43AF44EA351F65F06CBAFC077750FF2D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-down-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp04BE47EC15D0366A27ED78FF0AAC167A" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil34F4E6646F37DD108170026F8183AF7F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-down-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpEFAD02343F70EB07283B55A52902737E" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil9E8F8B2995B00601C0A2A6F9992B696D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-hovered.png" />
+            </Component>
+            <Component Id="cmp8A1E29FF2724CD76B9913E4A0C5115EE" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil9210DADBBD821FD79F76DAF74030D319" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp2C684ABEA3D9ED220C7A7CA6A16163A9" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil1B2BC6F3CC06315351446567BFFA8517" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp6A7C3EF3B91E40C4190B64D327DC0671" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil8DD0E1386C5D92EDF34B2BC281F2D46B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-up-hovered.png" />
+            </Component>
+            <Component Id="cmp666DC8564DF589AAE3087B2FBB60591B" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil48F660003DAA9AE3BB27BD19F04652D7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-up-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpE68B538C479672080A5023F76BEE0937" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil39E66CC8FE29DF173E9F4210CAAEEA8F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-up-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp31048F315BF4DAF10E35D2AADE5F50FB" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil23A443C1D0D44251776CF8931AFD3D95" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-up-pressed.png" />
+            </Component>
+            <Component Id="cmp731E6E46A643B0FAE5F833BEA4C61E0E" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil7CBC474CA3BAE6648B13A925199728F4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-up-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp1105FD3864A6F629335C934D2E361610" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil23066BA0ECA3405BB82E900901467DBB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-up-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp331F1BE9B3AEED77E4E602345E22E74F" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil5680D7D4E685CA2FC3F0A98E56FFC81B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background.png" />
+            </Component>
+            <Component Id="cmpE58A431C6F008AC9BEAB67266AB36A3A" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filC860C2012DAE4679C3952C43D4BA2BFA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background@2x.png" />
+            </Component>
+            <Component Id="cmp81E94264F90CE31F5A8D7F9C94E7E518" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil7F98D4260EAC10DBBA392685F5142983" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background@3x.png" />
+            </Component>
+            <Component Id="cmpBA3CCCE70703EE52E3E60E2E8053F192" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil53F905B42D0200024400237A6D9D73E3" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-atlimit.png" />
+            </Component>
+            <Component Id="cmp70465A86A2A9CC7014BECB9233AE1867" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil0866F4CB793A762F6AA490B6E4D25322" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-atlimit@2x.png" />
+            </Component>
+            <Component Id="cmp84EC36935E8610B7FCAB565BA2BCAACE" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil266DA530CF1E9CCF9219E3ECCE6A4DDE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-atlimit@3x.png" />
+            </Component>
+            <Component Id="cmp00CB1F0F3D485D980143AAAF367EAB6B" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil583F31E6A44FF40C86CF9A1E16EFB6BC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-disabled.png" />
+            </Component>
+            <Component Id="cmp8A29AEA8908EE79AECE55F190FF095D1" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filA72FBB10DC219D8D892CA28E0E5E4F88" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp5871B6D016D0363FBD34F30F9C56581B" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil4F3D615D9DF77BCD0F0AE80ECF902E24" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp566B10B822D4FB321ACE7B8FAEEBE8D7" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil82B849C1D80A32D91B4A7846C5F79343" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-down-hovered.png" />
+            </Component>
+            <Component Id="cmpD7058A528C65BDCB9B3298AB778AB490" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil8B49E37DE57FF6A7C8069CC059F81226" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-down-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpCC2AB4D18627B4399B73BEF7AB0B92F1" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filCBD8B7C3E3C9FEC5EE9E793CC4ACD291" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-down-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp47C9A3F94D01935DE5C53AB3E45B7FFC" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil497FBBC98DA61E35DEE2727D71660640" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-down-pressed.png" />
+            </Component>
+            <Component Id="cmpEF20229417C99A4337936CA53B9CBD47" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil4A09F0C57722DBEE006B513450348E3A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-down-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpDAB67763894D37EDB147FBBBE428636D" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filF0D28747124EA24A6F85754DE4A21779" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-down-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp96B0348543625E331B97919096366254" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filC1E99EF91E8CCEEF806D8BDA1A820EE8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-hovered.png" />
+            </Component>
+            <Component Id="cmpAFB8083501A61F8FF22DE01A5099BAA8" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil6C70321F049C59775848E7D308DBCF9E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpFE8760B06E7DBCE71CDD209A610F178A" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filEB5020A5CCA6CB701A9BFF2AD4DDEAEF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp61F2ABDC7D6C12BBD3DD48117E7491C4" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filEDF69A57F769545C8AF1E8417D63FA69" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-up-hovered.png" />
+            </Component>
+            <Component Id="cmp93585C1A026E58D18E5B05456FFD9C5E" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filE5E42D76FCA867BDE4B79A9082F3167F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-up-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp8ACD418C67F8323C261E698042FA3FDA" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filE1ABD7BDF759EB2727978A324E3D7451" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-up-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpAC8A2E0D06CD762972BA50D195A078ED" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filF838412BD55E439F03F0B32E9BAB7777" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-up-pressed.png" />
+            </Component>
+            <Component Id="cmpE9163E62E1CDFC0E26DF227FEF987361" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil2BE75CCBF1153A30CA70ED44F2AC3D6F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-up-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpB46F2E7591B38FC5B1767A3AD332BB72" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filDA1B5634CC2160EDEF3369A288A08CF3" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-up-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpC02A1534932DCC4FCB9A0889DDC29F26" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil8A5BDB628F4ADA6E86A2FF0EE9607C25" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background.png" />
+            </Component>
+            <Component Id="cmp944D681487EFFC6926CAE34EAD7AF3A0" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil70FE8F05B2A2C44FE4A860CDB417CE9C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background@2x.png" />
+            </Component>
+            <Component Id="cmpAFC615BDE7EDFB9C3DED43926A58A8C0" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filF8C7890943ECF171FC19FC9CAD57CA77" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background@3x.png" />
+            </Component>
+            <Component Id="cmp3FBF9902EB0FE98F805785723891208A" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filD02B2D9F4F2C16B1A2A04E6AC48194DE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-atlimit.png" />
+            </Component>
+            <Component Id="cmp0DF8D89A989CBABD20BE6E25C1F4CE61" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil382D0839CD6904B3B32FE3CC1666F206" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-atlimit@2x.png" />
+            </Component>
+            <Component Id="cmp4B2BBEAFE873D90BC8A9E22427A71353" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filFF8B01198BB9E5D81A9C5A4568F7EA2F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-atlimit@3x.png" />
+            </Component>
+            <Component Id="cmpF22CCF2C5D14F4224759921D026FD711" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filBA4E3B13F9C9C581CE4E3CA3B4E35B66" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-disabled.png" />
+            </Component>
+            <Component Id="cmp35F75CF6C528046500E4375C016449D2" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil1B911BEA779CE27ECB52DDE456D2319E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp69F55B5551617FBCBD31DED4ACD102FA" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filEF0D4859F7AEC75BF4E09FEAA1FB658E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp89CC0A9E326FF29BF8C262FBA3E0A8F0" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filAACB3FCE6E4F2DF5DC6774CBCDCEF233" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-down-hovered.png" />
+            </Component>
+            <Component Id="cmp0E647EC00DB2A16061EA6EF3FDF870E1" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil08C08268BDA59FE338674B81917FEE34" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-down-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp9F6E5DB51F46D9FCC69349C66804519B" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil8EB4D94F712A022C9ED43AB169F0625B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-down-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp8166E20A89FDDD112F44147645088872" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filFAB105F4CB17D5E57C9FE480754400B7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-down-pressed.png" />
+            </Component>
+            <Component Id="cmpAC64562E5A4F57AEC4CF2FAE97544896" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil699C89A8CF8224B060BB974AC196A5DF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-down-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp502CABD34A9021CE591ED9094FC8F2C2" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filF88561582A43FE868FF7077E12DD9735" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-down-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp52BA3AFEC375A6A90F239C4BFCCEB05C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil52E61E45226B4049D83C7EB3B3BF1F56" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-hovered.png" />
+            </Component>
+            <Component Id="cmp6C91026C4CC424A157C99F09EBBB87C4" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filD4140083D247D6B8DEB5C21B92F93CFA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpA46172D82A6200AD537824A6F0DD6154" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filFB7AF8549A029D0B60393718B658CD40" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp43F01EA4CC10DD79FFA2BF77671F94A3" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filDE32043D81C36768B69AF61FEA5991EF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-up-hovered.png" />
+            </Component>
+            <Component Id="cmpA49CC1739ACD7C9BD17B7F1A2D2A35E3" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil6A38490C55A9E57DAB4D04B11BBCA06C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-up-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp36F2887682E9132F47B371072EFB205D" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filA34CFBB92B28A11164F5D4B84D1CDA63" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-up-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp5A795A721BC284ACA9CB2F96FB9277B2" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil5D20637633795B8FCB34A9AA8B6CCAE2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-up-pressed.png" />
+            </Component>
+            <Component Id="cmpD6CBCEDEB46967E42A0CB1D0A546C720" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filFE3E30ED1AE2C715935620C9B725E59C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-up-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpFCE6A6D2B9A03B92D33D67684320B937" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil8856A1F04C6A08E45FD2D6FB43785555" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-up-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp9512AE7EDE9568877EAC8C00BA79CB92" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil5247BD38119D20F67CE1083B177C2CA6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon.png" />
+            </Component>
+            <Component Id="cmpE6D3ECDE74EC1A4CD1D4984DE903787C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil8BD22C6257306D63C6C260624ECF5A0B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon@2x.png" />
+            </Component>
+            <Component Id="cmp58AF15620F93BF76A527B1787CF7FD5D" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil6F83C31E497D97856EE85135EFFA870E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon@3x.png" />
+            </Component>
+            <Component Id="cmpEA445482015B87E9D2C4E79BBBA47234" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil098C7E92147192DB4C0E6B44F528334B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-atlimit.png" />
+            </Component>
+            <Component Id="cmp8F51B2BC1F6471F80E6A39CCBC5841AF" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filF0CAB9525FC2B6B38CAAB05C6C9C849B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-atlimit@2x.png" />
+            </Component>
+            <Component Id="cmp0875D911D17D11E6B2C07BCBE7AEBCA2" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil79714E65E618D9765A6055B931ABCEA5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-atlimit@3x.png" />
+            </Component>
+            <Component Id="cmp96FDE3509ABC48640CE71490D2B41C7C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filCABF9F8832E9293C4E15C9080DA34B09" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-disabled.png" />
+            </Component>
+            <Component Id="cmp9D3A98A1366E029226B4273ED510D958" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filDED77DD669145F017C4A34D0621FA3F2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp6DE98C84A053E88915E8380C19BF9501" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil2F1157F48314CCFF60AF1C6F106CACAF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-disabled@3x.png" />
+            </Component>
+            <Component Id="cmpC59A19A6C4A3195C5E8C00563C0DDD92" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filF4EB1AF5C6DB263EF3B1989DBAB60861" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-down-hovered.png" />
+            </Component>
+            <Component Id="cmp59A68899B8D0137E27961851FA43039A" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil2DC504428C2D974029334B0347756D71" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-down-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpF041130716E2460E019578ABE1F62625" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil52500CBB41500960160373CF108525E3" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-down-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpA552AAB56276096AD5E92F1289F82B8F" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil0A9CAA2B80EAB07FC87AA1DA5BBF685A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-down-pressed.png" />
+            </Component>
+            <Component Id="cmp3A1ECB118BC3B34529DB9C162020D542" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filF567F71CDC9E4631B527439B34FF2403" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-down-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp115BE4270F8D4A78BC2D79DAE19268FE" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil49BC7ABBB9004F52317464DE0E9F0B02" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-down-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpD5B23AA07202B544B6CFA6661C7D1A4E" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil308B0FD797DF30A315CDA68554C98944" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-hovered.png" />
+            </Component>
+            <Component Id="cmp6B1321D0AE9C9498ACB5C2FE97DDF2A9" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil2A1C86D3087BF090D980490CF6D70E18" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpF5632C8324BB43027251445B86F0EFC3" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filF5CA2C100E77D1A4B10D348A850B45EA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpA3C45766D7CA1BC5562B080DCFA083D3" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil194925AB72A9C883A40330B03E067DCA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-up-hovered.png" />
+            </Component>
+            <Component Id="cmpC279B373BED398BEBB8AF253715231CF" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil0B09EA9E11AB01F87FCD0EFB268B87F5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-up-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp5ABF5E188299E3E25093B57BD0320EBE" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil29808B22F5C2AF337565F89575174EFB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-up-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp9A22D175672721B0B8AB7ADA33F1E72A" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil979A5018D5580A3AD287AEDB9829D494" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-up-pressed.png" />
+            </Component>
+            <Component Id="cmpFFC78A8D87CC9DDB10113F483C175E24" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil02BA19172CDE6F3B83718F34FB5B14CB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-up-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp46C9306CD545CE0FF1AD97F96F313FB9" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil02699C7FDEA890A30FCF313404D49D22" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-up-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp6EE2C97C6DED461F3AC3EA0256AD3F91" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filED22FA56FEA710FCA7F71C9FC1F542EE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background.png" />
+            </Component>
+            <Component Id="cmp28CC5E21E75CE1B2E70A13543109262C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil9791C1BC7856B629FF7068B0AA1C9484" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background@2x.png" />
+            </Component>
+            <Component Id="cmp364CF8E108E43499526CE14FACBA07F1" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil547290A778522AA9D4CB10726E69EB70" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background@3x.png" />
+            </Component>
+            <Component Id="cmp16629A9BA364B8D76398D28F596C3271" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil55B31C012BF22068DED580663287B0AE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-atlimit.png" />
+            </Component>
+            <Component Id="cmp8CDF96564D07012F94972CADA51C89C4" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil8976CE6508017A6C6DB27CCE4CADB6A4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-atlimit@2x.png" />
+            </Component>
+            <Component Id="cmp2A13803997F6DB97F62AE933C0FAF193" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil033CE5DF0CDD138CA91D34402C7BD581" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-atlimit@3x.png" />
+            </Component>
+            <Component Id="cmpE36D35195DE030D9D6D020CC2B3A4FC1" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil0CA62A2ED5734B938DB61662F5A79843" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-disabled.png" />
+            </Component>
+            <Component Id="cmpA1A991FFE516DCB44DEF35BE1A6B6FD2" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil4D49613FE086E3515833F0B28F5C23C7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp7529FAA84B418A4F53ABA0EEBFFF145F" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil461C7B2D15EA492DA3FA6768A6B1E3CF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp8BB6FFBE326C4DC87EC05611AFFF04AB" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil0CCDECB47FD8E5A7244E33701E6EAD82" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-down-hovered.png" />
+            </Component>
+            <Component Id="cmp34BFC0621482C1243A75ABD3692C0373" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil57D98C0368007AA6CA4BF3D4DEA26F2C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-down-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp01470103A3984C11332EE20CE3136F07" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil27440A6EC20BAEC806E6163CE1D1901C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-down-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp81ED2ADB0C87EB43FEB1703E87B83934" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil4542370EC53F27E2586ADC5922B3033A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-down-pressed.png" />
+            </Component>
+            <Component Id="cmpE44DE604300FA1796A9A377AE4E988CA" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filB4FF5A786AC755D32DF9AE23F29F23AB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-down-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp62F2219A5542C10146D9818F372D9A26" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil2BA90A2BE65C7699D633D5C26E712437" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-down-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp666C43B90B099DDF74F5B44F61DAC8DF" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filD8C6AD35EF3FECEB66D05EA1F9C75F25" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-hovered.png" />
+            </Component>
+            <Component Id="cmpF25D259165D6DA774FEAF4FE5BBAF98E" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil8A332A8766FDB68F7F9A2D83D8B8639F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp392233237FF1C42EE809E7EEEF03F537" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil01F93B7F6823C69A2259FBC6364B2036" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp00532446B70312B5FC5F837CAAE6355C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil83B9331625349683A593C845328377C2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-up-hovered.png" />
+            </Component>
+            <Component Id="cmpBAC43FBF035E33D12ED50526E3D6B284" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filF8CB8BD014D106C61634E3EEFC424501" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-up-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp3FB551C47E3D5D52A696727CD9F7572A" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filAFF45579D3D59B71241E0B96D8391820" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-up-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp66C1DED73D1FEE9F644C3DB770A4990B" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filF4FF2F2EAF11816F254CB33165AAC45F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-up-pressed.png" />
+            </Component>
+            <Component Id="cmp810ABAEA674AC72610C36B1E5234C5A7" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filA9601C0B5C8E084C7901AA9138599B5E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-up-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpA192FE3B89AAE15DA828E70B2136049C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil5F713BB91B8164F600127F2BEAFDE8D3" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-up-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp64686C0C1E4A32BFA7EE728027CC65B7" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filF4473369595BA6385FF372D213D97E62" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon.png" />
+            </Component>
+            <Component Id="cmpC5B22EA71881F27FC1370FF747AB1EBE" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil772A75F8EA49AC5EC5505F464CE72130" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon@2x.png" />
+            </Component>
+            <Component Id="cmp002CD26EE890DA583F3BC791D01AEA5B" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filC1D3409B0DF0F09D0F8CACFA3999A92E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon@3x.png" />
+            </Component>
+            <Component Id="cmp8A34EBECCCDF41E5D047675628924B4E" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filE73846E8B4198D36BDAED82E69037E5A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textarea-background-disabled.png" />
+            </Component>
+            <Component Id="cmpAF49554C2090D013A41637583D7CC92E" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil9453EB72AA9996E32CAE21C202A1D933" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textarea-background-disabled@2x.png" />
+            </Component>
+            <Component Id="cmpCDBC4BED599FBA3E0CA2F37C990B797D" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filE55522224738DDBAAAAD03D23D5242CA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textarea-background-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp32B813766166A01EE8EB84DA32F8A16C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filFDCAE644BBDBA569F154AF6DDB3592A5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textarea-background-focused.png" />
+            </Component>
+            <Component Id="cmp39AB34C969F55D1DC24C3CD35D6CB936" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil15D2BCE359E7BD06E2A02BCC94ADA661" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textarea-background-focused@2x.png" />
+            </Component>
+            <Component Id="cmp167552B2E2CADE6C01A5288F13C9BDF4" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil8114D7CA3F35A216B28BD1D820141FB4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textarea-background-focused@3x.png" />
+            </Component>
+            <Component Id="cmpAC5111FB9A491996367AC90D0F43A7A3" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil4C0A389574355EAD5A0728F8AB60653C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textarea-background-hovered.png" />
+            </Component>
+            <Component Id="cmp975AD3DDFBC3626F4FB5760AFABA2FD9" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil1226F50D297D8F7B013A498582DDD3D5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textarea-background-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpD26D8A7BE4DF8EC53D7595ABF49F3F51" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil4C9C63F53734B2E74A6B07E841CC062E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textarea-background-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp7F0D2BDC54A320E878C0896DC235508E" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil4D8860EA28E074B2FC39303AC695ED08" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textarea-background.png" />
+            </Component>
+            <Component Id="cmpE395F9386EB23F629B6718629A3AF89E" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filF219A234810ABCE7BB43699BEA6051FE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textarea-background@2x.png" />
+            </Component>
+            <Component Id="cmpA68458668284F3F187B2D45C291F1A92" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil23A85022253871649582769344A245E0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textarea-background@3x.png" />
+            </Component>
+            <Component Id="cmp232D72E011EB13371600445DA0C1913A" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filADE59BAE62A3431F54527499DC139ABE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textfield-background-disabled.png" />
+            </Component>
+            <Component Id="cmp83410DF6EEED4330BD90ED44052114C5" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil82ABAAE51112A3A37DFEEEAD8B7E5B8F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textfield-background-disabled@2x.png" />
+            </Component>
+            <Component Id="cmpDD05232085E0555F43DF064256A8C222" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filFA532C9D968738F811B62A62013BF5D0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textfield-background-disabled@3x.png" />
+            </Component>
+            <Component Id="cmpA920ED4DE726C921437483E455345E8F" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filBC7FB9EF987B9A713F1652C549E1EDB1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textfield-background-focused.png" />
+            </Component>
+            <Component Id="cmp4527634A1747191513AFCED315D6857D" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filDA472E3A4C07A5CA2A740E9A1E89F6E5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textfield-background-focused@2x.png" />
+            </Component>
+            <Component Id="cmp69A6E1262442A6CDFDC5214EC5E9BEFB" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil5CB8B26FFE66AB8CFEEC94231403CE38" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textfield-background-focused@3x.png" />
+            </Component>
+            <Component Id="cmp564A67BE61E2B5B4A900BA50E7909572" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil88716CC042EDA76F08F38ED2268E72EE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textfield-background-hovered.png" />
+            </Component>
+            <Component Id="cmp7FB43793B17D69DE8755FBA97F62A889" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil757F97CB9B3DF9490A32CD9DA55338EE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textfield-background-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpBDCE28D63D42D8901C104CA5341B6CFA" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil9CF3912BDB30C7163BACBDAE5F7DDB1C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textfield-background-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp7C4A03A8FA73AB736046551FD367748D" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filF811ABFEED95AC03715A994454B1445A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textfield-background.png" />
+            </Component>
+            <Component Id="cmp81F9E20EE2F39641FCFB3343551F35A8" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="fil7247DC3C9D65D405434BB37DE5330876" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textfield-background@2x.png" />
+            </Component>
+            <Component Id="cmp7AA373C4D88B82C12665B6035B2F0C2F" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="PUT-GUID-HERE">
+                <File Id="filB1565C10438AD5E0253B23EE77B17CC6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textfield-background@3x.png" />
             </Component>
             <Component Id="cmp93BBA84C3F04B42711C94532FDCAA4F3" Directory="dir1A86B48CD44E777E78B13993BE3DFC29" Guid="PUT-GUID-HERE">
                 <File Id="fil123F8809BA31C59BD88BF52E11E576EF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Fusion\ApplicationWindow.qml" />
@@ -942,8 +3446,8 @@
             <Component Id="cmpB7362BFEADB697DA93C3B0E9471FC933" Directory="dir4E741D8C175690CD9096A89077530C9C" Guid="PUT-GUID-HERE">
                 <File Id="filC7915B57A913E31D3C4D427C6E2219F5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Imagine\impl\qtquickcontrols2imaginestyleimplplugin.dll" />
             </Component>
-            <Component Id="cmp7477DF3B20A2314AB9D9D7C2B37516D1" Directory="dir4E741D8C175690CD9096A89077530C9C" Guid="PUT-GUID-HERE">
-                <File Id="filBCA1409917679CAA35888D9AE61821D2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Imagine\impl\qtquickcontrols2imaginestyleimplplugin.qmltypes" />
+            <Component Id="cmpF01C48A1DB024CFA1F34E9EDAF67EF85" Directory="dir4E741D8C175690CD9096A89077530C9C" Guid="PUT-GUID-HERE">
+                <File Id="fil74C24C33882A2395E541932869A1E38C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Imagine\impl\QuickControls2ImagineStyleImpl.qmltypes" />
             </Component>
             <Component Id="cmp11D7D79C97B237EC913F8032C8F836E4" Directory="dir171007FEE30C4A50EC7ED2CB58E0B5E3" Guid="PUT-GUID-HERE">
                 <File Id="fil8E3F37E1853A667FFA38E60B8B1D9B85" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\impl\plugins.qmltypes" />
@@ -1347,14 +3851,38 @@
             <Component Id="cmpE68756474722B3F21FC5532D1062FB1D" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="PUT-GUID-HERE">
                 <File Id="fil83C17F6A6B9AE52616089E09065D4409" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\CheckBox.qml" />
             </Component>
+            <Component Id="cmp573E90785328E25C126D9FC210060DD4" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="PUT-GUID-HERE">
+                <File Id="filB15EF166A5C6F9662F274CB0A571DB99" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\CheckDelegate.qml" />
+            </Component>
             <Component Id="cmp3296BF97A2E0EF541BB34170D2415F01" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="PUT-GUID-HERE">
                 <File Id="filBCD6667BB8BBFA9456E666B4E33AB0B1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\ComboBox.qml" />
+            </Component>
+            <Component Id="cmp9223971C5152F6BCA532B25B943F2EA2" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="PUT-GUID-HERE">
+                <File Id="filC0C352B87091F1CBD51AC6033DF1C5CC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\DelayButton.qml" />
             </Component>
             <Component Id="cmp8C1B3E8BDCD066E43D0D7711C6230BF0" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="PUT-GUID-HERE">
                 <File Id="fil743C0CB7BC821AB1DE5E10195D4DD7F9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\Frame.qml" />
             </Component>
             <Component Id="cmp7837CC5D7098081B4DF4FF165458173D" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="PUT-GUID-HERE">
                 <File Id="fil71972C76D5C2B98132AF5B318815F12E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\GroupBox.qml" />
+            </Component>
+            <Component Id="cmpC7A59B8197710C7C23555DC5B2C03D2C" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="PUT-GUID-HERE">
+                <File Id="fil77B5E9BD9F3C2E2CFE8F35F5DDCB8796" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\ItemDelegate.qml" />
+            </Component>
+            <Component Id="cmpAF232299BF2345E15DD252C33E647E5A" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="PUT-GUID-HERE">
+                <File Id="fil707F214EA36C5CDF0FD77A4C203D5B68" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\Menu.qml" />
+            </Component>
+            <Component Id="cmp79968B9D48EB04C96AE4EFA71A59D45E" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="PUT-GUID-HERE">
+                <File Id="fil55225234A8763732B8FFA4E1E80EB904" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\MenuBar.qml" />
+            </Component>
+            <Component Id="cmpE38CBA961AA3932686834955AD290E45" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="PUT-GUID-HERE">
+                <File Id="filC1567EE4365636D0F927E69520BC7F51" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\MenuBarItem.qml" />
+            </Component>
+            <Component Id="cmp7E5E3C6DD6A37CB0EB96DAFD4F0F6509" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="PUT-GUID-HERE">
+                <File Id="filB068B277A34EDB70D41B7FF2FE327A63" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\MenuItem.qml" />
+            </Component>
+            <Component Id="cmp784CE875D48A2B308A4B05796233B6BF" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="PUT-GUID-HERE">
+                <File Id="filDEEE0B4BDDC15FCC60E2B8C522C1E59B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\MenuSeparator.qml" />
             </Component>
             <Component Id="cmpEDDCDA25E43BFDE157B14A1304F2881F" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="PUT-GUID-HERE">
                 <File Id="fil276159053BE57D0C24D41C849C2BAE91" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\plugins.qmltypes" />
@@ -1371,8 +3899,17 @@
             <Component Id="cmpC77F62D1E6B5F70004BAB55B363F9B11" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="PUT-GUID-HERE">
                 <File Id="filAE22C9B5BA41390AC226359F794FC06C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\RadioButton.qml" />
             </Component>
+            <Component Id="cmpC225A268E189ACEA151BBD9269A23728" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="PUT-GUID-HERE">
+                <File Id="fil1FB8C8E24B8FEF9F00C02CDA101C9939" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\RadioDelegate.qml" />
+            </Component>
+            <Component Id="cmp7CCF7BC987EA831EEE6FDC053D75168A" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="PUT-GUID-HERE">
+                <File Id="fil1C1756ACD1E5AE0E4287E9E09DE2AA12" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\RangeSlider.qml" />
+            </Component>
             <Component Id="cmpEF137D0A83F3A18031FFD79BFE04B9F2" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="PUT-GUID-HERE">
                 <File Id="fil685FF36668F4A89EF52829644479A47D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\ScrollBar.qml" />
+            </Component>
+            <Component Id="cmpB70E96F1C8D6938A7613B75763C1A125" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="PUT-GUID-HERE">
+                <File Id="fil41203CA31580AABA146D7E437207AA34" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\ScrollIndicator.qml" />
             </Component>
             <Component Id="cmpE22CC5E1ED8DF1A9868758098747EEFB" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="PUT-GUID-HERE">
                 <File Id="fil95C622A6C8EB1C2113128E62F1806D13" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\ScrollView.qml" />
@@ -1386,170 +3923,50 @@
             <Component Id="cmpDC4F51A305FA129D657009601950B7A3" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="PUT-GUID-HERE">
                 <File Id="fil00A561FEF601BE682473E1310E50E3DB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\SpinBox.qml" />
             </Component>
+            <Component Id="cmp3E41F91B9C56D88BE77D591D6EAAE077" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="PUT-GUID-HERE">
+                <File Id="fil1A7F5C04F469AFD7E7CE471E8CECCF03" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\Switch.qml" />
+            </Component>
+            <Component Id="cmp19B68115DB4EDB949ACD6A0207739BD2" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="PUT-GUID-HERE">
+                <File Id="filD8E27B7DB96DA6A974D46C355135C3CA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\SwitchDelegate.qml" />
+            </Component>
             <Component Id="cmpDF55645037117499DE465427DC8DF07D" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="PUT-GUID-HERE">
                 <File Id="filF35FCE92DDE8D63D8CFC96EEDBF8F66C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\TextArea.qml" />
             </Component>
             <Component Id="cmp2203A2072E1F1CCF26557C70F67B6390" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="PUT-GUID-HERE">
                 <File Id="filE88281D540F6A3D22F1B131E68180E08" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\TextField.qml" />
             </Component>
-            <Component Id="cmpC437AB325C956B39F47527216D28546B" Directory="dir3390D3B4341886F0DA85EE3BA92439FF" Guid="PUT-GUID-HERE">
-                <File Id="filFC0B5707CF45175E2548BA04998F9D14" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\plugins.qmltypes" />
+            <Component Id="cmp19EDF8A8B3980854E236D1B24FEDE619" Directory="dir0EBECE38763539163E6070C0EF39AFCD" Guid="PUT-GUID-HERE">
+                <File Id="filB1EA9478A8618149874C4A9E0263D9E5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\images\checkmark.png" />
             </Component>
-            <Component Id="cmpFD0F8FF1618CF94939B70BB1D4874BD5" Directory="dir3390D3B4341886F0DA85EE3BA92439FF" Guid="PUT-GUID-HERE">
-                <File Id="fil326E1B5A831353646A2BA9A334652C8E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\qmldir" />
+            <Component Id="cmp6678D172E6D38A1F1A219600EF2922C1" Directory="dir0EBECE38763539163E6070C0EF39AFCD" Guid="PUT-GUID-HERE">
+                <File Id="fil30568D60BDF8839DFF8E024E4E02FDA0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\images\checkmark@2x.png" />
             </Component>
-            <Component Id="cmp19505C3234633AD6D7F2A9FF634021A4" Directory="dir3390D3B4341886F0DA85EE3BA92439FF" Guid="PUT-GUID-HERE">
-                <File Id="fil6CA3AB34BE81C0480807D319DA4D1B52" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\qtquickdialogsplugin.dll" />
+            <Component Id="cmpA68BE8A79C9E0434E786E186A307B804" Directory="dir0EBECE38763539163E6070C0EF39AFCD" Guid="PUT-GUID-HERE">
+                <File Id="filC83FDFC12FEC83DE08379AB6664B9A10" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\images\checkmark@3x.png" />
             </Component>
-            <Component Id="cmp26A12B2050D05AC837B4FE95D70CF62A" Directory="dir34D1D6742B95CCA4110D8968A4544048" Guid="PUT-GUID-HERE">
-                <File Id="fil2EF39784619037E8CC60A1D82B089DB1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\plugins.qmltypes" />
+            <Component Id="cmpFB825A713BA4BE398C07BABBC39A5029" Directory="dir0EBECE38763539163E6070C0EF39AFCD" Guid="PUT-GUID-HERE">
+                <File Id="filF83D1A5F7E19E80617762C260AE59FA0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\images\menuarrow.png" />
             </Component>
-            <Component Id="cmp247A562FE0339C0E33051AE46663C848" Directory="dir34D1D6742B95CCA4110D8968A4544048" Guid="PUT-GUID-HERE">
-                <File Id="fil73A709C03D74D3472D379DD8D232B321" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qmldir" />
+            <Component Id="cmpEE647176C26965984B6B1495B86EE483" Directory="dir0EBECE38763539163E6070C0EF39AFCD" Guid="PUT-GUID-HERE">
+                <File Id="fil7C4BA191B44FC399895EEB42997BB7BD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\images\menuarrow@2x.png" />
             </Component>
-            <Component Id="cmpD771E4FD8559DD19611671F07F50AE86" Directory="dir34D1D6742B95CCA4110D8968A4544048" Guid="PUT-GUID-HERE">
-                <File Id="filF7DDABE25D647E77D24BC54ABB437481" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qtquickdialogs2quickimplplugin.dll" />
+            <Component Id="cmp6539517EA2D786955A6A2ED0994C0DA2" Directory="dir0EBECE38763539163E6070C0EF39AFCD" Guid="PUT-GUID-HERE">
+                <File Id="filD42A582CF1E7E31F0FA3E1A58B04B37D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\images\menuarrow@3x.png" />
             </Component>
-            <Component Id="cmp1F9B87E10A30CED8E63B585060A1FF8B" Directory="dir755D907146AC4C2DC7E3BE88C0F1A70F" Guid="PUT-GUID-HERE">
-                <File Id="filA0DF6F7D59B18B7A0A1AF7DA6AF2FF68" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\ColorDialog.qml" />
+            <Component Id="cmpA59B5F81CF1281A8F0604585490D0CE0" Directory="dir2682D39E9C78E1415E0A57E589F0A404" Guid="PUT-GUID-HERE">
+                <File Id="filCF4ED0BD4E8AFB64873401A5F82183C8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\impl\CheckIndicator.qml" />
             </Component>
-            <Component Id="cmp5CC1A9822278627BA1C6F6C0810F05AF" Directory="dir755D907146AC4C2DC7E3BE88C0F1A70F" Guid="PUT-GUID-HERE">
-                <File Id="fil9352455FFAFA7537481F68705CDAB62A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\ColorInputs.qml" />
+            <Component Id="cmpD3A28840DD49BA3839529C97D123D9FD" Directory="dir2682D39E9C78E1415E0A57E589F0A404" Guid="PUT-GUID-HERE">
+                <File Id="fil9DFE3845A918EC7274D9BA9B492A9D36" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\impl\qmldir" />
             </Component>
-            <Component Id="cmpCD8E153BC6DC54FB225F0335FD2F1022" Directory="dir755D907146AC4C2DC7E3BE88C0F1A70F" Guid="PUT-GUID-HERE">
-                <File Id="fil93D2D8A8DBA12B61620EBAF03A9BE6D6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\FileDialog.qml" />
+            <Component Id="cmp8FB17070703A07EC91BC91FDF959ED0C" Directory="dir2682D39E9C78E1415E0A57E589F0A404" Guid="PUT-GUID-HERE">
+                <File Id="fil8CB29BF313A87B364A04AC86CA8D53BE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\impl\qtquickcontrols2windowsstyleimplplugin.dll" />
             </Component>
-            <Component Id="cmpA43D16647F1AFE697DD7E77561269215" Directory="dir755D907146AC4C2DC7E3BE88C0F1A70F" Guid="PUT-GUID-HERE">
-                <File Id="fil209068D9C33B43DA14DC86382904CBEE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\FileDialogDelegate.qml" />
+            <Component Id="cmp461865270D60DF2C469656EAE8AC71DD" Directory="dir2682D39E9C78E1415E0A57E589F0A404" Guid="PUT-GUID-HERE">
+                <File Id="fil793F43FB6494FD5CC90AE96CD09CACAD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\impl\QuickControls2WindowsStyleImpl.qmltypes" />
             </Component>
-            <Component Id="cmpA5CBE15352FE008097BC876C40461A13" Directory="dir755D907146AC4C2DC7E3BE88C0F1A70F" Guid="PUT-GUID-HERE">
-                <File Id="fil4540A3A2DE480ED8F7FC352CFA54A0A3" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\FileDialogDelegateLabel.qml" />
-            </Component>
-            <Component Id="cmpBA80190D493F665368F7F2D88009CA35" Directory="dir755D907146AC4C2DC7E3BE88C0F1A70F" Guid="PUT-GUID-HERE">
-                <File Id="filD4C93FE2E3ECA41F2B088C15EE8E7B44" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\FolderBreadcrumbBar.qml" />
-            </Component>
-            <Component Id="cmp2B690A76E357815CD2278DADED472DCD" Directory="dir755D907146AC4C2DC7E3BE88C0F1A70F" Guid="PUT-GUID-HERE">
-                <File Id="fil0A290A43252CCACCDD06DC74AD3F0150" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\FolderDialog.qml" />
-            </Component>
-            <Component Id="cmpD2D023E7908B3EF1FBC9EE76B53FF954" Directory="dir755D907146AC4C2DC7E3BE88C0F1A70F" Guid="PUT-GUID-HERE">
-                <File Id="fil9048C8B68F95216847AB9C2BB586267B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\FolderDialogDelegate.qml" />
-            </Component>
-            <Component Id="cmp3FD2DFA51DAE6BF8C71900CA48779DC8" Directory="dir755D907146AC4C2DC7E3BE88C0F1A70F" Guid="PUT-GUID-HERE">
-                <File Id="fil090B870ACCCB3E9AC35C9BE4A09AC383" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\FolderDialogDelegateLabel.qml" />
-            </Component>
-            <Component Id="cmp89D2DEE36502469CA5E9442966437A3E" Directory="dir755D907146AC4C2DC7E3BE88C0F1A70F" Guid="PUT-GUID-HERE">
-                <File Id="filB7007AC91E08C3AF1B5D1FB0BF4E0D70" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\FontDialog.qml" />
-            </Component>
-            <Component Id="cmp23ABBE7C0C0AFCF242C44EDCA1D7A2B5" Directory="dir755D907146AC4C2DC7E3BE88C0F1A70F" Guid="PUT-GUID-HERE">
-                <File Id="filBA3B6DBDD6BF053B67B4C49EEC242FCA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\FontDialogContent.qml" />
-            </Component>
-            <Component Id="cmp0B0F513E9ED50F545C66F3A24CC92F08" Directory="dir755D907146AC4C2DC7E3BE88C0F1A70F" Guid="PUT-GUID-HERE">
-                <File Id="fil65FEDAF25F1E1AC39DC10AD70C88DAB8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\HueGradient.qml" />
-            </Component>
-            <Component Id="cmp41298595F02EF32949F1566F589B454C" Directory="dir755D907146AC4C2DC7E3BE88C0F1A70F" Guid="PUT-GUID-HERE">
-                <File Id="fil767F03E07565A9F69AF8C06A5EBADD4E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\MessageDialog.qml" />
-            </Component>
-            <Component Id="cmpF435AE4D59420FEEB320C8B81458D76C" Directory="dir755D907146AC4C2DC7E3BE88C0F1A70F" Guid="PUT-GUID-HERE">
-                <File Id="fil85F4300A5F660E5B427FFD02F328EAF5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\PickerHandle.qml" />
-            </Component>
-            <Component Id="cmpC4C42A5D0D070431E5C9FEED80365921" Directory="dir755D907146AC4C2DC7E3BE88C0F1A70F" Guid="PUT-GUID-HERE">
-                <File Id="fil67AAEC8993AE5CDEFC014103CC45F500" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\SaturationLightnessPicker.qml" />
-            </Component>
-            <Component Id="cmp69A36B9C73762AA365C1BC5F970FC8E5" Directory="dir929495D16D3C46BFD28C6AD595BCD701" Guid="PUT-GUID-HERE">
-                <File Id="fil45A808D742A78F7A926AD621F7283728" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Fusion\ColorDialog.qml" />
-            </Component>
-            <Component Id="cmp7BBF58B50638FEB770B04C7F73171AC6" Directory="dir929495D16D3C46BFD28C6AD595BCD701" Guid="PUT-GUID-HERE">
-                <File Id="fil7153DDC4143EAC85FD70680E09CE21A0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Fusion\FileDialog.qml" />
-            </Component>
-            <Component Id="cmp773DC90FC00B0677B841101198BF6921" Directory="dir929495D16D3C46BFD28C6AD595BCD701" Guid="PUT-GUID-HERE">
-                <File Id="fil87F4823E5A4E9CAD89C9F18EB7D940C2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Fusion\FileDialogDelegate.qml" />
-            </Component>
-            <Component Id="cmp93F9CB69ACD380F7D59D08819255322B" Directory="dir929495D16D3C46BFD28C6AD595BCD701" Guid="PUT-GUID-HERE">
-                <File Id="filA3DF900A1D2C6A4D414885D446B5C70C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Fusion\FolderBreadcrumbBar.qml" />
-            </Component>
-            <Component Id="cmp29403D08CB444131141FF50C5977F801" Directory="dir929495D16D3C46BFD28C6AD595BCD701" Guid="PUT-GUID-HERE">
-                <File Id="filEA8B9CAEBE85B9B32212D7D7AC61E3C8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Fusion\FolderDialog.qml" />
-            </Component>
-            <Component Id="cmp0F3406384273F4D43A9ECCF138617EFD" Directory="dir929495D16D3C46BFD28C6AD595BCD701" Guid="PUT-GUID-HERE">
-                <File Id="filE73DB30D303712F991084FF0EEB941F5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Fusion\FolderDialogDelegate.qml" />
-            </Component>
-            <Component Id="cmp1AD58D86AC860A01A93BF5C9248B5E0B" Directory="dir929495D16D3C46BFD28C6AD595BCD701" Guid="PUT-GUID-HERE">
-                <File Id="fil36CA66A25F1D4A60DCA8851C04360F5A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Fusion\FontDialog.qml" />
-            </Component>
-            <Component Id="cmp2E10228540CA4421B670586FA6F602D4" Directory="dir929495D16D3C46BFD28C6AD595BCD701" Guid="PUT-GUID-HERE">
-                <File Id="fil103C6B50716464DFCFF67BCDF19D268F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Fusion\MessageDialog.qml" />
-            </Component>
-            <Component Id="cmpB06D35D731CDFFF625B04E79D8E88BB4" Directory="dir8C28C0A2CF1DDABB1BF2872E8E6AE192" Guid="PUT-GUID-HERE">
-                <File Id="fil75D5FBD826D73921FABD447701DE184A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Imagine\ColorDialog.qml" />
-            </Component>
-            <Component Id="cmp53496C379F6D669E9DC8EE0F3AD3E17E" Directory="dir8C28C0A2CF1DDABB1BF2872E8E6AE192" Guid="PUT-GUID-HERE">
-                <File Id="filD95B88F29ACA98EBCB5B86D8F5FA2505" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Imagine\FileDialog.qml" />
-            </Component>
-            <Component Id="cmp94CCFDA09967CE02B01DF2FD85424408" Directory="dir8C28C0A2CF1DDABB1BF2872E8E6AE192" Guid="PUT-GUID-HERE">
-                <File Id="fil1939DC9854DE81CAD586E8EA8C9F11A5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Imagine\FileDialogDelegate.qml" />
-            </Component>
-            <Component Id="cmp28FD3CFF63249E9A333566E0D4403C06" Directory="dir8C28C0A2CF1DDABB1BF2872E8E6AE192" Guid="PUT-GUID-HERE">
-                <File Id="fil540156639772798B8D6CF3832BA6CEFF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Imagine\FolderBreadcrumbBar.qml" />
-            </Component>
-            <Component Id="cmp8FB0248D377F04FE065ED8D3F0956920" Directory="dir8C28C0A2CF1DDABB1BF2872E8E6AE192" Guid="PUT-GUID-HERE">
-                <File Id="fil1B2FC023BAB032527FD158332D7A31A1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Imagine\FolderDialog.qml" />
-            </Component>
-            <Component Id="cmpEB30E27FA4A0E15D8110F522E6E24AB9" Directory="dir8C28C0A2CF1DDABB1BF2872E8E6AE192" Guid="PUT-GUID-HERE">
-                <File Id="fil4C6AFCFFF15FA8BF18BBF16D8D04263A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Imagine\FolderDialogDelegate.qml" />
-            </Component>
-            <Component Id="cmpE831C08038ED1CE79CB86EA78782321B" Directory="dir8C28C0A2CF1DDABB1BF2872E8E6AE192" Guid="PUT-GUID-HERE">
-                <File Id="fil49DC57941DAE9D048E67CC9D4037E20F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Imagine\FontDialog.qml" />
-            </Component>
-            <Component Id="cmpC9A55BF0CB886578DBBE11A05E82098E" Directory="dir8C28C0A2CF1DDABB1BF2872E8E6AE192" Guid="PUT-GUID-HERE">
-                <File Id="fil4366D0DAFCA17243777D0FC31A6D7CCF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Imagine\MessageDialog.qml" />
-            </Component>
-            <Component Id="cmp0ABC2788AE2935B5CB49F7CFC3447AE7" Directory="dirC980C9942B69E6635E4CF7C57652D12B" Guid="PUT-GUID-HERE">
-                <File Id="filB61687597342BBBABAE1E94101F3EC6E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Material\ColorDialog.qml" />
-            </Component>
-            <Component Id="cmp1B66918327259E9332768B2CEDF63F3F" Directory="dirC980C9942B69E6635E4CF7C57652D12B" Guid="PUT-GUID-HERE">
-                <File Id="fil62168DF788419AC877C9C1D54BABA7E2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Material\FileDialog.qml" />
-            </Component>
-            <Component Id="cmp7D2F50F1ECA2513B10F2D9E268603803" Directory="dirC980C9942B69E6635E4CF7C57652D12B" Guid="PUT-GUID-HERE">
-                <File Id="fil5909CA77FA8E0522A5ABE19D201D339E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Material\FileDialogDelegate.qml" />
-            </Component>
-            <Component Id="cmp54231F7DE8257F6F679C508C4A324029" Directory="dirC980C9942B69E6635E4CF7C57652D12B" Guid="PUT-GUID-HERE">
-                <File Id="fil066B22B57C4829B076EF2637C8369609" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Material\FolderBreadcrumbBar.qml" />
-            </Component>
-            <Component Id="cmpEBBD3D3A57C898928DA40D237B8191AE" Directory="dirC980C9942B69E6635E4CF7C57652D12B" Guid="PUT-GUID-HERE">
-                <File Id="fil9364C24A62A278E0DF4A32219457A0E7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Material\FolderDialog.qml" />
-            </Component>
-            <Component Id="cmp4CFF955FC6C7A59A9C3686F6EA07DEB2" Directory="dirC980C9942B69E6635E4CF7C57652D12B" Guid="PUT-GUID-HERE">
-                <File Id="filFAB35638D14AAE200469B556D0704257" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Material\FolderDialogDelegate.qml" />
-            </Component>
-            <Component Id="cmpE18DF027A0BDBB96DACB63898F697766" Directory="dirC980C9942B69E6635E4CF7C57652D12B" Guid="PUT-GUID-HERE">
-                <File Id="filDA5275126CA3326219C5633BBAF43DA5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Material\FontDialog.qml" />
-            </Component>
-            <Component Id="cmpFE745526AAA642BA836DA29C9F77ED9B" Directory="dirC980C9942B69E6635E4CF7C57652D12B" Guid="PUT-GUID-HERE">
-                <File Id="fil54D49371701AEB3AD847CDD309D9B185" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Material\MessageDialog.qml" />
-            </Component>
-            <Component Id="cmpD4B5BFCAFB6DC32B78A6C9AC75762ACC" Directory="dir8C55A2520B05F605E480B8F2F2039F1C" Guid="PUT-GUID-HERE">
-                <File Id="fil4D10401F2E4EA015EF5CE8BEA0AE7121" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Universal\ColorDialog.qml" />
-            </Component>
-            <Component Id="cmpC67BC79E14952488E29CF9E27BD202FB" Directory="dir8C55A2520B05F605E480B8F2F2039F1C" Guid="PUT-GUID-HERE">
-                <File Id="fil35DAD56258028832AFB445B0E0263B84" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Universal\FileDialog.qml" />
-            </Component>
-            <Component Id="cmp9F8F91188C1B368A7FE7E51517C5ACC0" Directory="dir8C55A2520B05F605E480B8F2F2039F1C" Guid="PUT-GUID-HERE">
-                <File Id="filCCF6364980A7F563A9642915E70CB32B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Universal\FileDialogDelegate.qml" />
-            </Component>
-            <Component Id="cmp24B89BE2A868B73CC480D3F15E9AA30B" Directory="dir8C55A2520B05F605E480B8F2F2039F1C" Guid="PUT-GUID-HERE">
-                <File Id="fil39DD65F761C1D67E92728B9250518B4D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Universal\FolderBreadcrumbBar.qml" />
-            </Component>
-            <Component Id="cmp48D9FBFB9413B749E8E5568D27D9E7BA" Directory="dir8C55A2520B05F605E480B8F2F2039F1C" Guid="PUT-GUID-HERE">
-                <File Id="fil620700542B96A19799BA7151FA3C37CF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Universal\FolderDialog.qml" />
-            </Component>
-            <Component Id="cmpC5B074A0F5386F436C0457318AEBEAC8" Directory="dir8C55A2520B05F605E480B8F2F2039F1C" Guid="PUT-GUID-HERE">
-                <File Id="fil26FDE36A980B8A98EB003E08B71AAAFD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Universal\FolderDialogDelegate.qml" />
-            </Component>
-            <Component Id="cmpA671B669F6A248C1F3648B5295D227F2" Directory="dir8C55A2520B05F605E480B8F2F2039F1C" Guid="PUT-GUID-HERE">
-                <File Id="fil158685A04206B07FCFB74FDBDD3C4579" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Universal\FontDialog.qml" />
-            </Component>
-            <Component Id="cmp388F3D53B11EE0449503AEBC67192D85" Directory="dir8C55A2520B05F605E480B8F2F2039F1C" Guid="PUT-GUID-HERE">
-                <File Id="filF4BAFBB95A2A38BD425F65092CB041B8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Universal\MessageDialog.qml" />
+            <Component Id="cmp8DD0CF3FAD30D8F599E7381E8F9E9A95" Directory="dir2682D39E9C78E1415E0A57E589F0A404" Guid="PUT-GUID-HERE">
+                <File Id="fil07B9AECD3C0996F5081301CB41F1BF49" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\impl\SwitchIndicator.qml" />
             </Component>
             <Component Id="cmpED7844544FD113D2024E6D3A0A781CAE" Directory="dir7397A50E4D7D313615C4CF7C94C61160" Guid="PUT-GUID-HERE">
                 <File Id="filDB53B5FD7BD0B0F1464E81D6A058D610" KeyPath="yes" Source="SourceDir\qml\QtQuick\Effects\effectsplugin.dll" />
@@ -1569,15 +3986,6 @@
             <Component Id="cmp4260C68CD0F932092808D3942F80E172" Directory="dir7EBA39754BD2CE291EC25825433A43D2" Guid="PUT-GUID-HERE">
                 <File Id="fil11D74BAB954F6060FE25421FF4DF2D92" KeyPath="yes" Source="SourceDir\qml\QtQuick\Layouts\qquicklayoutsplugin.dll" />
             </Component>
-            <Component Id="cmpD7C080A5C7175B15B438D5E4851B9267" Directory="dirA6F6BC40CF508C5F92BB49483928E0FC" Guid="PUT-GUID-HERE">
-                <File Id="filDE9CEDD02770FA8D5A6B443C92AF13E2" KeyPath="yes" Source="SourceDir\qml\QtQuick\LocalStorage\plugins.qmltypes" />
-            </Component>
-            <Component Id="cmp6F365EE63059CFBDA7386B8F1B4B7E73" Directory="dirA6F6BC40CF508C5F92BB49483928E0FC" Guid="PUT-GUID-HERE">
-                <File Id="fil19E5C5D82A58C106C10F4EF71FBDC561" KeyPath="yes" Source="SourceDir\qml\QtQuick\LocalStorage\qmldir" />
-            </Component>
-            <Component Id="cmp56020DD868F550FF4C2761D9FCAF2820" Directory="dirA6F6BC40CF508C5F92BB49483928E0FC" Guid="PUT-GUID-HERE">
-                <File Id="fil373F860BFC86DCA9B91B06DE6B8312C0" KeyPath="yes" Source="SourceDir\qml\QtQuick\LocalStorage\qmllocalstorageplugin.dll" />
-            </Component>
             <Component Id="cmpE6642776D930163E5B3F23D206815BB4" Directory="dirF7455B984D3CF2564DED2759788752A0" Guid="PUT-GUID-HERE">
                 <File Id="filE1D8B4CEB7BAAD320C44F6CD0D7101AF" KeyPath="yes" Source="SourceDir\qml\QtQuick\NativeStyle\plugins.qmltypes" />
             </Component>
@@ -1586,57 +3994,6 @@
             </Component>
             <Component Id="cmp1052E5F49C616A54DF531B8121F3D962" Directory="dirF7455B984D3CF2564DED2759788752A0" Guid="PUT-GUID-HERE">
                 <File Id="fil4B9E63D0E3544A93D3C93F417E63A2D7" KeyPath="yes" Source="SourceDir\qml\QtQuick\NativeStyle\qtquickcontrols2nativestyleplugin.dll" />
-            </Component>
-            <Component Id="cmpC9C0D310B3B9C47633E52904919A68A3" Directory="dir3A2097370D43A6BEED9BF1FBE00B9935" Guid="PUT-GUID-HERE">
-                <File Id="fil4E74AF38A57B5DC51A0C8BAA7FA0248A" KeyPath="yes" Source="SourceDir\qml\QtQuick\NativeStyle\controls\DefaultButton.qml" />
-            </Component>
-            <Component Id="cmp8A89A151469884206970043CC9CF4D86" Directory="dir3A2097370D43A6BEED9BF1FBE00B9935" Guid="PUT-GUID-HERE">
-                <File Id="fil8ABD292511F2D365661FA57136628A97" KeyPath="yes" Source="SourceDir\qml\QtQuick\NativeStyle\controls\DefaultCheckBox.qml" />
-            </Component>
-            <Component Id="cmp998E8AF42C18DDD09BFF57E42546A8D5" Directory="dir3A2097370D43A6BEED9BF1FBE00B9935" Guid="PUT-GUID-HERE">
-                <File Id="filCAF57E8E6C8CC0D9A2780CDD88AD462B" KeyPath="yes" Source="SourceDir\qml\QtQuick\NativeStyle\controls\DefaultComboBox.qml" />
-            </Component>
-            <Component Id="cmpD499A28F8E9F6FEE97F97777DA6CB3AE" Directory="dir3A2097370D43A6BEED9BF1FBE00B9935" Guid="PUT-GUID-HERE">
-                <File Id="fil8B58BB6E6F240EEB5AB919B5E8FF3FCC" KeyPath="yes" Source="SourceDir\qml\QtQuick\NativeStyle\controls\DefaultDial.qml" />
-            </Component>
-            <Component Id="cmpDBDF7121809130D7416E032EA09C16B0" Directory="dir3A2097370D43A6BEED9BF1FBE00B9935" Guid="PUT-GUID-HERE">
-                <File Id="fil410E97B463184F448D3625740C057F2B" KeyPath="yes" Source="SourceDir\qml\QtQuick\NativeStyle\controls\DefaultFrame.qml" />
-            </Component>
-            <Component Id="cmp2948DD4EC5076256EF0BA0FE75947821" Directory="dir3A2097370D43A6BEED9BF1FBE00B9935" Guid="PUT-GUID-HERE">
-                <File Id="fil514160DB4A8D6516426012B1E5DCA0C4" KeyPath="yes" Source="SourceDir\qml\QtQuick\NativeStyle\controls\DefaultGroupBox.qml" />
-            </Component>
-            <Component Id="cmpBAD2FDC63EF91AF984D6977B2A9641A7" Directory="dir3A2097370D43A6BEED9BF1FBE00B9935" Guid="PUT-GUID-HERE">
-                <File Id="filC20F91CF453A8F4B5F75C95AADAFFDF4" KeyPath="yes" Source="SourceDir\qml\QtQuick\NativeStyle\controls\DefaultProgressBar.qml" />
-            </Component>
-            <Component Id="cmp6504A26398241286FD87575D3DDDEE30" Directory="dir3A2097370D43A6BEED9BF1FBE00B9935" Guid="PUT-GUID-HERE">
-                <File Id="fil82D83C5E4CA154FA270B4DA26EEB3BA6" KeyPath="yes" Source="SourceDir\qml\QtQuick\NativeStyle\controls\DefaultRadioButton.qml" />
-            </Component>
-            <Component Id="cmpF53E23CCF650110414BF5121E32F5801" Directory="dir3A2097370D43A6BEED9BF1FBE00B9935" Guid="PUT-GUID-HERE">
-                <File Id="fil203E12EF4C14B14DFCDA757CA082B189" KeyPath="yes" Source="SourceDir\qml\QtQuick\NativeStyle\controls\DefaultScrollBar.qml" />
-            </Component>
-            <Component Id="cmpC43D383FA22807D352ED92706A3B7BB5" Directory="dir3A2097370D43A6BEED9BF1FBE00B9935" Guid="PUT-GUID-HERE">
-                <File Id="fil336CE1259605D5F6DD75031302D1D172" KeyPath="yes" Source="SourceDir\qml\QtQuick\NativeStyle\controls\DefaultSlider.qml" />
-            </Component>
-            <Component Id="cmpE1F0EBE68EDB43973B9E52D9C0F96504" Directory="dir3A2097370D43A6BEED9BF1FBE00B9935" Guid="PUT-GUID-HERE">
-                <File Id="fil05CB3CD7C420EE0D632AB36B001DDC11" KeyPath="yes" Source="SourceDir\qml\QtQuick\NativeStyle\controls\DefaultSpinBox.qml" />
-            </Component>
-            <Component Id="cmp8D7D9681C26F0A7B52E3C668EA4BF45B" Directory="dir3A2097370D43A6BEED9BF1FBE00B9935" Guid="PUT-GUID-HERE">
-                <File Id="fil6324820B417FACA7B03D7631F502BF76" KeyPath="yes" Source="SourceDir\qml\QtQuick\NativeStyle\controls\DefaultTextArea.qml" />
-            </Component>
-            <Component Id="cmpF20525D1576510B72940A1B3A2B872E9" Directory="dir3A2097370D43A6BEED9BF1FBE00B9935" Guid="PUT-GUID-HERE">
-                <File Id="filE190EBA3C1D870E6CF7BCBFDC2EF4B9F" KeyPath="yes" Source="SourceDir\qml\QtQuick\NativeStyle\controls\DefaultTextField.qml" />
-            </Component>
-            <Component Id="cmp5C615FF3D38B0DAEA6E54192A348A499" Directory="dir3A2097370D43A6BEED9BF1FBE00B9935" Guid="PUT-GUID-HERE">
-                <File Id="filB2DF42D1E5EA322F47250AD21CF4E4F5" KeyPath="yes" Source="SourceDir\qml\QtQuick\NativeStyle\controls\DefaultTreeViewDelegate.qml" />
-            </Component>
-            <Component Id="cmp18CB7E4808B561BE6CFA935B7A701259" Directory="dir2105A1F7199CAE1171E138FDED1D8E49" Guid="PUT-GUID-HERE">
-                <File Id="filAF591582B9EB7D4C0EF0E76AB1774FE1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Particles\particlesplugin.dll" />
-            </Component>
-            <Component Id="cmp4F76529422F947A88380E6330781E9A8" Directory="dir2105A1F7199CAE1171E138FDED1D8E49" Guid="PUT-GUID-HERE">
-                <File Id="fil12011A3B6C5641C4DBB765FE3972890F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Particles\plugins.qmltypes" />
-            </Component>
-            <Component Id="cmp79A247854241165CFF0438015FC92CBB" Directory="dir2105A1F7199CAE1171E138FDED1D8E49" Guid="PUT-GUID-HERE">
-                <File Id="fil5CFE0F9500667BFD3E26D27A494DA78C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Particles\qmldir" />
             </Component>
             <Component Id="cmp451BE08037AE1075B3D0480F83957794" Directory="dir96881D4937C7E7E8DC6A06696EF52C96" Guid="PUT-GUID-HERE">
                 <File Id="filA5E21912CAC2144F8A23EB7C07A64E50" KeyPath="yes" Source="SourceDir\qml\QtQuick\Shapes\plugins.qmltypes" />
@@ -1656,39 +4013,6 @@
             <Component Id="cmp6B89F1FC6840B89D467D2EBE8B043FE1" Directory="dirA16BBE5DE11DF2FD79B07E2965737D3E" Guid="PUT-GUID-HERE">
                 <File Id="filED4C60CE9B81695ECE44D214DCBCCE02" KeyPath="yes" Source="SourceDir\qml\QtQuick\Templates\qtquicktemplates2plugin.dll" />
             </Component>
-            <Component Id="cmp69BEF3BE02352CA6B785101AAED71318" Directory="dir2C126EEEB46329DB6052C65B78F1DA75" Guid="PUT-GUID-HERE">
-                <File Id="fil1760F73BD6E3E7286EB8F1D3A33C2073" KeyPath="yes" Source="SourceDir\qml\QtQuick\tooling\Component.qml" />
-            </Component>
-            <Component Id="cmp10D98830533C42F8706977851B39A3A0" Directory="dir2C126EEEB46329DB6052C65B78F1DA75" Guid="PUT-GUID-HERE">
-                <File Id="filBF176D7C05C63830AFF6998ABFB38A7B" KeyPath="yes" Source="SourceDir\qml\QtQuick\tooling\Enum.qml" />
-            </Component>
-            <Component Id="cmp15249FC563E9C8918952F7D1A2F805C9" Directory="dir2C126EEEB46329DB6052C65B78F1DA75" Guid="PUT-GUID-HERE">
-                <File Id="fil2CAD05441DC803A5186E966A1DDA48C6" KeyPath="yes" Source="SourceDir\qml\QtQuick\tooling\Member.qml" />
-            </Component>
-            <Component Id="cmp4833C19054EF2E14E372AD2880495C73" Directory="dir2C126EEEB46329DB6052C65B78F1DA75" Guid="PUT-GUID-HERE">
-                <File Id="fil43B1B5A91FA45D5C106A45D805FEFC40" KeyPath="yes" Source="SourceDir\qml\QtQuick\tooling\Method.qml" />
-            </Component>
-            <Component Id="cmp33AC2E102B879ECCC6316EF7AEFDBB99" Directory="dir2C126EEEB46329DB6052C65B78F1DA75" Guid="PUT-GUID-HERE">
-                <File Id="fil95F6CB39A7A168DA09B6ABC8A860B095" KeyPath="yes" Source="SourceDir\qml\QtQuick\tooling\Module.qml" />
-            </Component>
-            <Component Id="cmpD956362F874FB96C3A0DFCADA1405E4B" Directory="dir2C126EEEB46329DB6052C65B78F1DA75" Guid="PUT-GUID-HERE">
-                <File Id="fil12BB133642A6251AFE56340C20C38432" KeyPath="yes" Source="SourceDir\qml\QtQuick\tooling\Parameter.qml" />
-            </Component>
-            <Component Id="cmp05C5F4FC22BE05FF20AF6B70F2648E30" Directory="dir2C126EEEB46329DB6052C65B78F1DA75" Guid="PUT-GUID-HERE">
-                <File Id="filC998D7BD8B71F6CD05288B0CF1CE0D63" KeyPath="yes" Source="SourceDir\qml\QtQuick\tooling\Property.qml" />
-            </Component>
-            <Component Id="cmpA5F05A0EC98A80D47E263C8226347F09" Directory="dir2C126EEEB46329DB6052C65B78F1DA75" Guid="PUT-GUID-HERE">
-                <File Id="filB09D42B54721DA6F6C88B761F67D1CD3" KeyPath="yes" Source="SourceDir\qml\QtQuick\tooling\qmldir" />
-            </Component>
-            <Component Id="cmp69C56DED012A8CF7146BB347775E1111" Directory="dir2C126EEEB46329DB6052C65B78F1DA75" Guid="PUT-GUID-HERE">
-                <File Id="fil2C39EC74EEBD3E3FB173F25F6474B71B" KeyPath="yes" Source="SourceDir\qml\QtQuick\tooling\quicktooling.qmltypes" />
-            </Component>
-            <Component Id="cmp8CF4D885EDBD87E92F14AD9224A64585" Directory="dir2C126EEEB46329DB6052C65B78F1DA75" Guid="PUT-GUID-HERE">
-                <File Id="fil619C9C3A532439F43969D239FC47574E" KeyPath="yes" Source="SourceDir\qml\QtQuick\tooling\quicktoolingplugin.dll" />
-            </Component>
-            <Component Id="cmp40C935D75C83A908961342FA5F190AB4" Directory="dir2C126EEEB46329DB6052C65B78F1DA75" Guid="PUT-GUID-HERE">
-                <File Id="fil9A187523ABDC241490F213412E806915" KeyPath="yes" Source="SourceDir\qml\QtQuick\tooling\Signal.qml" />
-            </Component>
             <Component Id="cmp3E281B1E4C74C596886969A2CCFF6DB0" Directory="dir27DABF0F34E48010C38FDC22DEE2453A" Guid="PUT-GUID-HERE">
                 <File Id="fil620C826946D01508C458662B95E34005" KeyPath="yes" Source="SourceDir\qml\QtQuick\Window\qmldir" />
             </Component>
@@ -1704,8 +4028,8 @@
             <Component Id="cmp072B7F91297F86D3BDCFBD50CEADEC08" Directory="dir30FC873BE970351C9459A1383DCBEA3D" Guid="PUT-GUID-HERE">
                 <File Id="fil830FE0B6AE85ABAD33F965FA48D2A9D4" KeyPath="yes" Source="SourceDir\qml\QtWebChannel\qmldir" />
             </Component>
-            <Component Id="cmpB9B4251EC70936E366F1ADEF4DBA9A35" Directory="dir30FC873BE970351C9459A1383DCBEA3D" Guid="PUT-GUID-HERE">
-                <File Id="fil2433013655774AC94A0236C340127486" KeyPath="yes" Source="SourceDir\qml\QtWebChannel\webchannelplugin.dll" />
+            <Component Id="cmpF6EF3D689902FFD67C9E9F76539478A0" Directory="dir30FC873BE970351C9459A1383DCBEA3D" Guid="PUT-GUID-HERE">
+                <File Id="fil61A21603A473D5195ECF714F1657AA8E" KeyPath="yes" Source="SourceDir\qml\QtWebChannel\webchannelquickplugin.dll" />
             </Component>
             <Component Id="cmp136E2541355213ECB53F1748901B5921" Directory="dirD4BB3B3030E6C19000CA3A1BC69B6F39" Guid="PUT-GUID-HERE">
                 <File Id="fil6E5C9BBEEE5288F679B12AE6A49657B2" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\plugins.qmltypes" />
@@ -1715,57 +4039,6 @@
             </Component>
             <Component Id="cmp8E3363215DF077EB827751DB665D9DD1" Directory="dirD4BB3B3030E6C19000CA3A1BC69B6F39" Guid="PUT-GUID-HERE">
                 <File Id="fil2497BDEBFF9ED845670AED37393D4EDD" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\qtwebenginequickplugin.dll" />
-            </Component>
-            <Component Id="cmp7A8772E58D71483AB938D78C8B7D1B79" Directory="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Guid="PUT-GUID-HERE">
-                <File Id="filE1BB18B10EE0470145DDDA0C5E4A3B99" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\ControlsDelegates\AlertDialog.qml" />
-            </Component>
-            <Component Id="cmpEE8B93301235F322A5BD23F0C50EED3F" Directory="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Guid="PUT-GUID-HERE">
-                <File Id="fil3D4C79F57FA6E2E2A3343868C653A6A5" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\ControlsDelegates\AuthenticationDialog.qml" />
-            </Component>
-            <Component Id="cmp2C69E47276AE27A52BD269FB9BE30AAD" Directory="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Guid="PUT-GUID-HERE">
-                <File Id="fil80A7B2A5FCF793D0801C69BCBD98F249" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\ControlsDelegates\AutofillPopup.qml" />
-            </Component>
-            <Component Id="cmpA9795EC6D9B937B8A86B7B2846C91948" Directory="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Guid="PUT-GUID-HERE">
-                <File Id="filA6C1CA6308618936A31EB03CEB74F27A" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\ControlsDelegates\ColorDialog.qml" />
-            </Component>
-            <Component Id="cmp59759C9323D1558B224AADEA2AAF9C64" Directory="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Guid="PUT-GUID-HERE">
-                <File Id="fil651A6A58BA66409A10279997FDF431A7" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\ControlsDelegates\ConfirmDialog.qml" />
-            </Component>
-            <Component Id="cmp1B4AF93D806ADB8B732F2A27EB652B98" Directory="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Guid="PUT-GUID-HERE">
-                <File Id="filF73B3538DC6FC52FF15D02C2C0E58D32" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\ControlsDelegates\DirectoryPicker.qml" />
-            </Component>
-            <Component Id="cmpF2CCD1A91F993653DF09C0E15EC64A4B" Directory="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Guid="PUT-GUID-HERE">
-                <File Id="fil74DBD34E74C737746E6CAB216E06D48F" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\ControlsDelegates\FilePicker.qml" />
-            </Component>
-            <Component Id="cmpA7D7583F9A23AD1D9C5E1762D7868578" Directory="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Guid="PUT-GUID-HERE">
-                <File Id="filD4288E12E49244FBBCD5FC5EFFE0298C" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\ControlsDelegates\Menu.qml" />
-            </Component>
-            <Component Id="cmp7101449A820EA328AA1A4D1B5E999A0C" Directory="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Guid="PUT-GUID-HERE">
-                <File Id="filBD111FAA5EF2C87B70E794D43B659AF2" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\ControlsDelegates\MenuItem.qml" />
-            </Component>
-            <Component Id="cmpAD3AF866463125CF8655A99CED3AA499" Directory="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Guid="PUT-GUID-HERE">
-                <File Id="fil98058066907D9EBDF12B81A4E59979BD" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\ControlsDelegates\MenuSeparator.qml" />
-            </Component>
-            <Component Id="cmpE19B99C56B831180E601BB3589E3F3EA" Directory="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Guid="PUT-GUID-HERE">
-                <File Id="filE382C586DDB2EA853C109D8235DF6C4F" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\ControlsDelegates\PromptDialog.qml" />
-            </Component>
-            <Component Id="cmp4715158A523F0FB8C16A313FD382AFF9" Directory="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Guid="PUT-GUID-HERE">
-                <File Id="filA500F08171E7AD5EF0B2841D2A86F407" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\ControlsDelegates\qmldir" />
-            </Component>
-            <Component Id="cmp2696C32671FC8FBEF137F3AC34DE43FD" Directory="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Guid="PUT-GUID-HERE">
-                <File Id="filE6605EF825D5763D112ABD3139E76B74" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\ControlsDelegates\qtwebenginequickdelegatesplugin.dll" />
-            </Component>
-            <Component Id="cmp2E51274B580CEE17803AD1CE80B76947" Directory="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Guid="PUT-GUID-HERE">
-                <File Id="fil93F79CE6E26226D4196803E05887053C" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\ControlsDelegates\ToolTip.qml" />
-            </Component>
-            <Component Id="cmp90F62D3657982F0E2E1182816125FED6" Directory="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Guid="PUT-GUID-HERE">
-                <File Id="fil61B872246F6A108B9B7BE4F4F7E90DE8" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\ControlsDelegates\TouchHandle.qml" />
-            </Component>
-            <Component Id="cmp14169E3CF5A8B218146130249FBB815D" Directory="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Guid="PUT-GUID-HERE">
-                <File Id="filFE30BDE0B2C918072AA010AE4AFF6C82" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\ControlsDelegates\TouchSelectionMenu.qml" />
-            </Component>
-            <Component Id="cmpB07E9D9CFF105AE7053ACEA3668A2A8E" Directory="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Guid="PUT-GUID-HERE">
-                <File Id="filB51A511EB7DCD4E087D230FD943C82DB" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\ControlsDelegates\WebEngineQuickDelegatesQml.qmltypes" />
             </Component>
             <Component Id="cmp740EB509039EF4F9005AA06519EACF79" Directory="dirAB78018B8375BAA818F1C40C8D16F821" Guid="PUT-GUID-HERE">
                 <File Id="fil22604A1353A5B198D4846DC21D1783C9" KeyPath="yes" Source="SourceDir\qml\QtWebView\plugins.qmltypes" />
@@ -1824,14 +4097,11 @@
             <Component Id="cmpC2267073DB55586843E13B823F6E0E8B" Directory="dir08941CEA6046320FCCF158F759AF80F2" Guid="PUT-GUID-HERE">
                 <File Id="filFDCD09910FB501B1A747E0A04B8D3E31" KeyPath="yes" Source="SourceDir\resources\qtwebengine_resources_200p.pak" />
             </Component>
-            <Component Id="cmp48ADD1B8E5492EE4CAF352021174B247" Directory="dirD0D2BD28387A827DDF373DED43543ABA" Guid="PUT-GUID-HERE">
-                <File Id="filDE0A213E8CE9DC57CA82C7CBF94A73CA" KeyPath="yes" Source="SourceDir\sqldrivers\qsqlite.dll" />
+            <Component Id="cmpE92806CD1DBEE716B77AA561DD943FDD" Directory="dir08941CEA6046320FCCF158F759AF80F2" Guid="PUT-GUID-HERE">
+                <File Id="fil36076BE7C94F9CC98F2D777B67200CE7" KeyPath="yes" Source="SourceDir\resources\v8_context_snapshot.bin" />
             </Component>
-            <Component Id="cmpFA34FD86FCB201001C1C95C2210B09BB" Directory="dirD0D2BD28387A827DDF373DED43543ABA" Guid="PUT-GUID-HERE">
-                <File Id="filABD7D7F4392312E7C2C8CDC617BC2016" KeyPath="yes" Source="SourceDir\sqldrivers\qsqlodbc.dll" />
-            </Component>
-            <Component Id="cmp5DAC8E92F0D1CE1028B76D02F12152DE" Directory="dir3BC41331752E78D0C2719C277915294F" Guid="PUT-GUID-HERE">
-                <File Id="fil4F3C3348649DA965E980E99B9E82B7FF" KeyPath="yes" Source="SourceDir\styles\qwindowsvistastyle.dll" />
+            <Component Id="cmp59B8D848C7C3855D56912CDC5BED1B97" Directory="dir3BC41331752E78D0C2719C277915294F" Guid="PUT-GUID-HERE">
+                <File Id="fil8419D0503B0E38F93B832F060E1D88F4" KeyPath="yes" Source="SourceDir\styles\qmodernwindowsstyle.dll" />
             </Component>
             <Component Id="cmpD57693E12A6CF9AFDC034864F2950D6F" Directory="dir509C75F94B9AF6C35CA00410005C14EE" Guid="PUT-GUID-HERE">
                 <File Id="filA3197B081536A45213DBC7CD12A615C4" KeyPath="yes" Source="SourceDir\tls\qcertonlybackend.dll" />
@@ -2004,6 +4274,16 @@
         </ComponentGroup>
     </Fragment>
     <Fragment>
+        <DirectoryRef Id="dir74C12D674F4D48CC8662780E32EF06CE">
+            <Directory Id="dir0986B5CAD2460321886B51FD51019567" Name="icons" />
+        </DirectoryRef>
+    </Fragment>
+    <Fragment>
+        <DirectoryRef Id="dirB030248D75EA99E75698A1E011FE9CC0">
+            <Directory Id="dir0EBECE38763539163E6070C0EF39AFCD" Name="images" />
+        </DirectoryRef>
+    </Fragment>
+    <Fragment>
         <DirectoryRef Id="dir175FB1A22F883092D2FC39E138CDC5FC">
             <Directory Id="dir171007FEE30C4A50EC7ED2CB58E0B5E3" Name="impl" />
         </DirectoryRef>
@@ -2024,8 +4304,8 @@
         </DirectoryRef>
     </Fragment>
     <Fragment>
-        <DirectoryRef Id="dir4B7D2A19DD0D33E235AA7BD43615A87E">
-            <Directory Id="dir2105A1F7199CAE1171E138FDED1D8E49" Name="Particles" />
+        <DirectoryRef Id="dirB030248D75EA99E75698A1E011FE9CC0">
+            <Directory Id="dir2682D39E9C78E1415E0A57E589F0A404" Name="impl" />
         </DirectoryRef>
     </Fragment>
     <Fragment>
@@ -2039,11 +4319,6 @@
         </DirectoryRef>
     </Fragment>
     <Fragment>
-        <DirectoryRef Id="dir4B7D2A19DD0D33E235AA7BD43615A87E">
-            <Directory Id="dir2C126EEEB46329DB6052C65B78F1DA75" Name="tooling" />
-        </DirectoryRef>
-    </Fragment>
-    <Fragment>
         <DirectoryRef Id="dir93F3A6F9A0F15C62D9983B7251AEF092">
             <Directory Id="dir2FA83874D84EB850CB9EC2829B8A3243" Name="GraphicalEffects" />
         </DirectoryRef>
@@ -2054,18 +4329,8 @@
         </DirectoryRef>
     </Fragment>
     <Fragment>
-        <DirectoryRef Id="dir4B7D2A19DD0D33E235AA7BD43615A87E">
-            <Directory Id="dir3390D3B4341886F0DA85EE3BA92439FF" Name="Dialogs" />
-        </DirectoryRef>
-    </Fragment>
-    <Fragment>
-        <DirectoryRef Id="dir3390D3B4341886F0DA85EE3BA92439FF">
-            <Directory Id="dir34D1D6742B95CCA4110D8968A4544048" Name="quickimpl" />
-        </DirectoryRef>
-    </Fragment>
-    <Fragment>
-        <DirectoryRef Id="dirF7455B984D3CF2564DED2759788752A0">
-            <Directory Id="dir3A2097370D43A6BEED9BF1FBE00B9935" Name="controls" />
+        <DirectoryRef Id="dir4C0AEAB06A20DFD201A07716B06C1B01">
+            <Directory Id="dir3C4F465FBDDD5BDFD3E942262340FFCC" Name="images" />
         </DirectoryRef>
     </Fragment>
     <Fragment>
@@ -2076,6 +4341,16 @@
     <Fragment>
         <DirectoryRef Id="dirC5F8EA44B55B774D108D66814D18D4D1">
             <Directory Id="dir4B7D2A19DD0D33E235AA7BD43615A87E" Name="QtQuick" />
+        </DirectoryRef>
+    </Fragment>
+    <Fragment>
+        <DirectoryRef Id="dir74C12D674F4D48CC8662780E32EF06CE">
+            <Directory Id="dir4C0AEAB06A20DFD201A07716B06C1B01" Name="dark" />
+        </DirectoryRef>
+    </Fragment>
+    <Fragment>
+        <DirectoryRef Id="dir5D9C5C438263983ED9371AEEDD3594D4">
+            <Directory Id="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Name="images" />
         </DirectoryRef>
     </Fragment>
     <Fragment>
@@ -2094,13 +4369,23 @@
         </DirectoryRef>
     </Fragment>
     <Fragment>
+        <DirectoryRef Id="dir74C12D674F4D48CC8662780E32EF06CE">
+            <Directory Id="dir5D9C5C438263983ED9371AEEDD3594D4" Name="light" />
+        </DirectoryRef>
+    </Fragment>
+    <Fragment>
+        <DirectoryRef Id="dir74C12D674F4D48CC8662780E32EF06CE">
+            <Directory Id="dir6760147796A3D8FCCEBCE06251BB6DC9" Name="impl" />
+        </DirectoryRef>
+    </Fragment>
+    <Fragment>
         <DirectoryRef Id="dir4B7D2A19DD0D33E235AA7BD43615A87E">
             <Directory Id="dir7397A50E4D7D313615C4CF7C94C61160" Name="Effects" />
         </DirectoryRef>
     </Fragment>
     <Fragment>
-        <DirectoryRef Id="dir34D1D6742B95CCA4110D8968A4544048">
-            <Directory Id="dir755D907146AC4C2DC7E3BE88C0F1A70F" Name="qml" />
+        <DirectoryRef Id="dir175FB1A22F883092D2FC39E138CDC5FC">
+            <Directory Id="dir74C12D674F4D48CC8662780E32EF06CE" Name="FluentWinUI3" />
         </DirectoryRef>
     </Fragment>
     <Fragment>
@@ -2119,18 +4404,8 @@
         </DirectoryRef>
     </Fragment>
     <Fragment>
-        <DirectoryRef Id="dir755D907146AC4C2DC7E3BE88C0F1A70F">
-            <Directory Id="dir8C28C0A2CF1DDABB1BF2872E8E6AE192" Name="+Imagine" />
-        </DirectoryRef>
-    </Fragment>
-    <Fragment>
-        <DirectoryRef Id="dir755D907146AC4C2DC7E3BE88C0F1A70F">
-            <Directory Id="dir8C55A2520B05F605E480B8F2F2039F1C" Name="+Universal" />
-        </DirectoryRef>
-    </Fragment>
-    <Fragment>
-        <DirectoryRef Id="dir755D907146AC4C2DC7E3BE88C0F1A70F">
-            <Directory Id="dir929495D16D3C46BFD28C6AD595BCD701" Name="+Fusion" />
+        <DirectoryRef Id="dirC5F8EA44B55B774D108D66814D18D4D1">
+            <Directory Id="dir831F2329F0F3ACEA4CAA1C1913D06297" Name="QML" />
         </DirectoryRef>
     </Fragment>
     <Fragment>
@@ -2154,11 +4429,6 @@
         </DirectoryRef>
     </Fragment>
     <Fragment>
-        <DirectoryRef Id="dirD4BB3B3030E6C19000CA3A1BC69B6F39">
-            <Directory Id="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Name="ControlsDelegates" />
-        </DirectoryRef>
-    </Fragment>
-    <Fragment>
         <DirectoryRef Id="dir1F7AD7AA9B228AED2E74CDD7C3088B5C">
             <Directory Id="dirA016FBC978C7F28C3C5CDBC06002A5D6" Name="qtwebengine_locales" />
         </DirectoryRef>
@@ -2171,11 +4441,6 @@
     <Fragment>
         <DirectoryRef Id="dir463F84444BF926F4998942302E2C59AF">
             <Directory Id="dirA55BCC7BED6B60785CEB74AFBA374495" Name="impl" />
-        </DirectoryRef>
-    </Fragment>
-    <Fragment>
-        <DirectoryRef Id="dir4B7D2A19DD0D33E235AA7BD43615A87E">
-            <Directory Id="dirA6F6BC40CF508C5F92BB49483928E0FC" Name="LocalStorage" />
         </DirectoryRef>
     </Fragment>
     <Fragment>
@@ -2196,21 +4461,6 @@
     <Fragment>
         <DirectoryRef Id="dir2B55988B75845F194F607E4ED40BB41B">
             <Directory Id="dirBF720220167083D5C665DD0D131194BE" Name="impl" />
-        </DirectoryRef>
-    </Fragment>
-    <Fragment>
-        <DirectoryRef Id="dir755D907146AC4C2DC7E3BE88C0F1A70F">
-            <Directory Id="dirC980C9942B69E6635E4CF7C57652D12B" Name="+Material" />
-        </DirectoryRef>
-    </Fragment>
-    <Fragment>
-        <DirectoryRef Id="dir92990262DE0ED5508C44523003A4B360">
-            <Directory Id="dirD3E9E07666E50DD0B119271684422637" Name="Base" />
-        </DirectoryRef>
-    </Fragment>
-    <Fragment>
-        <DirectoryRef Id="dir92990262DE0ED5508C44523003A4B360">
-            <Directory Id="dirD48123A7B6E2CFB660EC94F0CBE0276D" Name="XmlListModel" />
         </DirectoryRef>
     </Fragment>
     <Fragment>

--- a/win/qt6.wxs
+++ b/win/qt6.wxs
@@ -12,6 +12,7 @@
             <Directory Id="dirC5F8EA44B55B774D108D66814D18D4D1" Name="qml" />
             <Directory Id="dir9331125B8BF1F459D0AC9F91A6A2F779" Name="qmltooling" />
             <Directory Id="dir08941CEA6046320FCCF158F759AF80F2" Name="resources" />
+            <Directory Id="dirD0D2BD28387A827DDF373DED43543ABA" Name="sqldrivers" />
             <Directory Id="dir3BC41331752E78D0C2719C277915294F" Name="styles" />
             <Directory Id="dir509C75F94B9AF6C35CA00410005C14EE" Name="tls" />
             <Directory Id="dir1F7AD7AA9B228AED2E74CDD7C3088B5C" Name="translations" />
@@ -58,8 +59,8 @@
             <Component Id="cmpB6D50DE19D6ADD781A08727F7F6266E8" Directory="INSTALLDIR" Guid="{9CE1CD64-108E-45B7-855E-E9A783CB19E3}">
                 <File Id="filCF6DBEF1D6A13C80715404D32B934AD5" KeyPath="yes" Source="SourceDir\Qt6Qml.dll" />
             </Component>
-            <Component Id="cmp4E9BFD75DF26062E9937847116425997" Directory="INSTALLDIR" Guid="{3BA3D48C-4E32-4447-B837-0A9DF7AE9067}">
-                <File Id="filAE1BF7A9D9BF060761C9FAAB52C1582A" KeyPath="yes" Source="SourceDir\Qt6QmlLocalStorage.dll" />
+            <Component Id="cmpAF683EE0207F56E683FD073A3F2D2006" Directory="INSTALLDIR" Guid="{43C2D177-9C79-4ABB-83C8-1A0ED97B7B5F}">
+                <File Id="fil6331F3687384F1AB7BEF24F2A8B4AA20" KeyPath="yes" Source="SourceDir\Qt6QmlMeta.dll" />
             </Component>
             <Component Id="cmp65C2886373B0C96AD79BAD6B11F4BCEC" Directory="INSTALLDIR" Guid="{E0C4FC0C-4A28-460A-B092-FCB45FEAA648}">
                 <File Id="fil1A464A34B69E38E90B0748094F580925" KeyPath="yes" Source="SourceDir\Qt6QmlModels.dll" />
@@ -67,35 +68,56 @@
             <Component Id="cmp609AE9C23E17BA20AC06AEA3F3551DAE" Directory="INSTALLDIR" Guid="{B92EE4BB-8805-4317-BD8D-BF4C53D6306A}">
                 <File Id="fil70941CA86B91BA9374327AE51424DF95" KeyPath="yes" Source="SourceDir\Qt6QmlWorkerScript.dll" />
             </Component>
-            <Component Id="cmpF560A3BA9C9935A03A5C37CBAFF8321F" Directory="INSTALLDIR" Guid="{CE2EC749-6224-409F-8E35-3ED8816465C9}">
-                <File Id="fil123F08A484F5DF5CC72BFCCDC197DBF9" KeyPath="yes" Source="SourceDir\Qt6QmlXmlListModel.dll" />
-            </Component>
             <Component Id="cmpED65C4A3E125070BC17313D1A32F9C76" Directory="INSTALLDIR" Guid="{C8F815E9-AB86-4742-8D35-7354A635233F}">
                 <File Id="filFDA17D38CD6D73072EBAF9E430B8DCD4" KeyPath="yes" Source="SourceDir\Qt6Quick.dll" />
             </Component>
             <Component Id="cmpA463F9E3D9E20729888D635B58292550" Directory="INSTALLDIR" Guid="{2AD5E6DF-195C-432C-A40D-19196C3E57D2}">
                 <File Id="filDF57D75497458D7E64C07BB9AD1456C9" KeyPath="yes" Source="SourceDir\Qt6QuickControls2.dll" />
             </Component>
+            <Component Id="cmp233846C2BEE2F647CFB8678979D9FE2A" Directory="INSTALLDIR" Guid="{05A0F0BC-717E-4A30-A392-3C54F26BDE95}">
+                <File Id="fil9025E81D1684343EC39A0488A289C2AA" KeyPath="yes" Source="SourceDir\Qt6QuickControls2Basic.dll" />
+            </Component>
+            <Component Id="cmp539A635B8282736FFE569271963EB9BA" Directory="INSTALLDIR" Guid="{49BA48BA-69FB-40E4-B8CF-6E2BB5E5C13D}">
+                <File Id="filEC8BF7880F9C9499740FB738802F7453" KeyPath="yes" Source="SourceDir\Qt6QuickControls2BasicStyleImpl.dll" />
+            </Component>
+            <Component Id="cmp1F67893FFAFCE5107295A466BC3B3313" Directory="INSTALLDIR" Guid="{A4D74C6A-3B38-4F46-80E6-9AF119D8780B}">
+                <File Id="fil470A1FCB196D2864F277A8780846C1F1" KeyPath="yes" Source="SourceDir\Qt6QuickControls2FluentWinUI3StyleImpl.dll" />
+            </Component>
+            <Component Id="cmp8CFA3AD051A37FEEA263EFE73A8BA8BD" Directory="INSTALLDIR" Guid="{B38C21DE-A7A8-4167-82EF-8F05794ABDF9}">
+                <File Id="fil9244247757CBE6E1F72810713C4EECBC" KeyPath="yes" Source="SourceDir\Qt6QuickControls2Fusion.dll" />
+            </Component>
+            <Component Id="cmp65209AC7EBC7E60989C4807CDACDCC09" Directory="INSTALLDIR" Guid="{0270F351-E152-49E2-8C04-3849D0140DBE}">
+                <File Id="fil80A990BFE09B00A495C207224ADB5BDB" KeyPath="yes" Source="SourceDir\Qt6QuickControls2FusionStyleImpl.dll" />
+            </Component>
+            <Component Id="cmpDB52D9B1FD2BCE9B579FF9BBE5B0204F" Directory="INSTALLDIR" Guid="{083D77A4-BD68-4539-93AD-12CFCAF61988}">
+                <File Id="fil8F15B827E2E835F92443FC28E2531D08" KeyPath="yes" Source="SourceDir\Qt6QuickControls2Imagine.dll" />
+            </Component>
+            <Component Id="cmpAE751F6A0569A5ACC0F12E5E91E9EA64" Directory="INSTALLDIR" Guid="{61CB3499-07D8-4B58-991C-446F1C1CFA98}">
+                <File Id="fil14B9D585B7BF9DEA12D02B5DD13F8BE2" KeyPath="yes" Source="SourceDir\Qt6QuickControls2ImagineStyleImpl.dll" />
+            </Component>
             <Component Id="cmp0571EF0C5FB8E314588A9065CF74AE35" Directory="INSTALLDIR" Guid="{6C00C0D4-3FF3-4CBC-B5CC-7D5116782A33}">
                 <File Id="filDC1C47A2ADA5BD76E86CE6CE8EC4F5B4" KeyPath="yes" Source="SourceDir\Qt6QuickControls2Impl.dll" />
             </Component>
-            <Component Id="cmp2BB41ECBA565E0A0B4EDF020A49025F9" Directory="INSTALLDIR" Guid="{E2397D5D-10EE-49D5-B2BC-D25A5286321E}">
-                <File Id="fil57860EF8422A74A3CE88A88BAD0CABB7" KeyPath="yes" Source="SourceDir\Qt6QuickDialogs2.dll" />
+            <Component Id="cmp52F90B0CC4C64CD7297DABAA32382B1A" Directory="INSTALLDIR" Guid="{106C4569-EFD6-48C2-8C6D-1B135A8AE12C}">
+                <File Id="filBB3DB98EB685B0DA80E7D949397ADAD0" KeyPath="yes" Source="SourceDir\Qt6QuickControls2Material.dll" />
             </Component>
-            <Component Id="cmp73D256572698B6DB61D05CCD551BEF9A" Directory="INSTALLDIR" Guid="{2D33DF32-5940-4433-8273-C071C66C179E}">
-                <File Id="filC9FA5D0D485CF88CB948BE06870C3B8A" KeyPath="yes" Source="SourceDir\Qt6QuickDialogs2QuickImpl.dll" />
+            <Component Id="cmp60EB7CBF8EAC53D5AED329B93B6D47C2" Directory="INSTALLDIR" Guid="{4F55194A-D981-4AA1-AB1B-40BF2615C9A8}">
+                <File Id="fil4882D38AC1397034ED3F2303FC5DAACA" KeyPath="yes" Source="SourceDir\Qt6QuickControls2MaterialStyleImpl.dll" />
             </Component>
-            <Component Id="cmpC26015BC765576311A63C5B026DB71FF" Directory="INSTALLDIR" Guid="{E0DFA170-69C3-41FB-8E1E-6F17DC027777}">
-                <File Id="fil2911EE010D604A656A176E72D572CCAC" KeyPath="yes" Source="SourceDir\Qt6QuickDialogs2Utils.dll" />
+            <Component Id="cmpA7A0CBD344B074F175E448ABC0BFDE58" Directory="INSTALLDIR" Guid="{0A498DA4-6623-40FE-ABCD-237FD1168665}">
+                <File Id="filD97D25AF582D747D0239EB5A50746D35" KeyPath="yes" Source="SourceDir\Qt6QuickControls2Universal.dll" />
+            </Component>
+            <Component Id="cmpA2589BC5C5022DE7265258EE8F15FC3E" Directory="INSTALLDIR" Guid="{BCED604A-A0C7-4EF8-A1A2-4EF7A5544E48}">
+                <File Id="filCC14AFBEEA05EA8721B3375EFB3A35DC" KeyPath="yes" Source="SourceDir\Qt6QuickControls2UniversalStyleImpl.dll" />
+            </Component>
+            <Component Id="cmp54DF42DCE2675E57F9EAAD85CC8641F2" Directory="INSTALLDIR" Guid="{724780B1-73A4-411E-99C0-D44B4BC44C23}">
+                <File Id="fil6CB329504ED279D670301CD15966AA7B" KeyPath="yes" Source="SourceDir\Qt6QuickControls2WindowsStyleImpl.dll" />
             </Component>
             <Component Id="cmp2ABC8A6031A24B9F3C70C18AE40B4CC3" Directory="INSTALLDIR" Guid="{07D87922-39D7-4F44-9E7B-F8ECBB11D86B}">
                 <File Id="fil0C6C0D67878BFB0A4BD30E472A40969B" KeyPath="yes" Source="SourceDir\Qt6QuickEffects.dll" />
             </Component>
             <Component Id="cmpD246CE6E593DB826C58A42EFAB8AC176" Directory="INSTALLDIR" Guid="{55D69872-A85E-43F6-912A-BF1E493C8928}">
                 <File Id="fil89BECDEB84C26F37AC111B6D300D2835" KeyPath="yes" Source="SourceDir\Qt6QuickLayouts.dll" />
-            </Component>
-            <Component Id="cmp05C682DFA26731F5F96864E240BB9367" Directory="INSTALLDIR" Guid="{9D8C8DAF-F52F-4FC3-A765-94117661FF1F}">
-                <File Id="filF00A542F2EB321619F0825C65334A7F5" KeyPath="yes" Source="SourceDir\Qt6QuickParticles.dll" />
             </Component>
             <Component Id="cmpB2448C4481D00046098304AC1C230B93" Directory="INSTALLDIR" Guid="{78810566-5226-4058-AFB5-478189D94251}">
                 <File Id="fil359D410486F61CCCDFEFE2410735AC75" KeyPath="yes" Source="SourceDir\Qt6QuickShapes.dll" />
@@ -106,23 +128,20 @@
             <Component Id="cmpD5FD28F099F28B38A8C5C6C43481E545" Directory="INSTALLDIR" Guid="{46866E68-D822-498F-B97A-F172CB5B3E0D}">
                 <File Id="fil1A12F96CDBED6EDBD83A1228E643DFE1" KeyPath="yes" Source="SourceDir\Qt6ShaderTools.dll" />
             </Component>
-            <Component Id="cmpDAA5AE12CA74181FE29953002CC830A3" Directory="INSTALLDIR" Guid="{2C9383C2-EBF6-4FFC-B3F5-A014EACC05C7}">
-                <File Id="filEF75955C67A60E62CD86B26117C750AE" KeyPath="yes" Source="SourceDir\Qt6Sql.dll" />
-            </Component>
             <Component Id="cmp2BFDE38E15CC8879E8B911A7A296477A" Directory="INSTALLDIR" Guid="{5B1DDDD7-72B7-4804-B939-BD805721BF9E}">
                 <File Id="fil08B70D0B09545B2C830255009EF93341" KeyPath="yes" Source="SourceDir\Qt6Svg.dll" />
             </Component>
             <Component Id="cmp501A53153FAB3908951DADAE039AB865" Directory="INSTALLDIR" Guid="{F754EC1C-C49A-4BB5-B1F6-44F39D697964}">
                 <File Id="filDAAFC08AB32ED0F61D6C56EA5B665627" KeyPath="yes" Source="SourceDir\Qt6WebChannel.dll" />
             </Component>
+            <Component Id="cmp5D67931A769831745EAA389FCBE18DB4" Directory="INSTALLDIR" Guid="{E7C8219C-B0FA-4D23-95B5-73FEEFB8252F}">
+                <File Id="fil527B55E277F58ECE350A9D331EC489F4" KeyPath="yes" Source="SourceDir\Qt6WebChannelQuick.dll" />
+            </Component>
             <Component Id="cmp5046A1A989E72DACE21F8D481D0D71C5" Directory="INSTALLDIR" Guid="{63DC7AE7-1E3D-403D-9172-777C8F2185B9}">
                 <File Id="fil4DF01BF67F8DD9C408204A2F5BD56FF9" KeyPath="yes" Source="SourceDir\Qt6WebEngineCore.dll" />
             </Component>
             <Component Id="cmp8015426E62DE3ED33343DB50BE0A9A0D" Directory="INSTALLDIR" Guid="{F4778D74-570E-4173-912A-CEECCC885B65}">
                 <File Id="fil58988C3D49189FE2287F68174F6944A2" KeyPath="yes" Source="SourceDir\Qt6WebEngineQuick.dll" />
-            </Component>
-            <Component Id="cmp268C15DC40B82F983C534C9C3DAABD1B" Directory="INSTALLDIR" Guid="{1B8AC40A-AC0C-41C5-B5A8-D7C52FF8C206}">
-                <File Id="filA069DC2EC3525A8E547CF9EFC89A25E6" KeyPath="yes" Source="SourceDir\Qt6WebEngineQuickDelegatesQml.dll" />
             </Component>
             <Component Id="cmp7B3BE582AD25B07FE55DD249E6D5C333" Directory="INSTALLDIR" Guid="{2D8AA939-E8CB-4EFE-8C38-2D8D6BF0E65C}">
                 <File Id="filF8FC62A4978258AB67C456CC256AAA8B" KeyPath="yes" Source="SourceDir\Qt6WebSockets.dll" />
@@ -183,6 +202,12 @@
             </Component>
             <Component Id="cmp8539D5D6C3427F1F4C82034569A0F132" Directory="dirC15EA267FAD4FC447E84FB3A32CBDB68" Guid="{43FEA413-3848-49B8-848E-15455D1C4803}">
                 <File Id="filEF2EB40CA1790B7BDC4320E6F7638744" KeyPath="yes" Source="SourceDir\position\qtposition_winrt.dll" />
+            </Component>
+            <Component Id="cmp461F0596AA5F86FE89448A8ECC13E885" Directory="dir831F2329F0F3ACEA4CAA1C1913D06297" Guid="{FC1FA6CB-271B-423E-AF34-11A7A6A95C36}">
+                <File Id="filBA6172E9C08F8F6EAA6EBEB7C72E3EF5" KeyPath="yes" Source="SourceDir\qml\QML\plugins.qmltypes" />
+            </Component>
+            <Component Id="cmp780E68E2C2E0DEE8BA15C9717A6569FC" Directory="dir831F2329F0F3ACEA4CAA1C1913D06297" Guid="{7CF88103-B879-40DB-A122-F8AC72D315CB}">
+                <File Id="fil2E6126A89886BE286E566A28753D81F4" KeyPath="yes" Source="SourceDir\qml\QML\qmldir" />
             </Component>
             <Component Id="cmp0BF1B39B0DF9604C417C59F0C26849DB" Directory="dir2FA83874D84EB850CB9EC2829B8A3243" Guid="{81CFDDE4-236D-4CD7-B112-3FBD76350D12}">
                 <File Id="fil886A06C8346FCEDB309427F45C47C7A2" KeyPath="yes" Source="SourceDir\qml\Qt5Compat\GraphicalEffects\Blend.qml" />
@@ -298,20 +323,14 @@
             <Component Id="cmp2AE301345F7F9CB39B6986A6FE1B7770" Directory="dir7B12C3FC704EE1F6A1CBC6ECA590217F" Guid="{22CD8C88-8C2C-4F66-B372-1A116136F155}">
                 <File Id="filFEA2206E424A82D72528F1EA358D0B69" KeyPath="yes" Source="SourceDir\qml\Qt5Compat\GraphicalEffects\private\qtgraphicaleffectsprivateplugin.dll" />
             </Component>
+            <Component Id="cmpFC1B21C84B8D28BAD32C0AD91ED15B61" Directory="dir92990262DE0ED5508C44523003A4B360" Guid="{3EB79674-733E-4AE4-A0C6-46F0BA15CF14}">
+                <File Id="fil2A5F168842EFE199DA0A8B5FD525BA3A" KeyPath="yes" Source="SourceDir\qml\QtQml\plugins.qmltypes" />
+            </Component>
             <Component Id="cmp8EABE0B8AEB6B59BBA116FC21CB7E5F2" Directory="dir92990262DE0ED5508C44523003A4B360" Guid="{64FE7562-0E53-48AD-99D2-F08C9806A91E}">
                 <File Id="fil0117CF5445EF1792DFCE8ED7540F81CA" KeyPath="yes" Source="SourceDir\qml\QtQml\qmldir" />
             </Component>
-            <Component Id="cmp0C776837FB1ACA4E4665746624A1F66D" Directory="dir92990262DE0ED5508C44523003A4B360" Guid="{07E220E4-5AAC-4B0F-9A92-169B39003F13}">
-                <File Id="fil4003B93F14AAC88E53C18C94ACEB86B8" KeyPath="yes" Source="SourceDir\qml\QtQml\qmlmetaplugin.dll" />
-            </Component>
-            <Component Id="cmp276C50F9766B97EB467160CC10A6A356" Directory="dirD3E9E07666E50DD0B119271684422637" Guid="{78195003-8786-4500-BD14-58C73367C2A0}">
-                <File Id="fil0F05D62E45DA4E9EFA2FBFC0D3553F36" KeyPath="yes" Source="SourceDir\qml\QtQml\Base\plugins.qmltypes" />
-            </Component>
-            <Component Id="cmp517B71582230A4698CBF9E3F6048550D" Directory="dirD3E9E07666E50DD0B119271684422637" Guid="{3DF89265-E7F6-4660-B9A0-F90F723076C3}">
-                <File Id="filEEB49B8A5C313E798DCB3FC5DE04D86F" KeyPath="yes" Source="SourceDir\qml\QtQml\Base\qmldir" />
-            </Component>
-            <Component Id="cmp870C95E4B9F919D6A3987C4F468D8305" Directory="dirD3E9E07666E50DD0B119271684422637" Guid="{3DB97C83-8281-4A7F-8EF2-5FB214AC4AE2}">
-                <File Id="filEED866F0018D6A66CAAAC4D5E08D6EAA" KeyPath="yes" Source="SourceDir\qml\QtQml\Base\qmlplugin.dll" />
+            <Component Id="cmp4C0332CE67535B43634DCB1FDD8FEE6C" Directory="dir92990262DE0ED5508C44523003A4B360" Guid="{94D576AF-F34D-4E6F-9B29-DE82CAF9832F}">
+                <File Id="filEB541820C36F6F6FB28C37EA81F4BAE0" KeyPath="yes" Source="SourceDir\qml\QtQml\qmlplugin.dll" />
             </Component>
             <Component Id="cmpA1F1D19580CB3E153905BE6B71792592" Directory="dirAA6B0932D46A7D6E35A8D1E06E10B2B7" Guid="{B7C9CD4F-5D9B-4EEF-8D24-64CC6416102F}">
                 <File Id="filF67E33CF8E5416727B865F3F9EA9A8E7" KeyPath="yes" Source="SourceDir\qml\QtQml\Models\modelsplugin.dll" />
@@ -330,15 +349,6 @@
             </Component>
             <Component Id="cmp08D9C9933EFB91871225B53380202A87" Directory="dir92A51CED876E1F4286E6663FD7D54CDA" Guid="{25C02117-21FA-4FC2-A60E-B6B7F03ED4E5}">
                 <File Id="filAEEE5B727783E6621123551D42A7F31B" KeyPath="yes" Source="SourceDir\qml\QtQml\WorkerScript\workerscriptplugin.dll" />
-            </Component>
-            <Component Id="cmp30CA6BFC8F040C1F22D888FD79DC9B1B" Directory="dirD48123A7B6E2CFB660EC94F0CBE0276D" Guid="{78AAC9A0-AE99-4551-A4AB-9B367F2F8AE0}">
-                <File Id="fil49ED9A9A100F4B7848AF9A02B69490F3" KeyPath="yes" Source="SourceDir\qml\QtQml\XmlListModel\plugins.qmltypes" />
-            </Component>
-            <Component Id="cmp50357C4AABC622F51AD737AB1256FE31" Directory="dirD48123A7B6E2CFB660EC94F0CBE0276D" Guid="{CD9B6DCA-A162-4249-8298-A33A4FCEDB26}">
-                <File Id="filFBD23B1E55B401CA6C9778F361D5EC66" KeyPath="yes" Source="SourceDir\qml\QtQml\XmlListModel\qmldir" />
-            </Component>
-            <Component Id="cmp86A326EFCF0E1704C41D4A3BE3B2B50C" Directory="dirD48123A7B6E2CFB660EC94F0CBE0276D" Guid="{E022B1AC-7D09-4E7A-9EC2-23CAD69FFF41}">
-                <File Id="fil52EA3E4F82010DABF3A854BA9390EEAC" KeyPath="yes" Source="SourceDir\qml\QtQml\XmlListModel\qmlxmllistmodelplugin.dll" />
             </Component>
             <Component Id="cmpE4E1A33E38557FB60B3F45555FD20ECE" Directory="dir4B7D2A19DD0D33E235AA7BD43615A87E" Guid="{A5A470B8-018F-4306-90E3-FE22FFFCFA15}">
                 <File Id="fil1C0EEC7BC400302C41630BA92C1C307F" KeyPath="yes" Source="SourceDir\qml\QtQuick\plugins.qmltypes" />
@@ -567,6 +577,2514 @@
             </Component>
             <Component Id="cmp191CA6324FBD06A3B02B1B7F18C11E96" Directory="dir78C3D911E47BC1C88AC3A9AC7D40EEC3" Guid="{51C2FBA6-A09F-4355-91A5-AA2CC6E95CBE}">
                 <File Id="fil94069F412C19B914E634255D82E89B35" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Basic\impl\qtquickcontrols2basicstyleimplplugin.dll" />
+            </Component>
+            <Component Id="cmpBEC5CEBC6AFF05B265496A46A98831EC" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{2EC36315-A46A-4CD1-8D1F-02D68D1F718C}">
+                <File Id="filE7454071DB283322A310481DC72151A1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\ApplicationWindow.qml" />
+            </Component>
+            <Component Id="cmpD407CB8459C1B1B530CF49F3757A7628" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{A27FD76E-F019-4FB6-9380-186D8D78578E}">
+                <File Id="fil247FD47495EE34D5F907961789C413EE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\BusyIndicator.qml" />
+            </Component>
+            <Component Id="cmpAC7BB06BB817F8E44458D576FA35F1F5" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{ADAB69B0-DD5F-4EDD-AF37-18EFCBA0024F}">
+                <File Id="fil8171E082BA4EEC420369C8F484B43E3C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\Button.qml" />
+            </Component>
+            <Component Id="cmp7423540D4E30B0CBB803418ADE99F49F" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{30C6C621-E05F-4154-81F2-2ADC6692FB67}">
+                <File Id="fil9B39D1CEB6B6E6CD5889ADC8417CD908" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\CheckBox.qml" />
+            </Component>
+            <Component Id="cmpD1E6B1570A3D1E1357C04E496A1D3F36" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{298EC33D-CF1B-41D7-B45E-722B184E481C}">
+                <File Id="filFF4E8602EB8C4D7947EC1852DBCEEC22" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\CheckDelegate.qml" />
+            </Component>
+            <Component Id="cmp7A9FCF5DFFC41C252BE968D8701A14C6" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{C3B16FEB-A183-43CF-90FA-907B25DA59D5}">
+                <File Id="filDA556695542CEA579EDE7F8A778B31FA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\ComboBox.qml" />
+            </Component>
+            <Component Id="cmpBF2783833711046DE6FD6BD58A09D1D9" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{EAF2799B-67DE-4ED9-BFA6-4E92E4C2C966}">
+                <File Id="filC92972D564BBEAD3A8C5E0FF69E34F8D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\Config.qml" />
+            </Component>
+            <Component Id="cmpCAF4B0FAF03D579A728F1926FACA2017" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{481C7FDA-E365-432D-B881-A5ECECD26FFC}">
+                <File Id="filF410D60B2E8C7D4176B638E08701305C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\DelayButton.qml" />
+            </Component>
+            <Component Id="cmp24E6E2D6014C11C0237774E3D24439EC" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{2E9EB2C0-57AE-4DDE-9B8C-999F4543BAAE}">
+                <File Id="fil3D644ABBA54437F87AF43D33013808DC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\Dialog.qml" />
+            </Component>
+            <Component Id="cmpD87559774E2DE214C8877A4BD32565EE" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{69229336-0B23-42A0-B1A6-B8A8A71F3EAE}">
+                <File Id="fil1498D2D321E9D106DEFF5BA94E6659C2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\DialogButtonBox.qml" />
+            </Component>
+            <Component Id="cmp66ACC3897EF8B5F1667FD8303AA95A52" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{438C3358-962F-4656-8AB4-B3AAA923D165}">
+                <File Id="filF8F8521DB76409C9309A33A6E37E8EA4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\FocusFrame.qml" />
+            </Component>
+            <Component Id="cmpDAA15B7E105F0CFFF27139E95A68395E" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{8F523EE3-B7C2-4155-8AB3-7119FC78C368}">
+                <File Id="fil89E25C836EACEE23C8C43F159201E806" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\Frame.qml" />
+            </Component>
+            <Component Id="cmpCC9678D26FEEC236D88C06A8B10F9B31" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{2D163EE0-027E-4455-BCEE-08CF17252317}">
+                <File Id="fil983738FCC975A797235595E4AA6480B1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\GroupBox.qml" />
+            </Component>
+            <Component Id="cmpF22434C74A89D374E2390BAD597DDCEB" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{910971FC-3498-4F37-A0F9-F43D00FFD39B}">
+                <File Id="filB695D4B23CAEA6DC02EAF06F2687824C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\ItemDelegate.qml" />
+            </Component>
+            <Component Id="cmpBE6C9D000F09B344019353A05DB3D90E" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{A4581593-8C93-435B-8599-7C62C8991950}">
+                <File Id="fil28301E6E0A63A887E79F32749D64300F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\Menu.qml" />
+            </Component>
+            <Component Id="cmp81688D192412A7AF329943685DF43850" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{E7AC967A-E815-4A1E-94AA-9E714BA3839E}">
+                <File Id="filC2E3A3FDB8C9E37A03D277F828AF2367" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\MenuBar.qml" />
+            </Component>
+            <Component Id="cmpFDA409BE444B8FB89F40323EFA636518" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{861E0514-6BDD-4496-884C-379BF5F7244D}">
+                <File Id="fil5EECBF4C03AF0B35B07F6F7DEC893304" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\MenuBarItem.qml" />
+            </Component>
+            <Component Id="cmp9BF9F75C4F6648157F918AEB02FB987B" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{8C2ADC67-38D8-4D70-AA59-CD32CE3C6A88}">
+                <File Id="fil12C025630051A0346B995320C179AD83" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\MenuItem.qml" />
+            </Component>
+            <Component Id="cmp594AE21ED3FA4E76E6022887C091DEDA" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{E376E029-6F98-425E-804C-6825D863F0FC}">
+                <File Id="fil89B6A5312333DEB62D6095E577414F92" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\MenuSeparator.qml" />
+            </Component>
+            <Component Id="cmpD26245D682D8A4FF6A923F3A04FCD6CC" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{D61DC8F6-6FAE-4FFA-B812-3C1F3D586DB1}">
+                <File Id="fil0DB14E44C2350422338A264F7292E0F6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\PageIndicator.qml" />
+            </Component>
+            <Component Id="cmp070DCD11EBE4CB6801FD25FF3D88FB0E" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{C5F6E31C-E1EC-4D52-9B01-2C86D2577A2E}">
+                <File Id="filA2AFBFD9E681DD2BE83341BBDA852B97" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\plugins.qmltypes" />
+            </Component>
+            <Component Id="cmp0C025F6409BE9855A779EDB6FBB10331" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{D6126535-09CD-4958-A227-6A38921F4711}">
+                <File Id="fil68F925FB01F1767C39ABFEF2EA43975C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\Popup.qml" />
+            </Component>
+            <Component Id="cmp3763924DB647B4450CD56B89437DB415" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{8EF82419-6272-4CD5-9B17-4CCC4E027EFA}">
+                <File Id="filE35C4631ABBDB3A15B9E1B39E87005E8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\ProgressBar.qml" />
+            </Component>
+            <Component Id="cmpCF0A8D6670C1D2BE9D013D1B323CF863" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{F49B8E37-3A9F-45B6-A3E3-AB36AAE7BF87}">
+                <File Id="fil91307AEEED3351AEA98B937676FDC6B2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\qmldir" />
+            </Component>
+            <Component Id="cmp5513795A63453D025823BB61C9AF1083" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{1A98E577-34D4-486C-846E-FAE634B29280}">
+                <File Id="fil018D6A09AAEEAC155E038A153E0FD562" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\qtquickcontrols2fluentwinui3styleplugin.dll" />
+            </Component>
+            <Component Id="cmp237DD73DAAF688C3789D30EB4F83E61A" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{E195D53F-99D9-4718-BC32-B912A40E3F15}">
+                <File Id="fil6E1B678E5895330BC27F4D8F97EA68BB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\RadioButton.qml" />
+            </Component>
+            <Component Id="cmp3B5BFD085840E59DBF97450274C370CF" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{F96F69D9-2286-44F0-98E6-4EA7AE1D329E}">
+                <File Id="fil7CADA6BC067805C69987778106187ABF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\RadioDelegate.qml" />
+            </Component>
+            <Component Id="cmp26DABBF1ECA876E1AA9166C76AC878D6" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{DCB10CA8-13F6-4409-B548-6C0C165956E3}">
+                <File Id="filCBD2B6971CACDB39BD25B10ABB5DD67D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\RangeSlider.qml" />
+            </Component>
+            <Component Id="cmp1F10E0F63A15E80DC6CAE758AFDF5E61" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{714843A6-67F9-4728-A08E-26EF57933F32}">
+                <File Id="fil2336F9078803E2F3B72D153DAA32C65E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\RoundButton.qml" />
+            </Component>
+            <Component Id="cmpA780D5753E011037CFDCAA49E34164D3" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{9478B8BC-6234-479D-87C4-0F9BE1980CA2}">
+                <File Id="filE9EC9D01C476A0DB8826F197CF1AB5A0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\Slider.qml" />
+            </Component>
+            <Component Id="cmp0192ABAC199B2E6EB7FD7A67DACFC728" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{229EDCCF-A1FB-45F2-A3F2-FA79F308EE61}">
+                <File Id="fil1CFFB2FAA2B61D9DA6A7C03D1D5ACDFA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\SpinBox.qml" />
+            </Component>
+            <Component Id="cmpB4939353B0641105713876427B30B8BB" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{39C5E985-A222-4DC2-B151-8046DA755CDD}">
+                <File Id="fil2188D7A3F182193CEFD6079813F76709" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\StyleImage.qml" />
+            </Component>
+            <Component Id="cmpFA0E535D853C42573DBC949E9C73C85E" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{D52F7EFA-0B5C-4F26-8A55-255588CDD36A}">
+                <File Id="fil080E2EFC77A649C3500BD832BE76FA1F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\SwipeDelegate.qml" />
+            </Component>
+            <Component Id="cmp6DE2DD6F4EAFF2F2CB17C721528F8F06" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{7BDD9ECD-AE36-4235-B3F5-A31FEDE2FC2C}">
+                <File Id="fil9191A185B439D4E3A3A21F1A3199A720" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\Switch.qml" />
+            </Component>
+            <Component Id="cmp691179C823A8384446B95600F9F89091" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{F386AF31-C295-496A-A965-B4F195A4A3F0}">
+                <File Id="fil71CA5C85B955A7979D623B08C7B3B4EC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\SwitchDelegate.qml" />
+            </Component>
+            <Component Id="cmpD932D3550D9DC5679565FE8E1DC1AB02" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{D083C788-9E42-4F46-AC3B-6996CA8CDDF4}">
+                <File Id="fil433C97022DAD73E4437AAA698F15B46B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\TabBar.qml" />
+            </Component>
+            <Component Id="cmp5E7EE5E0AA9DDEE0F618772164AFB017" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{818D1E7E-F5E2-4981-8B27-67A6A2FEE441}">
+                <File Id="fil0AACF02B5AF82702342427CA207DE0C9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\TabButton.qml" />
+            </Component>
+            <Component Id="cmp1BCDEAF28681BC9747BEB147D8D1BFC4" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{1970CEAC-AAA7-48A4-AB8E-89F12BA629A1}">
+                <File Id="filC064725AB88FDA36F5CCB7BE1ECCE34D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\TextArea.qml" />
+            </Component>
+            <Component Id="cmpF4C2D103D24403966706363FD911796E" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{845AC1D3-F771-47E0-9C80-A272F724C8E8}">
+                <File Id="filF74D2CCCBDE90C647967AD060B185E96" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\TextField.qml" />
+            </Component>
+            <Component Id="cmp4421BAFC7077735B15D735DB3D77F331" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{4EB456D7-7AF9-4AAB-9FC7-8FAE10C9E3BC}">
+                <File Id="filCEE749F4708B9DC4FCD681F897F8495A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\ToolBar.qml" />
+            </Component>
+            <Component Id="cmp60DC82E68BC2274F0D7E4F2C4D9F4692" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{F5679D4F-D681-4A52-A2E3-3BD1265BFBEA}">
+                <File Id="fil83E359A369182400875C264C18E9A046" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\ToolButton.qml" />
+            </Component>
+            <Component Id="cmp2C488F1C4FB310AE376A3E902E018393" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{476ADADE-084A-4417-AF79-45838417DAD8}">
+                <File Id="filAB53F4F085C8C819E61207A594ECFF27" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\ToolSeparator.qml" />
+            </Component>
+            <Component Id="cmpC1F25A3E55398B55DB1D46D557930BB0" Directory="dir74C12D674F4D48CC8662780E32EF06CE" Guid="{7A469D60-F40F-4E8C-BEB6-F57DB7886A66}">
+                <File Id="fil2C5184A1ED5B2230D526D0F25DEDAA56" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\ToolTip.qml" />
+            </Component>
+            <Component Id="cmp8721796279895CF4D1D789ACF3707314" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{8F08F6A7-3C69-48D3-8F29-3E0D50985362}">
+                <File Id="filB8D7FC78E030D8AD1D9C95A9F99664BC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-checked-disabled.png" />
+            </Component>
+            <Component Id="cmp3EB3229D74B00F835E6EAC2D589890EC" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{D745F00C-A628-4BF1-88FA-3A945D26CF05}">
+                <File Id="fil460CECE935406A184B8CA6F264009A5F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-checked-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp93EDD2E7297C6A01836530B0281DB955" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{C4A4114D-C846-4547-8505-24691F395AC8}">
+                <File Id="filA978E633FB793E4BB9F23FF555168C12" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-checked-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp363D4745A94CC1930672D4AA475EF7C2" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{664C6B45-E9E8-4070-A82A-B017E5BB37ED}">
+                <File Id="fil7FECFAE69B2AE76BC27EF5AB06890BEA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-checked-hovered.png" />
+            </Component>
+            <Component Id="cmpA8B438CBAA6D751191A9C4A0C9265E07" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{7C6FDA0A-C207-424B-9107-6E9DCEAA0321}">
+                <File Id="fil60FE31A01E468BAD58C7AB6D4E3B59E6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-checked-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpD49A29F9A5F32AE3241C86BA7EDAE788" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{3925DAAF-91F3-4B56-9C04-293FFA018160}">
+                <File Id="filA45652A5E2A0BC36C072BA103B029A1F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-checked-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp4346F725060AA2C337D2C385D05C75CE" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{ABC513F5-99F7-4E6B-AEC7-B577666D6606}">
+                <File Id="fil59D9560F6EAAA23B5D3B180749C64854" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-checked-pressed.png" />
+            </Component>
+            <Component Id="cmp3B482CC47BB24E35C592A5CC67AC89C1" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{65AC2594-E7CE-4760-8485-169BF5A26F78}">
+                <File Id="fil03211802764C8F8B66DDCB83C4322934" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-checked-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpCB07CD2377448CD36D84D9C909E4D780" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{27185756-DB83-41A6-B0D5-4C52243125A7}">
+                <File Id="filF0DA0FFF491C4A9EFBA403E6417D926F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-checked-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpED83B0B18DFEBD7335BE581CE73BAE0D" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{C1D940D0-9B8F-49A8-B8A1-B74602AA66ED}">
+                <File Id="fil2EE1F694FE500FF9B1F88478D6514CBA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-checked.png" />
+            </Component>
+            <Component Id="cmpB2530EE7175268CE014B09C628DD201D" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{5E813D55-B442-40F6-AF77-E49FA885C6F4}">
+                <File Id="filF5F6FBB6C283D84248780BEB67C692B0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-checked@2x.png" />
+            </Component>
+            <Component Id="cmp466755033794D475259AD9D32395C7E1" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{1C0BBA75-BFB4-46F7-A822-2110C16E5EEB}">
+                <File Id="filE50E0E1B22A611FB221DB760C25C148A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-checked@3x.png" />
+            </Component>
+            <Component Id="cmp6FAB0E150883D6A86B3EFBFE677E6288" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{06298679-6380-4AD3-8ED6-1C51AF361D54}">
+                <File Id="fil7F9CFDCF6F55B88526F3CA6C9051E6DA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-disabled-partiallyChecked.png" />
+            </Component>
+            <Component Id="cmp76EEFAF6992C3563B4D3ED149B93048C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{2922985F-8589-4268-9A3B-750B858AB214}">
+                <File Id="fil5C77C87DE710FF80CFD7C0CFEED4908B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-disabled-partiallyChecked@2x.png" />
+            </Component>
+            <Component Id="cmp30D9DB59A69BC6D8E99D4E386FA5E68B" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{EF1A4672-19ED-44E1-A76D-B741C6752657}">
+                <File Id="filAB6B4EA8E1FDC320C3A225DED4AA1130" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-disabled-partiallyChecked@3x.png" />
+            </Component>
+            <Component Id="cmpD674292FCCAFDDAF0E64F0076CA09D36" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{63DF90D7-35B5-462A-81A7-1EE61628493E}">
+                <File Id="fil652912FB156748E3ECE21EED54732B18" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-disabled.png" />
+            </Component>
+            <Component Id="cmpBDB59A04B151122059D8762806F2DBDB" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{BD68F70C-2E94-483B-BFB6-93C62E17A41F}">
+                <File Id="filDDEE1029AEA324EC33258FE00DBBF2D7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp9CFF8A63C995F3E9C44B2B7AECA1895F" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{D65022C4-0A21-4AA9-A536-9AF55ACB1795}">
+                <File Id="filE5C07CAE97E8C507D9DC1CB5DDFAB44E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp46983BE079B3E9308C3DB4611FCAF9E1" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{7755886A-BC5B-49CA-B31F-579A8CF1041F}">
+                <File Id="fil61C0C97FEA0DBF551D045F83C7A23134" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-hovered-partiallyChecked.png" />
+            </Component>
+            <Component Id="cmp3B3ED8778B661EAFAF3750A7ABC66215" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{077F8DA1-8307-47FE-B07D-9308D864BD7F}">
+                <File Id="fil4E8DAC2BE3A7F557446892D447868279" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-hovered-partiallyChecked@2x.png" />
+            </Component>
+            <Component Id="cmpD254236BF232A54FC978B3E50F0A2429" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{D2185C81-D560-45F4-973F-FF18CD91AAAC}">
+                <File Id="fil00B3EA131CB6611EDD99EA7F5D1AB6EB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-hovered-partiallyChecked@3x.png" />
+            </Component>
+            <Component Id="cmp7D05F18D4777C434EF5080581253D033" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{2B196CCB-8CF5-4110-986D-44F3884F4D90}">
+                <File Id="fil9FFA1167A32A9827B53B18BBE9D27E21" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-hovered.png" />
+            </Component>
+            <Component Id="cmpB4E58D6077A19A3A957E7EF006E29245" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{A8EE84D1-2623-4BAF-B7D2-A256742B06AA}">
+                <File Id="filE430377303A931FD4F64F2999C398DF2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp5DAF5C97D3744903481B1BEB29F0E714" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{CE3B2E31-1672-473C-9644-B9E6C9F89C97}">
+                <File Id="fil4BADCE47092E481E45DCE158B259A0CB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpBA959D82589453C1284CADA7CEC09906" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{B23F6C05-0F58-4925-BC25-19F5B1ABAED9}">
+                <File Id="fil34CDF5F477271F0C927BFD25565729E6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-partiallyChecked-pressed.png" />
+            </Component>
+            <Component Id="cmp091C767D045B7748C353E0FF5BDF0F0E" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{D29F9D1D-BF75-4DF5-82CA-2DA811A6E2B7}">
+                <File Id="filD235BB415F7B2A55E92F1E7873A1BDA0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-partiallyChecked-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpA394ED27A8DBA527D9DDC428880F30C5" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{0C252405-3970-447E-9BC9-B5D533243F17}">
+                <File Id="filBB9B7AB2AFEF824972868F9C7391D594" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-partiallyChecked-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpD26B5BF7E2DBFC2513CEFEC8255676F6" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{022AD934-75E7-4053-B497-EF9243E7C61A}">
+                <File Id="fil48136B9FE38DB86D0DD8346F3C29AD02" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-partiallyChecked.png" />
+            </Component>
+            <Component Id="cmpFF4B734C1513CCC7028BA3D7D8F94B8F" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{D629A341-4E36-4240-B186-D78EB2BB2030}">
+                <File Id="fil40C9CFAB35F3F35AC109B0C3CF28634B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-partiallyChecked@2x.png" />
+            </Component>
+            <Component Id="cmpF47C36A96B5BAD5CEE5E6F8BBBCC2FBD" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{58A6885D-B997-433A-B601-8B2432C3FDAC}">
+                <File Id="filCAAA8542E7FDACD84FBF97978E900157" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-partiallyChecked@3x.png" />
+            </Component>
+            <Component Id="cmp398E8C480D998E40A0828D7FC93AD66A" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{FFE256DF-8CC5-4E4F-8451-31AC3F311BF1}">
+                <File Id="fil49C347F1FCBB34F45F1F231B02288223" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-pressed.png" />
+            </Component>
+            <Component Id="cmpE06625474542ECE5DFFCE6BAC36D9C6D" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{6167730E-6FF2-4B28-BBDF-1A350D053AFC}">
+                <File Id="fil1CDBE03F70EE032095C2B2E8EC5A3DD7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpC6B752DE6F94A1BA12FBBBE8DBDE8054" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{19912CCD-E106-4668-BB50-D88FAE404B52}">
+                <File Id="filDFDC7F96299A0A1A2B207B0AC117FBE3" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp153DC955035DF8906B31D61252A84DA8" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{EBE8CE4A-7A45-4FA9-B890-7CF3DD92AE19}">
+                <File Id="fil18BE92A4CFFDAA2A1C97F0B96DDCB7D8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator.png" />
+            </Component>
+            <Component Id="cmp3D9321C333BAD8590582C14D042FA99B" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{00648396-BF1C-449E-A5EA-189A7368FD00}">
+                <File Id="filECF4355653CCB4AAF36DD6F3C54836D8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator@2x.png" />
+            </Component>
+            <Component Id="cmp9457EBBA75FF4345C0177F6DD7DCC839" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{60351D32-413B-4FAD-BC81-44805F6EA026}">
+                <File Id="fil3B5698D155D5014EDE9663A2B1722F5C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\checkbox-indicator@3x.png" />
+            </Component>
+            <Component Id="cmpD5724FDCEB3DB2F82B59EFFB92E3C491" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{3403571E-8FBA-4C32-BF80-AECAB5616EB0}">
+                <File Id="fil00E62B42B51379F892FA5435772EF6E9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-disabled.png" />
+            </Component>
+            <Component Id="cmp404533A260B5E873A8F4A77BDF0AE4F0" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{D3FF2F8C-EA9C-400C-957F-B606E41E6D2D}">
+                <File Id="filEF6299DB3C73D4911631E602B74D4730" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-disabled@2x.png" />
+            </Component>
+            <Component Id="cmpFF210C8877A6A5F455E40A5841E43C86" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{169C1B4A-D34B-42B2-AC7D-69C6FAFC6805}">
+                <File Id="filC41CF27BF72521F5C3969881F7E865F8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp637A177DBBAD3C84647EAC895BF40DB8" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{8D817747-7CB1-429E-9B5E-92C9A30D6E6E}">
+                <File Id="filD07BAC4DC972036E9B943A9EB20532AC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-focused.png" />
+            </Component>
+            <Component Id="cmp99B5BDCF6EA3D0DEAB453B16520B7832" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{C4E0CC96-96D3-4816-B4ED-972ADA52AF5B}">
+                <File Id="filE51C62D665F97F83DE1722BFB1716CFB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-focused@2x.png" />
+            </Component>
+            <Component Id="cmp5BEA3329794AE34920BAD72C60D65301" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{F8D3BF89-28A0-413B-B9B2-4E3B770828A2}">
+                <File Id="fil52FA620E27CAE876292FFC62A3B5FF0C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-focused@3x.png" />
+            </Component>
+            <Component Id="cmpDC38329D8E8677658A5F9C78A6560ABE" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{876B70B3-84EF-4239-AD0E-127C28A06F1E}">
+                <File Id="fil819189B6B89176F56843C646B11490C0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-hovered-open.png" />
+            </Component>
+            <Component Id="cmp4F3557142E08073AEAF69AB968DD39EE" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{79CDE494-3FD7-43AC-BAD2-04A25CA9AB92}">
+                <File Id="fil3B5DD9B981584F3E8E1B479D4C555F5F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-hovered-open@2x.png" />
+            </Component>
+            <Component Id="cmp07605ADE55553EF48D9B2EB66F56957A" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{6479FA29-1A0C-4F91-A46B-6F30DF2B74A4}">
+                <File Id="filA8DE5DA834697930EF36DB09F1FDBC62" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-hovered-open@3x.png" />
+            </Component>
+            <Component Id="cmpC4F6E5732A118E9CE7A08A09090BC8CF" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{DB066E01-E418-4C79-A624-753BD920685A}">
+                <File Id="fil94DA1F4F04DD30D393A13C6E400EED45" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-hovered.png" />
+            </Component>
+            <Component Id="cmpFA60F4E2AFE91F057B533A38E2D38920" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{27488F01-50CD-4EF7-8466-4ECD5239E6D4}">
+                <File Id="fil2992C5F540CB03105338A4A6FF8AEBC1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp037E90877A40E75B9DF9648D38A9D756" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{144B5CAA-ACB6-4C90-A9C0-36FBB1B0D163}">
+                <File Id="filCF9E27EAFA53C075092243E54B482B92" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp1722C79067C39F257930B79C1F904A48" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{289964F7-21F0-44A1-802E-3019169739CA}">
+                <File Id="filDAC75E65C2CD1736562B937066C12693" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-open-pressed.png" />
+            </Component>
+            <Component Id="cmpDE5BAABA243FE4D5FBBA4A83DBB97378" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{E6B19CCF-7254-4A9E-B08F-B57101ABE43E}">
+                <File Id="filE6A428254613FB18A207C9CBDE6AB68D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-open-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp3A4A6D25D838C4281D148B7C61FBE67F" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{D80603BF-1F8F-47A0-BD9C-3F6547B6FFF4}">
+                <File Id="fil36D2CD75536C4B9DA1FD5BD47961F925" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-open-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp751C01DF0979E4ABC3F4E0856B99071C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{59590524-2FA0-4577-8934-B5934672EFAD}">
+                <File Id="filBA6AFA66E46050B76F1F9BF6BC584861" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-open.png" />
+            </Component>
+            <Component Id="cmp53A40CBC4686A321FB4976281E67A235" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{65F9363D-16C2-4AED-AD23-13C3D813528F}">
+                <File Id="fil0342CE6954D0A17336F4574F62B0E958" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-open@2x.png" />
+            </Component>
+            <Component Id="cmp60FB6917A2AF5FF992C0FF5224A6CCD4" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{E34A8A67-03AE-43F7-A989-A96F1A0F24DE}">
+                <File Id="filEF524348CC7FA0F9527F3F9B86294EDB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-open@3x.png" />
+            </Component>
+            <Component Id="cmp2F848B85A5701233A0DCA63EB412DD16" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{149E6D1C-8F44-4FAF-80DF-6F50C9098B00}">
+                <File Id="filE18F607BEF6841741E22F8EAF772023B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-pressed.png" />
+            </Component>
+            <Component Id="cmp49A52D7C85CE6BD98E32A54B29F062BA" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{CA55528F-A50A-4590-BB99-601855687744}">
+                <File Id="filF4CA05B8CE8D8F4C360A6724FD1A897A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp8B928A820DE4E7817BBD118C4569DDD8" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{85C31B5A-15BC-4ABE-9927-0F353FBDBA56}">
+                <File Id="fil5ED0404F4A14FA5C2F52FBF146B2BDAC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpF08D9421B64A90FAC63AB17ADDF31305" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{7705976D-48CF-4D4C-B36D-02274A609654}">
+                <File Id="filD724A7247C57E645E105856D43A535D6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background.png" />
+            </Component>
+            <Component Id="cmpD45645C908016D47C0954E939DE45B92" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{ADB46552-4C9F-444C-A597-6C0AFD0D81A2}">
+                <File Id="filF9293A38FF869F08131E06F4D8EC2A67" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background@2x.png" />
+            </Component>
+            <Component Id="cmp3299C583164886EEE164318A71CEF78E" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{283CBC1B-86AB-403E-B089-4DFBD265AE8C}">
+                <File Id="fil1B3817A61B54887122215046AC66EC5E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-background@3x.png" />
+            </Component>
+            <Component Id="cmp0593D3B46572B88352B98EFA253FC13A" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{B90511F4-99BA-4F4E-A2F9-B77D6C5266ED}">
+                <File Id="fil7850D1EA75D1878ADB09E8268D29614C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-disabled.png" />
+            </Component>
+            <Component Id="cmp2A075CB4E094FF2B1FCA9295ECF2EC95" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{2DC517DF-F4E6-461A-B049-DCA1BDDDF88E}">
+                <File Id="fil8B021E3C391A87B54B02E4E743BE2B24" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-disabled@2x.png" />
+            </Component>
+            <Component Id="cmpC8264EF9C4CE0DBBF43542E802D85A6B" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{22FF2A65-1E76-45A7-8557-0ED212F637D6}">
+                <File Id="filBA238DCEE3396627A1B62915A1A6BB46" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp3A333D5AD99BCF94F0C651F4557B5082" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{5C6718BE-E3D1-43E6-87AD-74949EA1E145}">
+                <File Id="fil41A56E6C704D9E41D8D3B175D5119DD5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-focused.png" />
+            </Component>
+            <Component Id="cmp1205F8DDE72F06FD391CCA208ADE4704" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{88EA4DB8-F092-4001-AB57-B9E54C8CEF2B}">
+                <File Id="fil610F8B4A9065665ED3C61F4920390F4C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-focused@2x.png" />
+            </Component>
+            <Component Id="cmp0622C5AF7200E0678F65ED82C578720B" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{0B4DBF75-1F07-48C2-857C-BC7920094183}">
+                <File Id="fil9960C7A6E241A53BD92D82AAEADDA8CA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-focused@3x.png" />
+            </Component>
+            <Component Id="cmp729E48799E3EE3CCA67F65180F904955" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{446AC654-C3BE-49FC-A5AF-B2F628D34127}">
+                <File Id="fil118D137837457D67FE0329F447F2AD5C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-hovered-open.png" />
+            </Component>
+            <Component Id="cmp1E9DA0AD9E148810A2A38C6DE8681A71" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{7AC1239D-5624-403A-92A4-C062969C3C43}">
+                <File Id="filF4B854609FF560336D1F292B48797AED" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-hovered-open@2x.png" />
+            </Component>
+            <Component Id="cmp868DB35629607051330788879F9B1D4A" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{3281247C-2631-4F41-A72D-0DEB16253C79}">
+                <File Id="filCA48C0E2BED16E83032ADC87A30DF99F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-hovered-open@3x.png" />
+            </Component>
+            <Component Id="cmpE9270F4926B7D4CD21694A74A79CD3AF" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{F6ED2F5D-1BB1-4AE0-87D5-78A596213097}">
+                <File Id="fil944B2F855F58D7E8BA1EEB05046A6E87" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-hovered.png" />
+            </Component>
+            <Component Id="cmp37266D9682666E5A1C07ED3F7198F10C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{9410CE65-6330-4B86-949F-61B56A8644B9}">
+                <File Id="filC3845A1D7EB8FAA8603B336138176CAD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpDDC2E00A8EA457CF7B507FA3B776929A" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{B2BB4BB6-D28D-4AF4-9CA5-D3CD6113DEAF}">
+                <File Id="fil2FCB2D2DD7786E943CDD39F6F7C2EE64" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpD9F74ED075E99BDDACE46BC4E4CC93F8" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{5C86804A-077D-43E3-93B9-6A620A9C30EE}">
+                <File Id="filE04D8B4FE6D562E687312A33BDDE68DD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-open-pressed.png" />
+            </Component>
+            <Component Id="cmpA17C6D2780258AECBA53127A66733A26" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{A3B85EE7-7782-4C1B-80A1-491ABC2DE085}">
+                <File Id="filD1CCEF162ECF6C5ED809CE09726DFF3F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-open-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp9F6B196964A7C380139AA0A2CFFEB187" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{2AB284FD-57C1-4C5C-B4DD-5CB9FA263E8F}">
+                <File Id="fil2AACC27FE9C55EC805F808D6E1B86A2A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-open-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp0A9F426B3925047FD9DCD6C3BB134E15" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{E9ACFD2C-AFAF-470F-9E90-5D26696788C8}">
+                <File Id="fil4E765F11C4AD218BC6B77A0BAEE9D16A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-open.png" />
+            </Component>
+            <Component Id="cmp82D915804AC2FDB4E851C070FC5D0017" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{8EB3AA73-6C4F-4DB4-90BD-0A5A1229F5B6}">
+                <File Id="fil286D823FE73F9EE715752A5CEB44D893" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-open@2x.png" />
+            </Component>
+            <Component Id="cmpEB9DD804ED37524A9C34F6BC22C0FF96" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{F8421710-F11B-4C74-A694-D95C42BE2960}">
+                <File Id="fil0E2853143E56341031E1304794F186A1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-open@3x.png" />
+            </Component>
+            <Component Id="cmpE7615C9200750E08CFF9913884C331B5" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{FDDF1444-52F7-458C-B3B2-E6431B083976}">
+                <File Id="fil367E8F4E1B56E8152FFDF3E8C80C542E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-pressed.png" />
+            </Component>
+            <Component Id="cmp459A5E97350322D0FBFA6B9BE1B360EA" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{5325733E-FEC0-47E8-8C77-3C7E7DE6D8A4}">
+                <File Id="fil562A03CAAB1C7B8338F3D0D41E6BCF81" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpD8E57F7535034D40732562FD3BE661E1" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{1C0D6448-56D3-41D4-9CF4-9BF09BF6B137}">
+                <File Id="filC426DE88BD133BC28AF99B0CC32F1BA7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp913DCE0ADD1A07E3C49B9A8100B772CC" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{21D870F4-4FC5-46E5-90AA-53B58A94A7E1}">
+                <File Id="fil321D25A6540F7B3483F55F8ABC9D61E6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator.png" />
+            </Component>
+            <Component Id="cmpEB80488DC1A2A33E73C5FC664087E51A" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{FD6E9C90-734E-480A-B65B-C7AB045F1C57}">
+                <File Id="fil8660BE7976966BD5128B910ABAF5F45B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator@2x.png" />
+            </Component>
+            <Component Id="cmp6C01059487DCB308E196D8452FA03B01" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{D7014166-C391-40C3-8BA6-CA974E5B99FF}">
+                <File Id="filD169A846F68D6D64631AF805340AA178" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\combobox-indicator@3x.png" />
+            </Component>
+            <Component Id="cmpBF330BC7C4C7EBA6EA4D0D363F82AC77" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{26FA4242-9BFC-42A7-8E7B-F12EBDB2E5E9}">
+                <File Id="fil2FDE03BE837A297D17A956BE18E804CA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-background-hovered-open.png" />
+            </Component>
+            <Component Id="cmp26C4499F0BC29041206F042AEDD619B7" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{25BF8DD3-2A90-48A0-B0F9-3AFDFA2CAC56}">
+                <File Id="fil7AF0D9EAB67A05EC6CF690C033251FF3" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-background-hovered-open@2x.png" />
+            </Component>
+            <Component Id="cmp0BD25EDF358CB6428DF04DA7874684EA" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{1DCD1F83-DD37-4205-A65F-3580D8208EB3}">
+                <File Id="fil5EA85133115EBAE548BE119ECCDABBA4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-background-hovered-open@3x.png" />
+            </Component>
+            <Component Id="cmp5AA3030468E022A16112DBB053E75E61" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{249CC691-0E5D-4B66-AAF4-A29030A54910}">
+                <File Id="fil3638901EF46B4E84434A7F5E29D26A00" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-background-open-pressed.png" />
+            </Component>
+            <Component Id="cmp8D2559BF3782018E5DDE1DF0D6F38E87" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{70B1FBA2-8269-4CD8-9939-97E192B1451D}">
+                <File Id="filF4FD64E911CC1D584074A15BDBE689DA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-background-open-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp2F2E213D87BA9B5F234C339393BB9196" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{5C4A06D8-3816-4C26-A8D0-0437821CEAC2}">
+                <File Id="fil4A25E27EF51D350653EC11B66BE5AD4B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-background-open-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpA403A1D842C40990F7DD729718CF01F1" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{284F6304-0108-4E6C-9CE9-456CCF0838CD}">
+                <File Id="fil1D38D01243E800AA4F5510DDC6086B32" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-background-open.png" />
+            </Component>
+            <Component Id="cmp619C340E39B021C2398DD759BB2F2750" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{E20030B4-FFC8-4928-9B2B-19912954B768}">
+                <File Id="filDAB8623E900D4182BD33FC0AA345A6E2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-background-open@2x.png" />
+            </Component>
+            <Component Id="cmpE92F8E0ABA9F17499958C14BF05117DB" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{8A34B9D5-8342-4A0A-827C-CC8C2910CF0D}">
+                <File Id="fil2AB9AF27788F1E39300F49D32C3D93CD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-background-open@3x.png" />
+            </Component>
+            <Component Id="cmpEDBB1ED7F29AD591FE7A8A3E9B4A7EA5" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{01C5EFED-0D37-47E4-AB32-7D554986B4E7}">
+                <File Id="filF28AA6E94FFCBB999D84717308BF7237" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-indicator-hovered-open.png" />
+            </Component>
+            <Component Id="cmpD1E234688002465C1D2506BBF3E48C19" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{A67690C0-C798-4E8A-A048-2661DB4A22D4}">
+                <File Id="filC88B9B13831E25238B73C135F8F724D1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-indicator-hovered-open@2x.png" />
+            </Component>
+            <Component Id="cmp5114FA69EF39D88163782B2622E3ED39" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{EDD4F451-DC46-439C-A894-B7DE41F32DF6}">
+                <File Id="fil0226BAF7E545DD45F078341D1DAF1CD7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-indicator-hovered-open@3x.png" />
+            </Component>
+            <Component Id="cmp5DE96F626119F38514F0EFF7C587F139" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{534D2AE5-74E8-416C-B5C9-A272CB704E78}">
+                <File Id="fil245FCA40A0D718B470EB0B2C71E9076E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-indicator-open-pressed.png" />
+            </Component>
+            <Component Id="cmp725287BC85FCE71C32A8A0EA3BF603E7" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{60D4A3F9-4251-40A4-83BF-2CDE1F18BC0E}">
+                <File Id="filF4E7448A989B47DE746394DDC9385417" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-indicator-open-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpD4ED98F862E2AE14A0DD05F547D2D193" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{79DBCB7F-8EA5-4F9F-A569-34802A87EAAB}">
+                <File Id="fil734CF477BC59101E30BF9060E6273654" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-indicator-open-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp40C6DC2EEB369F26C22650385885D94D" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{C2651945-06B5-4188-9131-CD831C68A2BA}">
+                <File Id="filFFB773F276EC619A6FE352BE595F83C6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-indicator-open.png" />
+            </Component>
+            <Component Id="cmp258EBBC9B8204D2502D2E5BFCB7A0441" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{B24043E2-E47A-4EB9-A2E9-86C3AD363D14}">
+                <File Id="fil35B67742BA696F678D5EAAF842C68D33" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-indicator-open@2x.png" />
+            </Component>
+            <Component Id="cmpC7E76E2716C48DA3647B198433A671FF" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{5C3A49E1-02C2-47EF-9428-CC1FF0929852}">
+                <File Id="fil4F7F0C20D3F28916962641FF89B6B94A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-indicator-open@3x.png" />
+            </Component>
+            <Component Id="cmpABAEB5D51011EF92AFD1F57E10721B9C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{1142EAB7-1773-45BD-89CF-6EF86A512441}">
+                <File Id="fil9AAD491F40EBC5A6B84F8DC1E5D7EC53" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-popup-background-hovered-open.png" />
+            </Component>
+            <Component Id="cmpE58F9627D4190EE5C4DEF899BC21CA0B" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{02A8C6FC-AF91-4D2C-BE80-7F85B0136FC8}">
+                <File Id="fil9D63176B09E2C6224DAD3ABC4988DC94" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-popup-background-hovered-open@2x.png" />
+            </Component>
+            <Component Id="cmp4CE477F271A6C6126DEF0694FE339C4B" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{674D959B-9C50-478A-94D5-D009E7AE7574}">
+                <File Id="fil62E25869C06F055A87C0E8DA7F2923D7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-popup-background-hovered-open@3x.png" />
+            </Component>
+            <Component Id="cmpBAD12E3C00C7F20D54D9837C38321556" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{3F71259E-7557-4C1D-918D-439614C28317}">
+                <File Id="fil9E781AB959FA2322537EBA5F8C556684" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-popup-background-open-pressed.png" />
+            </Component>
+            <Component Id="cmp9AF0146A75A179E66A24F71E709732C8" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{7BDBF3DE-6E71-4006-AD22-130AECD875B4}">
+                <File Id="fil32D93A717A9E00536FA3452AE072A35A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-popup-background-open-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp927FD1FB5D00AAD622F68285E9D69362" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{195F284D-8C12-486F-B051-1B74D9C3F5BD}">
+                <File Id="fil6ADBABB576B1C7C62596DCF77FA5B802" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-popup-background-open-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpE7AB64C1F5CE92B9B5CA3D1B8F7CF7B3" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{3C15BD12-66EF-4A6A-9832-5915C7B89710}">
+                <File Id="filFED4351F2970120F8918AD8DF1A5828D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-popup-background-open.png" />
+            </Component>
+            <Component Id="cmp93B3A0E52FD73C6365FE39875121AAD8" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{173D8D16-257E-46EC-99E8-E1E7566AD3BE}">
+                <File Id="fil43D7E83914D9B710B6B460A8B8B42901" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-popup-background-open@2x.png" />
+            </Component>
+            <Component Id="cmpE257C54DCCE460E400BDC1388FB88716" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{4DB4201C-545B-4464-AAA6-B6ABCF93E2DA}">
+                <File Id="fil2F65AF9A238AC6945A1E927E533E19E0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\editablecombobox-popup-background-open@3x.png" />
+            </Component>
+            <Component Id="cmpB1C8BB0FB8D9147EA6E6CF2713C0B584" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{217AE239-EF92-4F3E-9844-58AF5BC28169}">
+                <File Id="fil7F4F20CFD343C83861BC17C4E6E91865" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\frame-background-disabled.png" />
+            </Component>
+            <Component Id="cmpD9E4D6D41A575D9EEDF0D2F19A03E76A" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{AC6C8661-FF78-4AAD-B1FA-CD023077DC85}">
+                <File Id="filB3670C170E42C83EF33DD1110B3C7B9F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\frame-background-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp4BC3FF1D46FCF61C1555B946042E0F46" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{481AC9AB-BBD2-4FFC-81BC-8000FB60BE76}">
+                <File Id="filF223F6B036E87C8E42519F7DEB183654" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\frame-background-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp09E153F289E1ADAA85B195AAECAB37C0" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{B321FED7-9C65-4CB1-A8F8-D9A02FB29B91}">
+                <File Id="filF560697DE374DE85373D1CBF660E4FB0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\frame-background.png" />
+            </Component>
+            <Component Id="cmp04E41BD49FBD31FC395FE98DB87D724F" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{35F76F2F-68BD-4141-BE84-6BD1EC41DD6B}">
+                <File Id="fil78D4256288C7758C333E230895083859" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\frame-background@2x.png" />
+            </Component>
+            <Component Id="cmpCE347089DE3D5C1B091B7DBB20A8AAED" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{D44634D7-8BE3-4543-93B4-DFCC4E36A7EF}">
+                <File Id="fil38FCCF8AA384675AF181CCE88F6DA576" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\frame-background@3x.png" />
+            </Component>
+            <Component Id="cmp9C3CE30F80DADAB1BDEFD8CCD99FB142" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{FA29BFF5-8097-4211-AB99-988E34253E6F}">
+                <File Id="fil2D6F98C87086F0B3A43BB60F2718F12C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\itemdelegate-background-highlighted-hovered.png" />
+            </Component>
+            <Component Id="cmpA7AEB77768210E8D20F3BBDD9A767C13" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{FEFE951B-0861-420A-9809-8C89EAE19E49}">
+                <File Id="filCB197B4C7DB450426F7D7455A5D803CA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\itemdelegate-background-highlighted-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp2496B0A2F62DC28DB9BECA8CB5946EB6" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{03AB1195-6D26-4703-9B72-8783B32841DC}">
+                <File Id="fil87D67892E22E0CAD2D6BE4373AABB761" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\itemdelegate-background-highlighted-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp7878E8E4A175C90CB2D0D0460E25F408" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{B2657718-9879-44D3-98C2-13FD57E12273}">
+                <File Id="fil3E5F1945FBB22D26A737D63A34C3139C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\itemdelegate-background-highlighted-pressed.png" />
+            </Component>
+            <Component Id="cmp9F48287DDE734DE7DC71BF94A85BF94A" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{2A6279B5-2801-44F4-A1C8-5AACC57AF438}">
+                <File Id="fil1F419EB33D50CF6BFC975D2861816E1B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\itemdelegate-background-highlighted-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpF56E72E13EBDC2A97CF379241B39BB6D" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{C94BFB32-E840-4AE7-94DF-8C577AAAE899}">
+                <File Id="fil7230EF87E97449CD1A128938A0344FE2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\itemdelegate-background-highlighted-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpBC93705947568B80815CBAC29BFF395B" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{37E91274-8414-46C0-8E4C-E9E82CC921B1}">
+                <File Id="fil5E11A3D6FB02244111FE639A6EA10A7B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\itemdelegate-background-highlighted.png" />
+            </Component>
+            <Component Id="cmpE28DAC97C5F65C3202C5F3AFEFE6470B" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{A74F4F6D-73B1-45CB-ABEB-00576CB8129F}">
+                <File Id="fil3BCA6C768842672AD7F16CED36AA1E94" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\itemdelegate-background-highlighted@2x.png" />
+            </Component>
+            <Component Id="cmp4C4637F92F2902455A264AEFEF922124" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{1D5069B5-A4BC-42A3-A126-2D0BBDA5CB14}">
+                <File Id="fil946B7A7BCE26274CA11FB14F5207DF14" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\itemdelegate-background-highlighted@3x.png" />
+            </Component>
+            <Component Id="cmp64082128100A9C6047787BE5B74AAD60" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{F4F3DDCE-F5C9-4F57-81C9-B62734211531}">
+                <File Id="filEB93F7B4B28698934B231228D5DA1EC3" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\itemdelegate-background-hovered.png" />
+            </Component>
+            <Component Id="cmpB8623BF5BB1D8EB59B473A3784B1594D" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{2D7A19A4-69F4-4E5D-BBA3-9D1F8A5572BF}">
+                <File Id="fil392061DFABCA55D8C49538CDD48B7726" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\itemdelegate-background-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpC8A68688A765ADB70CA87E7D663CA3DE" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{7D0C78D9-E408-4ECA-BF9A-A5A4761912A6}">
+                <File Id="filBE83C6539190001450209F1FCE0256C1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\itemdelegate-background-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpB34CBFCFBE662BECDC2EAFBEE2ECD579" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{04BB53F2-D98A-4568-9632-76AD398D67B9}">
+                <File Id="filAEB34EE24B77C2BF01F3723296A9D000" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\itemdelegate-background-pressed.png" />
+            </Component>
+            <Component Id="cmp260EEB22A29C1C9C25186F91E1DF3E06" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{B613086F-17DF-429B-A1DF-EB3C734C002D}">
+                <File Id="fil04F85B004848C35F39EB444E6DB5B564" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\itemdelegate-background-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp0E365E479FCE4980884CB0BCC81ECE92" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{F1D45CBB-A82B-4FE3-B41D-7D6EF16599FB}">
+                <File Id="filDB7C0006F957AB34F7C029E4D731E07A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\itemdelegate-background-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpFC6A95B011647882B4B1EE7E2B1EDC01" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{2673D92E-C5FC-4A6E-B29A-253CA243B6A3}">
+                <File Id="filA9153DBB25D9E5D9E730E6D5EDF8817B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-delegate-current-hovered.png" />
+            </Component>
+            <Component Id="cmp227D0013242AEECB4B9F5E616B923185" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{AFACCF08-B0A3-43AE-AE06-9A8BE077366D}">
+                <File Id="fil8DADDE3F02446EABCFB6583C28B471EE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-delegate-current-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp3625F2CC21BD626C02FD818F98FE8629" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{F2D15EDB-F1ED-479B-8521-4A611A23FF1C}">
+                <File Id="fil3A9120EEC87C73BF10E0620F0F5BE751" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-delegate-current-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpFF58355B5BCA0B83C7A4EFE74062C308" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{62AE1860-95DE-49A0-9AF5-A1951DFC7C0E}">
+                <File Id="fil9D48CF3F741AB34AEBAB965435561C5E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-delegate-current-pressed.png" />
+            </Component>
+            <Component Id="cmpBAC2AA109568BEC9D9085FC08C620AAE" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{B417D61C-38F9-47F9-A185-472E4A3BDD6D}">
+                <File Id="filA8A7FCE6CC1CCBFD79C71ADB72CFCC18" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-delegate-current-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp7A3CF3E124BD5DD9B39C827AE372FF11" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{8A83C2A1-C190-4909-B447-15703B311A7F}">
+                <File Id="filD21B336A6171D1CAEDFDEA23C995D1CD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-delegate-current-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp0EAE9C15BEE119316F969577F025EFD7" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{61EA1055-F44C-407F-BF24-C78645AA2BCF}">
+                <File Id="fil1842ADB5F323B9AD0792D4B015CCE370" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-delegate-current.png" />
+            </Component>
+            <Component Id="cmpEEC527BDD5D10F0AA61D7F5D52102134" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{2672BC4A-5B5E-402A-B258-40B3AE4BA17E}">
+                <File Id="filAD7CDCA7069373AE8BD1963278BA8E8F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-delegate-current@2x.png" />
+            </Component>
+            <Component Id="cmp13588E3370C460C14FE52E7163B9451B" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{6AB953EE-D600-4360-8318-DEC4BCC38714}">
+                <File Id="filE6023FB36F17DDC8CA26E43E83F29FD9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-delegate-current@3x.png" />
+            </Component>
+            <Component Id="cmp75E4749166E25E2CB401CE538E4EAE0C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{89F93600-A51B-474A-932E-1A1D8E934D82}">
+                <File Id="filE9DB57A061C2828AFD9C12EEB167B651" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-delegate-pressed.png" />
+            </Component>
+            <Component Id="cmp08F42DBFECDDD10264D060550E5CCB2C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{06B0E7A0-E939-498A-981B-33877E9CFF57}">
+                <File Id="fil9181127572C188AA959EB3815FEA1A48" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-delegate-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp88BAF8F710E829D01AB8A061765C4853" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{4E46FF72-DEBF-487C-B4D3-E9C86F1A3024}">
+                <File Id="filE1208A2693EE480B26B9D70744F0649B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-delegate-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpA0216E783D01D4ADF9D854AA1352121C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{BF1A5132-3FCD-48A1-BF2B-0D6ADD295D18}">
+                <File Id="filA4B0D1EA57689847FA480E6451DBE94C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-disabled.png" />
+            </Component>
+            <Component Id="cmp369A5BCFC78989321ECCF2F23A367591" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{DFA0826D-5ACD-44CA-9FA5-DB90AD5AEE9A}">
+                <File Id="filE620B0CC8C5809428AE00BE5C60DDAFC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-disabled@2x.png" />
+            </Component>
+            <Component Id="cmpE923659A939143B8FC1F0FBB2D82F604" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{4A8EA513-80B9-4C28-B974-A9F33A086E29}">
+                <File Id="fil1FEE0663247763E7DD569D0069224A4D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp7F8DCA313F4E66AAB8EE70AE48196E8B" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{2BD92440-62C1-4DAA-AA2C-CD881E9030E0}">
+                <File Id="fil1AC384A006D1072B50BA4575CF71A795" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-hovered.png" />
+            </Component>
+            <Component Id="cmp540F8F86999A9DFCC87679FC5AFEF39C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{6935909C-3477-4860-87C6-26D13B927D6A}">
+                <File Id="filDEDBA380D3EC285932F1CD4E242F3D6B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpDED1BE30FF1696E927D92DEC68F3D4FB" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{D0404D9C-BD0E-4B49-B335-51B6FAB44154}">
+                <File Id="fil8C0A3133F844AD9C51965D1610E96CBC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpF974BA2D6FC85200C094183DC7EF8089" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{5906E967-9128-4E70-AA2A-F0DAB94748CA}">
+                <File Id="fil4CC6EFF8219BB98FE72562B8007C3435" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator.png" />
+            </Component>
+            <Component Id="cmp90FC9D73BCFBF4F9D2DA3D38AE2BC7D5" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{7371F840-A297-4CB8-A6B1-128A779BBB17}">
+                <File Id="fil678E3BE216FC0069F8DBDF7D2B7F9198" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator@2x.png" />
+            </Component>
+            <Component Id="cmpFD16216FDF70BDA2F7819DD43E8C5421" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{B2DBD143-E787-4E08-AF1D-FB8B2CB969F0}">
+                <File Id="fil8345CC2CFECD9F2C70A21DD7D4E954E2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\pageindicatordelegate-indicator@3x.png" />
+            </Component>
+            <Component Id="cmp001DB5977A6EA2849A1325E1EA3A3D66" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{0BB4CEFC-D981-4473-8972-C969595386E9}">
+                <File Id="fil8A678AE34C028669487A045B1D3577F5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\popup-background.png" />
+            </Component>
+            <Component Id="cmp6595F8D997244ECF20D62418FB6A2A1A" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{86854290-903C-404D-BCAA-A72E51D90734}">
+                <File Id="fil4D4D3ADDEBCB883AB502AC21065DD014" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\popup-background@2x.png" />
+            </Component>
+            <Component Id="cmp206413D1227964ACDA532BF47F664FFD" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{C18FF8C6-0A0D-4292-97FC-8E3ADCA1C94E}">
+                <File Id="filE8968A560CF165CA1B418394386E5696" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\popup-background@3x.png" />
+            </Component>
+            <Component Id="cmp575FA2D7C6F79A5363B5BD96E0BF8004" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{52F606E4-E935-4E8E-B0CB-2387AC9B87AF}">
+                <File Id="fil9367497245E7A73CAF1E47390A59CFF0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\progressbar-groove-disabled.png" />
+            </Component>
+            <Component Id="cmpD2949F75AC106406CA4DCFE513F50608" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{64600147-D5EB-4755-B857-E938184A7904}">
+                <File Id="fil3D0471389BE1382ECD82405B01734DFD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\progressbar-groove-disabled@2x.png" />
+            </Component>
+            <Component Id="cmpBBCEEC0195A2CFC8C2EAF1B31541FF4B" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{1A308D66-7150-47EF-99DB-E20B0253A974}">
+                <File Id="fil3DF78E2C50C24FD224D3BC35C869F8E8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\progressbar-groove-disabled@3x.png" />
+            </Component>
+            <Component Id="cmpDAE2BBE6EC2ABECBA2A7BEC34ED4EC40" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{1BB47B40-9CBA-4DD8-8029-B061BEC597C1}">
+                <File Id="fil8C3040A3A9A6BA5CC4B57AC62984FA85" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\progressbar-groove.png" />
+            </Component>
+            <Component Id="cmpE7DE9EA284C1FDE59A12CF4F9FDB61F7" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{5A25125A-7CFD-4C6E-B28A-69791E1C6555}">
+                <File Id="fil99F1DCDE69D9D20DFB7D8997E1DAAD32" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\progressbar-groove@2x.png" />
+            </Component>
+            <Component Id="cmpDF69E7F5AD4452C90C95C385226366B6" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{54382B5D-BD18-4E19-B669-E8FA380143E5}">
+                <File Id="fil7B5227F8EBDCBB244003390EB230AA44" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\progressbar-groove@3x.png" />
+            </Component>
+            <Component Id="cmpAF75F14808A91927EFE293927496F387" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{5ADF31FA-7F62-45C9-9034-A48F6745EDA4}">
+                <File Id="fil352452EA615BB05FB634D822631686AF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-checked-disabled.png" />
+            </Component>
+            <Component Id="cmp2E327D258876C78D4150154BDF87A676" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{7F278A55-DBE0-46EA-92AC-1F708D2EAB0C}">
+                <File Id="fil0283057D99F12FEEFB691604D16038C0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-checked-disabled@2x.png" />
+            </Component>
+            <Component Id="cmpF737C43193D6EE60289227B7B062BDFF" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{4AB7ABA2-4E9B-4906-B1E3-E1744C601CBF}">
+                <File Id="filB74ED56C0234CCC104573271CC2BDB9C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-checked-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp7DD31E40D0191E5752C0A71CC0979C0D" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{54C5DD4B-C358-4FC9-B340-865D34FD78A4}">
+                <File Id="fil28A74E7ED13973D3CA9D499A7F8969A7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-checked-hovered.png" />
+            </Component>
+            <Component Id="cmpA0CFA29C162D405F48E7C3FC70E79CAA" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{9FD73D69-3644-4DC2-BC2A-0CB68FE01607}">
+                <File Id="fil823575DBBF6C87B6554EEA0F9DFF331A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-checked-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp31A98701662F6F983AC28A12C93458FE" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{B82284DD-96C8-4FDC-8800-40E1123A1AE6}">
+                <File Id="filC8C7F77EEDB5B7DBD343D2133C5CA1DC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-checked-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp3D6264E93A17CBA3E83B85816F31D1E7" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{0374175F-9736-4B91-92AE-E98DCFC07BBB}">
+                <File Id="fil3CDDCDA60FC39E2064A767E02AF5F206" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-checked-pressed.png" />
+            </Component>
+            <Component Id="cmpF011BE96DB49F35E593C0783717BE649" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{5309B497-EFC3-4D33-A36A-D37226BE9CFA}">
+                <File Id="filD06EBE4A7716E481BA3B137269F5EAAF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-checked-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp70E45CD253E41635BC89577D4B7EEF14" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{40F0ACA1-C2EE-40CE-86B6-15A65AB41D9A}">
+                <File Id="fil83F2DCBC4C20A469ACD58AE29C941A83" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-checked-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp81D11858E0A46F954E26840C35FCF4B2" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{5E948CC1-D833-4BBC-9900-FB7B5CB1DE19}">
+                <File Id="fil133CD3034B97E7AC41F2106BE0E95810" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-checked.png" />
+            </Component>
+            <Component Id="cmp020459DC9F172B712DF46551635EFBEB" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{B8D6E958-96C5-4239-AD6B-BF903ACCECD5}">
+                <File Id="fil66E35B4E301A20982988E7CA7DE71227" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-checked@2x.png" />
+            </Component>
+            <Component Id="cmp3C7F061300D0105DCE1E85A2EE0071CE" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{9D6A737C-3A95-4FAC-89C1-FD465577CED9}">
+                <File Id="fil6117B3488DE0B0D82FBD4FE089FBEF0F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-checked@3x.png" />
+            </Component>
+            <Component Id="cmp8041E94D11E3ADE69CD60250C1EB59A0" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{9E0862EF-350E-495D-A8D5-6C1B0C0CD1CC}">
+                <File Id="filF6ABA5F853576429361A2A08BA5F9459" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-disabled.png" />
+            </Component>
+            <Component Id="cmp78586C7DA16DF4EC858EC2C6AD99499F" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{51183D79-929E-4A74-B3D4-A384CF9357D0}">
+                <File Id="filC05EAFC57BADFF50674256B76E5891E8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp6A1398AA9DA1BDE52DEBB0E76ECA216B" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{2A5E6F6A-2FE8-442F-A29F-465F0D6A7579}">
+                <File Id="fil5FDA1843EC99EBDACBC028501BF72B3D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-disabled@3x.png" />
+            </Component>
+            <Component Id="cmpFBC3B4145488B853B71AA1B21E9D0C84" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{223B1AE1-5008-42A5-A3CE-7C021B381574}">
+                <File Id="fil3AD9AB10D22D796F175A1129A70CC2D1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-hovered.png" />
+            </Component>
+            <Component Id="cmp491933FE81E20DBF96D69E4F167264D7" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{E834889B-9E66-48B7-8AAA-B2E5B8CD6E2D}">
+                <File Id="fil0409C9D4663DA8C570B552C41FCCEAF9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp30170248A115AFAC7636171A46D6883E" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{C917EA03-95B0-4C89-A3B7-865B6CB86F10}">
+                <File Id="fil4147F6E86B47D6EA55723D17D557AC63" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp56AFC3FE219BC5F3A1CBFB66CB93E4A2" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{3E14CD5B-D5C9-4B43-B791-C7A9612BDC0C}">
+                <File Id="fil8810A70B08830DFF5621E8CC35C45F1A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-pressed.png" />
+            </Component>
+            <Component Id="cmpAA582E12307A49C8997B20ACB3BF068A" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{324077F5-2E0F-4B76-9517-8431604391AC}">
+                <File Id="fil3A41E61CEA1D7E7AC5CFADBCFEF5D343" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp868615A60CBF5F507DFEEAFD169698E5" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{4F7E150E-8F0E-4B81-B1D7-C7199D9BF1A5}">
+                <File Id="fil31A434A7993A2A651E21FC96B7EF8825" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp98D7A72C338F2590E488C79823AEE7F5" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{AAE9BC35-D8C7-4124-8643-903A146B3785}">
+                <File Id="fil5D8CAD075481F7844AD0575656D0FE2D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator.png" />
+            </Component>
+            <Component Id="cmpB9D7E7515B24CE13D53F3D800A532D47" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{483CA0AF-19FB-4358-A880-8B6BCB8338CD}">
+                <File Id="fil18D026FB38F7C3F1EF6E66FA54AD8196" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator@2x.png" />
+            </Component>
+            <Component Id="cmpF0E7023E13CB8A3DD471884262F94EB7" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{76239818-A0D4-45F4-A67D-EBB610BBFE0C}">
+                <File Id="fil5C91E6AD9A8CEC0436774D750A06AB5B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\radiobutton-indicator@3x.png" />
+            </Component>
+            <Component Id="cmp31D16236755D3481138FB1DCC32FC55C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{E4C1C9AC-18DB-42D9-BBD7-119D19176420}">
+                <File Id="fil28728BA7F62F346B1A254A616B104AA4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-first-handle-disabled.png" />
+            </Component>
+            <Component Id="cmp7AE4459D6A462BEC3089E5CC30518DBD" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{BAFFED4D-3D1A-4406-8B05-02BF724144BA}">
+                <File Id="filC6918D6EF618AF9B610E8C2927E04128" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-first-handle-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp462024A3A6649BE3638D13642A987D7A" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{3ACC7763-C09A-470D-8E6D-250A53EAE8E6}">
+                <File Id="fil06E2A95460AB8984F40CA918D57C3AE6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-first-handle-disabled@3x.png" />
+            </Component>
+            <Component Id="cmpAB40AC48C357F11E445566A0728ED146" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{B3AA13C9-DC73-401F-BF53-09BF96528B40}">
+                <File Id="fil43786224182A968EF2A3659DE17D5580" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-first-handle-handle-pressed.png" />
+            </Component>
+            <Component Id="cmp4821D18F3AE74DC318DC3C4D81D8F6C5" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{1FFD971A-2923-4591-A18B-147618238776}">
+                <File Id="fil7ACD527FEFAEFA8059CB701B122AFE62" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-first-handle-handle-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp9E2A18258F09C7BF4A6F257600395AFB" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{384ECC84-A57D-4E41-9B74-06498536E09F}">
+                <File Id="fil11099990CB60535BDCECC51CB2387403" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-first-handle-handle-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp32DBD4892B52F016727611D8AFF36746" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{E7CAD379-FE21-4064-B076-6E25B59EB57D}">
+                <File Id="fil6C5366B5D08EE4396D0361EADBC28E2B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-first-handle-hovered.png" />
+            </Component>
+            <Component Id="cmpAFDDAD51597AC7BC4B53868FFC97B87D" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{F2894C2E-CEE7-4240-9A3B-E5B8ED4086A6}">
+                <File Id="fil04A6E37FA3F60752F1349D72E1499D50" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-first-handle-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp67B230EB638ABD809F2CD7A4E803C7A3" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{BB4D272C-4C49-4192-9645-C69FFFCB1211}">
+                <File Id="fil78CDA1695A16C63D641C3FC079273024" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-first-handle-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpA5F130DDE5E529DB5BF1DD94700B5956" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{A8E358F4-1F28-43D2-B9C1-EFDBA48618B9}">
+                <File Id="filBD8FB6600E313AB41ED0B2DDEE82C301" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-first-handle.png" />
+            </Component>
+            <Component Id="cmp85B4113E018FEB67EE5BC894E54085F1" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{ADED2188-2D75-4DA0-85CF-1B4F717650B5}">
+                <File Id="fil4C62A4CA9C60749EB27B9341BCED522D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-first-handle@2x.png" />
+            </Component>
+            <Component Id="cmp69EC3CF9DCEFB354697289B168DF06EA" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{213FD2AE-0F57-40EB-846E-DE5616489D93}">
+                <File Id="fil878C45863896D8A411048638408795BF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-first-handle@3x.png" />
+            </Component>
+            <Component Id="cmpF16931AC36B22E6AAC0353CE5901EC98" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{CC8AB510-E68F-4BB7-B585-6672506D9D99}">
+                <File Id="fil04EF0B63A31AE275D51B7C473BA2AA44" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-groove-disabled.png" />
+            </Component>
+            <Component Id="cmp944558BFD3DB285D65E040A4009289E6" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{EE23F880-8948-479A-9E72-831579297F31}">
+                <File Id="filE3A584B5E1886013848C20B3E611DEFB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-groove-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp6BD37BCABA23D8D8F4D19DE845CBAC87" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{B9929CA7-4D8F-42EB-9544-3AAF5CA0B6B4}">
+                <File Id="filB14B7C5AB1F928EAACE4F0435B076550" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-groove-disabled@3x.png" />
+            </Component>
+            <Component Id="cmpF43AEA17995A8145B992BBD375E65D10" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{E440813E-077A-47DE-9221-CD94379133DD}">
+                <File Id="fil2D28BBC5F0F7776708681D50C72D33B5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-groove-handle-pressed.png" />
+            </Component>
+            <Component Id="cmp684ACC1C9AEA99B8E482440F0960D120" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{6B8E9E23-917B-4295-B745-25E17E7C71F7}">
+                <File Id="filD752660D36C7BABB38F1A90C75CF5EE8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-groove-handle-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp74EC66511E9A9450DAF5FDAF1323B97D" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{6AFC077E-E5C5-4881-A9C7-CE9B09BEABF7}">
+                <File Id="filD2C5773F147B0E0875004EEB83D4B021" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-groove-handle-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp90A8709795FC31907E11CC892C932F4C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{579310F2-4672-4E1E-8094-960735BBEC41}">
+                <File Id="fil935FD6C58E613E66D9E95156CFF56198" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-groove-hovered.png" />
+            </Component>
+            <Component Id="cmp7D5987B97B94C090C2A62AA81EEE7378" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{EB892F44-A64A-436E-A193-4995EF7B8E92}">
+                <File Id="filEEA68A54CEB04A65A4589610C38A2794" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-groove-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpE57ED60C72FC98EAFEEA29515656065D" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{DBEF2AD7-A52B-4EE7-82F1-0EB3495C954C}">
+                <File Id="fil2719A234DE909FB2C47F89CC9AFB1191" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-groove-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp4E45C2F2FE5C904879A0BC4D59EE3870" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{073EB30D-13DE-4F49-9C1F-5514DC275734}">
+                <File Id="fil925CDE0805EFEDD0C2CAF9BFEFF38229" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-groove.png" />
+            </Component>
+            <Component Id="cmp249096D8B4822A5905BF952A26226033" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{B18F30FD-A6E1-4F96-87AB-E3554495AB8B}">
+                <File Id="fil3EA19A8A33D8BEF3A9A7C17AF27E693B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-groove@2x.png" />
+            </Component>
+            <Component Id="cmp42480DDF2C3A9CC607443C816256DEF5" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{999A689E-7684-45F8-AE15-93437F8BDD7B}">
+                <File Id="fil9E8C31012D905FA943DFC4E33A6FF4A0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-groove@3x.png" />
+            </Component>
+            <Component Id="cmp894A07D119D15D875B72FA80DCE9BC8A" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{62356908-9555-427C-A966-55C43B08E046}">
+                <File Id="fil268CBC76BF5F7006C53A49292B1E47CD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-second-handle-disabled.png" />
+            </Component>
+            <Component Id="cmp9DA5F03CE617AA096299FB4EA561DBBA" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{BB9C47DB-4D40-43E1-80BA-4C22A991BDEF}">
+                <File Id="filA025E1982A3EE541C07248A761D635FC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-second-handle-disabled@2x.png" />
+            </Component>
+            <Component Id="cmpDE6932CDEDD61B2159ABC0B1EBDD509E" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{BB16439C-3A46-4960-A791-B04A2179A50B}">
+                <File Id="fil560BAFC3BF512DB28FBE4D2AEA1B936F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-second-handle-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp79C758817490C355C80181F5C5B8C2B2" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{9860D1E7-6C50-4E65-BF65-B85C6E34885D}">
+                <File Id="filBB74A6A34CE8AA8CFF782E28C7BA3ED5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-second-handle-handle-pressed.png" />
+            </Component>
+            <Component Id="cmp694C70990A5ED0AEDB45939F6BE07A46" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{0F3CA38C-EF51-4CB7-AA34-C7AB13B8BCC1}">
+                <File Id="fil0804BCD1416C77AE948EFC6C69737AB9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-second-handle-handle-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp128A76944D3B53BEA70D414FF9D699F7" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{BAB4FEF2-C03D-4CB4-B9F1-B477EE6D3D2B}">
+                <File Id="filE7A89A2925F7DCF83C7189DB50CD9EC1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-second-handle-handle-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpFB2E2B38EE61D26B0E0B5FD63C592F98" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{650EEF78-D341-4AD6-894A-43712F474947}">
+                <File Id="fil46A70C002C893842C3ED4BD6A9B42C2D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-second-handle-hovered.png" />
+            </Component>
+            <Component Id="cmpB1EC6AB5B981F2D2CA47379B8B3673C1" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{AB191734-7BA8-482D-9D10-1910274D179B}">
+                <File Id="filB063C2D40BDD09729426F125F47353A4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-second-handle-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp34C669EDC43C036A1CD078953263FA9C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{73C0C7D2-667E-49B8-87B8-A84019B4D601}">
+                <File Id="fil85AAF6F764A790E6CC119067196B4DDA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-second-handle-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp2077C7CFDA4E92083B0410A37E78FC87" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{2601934A-280A-453C-A3FF-C16996E9D821}">
+                <File Id="fil57414B139956E3BC8D6B58CE57EC6CBC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-second-handle.png" />
+            </Component>
+            <Component Id="cmpB67C5034282C61543B6085FAA1F3D904" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{5F8281B1-96A8-477A-950D-CE0BA0C15505}">
+                <File Id="filF65D55A20CBB12188B9B100C2F6C5C7D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-second-handle@2x.png" />
+            </Component>
+            <Component Id="cmp715B236FE0FDCC7E4EC38C12CC98BB47" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{122F4E49-23D4-4DA0-B9FE-02CB2252226B}">
+                <File Id="filFFCE33D488C5BCEF9F3B81CA4B69A97A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\rangeslider-second-handle@3x.png" />
+            </Component>
+            <Component Id="cmp89BE99E4F93ED8E733A069E7C4DAF06C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{13C59014-9CCC-4CCF-93DB-E577BE564254}">
+                <File Id="fil25C102DC48CF9E07F6A7B00AB8BAB932" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-groove-disabled.png" />
+            </Component>
+            <Component Id="cmp0D2069C8023687B93039C87FDDECBFB1" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{40D08AC6-E965-482D-A0B2-399A305C6E38}">
+                <File Id="filAF9C508DCE5551C509C085FB05B3E397" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-groove-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp5BE9DA91C787D49EEDA003CB07AC4B01" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{F5B734D7-E593-4914-BFBA-C037CF0DF0C5}">
+                <File Id="filB69A872340937932BE568A935F6E3189" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-groove-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp931210B12E72E9B817C7EDF3303C5AAA" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{955073E7-4ABC-4650-A9F5-1D425ED5CB56}">
+                <File Id="fil328B95FD1FF378564C871CAB7548E67E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-groove-hovered.png" />
+            </Component>
+            <Component Id="cmpC0DBE56492C4592A0288C016BDFEE643" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{5B8D2757-B8F4-4CFE-9B5B-509E1AD7C7CF}">
+                <File Id="fil1A8D73FFA737DC15FF0ED6A27ED4785A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-groove-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp39D5388278DF655CD1A628086EABF5EC" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{93A03E18-BC58-4234-BFB6-85FA21B56AFC}">
+                <File Id="filE03CA4221DA483C31136855CC4E3F227" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-groove-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp9FE8883A52E5E916757100EB83EBDA29" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{AD927813-B74F-42C7-A399-5A125B02ABE8}">
+                <File Id="filE48D23A3A11F823AC28C48711525C8D9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-groove-pressed.png" />
+            </Component>
+            <Component Id="cmp38C8D2FA2E8A3A077C0DE03A8038D011" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{F3293B83-97C4-4618-AC02-71AA6F6E691C}">
+                <File Id="fil55C6CA176ADDA58A838544E809FC71C7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-groove-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp94F86EEDF5B701DE19FF2C684E0D5CBD" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{EA13B109-358E-432B-A0C3-CC334A8E3864}">
+                <File Id="filE688D9F33A02778656247EA43650909F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-groove-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpC7B6BF83EC9C94451A579DB1EB43AF24" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{58E8E0C1-A9CF-4BED-A96E-500BBAFA0459}">
+                <File Id="fil98FD341467647967D681D7067CE26B8A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-groove.png" />
+            </Component>
+            <Component Id="cmp59EBCBE027762165F7792AD6F3979ED8" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{C8A1116B-8939-4EEA-A505-5327AC76A7FD}">
+                <File Id="fil4F475144A0E963A7F51854A3AFA10364" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-groove@2x.png" />
+            </Component>
+            <Component Id="cmpAB3CE7C3D325E3CE51D2E095302BA5B7" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{726F8E89-EA87-4D6D-9FAD-7C89D75B4753}">
+                <File Id="filED79AEBE8A728DC48381D9CCC408D731" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-groove@3x.png" />
+            </Component>
+            <Component Id="cmp2624E79830EBE64BD227D0E8F34AE327" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{5F082FA6-81E1-4849-8FA6-571988C8FD86}">
+                <File Id="fil598CACCC6E9DF7A644864FE8247E3109" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-handle-disabled.png" />
+            </Component>
+            <Component Id="cmp470C5F5A463FA9D5131A230F2893CB90" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{BA56770D-35E2-4FEF-803B-08D1A65C0E57}">
+                <File Id="fil050043F8894CF5A0863FC754BA5CD71E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-handle-disabled@2x.png" />
+            </Component>
+            <Component Id="cmpAD015BE2B5E41452C610537683DC3D56" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{D734BE18-876A-4F6F-ACD9-33F1C289E411}">
+                <File Id="fil687DDB2A7262495D919A857AB626E082" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-handle-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp85B87786B28D9199DDC9110C43C95E23" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{2A65D400-34EE-466D-8EA1-9B2AE212FDAC}">
+                <File Id="fil3FF11996B13E7F8C235F45C05A842488" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-handle-hovered.png" />
+            </Component>
+            <Component Id="cmpCECAA5B506E53845F9D93497E871A241" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{30D4F736-4C99-475A-9DD1-45D407E188E0}">
+                <File Id="filBFB1ED3865AB9F3BA89CBD6C85746E41" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-handle-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp957A0A2ECB8E90448D1729CC19680B3C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{2009F474-2290-4BF9-8D36-72873D5882A2}">
+                <File Id="filCF2D1F451FA495DAA821A0A3593D49BE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-handle-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpA8C2C7794837A0C38F9987CBA7D22778" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{042DF21F-628B-4FC3-AD21-218D5926473E}">
+                <File Id="filF735325DDE8E98CF69EB7F13756BACC6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-handle-pressed.png" />
+            </Component>
+            <Component Id="cmp103A85441D77FC983DBEFFA53946FC6E" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{629292CA-6740-4A19-B7E2-E074B98DE63E}">
+                <File Id="filE30CEDF558E7EBFC78AEC01C207FC626" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-handle-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp05D28D9F519027D1D6E56E43DDCC1C45" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{34009EAF-D4FC-4F5D-8CCE-F292059851F8}">
+                <File Id="fil22A8AB250DB83965395427BCE64E9122" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-handle-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpE75CE6D6D526C513692B7FE8031DEE0F" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{2050B3D1-DD1C-4877-AB7E-3664DA0218B6}">
+                <File Id="fil99CC9FCB8496C83EF58F45CE2DD4FBE6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-handle.png" />
+            </Component>
+            <Component Id="cmp3395AE3028B20D10AD97198AFECED416" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{F9EB5856-8FD5-4FCC-AA05-511F3BCE8DB5}">
+                <File Id="filD7CD9674AB6001E8D8C31723847D87A2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-handle@2x.png" />
+            </Component>
+            <Component Id="cmp15EDCA58CBA3F0578EE5A810F9E65049" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{0C906EDB-B157-47DD-96DF-12D3F1C050DC}">
+                <File Id="fil38836EAA113B4B7C4EDC3623041C0020" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\slider-handle@3x.png" />
+            </Component>
+            <Component Id="cmp580B2042B2D2B7A1157A86BC80724A07" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{14186D44-9441-4465-BB66-D375E0AD4EFE}">
+                <File Id="fil0566D42C1C7049FAFF4183F1DA73FAF0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-atlimit.png" />
+            </Component>
+            <Component Id="cmp46FC792AA4F5F06253D4FC17AF08566D" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{572897C6-AA55-4CEF-988D-FBB2594230A4}">
+                <File Id="fil46447F1C8FE79BBFBA6E28EF6A600FDD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-atlimit@2x.png" />
+            </Component>
+            <Component Id="cmpF15DBD5D96999E95F18EE9FB887FAC97" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{386E98BB-7AA6-498E-8CDE-283AD45D9C8B}">
+                <File Id="fil31E1DFAC8F3909FB4646D1A50C03F670" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-atlimit@3x.png" />
+            </Component>
+            <Component Id="cmp31939FF84A3D1074A26A57E13869FC08" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{CE0A9C58-8E0D-4B9C-A53C-52725DCF84C7}">
+                <File Id="filFDD630C2B0AAD55B6275AF4E9E295D92" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-disabled.png" />
+            </Component>
+            <Component Id="cmp8038611DF66AE331D32B116B34D7B2F1" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{2C7B92BE-4E0D-4D09-B67C-A56CD68C744E}">
+                <File Id="fil27C63C9F663B03BDB3973E5A00EB7326" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp92D2A312614D046D8D84DC920850D86F" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{DA8F1DC2-ACB6-4BEA-96BD-1F667454F182}">
+                <File Id="fil384980E59DEEFDE58174385835E09370" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp64E044A30A78419190DDDB88DA3E47C1" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{254734A3-2A02-4B6C-BC32-603D0696DA39}">
+                <File Id="fil0712CEEFB2D9C726AD1B7BCC97818B02" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-down-hovered.png" />
+            </Component>
+            <Component Id="cmp8D7D85AC41CBA47FDFB38BFE7B45E3E8" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{050F655D-6C4E-4D45-8DAC-CE0271E675EB}">
+                <File Id="filC3475F77F6F68324FF076481AC7AA2CA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-down-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp7A3CB534202DFCCC64AC3B86BF96EDD6" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{05F4A226-DF44-421B-986D-F6BA7C63EAF5}">
+                <File Id="fil38CA12AB43415EE8DBD965554C0C04C7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-down-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp43A0024A39C34277C9984F2465AA3A24" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{AC956615-6554-4A45-AD0D-DF39B2A343C3}">
+                <File Id="filE1D382DF6FDEF29C0467283BD242B522" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-down-pressed.png" />
+            </Component>
+            <Component Id="cmpD5207F5D25B4D06AB574AE9C3AEF422E" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{7C981DB3-33B2-4A81-A110-3A259496E735}">
+                <File Id="filD270F391AC986AD2B1221C1B71F3713C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-down-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp71009641112135DC51745EDBAF94485C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{1FEA04AA-C81C-430E-B50A-FDB11575FDC5}">
+                <File Id="fil131D68247FFB724A9C1E43F651A0BB25" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-down-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp5FD8D2D9543F0203CA29437E495BF810" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{8A8D0167-9F8D-4EF4-94E7-3A0EB155B5A2}">
+                <File Id="fil9E0CA400FC2FA99ED24AF5E192C570EB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-hovered.png" />
+            </Component>
+            <Component Id="cmp59A065A31A87EC513CF9F7FE68D6778A" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{3ED90158-7B1A-4A6D-854E-D3A85E08F41F}">
+                <File Id="filBEDAFCDCFE1B0CED153B59F93A52DEA2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpF627FEF9CFC0ACED23043640733DC60C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{C5ACEEB7-512E-4340-B9A0-A4E9A49A96B3}">
+                <File Id="filA53DF37AF5ADB0096BE60962CE13B394" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp18E89ACF3BCE5FFD2A2C4C8A9FD5507B" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{4D18690B-37FF-4D51-B441-8EB50E62FC55}">
+                <File Id="fil4BDCF09ECA17AC3129BE9FB6CA8C7737" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-up-hovered.png" />
+            </Component>
+            <Component Id="cmpF9A4163AD308EB9C6F9E92B287A50875" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{734F10B6-F8BA-4AFE-AB7A-1B201027A455}">
+                <File Id="filE9539C45F775C6F412EDCF8B976D8D94" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-up-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpF00E234E9FF7ADBE99787D4BD3ECF616" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{6BE3384D-8739-4E06-BB94-FE420F710390}">
+                <File Id="fil516FAEE61E31CA566A9E607097207C83" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-up-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp56C6A926983785B2644A3794F03FED4B" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{966F2A7D-B078-46A6-BF2F-112D5AF37491}">
+                <File Id="fil5DD4A137C42ACAFE852A20B1D08B10F9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-up-pressed.png" />
+            </Component>
+            <Component Id="cmp91A54B44689191B9FC084D58CE9F5917" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{1D10E751-07A6-4445-81FF-4039258438CA}">
+                <File Id="fil3003AF8A3ABF953B961E853CA12B70F5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-up-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpD771B5077765A55E7BDB04079AD95D6B" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{38D8E8CB-ED61-4F30-9076-31E2C05F115A}">
+                <File Id="filF44BAABBBC6602A7C21DDE11C92BC970" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background-up-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp38D8EBE377F143BF61CF9133D9815297" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{2527952D-0A9A-404F-B745-715FB953E11B}">
+                <File Id="filA7619277339F1B712D70B93CB1DC12B7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background.png" />
+            </Component>
+            <Component Id="cmp21CFF6C956A457718B06A0C6715D3B39" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{BB0E8DC0-E613-4BC1-AAA0-FE38BDD5BC81}">
+                <File Id="filA726558E8D877AF49A2529DBBE8F7EEE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background@2x.png" />
+            </Component>
+            <Component Id="cmp63D3A3AC458C62B1DC44C17B54ECACD8" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{800E370D-0A00-45A1-8CF9-85768A7DECCB}">
+                <File Id="fil6F2947F7E857D73DBDFE1C9AE5805039" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-background@3x.png" />
+            </Component>
+            <Component Id="cmpAA83D144077DF996E3C0FE4B2009A24A" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{253933F0-D500-4402-BF08-A81CAA6E35D3}">
+                <File Id="fil52DD1C61CA2797407C5FC6F5CA905524" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-atlimit.png" />
+            </Component>
+            <Component Id="cmp27500576ACCCCAF88965B6E19C3B827C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{00BA36B7-323E-4B18-9D49-046D5464D02E}">
+                <File Id="filBB5230FC9E6BDF789EE48D0A15DD4885" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-atlimit@2x.png" />
+            </Component>
+            <Component Id="cmpCBAEEA4D0615F8775B9C48DE64C9B706" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{F1DA65A6-7F11-4C41-8AC1-5651494CA121}">
+                <File Id="fil7A2856CFDEC823FABACE39204AD398FF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-atlimit@3x.png" />
+            </Component>
+            <Component Id="cmp2251B71B1A4159D777F865ABF683CBB9" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{85BE7620-B184-4479-B780-688E2BEA7F33}">
+                <File Id="fil11BD3DADF6D487EE4BF55928A3D4F65C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-disabled.png" />
+            </Component>
+            <Component Id="cmp931F895F425C977FC1C763FA70104EB6" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{288956AB-9335-4940-AE41-4D1E79D3D187}">
+                <File Id="filE3A2C410B2DD22E5231CF3FCC9083A9B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp713DF617A6203D258F2A8AD385CBFDF4" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{015EAE12-961F-4660-9A18-D78DF2157605}">
+                <File Id="fil0CBBAB2C580BD332BFD3FE7D738DE3F5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp6AD2D3057FCB1662E1C2EFB4665B8B18" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{A63654EB-67D2-4046-95BA-F30FF88A9919}">
+                <File Id="fil18FE7480A5FFD2590A8E8F857773D735" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-down-hovered.png" />
+            </Component>
+            <Component Id="cmpDD74131968A0BA699B01B7ACAA8724A3" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{8BF1D0A1-5F68-49E4-8250-D7D91D4BF0D5}">
+                <File Id="fil1A549CDBADDA0D44CC40B0BE44352479" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-down-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp7D021D42498A1788B42F140C8D330150" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{7536EB5A-1EA4-4CC8-8467-DAC889939BA2}">
+                <File Id="filA251DE482707E7DDDD158FF4BEF5F7F3" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-down-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpBD977AE6B41935E1EA6F4AB7C5426C78" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{07505E70-7B89-40F8-8907-5C45023BF909}">
+                <File Id="fil44B98A579E45636B33C35279E389B13C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-down-pressed.png" />
+            </Component>
+            <Component Id="cmpFD802F22D33F674BC7008327D442A7A0" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{2DF03ACF-DFCD-49DB-8E4F-8BB7A6FDA997}">
+                <File Id="filCDD3D4AC2205B8CC63ECAD705F2D6B49" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-down-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp64B9CC422D5E17F5A8EF2541B85C8194" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{23829D8B-EB8A-422D-B419-925F36176F58}">
+                <File Id="filA74447502ABD4593B58B8533AFF7B57C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-down-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp839A094865AB3C49CF1145A305C7359C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{9E84B4B8-FE4C-4E1B-AE82-860F6C70AD3C}">
+                <File Id="filDCCDFDD5DB72D5794C2EE949E6F04A7F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-hovered.png" />
+            </Component>
+            <Component Id="cmp3A65DB960E085F6D210F7546DA03039E" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{107E445B-791D-4946-B7A7-F142F15733B0}">
+                <File Id="fil92943531FC7551540CEA96C1A9F24053" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp45AAB85C958F99494205B435E84ED9A4" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{B3EBB3E7-AA7C-4CE6-9FEC-9840927F055F}">
+                <File Id="fil7FAFD9EEC5D1F6333874588134C0E3E2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpDAF6F7E4C6B5B9C305410ECF05025091" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{2D62AAF5-F298-4D38-84DA-7750772F5DF5}">
+                <File Id="filAAA6C16A4A40A5462BCC1BC0A216CDBB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-up-hovered.png" />
+            </Component>
+            <Component Id="cmp809D41F829240067C0072806C065602B" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{B04433F8-C7E9-4E75-986B-C265FF309C52}">
+                <File Id="filF44812094F2817E41369CF24D89AA6EF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-up-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp0FCEA69ADE2C5D6A980BD9814209C3C2" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{C78F4F8C-2E59-43DD-B364-68B60B8F1372}">
+                <File Id="filDCF6B80AA92DEDDA5966A8D86A1DF903" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-up-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpDF38EAF1B92E74BD75D5C81E13A8C1E0" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{83268E5E-97F9-499F-ACB9-CA22AFFFB84F}">
+                <File Id="filA76397784CA8E4B1464DA7E2840259EB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-up-pressed.png" />
+            </Component>
+            <Component Id="cmpCD2C0A85C5506FF30F10F78EA79AD56C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{0B890507-A76F-4922-A03F-E1C3E5E26C06}">
+                <File Id="fil820BF74C3E39ABE53B24114B39BE6A1F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-up-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp7A2ECBBC616E8AE9B59C52CEED331677" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{12786172-C09F-42BD-9B18-0176C53A98B8}">
+                <File Id="fil9F4AB13807735A723304235AECE485A4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background-up-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp2E39FE10693B20CC837240FABCBBFEEC" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{6C0D0772-A4E4-4E9D-B10F-6C7783AC6C8A}">
+                <File Id="fil95208D3113AF3C6FA12ABEF8A129774D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background.png" />
+            </Component>
+            <Component Id="cmpE7FABB53128059956962916CF8036868" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{C97ED837-B16D-499F-9306-A72BB5B41C61}">
+                <File Id="filB9BE9740F511405C93A2B44287815B32" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background@2x.png" />
+            </Component>
+            <Component Id="cmp0D5A40BE8354122A0642D2350D94715A" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{6D89C90B-1BE2-414A-BB8C-BF948D82C0B6}">
+                <File Id="fil1F1E68248D8801E0A1645F77E9F3707C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-background@3x.png" />
+            </Component>
+            <Component Id="cmp8494804C08B2DC45FC6A06E978A1FE42" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{91FF7640-843D-476F-9C3A-604AC243CE0B}">
+                <File Id="fil9E5BC8A13B45BC37EA44691241AF637F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-atlimit.png" />
+            </Component>
+            <Component Id="cmpE5EC8C4E3965F3E653882C52CC0FEA33" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{DAE78D7A-ABE1-40F1-9807-78284FD4DB55}">
+                <File Id="fil2FF2544B0BD0CC4007CA568E3507AD80" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-atlimit@2x.png" />
+            </Component>
+            <Component Id="cmp180A4D008E50DE69F34BC044AB305C6C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{86D52568-7DB1-4D44-AF60-4B4850A1389D}">
+                <File Id="fil9429B590CFE0ED45DE776AB29D40ED83" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-atlimit@3x.png" />
+            </Component>
+            <Component Id="cmpE6875FBEA1DD36B58503D32B74B661D9" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{CDC548DE-37D9-4A6A-A4EC-3240AF01D416}">
+                <File Id="fil0ED6E52596AB5C648531EC2B354D7FEE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-disabled.png" />
+            </Component>
+            <Component Id="cmpCB564C8F4690215AF3757BB196922317" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{041442D2-AE3D-4F79-A7AD-E216AD151C8A}">
+                <File Id="filDEE0762A7340603E9BA9749D795897CA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp566F225833567198C54ED9F7DC5DC96C" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{0E1B2EFC-FC3C-4244-9163-09926C8D3131}">
+                <File Id="filD8E144A070A620CFBEAB85BF155CC51B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-disabled@3x.png" />
+            </Component>
+            <Component Id="cmpD58105818529285177D24B8A892CA492" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{914F51B9-8CFB-47B9-8200-737EF76449DE}">
+                <File Id="fil624015DDD0BC6B548FD6CBB4B4FA19CF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-down-hovered.png" />
+            </Component>
+            <Component Id="cmpB643D3CCF417FD0C4239573732D627BF" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{F67A57AD-6BBE-41BD-8864-0F3A26453F5F}">
+                <File Id="fil3B93E30DB42ACAB25DB6A86B998D2AAC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-down-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpEE5FD24684DB5CBA6EB095E6A64C3E3F" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{49BA5B71-57DE-4AD3-B6AE-74FD6F17A8EF}">
+                <File Id="filD028B0DA779080607636CAE4E38C00C8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-down-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp5AC8AA0FE71E66340A38C40FF5426024" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{0304C3C6-3452-49ED-9FAD-46439CD55908}">
+                <File Id="fil5AEB63E9FFB7F9096AB11F7E9B960A1B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-down-pressed.png" />
+            </Component>
+            <Component Id="cmp1E747C8EB12449FEA7641C445E3DABF7" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{B22EBFB0-DF9A-449E-90AA-CB0579F7CA49}">
+                <File Id="fil15E2794FA3D30E66B9AC1067DAB3C7BC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-down-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp35FF670182A5B8F1F70C89F6E1AE7DC8" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{87004B1C-6D25-4691-9080-5EBB054093AC}">
+                <File Id="filBAD556A99734A7EB946ACD6263F6429E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-down-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp119D8CC1C8F46606BA347AF4043B5593" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{EF12AC6E-D803-44C0-8FC6-AB8D7C803F43}">
+                <File Id="fil929316507EB21D59E42A64ED57560CA1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-hovered.png" />
+            </Component>
+            <Component Id="cmp5641BBA428729933C705A04A10FA3740" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{781798B6-22A4-403A-95D2-D438EE788D64}">
+                <File Id="filE13339E93D7FED2E8D38175E46BD1A99" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp64609DD24EB1B0F499E3C061637CD8B1" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{59F74135-A972-46DB-8DBE-5451DCB8427A}">
+                <File Id="filE24DBBE23E07E06A738D0BFD6945F8E1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp7035C477A755DDAEECB531322CCA4507" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{FD8BAE09-133A-42AD-AE55-C349C6E7A857}">
+                <File Id="filF3A33010CAEDCC811E3AFED231F5917A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-up-hovered.png" />
+            </Component>
+            <Component Id="cmp7C9A2BCC74C7041B5A1F199007A52C7D" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{0FB6DA11-FC3B-4A71-A37E-40D6D8407BCE}">
+                <File Id="fil8EDA186BFE5F7E5CB6202BF680FEB092" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-up-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp48406F10AD16323F06CD554F0AFF0AF8" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{372A318A-9D78-45AB-A51D-DFF83FE1C361}">
+                <File Id="fil9726C5FA7A25ABECE5973B0A54E37D7F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-up-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpFFE3375BCAD45951269312579012A1BD" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{BF3E8683-734E-4D21-857C-7EC2983F9A82}">
+                <File Id="filE5F3B0311A4FF7FF9DD3F0BADF2661C8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-up-pressed.png" />
+            </Component>
+            <Component Id="cmp0D0B065EFCAEB8436568F7BD1B7A5548" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{216916CA-FE2F-4015-8C7F-2B4D974AA63B}">
+                <File Id="fil23156F1E8330F7DFEFB13E3056E49764" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-up-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpFB98BCBCB2CB6D7E27C0A486D9CE67CA" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{200E265F-054C-4C23-AA27-41FE3935F1B6}">
+                <File Id="fil6F1B036DE50C5A59C34864E48EE249F9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon-up-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp8985F4BD491DAE58BA7A78CA8B2FFF76" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{225415AB-BB38-44F3-86B0-E6634B221FFC}">
+                <File Id="fil6A8903F8CABB07E6B0B74F3C2493207E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon.png" />
+            </Component>
+            <Component Id="cmpB048DDCDED98A032D7AEE3A295D85F87" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{B5D2BFD2-43C1-4AE2-BBA1-C5323E53BF49}">
+                <File Id="fil6F99B277E3E652FC624B0739AEF05F54" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon@2x.png" />
+            </Component>
+            <Component Id="cmp926EC0028F4EFF2DBFDCD67BB8856A50" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{C4C24608-35A1-4213-9426-9F8651C85C0E}">
+                <File Id="fil60179D821875579AB15E6927B0A10EED" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-down-icon@3x.png" />
+            </Component>
+            <Component Id="cmpF54B5999A3BBC1074B9307D7A05DE551" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{0A3E6501-040B-41DD-848F-E029EAA36423}">
+                <File Id="filEA615C7DFF529927A21DE57FA1C2B949" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-atlimit.png" />
+            </Component>
+            <Component Id="cmp949BCF97D92DB79AC7C97D70B72CA808" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{EB23DCEF-5574-4BCC-83BC-D137268F2E8A}">
+                <File Id="fil11E40116068F8C160C2C6391437643C9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-atlimit@2x.png" />
+            </Component>
+            <Component Id="cmp883485F9E7A1F7A41279AEBD5656941E" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{E274756C-BD03-454F-A6A6-6B3366F17F03}">
+                <File Id="fil7616676C36FC769139B64F86C0659BFC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-atlimit@3x.png" />
+            </Component>
+            <Component Id="cmpBA6688007706A0C9B9F6C5904D0DF877" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{0DE4A2BB-02A5-41B5-8431-960AB1DD77AE}">
+                <File Id="fil58D1F1C5BA4205479758EE4E43A7C04F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-disabled.png" />
+            </Component>
+            <Component Id="cmpA62EE0E3912CB072EF416920F11C4611" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{E3DD1335-B83D-4FEC-95E0-2A12B6D94BF9}">
+                <File Id="fil875A8325167AE37677BCA87A67C9B299" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-disabled@2x.png" />
+            </Component>
+            <Component Id="cmpFA3E083D850447C068E5E2032F3D00EE" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{837282AD-2F99-4D12-ADC1-9FB072C13968}">
+                <File Id="filE6D2390C1BBE9D2A6AAFB40CAAA5E2A2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp7D71D29D14C6ADD06094C7CC87790278" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{0F893D6E-3C79-4489-B5D9-9196E0F4DDEF}">
+                <File Id="fil6DCB493652A8DEE4911126269BBD7F00" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-down-hovered.png" />
+            </Component>
+            <Component Id="cmp628AFD0BC2075C2FE679BB3F43881162" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{0C9D160D-92A1-4BD5-A8AF-6D0DEF41E28B}">
+                <File Id="fil1F223BCB1DFC4E7650313207C7F05D7B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-down-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp28EB13FCCA7961195024DD1BAAFE9BBA" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{142E3148-DECB-4C50-B173-34E300835158}">
+                <File Id="fil114AD191504883D1EDBE5867FA7FD91A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-down-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp0025085E3CA9ECC9C99142252ECE5CE9" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{34872E76-4E84-4D37-A663-AD785622F6D2}">
+                <File Id="fil20D6AEF1F2391146983B0E48D1FAC8F0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-down-pressed.png" />
+            </Component>
+            <Component Id="cmp487AD00109DF23884288CFAAA05E2F48" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{85FC0D2B-76DD-4441-8F16-3A705D3C8216}">
+                <File Id="filCC5248167AD0CEB59D96438C10D2946E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-down-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp8A3062B28C9F61824DAAEAD1A72DDB08" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{03DF48A4-16B9-4B0A-BEFC-1D4BE29CB3FF}">
+                <File Id="filA685B92DCF4E9CAA929EF59EE43D5874" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-down-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpEBC9488CCA5418BB31FF3D04FB4B6026" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{438148C0-CC53-4FF5-ACB8-96AF9585DB32}">
+                <File Id="fil398F4C71ADB4372885D6C7B27D72311D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-hovered.png" />
+            </Component>
+            <Component Id="cmp0DB529084B9FCC38C416A3F743C11614" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{4E6F1233-2A62-4B55-B2D5-C4F28876952E}">
+                <File Id="fil86F520B473658E517A17DD58BA5F6549" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp695A2A0695007E9C3EF476B045161D3D" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{D68DFCD6-FB36-491E-951C-F71BAD7CFFCF}">
+                <File Id="filA54B02227B17555E01A4610629BD2BF7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp38C884D07467C23B20B299A9018343D0" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{3379C771-FA8B-4175-A259-6895B38EDC76}">
+                <File Id="fil7475673FCD4501315E417D6B753B12ED" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-up-hovered.png" />
+            </Component>
+            <Component Id="cmp857381C9E7B065948CA596466536D1E8" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{04C389EB-2395-43F0-81B0-DD72F4B7FE24}">
+                <File Id="filB836E617902FBE94E0BD5044BEC4819F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-up-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpD5E53D9EC18F8EFA2C8923248FD4AF90" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{14D4300C-9895-496D-8914-6B414801FCE8}">
+                <File Id="fil6CBE2F28DC48EF1B25245C5DD1C34C95" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-up-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpC4006E152307B688202E3BC27309B0C9" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{8FABCE2A-1794-4DD3-BA80-D58F506D03A1}">
+                <File Id="fil8E81FBD32A5D74082E14919BCCBA9328" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-up-pressed.png" />
+            </Component>
+            <Component Id="cmp8E3C9675C52600E1DD3914A6D1D7B583" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{1AA7B3CC-FF1E-4BC3-9F3E-AEB8CD5A510B}">
+                <File Id="filCC130D927875542B59E0382C75CD6D52" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-up-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpC1C172A8FD9664E27B990D9080DFC2F2" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{6152E069-0F2C-49AE-9CB0-207282DAE62E}">
+                <File Id="filA2F985BEAC694FE76C2BA3236EBB5D36" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background-up-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpB69EAC27131C4E52252ABC03BB070721" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{6E5F4F0F-66A2-462E-B55F-F1DE4A0803B9}">
+                <File Id="filF593EEDAAC5A22FAAEA31A49354CBFD5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background.png" />
+            </Component>
+            <Component Id="cmp442109289DF469F0DB3376C99C244F46" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{68EFA50C-D79D-4F13-8A6F-F17E66433F50}">
+                <File Id="filD6B6149A3A62B3AF288FA021F486A5B2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background@2x.png" />
+            </Component>
+            <Component Id="cmpAC2C93A69483A403DF88971B3A896FAD" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{92AB1CF8-20DD-4170-9698-C67E3AA5237C}">
+                <File Id="fil278FDDC2DEB1496329518E2A1E3390F9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-background@3x.png" />
+            </Component>
+            <Component Id="cmp07A4F7ABF87276DC13134D7B2CA43DBD" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{4A4E8048-4EC1-4962-9E30-21FA3A3FC41B}">
+                <File Id="filF4EEC381458DE0271F871012268D80DF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-atlimit.png" />
+            </Component>
+            <Component Id="cmp69D0CCCC5C7CB7D6B08D2CD622550A01" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{5FEC2AFE-CDE5-4E84-98F3-D97EA9F66BCA}">
+                <File Id="fil8C1CB6103AFF82DE48DFCD7ED2152D54" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-atlimit@2x.png" />
+            </Component>
+            <Component Id="cmpE64A0E96F93D1F1CE425724DF12802A2" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{81C1E575-F192-4F4B-AD1C-4D6A22BBD91B}">
+                <File Id="fil48A9C101BC30517A8116BA0918660B2B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-atlimit@3x.png" />
+            </Component>
+            <Component Id="cmpE2E6B82B944E87F1F2635F3B28186EFF" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{804E5CCB-50BF-4C47-BDAB-9E5C39864141}">
+                <File Id="filB8C3960581FE3E9CA752369DC824CC12" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-disabled.png" />
+            </Component>
+            <Component Id="cmpBCA57E3530E82DE7CE0D0F22ED9B7956" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{41F4BF5A-16A7-4351-956E-2B167FFEF185}">
+                <File Id="filD92A4E0A67FA9C630642F822AD28A5BB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp84C99A67DC353AD4FDD969D348C549F0" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{CFCB34AB-E086-495F-8AF6-FEECE4BF7629}">
+                <File Id="filC2FE86DA99BA2B6C670F10E0D1968B09" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp24BAC3D70B886B6CD81F34B9010CCAF7" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{0F4044F5-C8A0-48AD-82EB-F3BB2AA83791}">
+                <File Id="fil5BCDF50920AE567BD191431ABB65972A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-down-hovered.png" />
+            </Component>
+            <Component Id="cmp989D67F88238BB7091A7E343755F77A4" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{75930592-97B8-453F-BD93-1D0B2A0310A5}">
+                <File Id="fil3B8F0B2455A430EC5243226449D50316" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-down-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp6BC3872C85B160901A863B497270B2C3" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{7D60EBDE-EBE6-4D8F-BA61-63790F01F42A}">
+                <File Id="filCC17D7BB9988D14D30D06D721E6BF8A0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-down-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp8D5095B0793E246C594615B6334F0838" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{D5294B72-CB0C-4DBA-BEC7-4BB3A7DAAC2B}">
+                <File Id="fil80870DB9ADFBBCA03DB69022EBE1CA85" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-down-pressed.png" />
+            </Component>
+            <Component Id="cmpCB8EA7805AAC14BDB4D25ECF51430DA8" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{C8ECAFA3-3E16-4D9B-93EA-30879395FBCE}">
+                <File Id="fil8A2AFC77981E061F3D94B8CE27BF2CE2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-down-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp982C7786060C0D312E10DFE85F50E139" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{2E75D475-9DCB-43F4-81EB-0D80CAE4EEA3}">
+                <File Id="filB8FF15856FBCE9475D15DABC1C8724F4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-down-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpB5EFDE1E07C85AA2EB40EF47383B09D8" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{C51A229C-C4B2-4727-9961-00D73B13742A}">
+                <File Id="fil86E1D1B57B051853770C97EEF73CAB6F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-hovered.png" />
+            </Component>
+            <Component Id="cmpAE21B56C1F6A53D75336ECCA7D692279" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{C54C9C24-5A2B-40E9-AF87-80E53F2AFC52}">
+                <File Id="fil97C8B516FE4B91F333AFB1AE941EBDAD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp1D30A0ABD3B6F2575FAB3139D2AECB78" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{6D1D6879-8FB2-400E-A382-17D5D72E1ACC}">
+                <File Id="filF2F8D94D499AC02AACB56E5C1991F150" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp2B74CDE1AD43D39AE1D2661DA67778C4" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{7951237A-3713-4280-B895-F15F36C2B73A}">
+                <File Id="fil0731555B95646B20A3707BD2DA37A751" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-up-hovered.png" />
+            </Component>
+            <Component Id="cmpB2721C2BD8DCBD146B94C3F0EBA42D90" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{6F36EC87-5775-4489-8492-7FA97E0CDD82}">
+                <File Id="filA432ED3B8F7634BC08A2C267E4411DD4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-up-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp6C09A34191357EACF7F84DF133BA7BCD" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{C80F3F47-F39A-4ABD-8054-C530C6772642}">
+                <File Id="filBB349EFD51C4A00A57DAC62122BD2D8B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-up-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp4D7E8A7D25B4C2BC58FD04DA2A816450" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{D608EEFC-1A48-4458-96C3-C588E9D1443B}">
+                <File Id="fil960D016A1876179887DFC3F02930245C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-up-pressed.png" />
+            </Component>
+            <Component Id="cmp075E41972FCAED1661EFD0CA4B75C1D9" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{2A17D7D2-B0C8-409D-8BC2-615DF4B3B2CA}">
+                <File Id="filC2DC7D92E68591C7A13861E1E4D4251B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-up-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp24A69C41CCAEA94E0B244D93E660AD1E" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{881C3CAC-ECBE-4D9C-8C3C-00FAC369DE0A}">
+                <File Id="fil77AE8A3535902329196EA1CAB826E09E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon-up-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp050869D698975F75807A25801FFEF2E8" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{BEFF2CCD-971C-4183-ABC3-53768418F0AA}">
+                <File Id="filBC3CD24F3864B828C8DB87F59F2F355C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon.png" />
+            </Component>
+            <Component Id="cmp18B86D48721B7DC0BB1EEA826C8696C9" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{E2F128A4-DD8D-4799-9FF9-1586DBA15BDB}">
+                <File Id="fil31021A2FB8C9BAC35B2316CFAABB743A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon@2x.png" />
+            </Component>
+            <Component Id="cmpF236F632127D51F025A7A0B3BC89CDAA" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{9E933262-271F-45A0-BC83-9F5D0A08E488}">
+                <File Id="filF34904BBA34BC3DDCD057F6563A717C4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\spinbox-indicator-up-icon@3x.png" />
+            </Component>
+            <Component Id="cmp6A41BF30FDBF24748B89842A47E4909B" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{2F55825C-EF2B-4B01-B0B9-7B1222DE1A1D}">
+                <File Id="filA235E94A1B86B7540112A1263B46B3D2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textarea-background-disabled.png" />
+            </Component>
+            <Component Id="cmp7C8242EA27097EB39C43A9671ED0DD60" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{06B2071E-8378-4C7A-BEA8-A0BC429912F9}">
+                <File Id="filC5128F2A3C7CF820828C780439B804FD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textarea-background-disabled@2x.png" />
+            </Component>
+            <Component Id="cmpAC18F3987F56132B75DFBDBDDC439735" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{191B32E3-04D0-43C6-A72A-3E238FC76DB8}">
+                <File Id="fil212748FFD86FAD5ED84DFFEFF2CE220F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textarea-background-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp7FF3AC8A8A66CF47DD9C1B243D1D5019" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{7101A1CD-65AC-4A3B-BD69-B149A4DD164D}">
+                <File Id="fil8A4578F9C414CA98562A0D27361283BE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textarea-background-focused.png" />
+            </Component>
+            <Component Id="cmpEF556CFE50A48B46A3F947D7979E5CCC" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{D4D73067-D8BB-4F0D-B081-8E682A1C7375}">
+                <File Id="fil6EA21948D16BEEFA44725610EEB6F5D2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textarea-background-focused@2x.png" />
+            </Component>
+            <Component Id="cmpA27A6F8CAA34C34380A05F4D08BEF0A2" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{D1A1FE87-917E-41A0-9DF8-9D60973CAA1C}">
+                <File Id="fil1B999C438889038B6B7B7A2DA6B035CD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textarea-background-focused@3x.png" />
+            </Component>
+            <Component Id="cmpC31F819ABD883EFB948198ED9B953FB8" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{51F7D71E-367A-47A2-985F-F8C439E9B0F1}">
+                <File Id="fil51DD033CC3CF966E1EE88BA367478811" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textarea-background-hovered.png" />
+            </Component>
+            <Component Id="cmpBDD7AE4017C56C02949D3190F848CEF9" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{1BF2CF9E-37F3-49B9-A980-BEC3C2430074}">
+                <File Id="filC5763F751CF46F4B7CC42E4423AF844E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textarea-background-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp0CE8DE92F0E6D8AB21DA91480245C2C7" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{1794B319-C7EC-4086-BF43-9D749D068EDD}">
+                <File Id="fil5CC688B1B35E8CF99E3135FB919072D9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textarea-background-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp8230384C5DA7378C7013A3EF5862279F" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{0F0BCC4A-348C-4D10-8ED2-BDD89693444D}">
+                <File Id="filD222B952EDD11B69848DA4FFC03AB687" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textarea-background.png" />
+            </Component>
+            <Component Id="cmp92CE6FA5657A1C81A268C87D20D11979" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{4DDC61EC-8CFB-4D12-A454-B31B39E6A085}">
+                <File Id="fil3C5CCC275AF4D431E5717561738B1DE3" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textarea-background@2x.png" />
+            </Component>
+            <Component Id="cmpE5EC84F256EFC334394720F13DAE4268" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{F5299009-F5D7-4992-AA27-C0315A7FB1A9}">
+                <File Id="fil1D9BD13E048698E487417364F193A5FD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textarea-background@3x.png" />
+            </Component>
+            <Component Id="cmp6F32A6C8A9CDCE24CB07EA681BB7A493" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{9D6FE52F-E79E-4A50-954F-3EB8E0008177}">
+                <File Id="fil627E8BED02EEC1593E0C58C417F72358" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textfield-background-disabled.png" />
+            </Component>
+            <Component Id="cmpB1B3F16E0AF55B07C5E11A210E1DC108" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{7430D8E9-467D-457D-939D-334D8A79AF68}">
+                <File Id="fil87A7DE6E002D2C760CAE151304B6BBC1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textfield-background-disabled@2x.png" />
+            </Component>
+            <Component Id="cmpAEC017AD179AF373848F033753383438" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{AB3D0B00-1754-4137-AB78-32CC1BE29CD4}">
+                <File Id="filA3DE96334BA9DD72F36ED7AC55247505" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textfield-background-disabled@3x.png" />
+            </Component>
+            <Component Id="cmpF79600AF463E89F964B790E75E776217" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{C3922412-3B16-4438-B2E1-3B9CE3B7710A}">
+                <File Id="filC90E759B733C99C942D7B59CBAC3B081" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textfield-background-focused.png" />
+            </Component>
+            <Component Id="cmp84F60C8194EE46EA4C2587C572CEA93D" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{11FE7B1B-C3B2-4FFE-939A-DD22ED710D84}">
+                <File Id="filC494C4C860630ABF9FE5FD9FDBC535B4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textfield-background-focused@2x.png" />
+            </Component>
+            <Component Id="cmp7C224EF05736BD307B0906B7F270561A" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{F9AD7B86-B711-4D60-A646-5B73ED2ED8C0}">
+                <File Id="fil1538C27744E7FDB238D446C0D41F7734" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textfield-background-focused@3x.png" />
+            </Component>
+            <Component Id="cmpD3D8129DB97C95CBFC014BC23BFF5E63" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{B0CCB793-C717-4969-A851-412273C7449C}">
+                <File Id="fil80F10F9E14C7C1CEF28946013419E377" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textfield-background-hovered.png" />
+            </Component>
+            <Component Id="cmp29F0F55DABD11E0A4AEA5C33864A4F61" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{57D8D13B-8F5C-4C45-BDC6-88D3840A9AF7}">
+                <File Id="fil65A6FD4CFB338C912D042A0FFEF6E86B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textfield-background-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp54968C02AA2107F19070233CC13CB102" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{2FFF762E-4C48-447B-9402-ECC84CCBCAFD}">
+                <File Id="fil86085411D62F8A0C07778BE583499D26" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textfield-background-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpF29B459C9E7E3E214CEBC564C6D2FE68" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{9EE75CA5-C59A-410B-9345-D4D38305FDF8}">
+                <File Id="filA14E928E61AFA5B6BC62F0E40293BC17" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textfield-background.png" />
+            </Component>
+            <Component Id="cmp07F2BCA46B177EADE0F42AED05534B3F" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{87B4F1C7-3DDE-4A63-BF9F-516B2B8670AB}">
+                <File Id="fil02878927DBF9284C032AA5D7E1DB6627" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textfield-background@2x.png" />
+            </Component>
+            <Component Id="cmp40019F8E324DE798614ECF01FBA1F748" Directory="dir3C4F465FBDDD5BDFD3E942262340FFCC" Guid="{98A11178-0893-428A-965C-EBA0351D97D8}">
+                <File Id="fil08E8A626D30AC8ABA1E6DD0D470CAD28" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\dark\images\textfield-background@3x.png" />
+            </Component>
+            <Component Id="cmpFA4B9985AD60504DA4E760DEF1A74D92" Directory="dir0986B5CAD2460321886B51FD51019567" Guid="{AF4C2CBC-FB39-4127-9E28-6E7188E29D7D}">
+                <File Id="fil2E1755F77B25CC5EAEBB81C861D41A8C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\icons\checkmark.png" />
+            </Component>
+            <Component Id="cmpD630A83D7FE5FC40C8D44998950D713A" Directory="dir0986B5CAD2460321886B51FD51019567" Guid="{D5400BFB-8CB2-4BBF-BD71-3A06A2A25B80}">
+                <File Id="fil8E045D228CAA8C8B7E13482D6A1AA115" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\icons\checkmark@2x.png" />
+            </Component>
+            <Component Id="cmp620945788E96073B6EE0E9BF6381DCF3" Directory="dir0986B5CAD2460321886B51FD51019567" Guid="{D44101E2-831C-42F0-A74D-4C04B929F0A5}">
+                <File Id="filE5C92BAF0C75D5F13FE0181EF73048AE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\icons\checkmark@3x.png" />
+            </Component>
+            <Component Id="cmp49F18407161A99E21CBAD428844D2FD1" Directory="dir0986B5CAD2460321886B51FD51019567" Guid="{0F47FF61-5825-4D93-B3BF-2F2277B163B9}">
+                <File Id="filA429C3E686558435048D14AFD6DD7D5D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\icons\menuarrow.png" />
+            </Component>
+            <Component Id="cmp7FEDBE0CB3797A3933023C9D07FB183E" Directory="dir0986B5CAD2460321886B51FD51019567" Guid="{A9DB378A-BBB7-4FA4-83DA-931D01B5C0E7}">
+                <File Id="fil7407011DF9AC11AC3110BEA846C39B4E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\icons\menuarrow@2x.png" />
+            </Component>
+            <Component Id="cmp962D9C3F8451B480FD9EABA95DF4AE60" Directory="dir0986B5CAD2460321886B51FD51019567" Guid="{336CDD54-6A77-4CD5-A30F-35F211E5FCC6}">
+                <File Id="fil2256DAFC0C07F140E1990C99400171E1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\icons\menuarrow@3x.png" />
+            </Component>
+            <Component Id="cmp82F3521CF064FABD14FFE2AAEDD34D89" Directory="dir6760147796A3D8FCCEBCE06251BB6DC9" Guid="{C958EBB6-8798-48EC-9E84-F2B5374EC51B}">
+                <File Id="fil73D72DE30FEB90E8AEFB8FB603A5ED3C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\impl\ButtonBackground.qml" />
+            </Component>
+            <Component Id="cmp2BB2F93E24472D3B6332E7A46B8FE6B9" Directory="dir6760147796A3D8FCCEBCE06251BB6DC9" Guid="{239604CB-8642-4BE7-9F2F-EBB662EA4536}">
+                <File Id="filF040BE832AD7F9182AB13A852046E278" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\impl\CheckIndicator.qml" />
+            </Component>
+            <Component Id="cmp7FE7670BAE1C5A91148421E35A018814" Directory="dir6760147796A3D8FCCEBCE06251BB6DC9" Guid="{F15C5AE2-2A96-4AD2-B8A2-63A08A6CC066}">
+                <File Id="fil92EE971F8C3D3219444D8F3481F9A74A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\impl\plugins.qmltypes" />
+            </Component>
+            <Component Id="cmp4E32E41E189BB6A13DB7C1EFF120F462" Directory="dir6760147796A3D8FCCEBCE06251BB6DC9" Guid="{8E9DA096-6276-464E-A05E-5B1046D968A8}">
+                <File Id="filE696FA4D7C96095E906DB2AA630FBEF9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\impl\qmldir" />
+            </Component>
+            <Component Id="cmp81071CB2D663F93F765BC9495D3E8459" Directory="dir6760147796A3D8FCCEBCE06251BB6DC9" Guid="{07D6EF4D-AFCC-4637-86D7-EFE21A264DAA}">
+                <File Id="fil7E51880DF16E3C4F6D1E212AAE068210" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\impl\qtquickcontrols2fluentwinui3styleimplplugin.dll" />
+            </Component>
+            <Component Id="cmp0CFE29A505F6D9BA2C3636F27B6716E3" Directory="dir6760147796A3D8FCCEBCE06251BB6DC9" Guid="{9768A762-D8EF-4364-9C8B-BB53975711B7}">
+                <File Id="fil48FCAE1AD347F6CD88785402ED1CBDFC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\impl\RadioIndicator.qml" />
+            </Component>
+            <Component Id="cmpFD5FCBCA01EE57A13DE2BB44F2F10160" Directory="dir6760147796A3D8FCCEBCE06251BB6DC9" Guid="{5FCE7A67-AAD8-43B4-BBE4-38D89B0E5CCE}">
+                <File Id="fil2F25B9994B2EA0A602D63EE705A0E13C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\impl\SwitchIndicator.qml" />
+            </Component>
+            <Component Id="cmp9AF60978003A61A67308A051310E14F7" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{CD17344B-26A2-48B4-B2FA-D8413456C77B}">
+                <File Id="filDC6A021BC573FCAC4FBD67F800A6C7A9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-checked-disabled.png" />
+            </Component>
+            <Component Id="cmp47C0B7336586C8F30FDDF2292B6B2903" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{576CC60B-C07D-4EAE-8145-F0D77FECEBDB}">
+                <File Id="fil861F6C34155FCC84B024834B219437AD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-checked-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp12598B6AFE978595B8EF43C104BDBAE5" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{574EE4BB-031F-436F-9B81-072704390659}">
+                <File Id="fil7F9ECF72406764960BD4BA970157937F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-checked-disabled@3x.png" />
+            </Component>
+            <Component Id="cmpE22123D2176A4EFF58393FFDDD705CD5" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{AB1B2C81-8ED5-41C6-9109-6BFB2934A91C}">
+                <File Id="fil9621D2FC552742D9EEBBEC33D295E2BA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-checked-hovered.png" />
+            </Component>
+            <Component Id="cmpED424D6C75BBDFEA2E53F63449A2EB37" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{47E2EF48-E6AE-4574-8065-90F7FAF88ECE}">
+                <File Id="fil4AA41A216D20412CB398E43CD73E941C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-checked-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpAE63BC9F355C4E75439413FBEC855781" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{33460181-D7D1-42A0-9F8F-E3FE290A1FEF}">
+                <File Id="fil7DC7FB5D1DDB3DDFA609753D4743E01A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-checked-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpA34676C2DDF9187E37ED22B26808098D" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{03CDF1F1-9990-425A-ABEF-AFBBA0344D95}">
+                <File Id="filDBA1CFC40B5E75CE69A40610C0CA5617" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-checked-pressed.png" />
+            </Component>
+            <Component Id="cmp4EE2FAFCB4D55EC1B34DD9A5BDD1E427" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{619D498B-9AF5-4CD2-BCDE-68B26FFEF127}">
+                <File Id="filD0C527CAA361BFAB436EC2C83FD550ED" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-checked-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp0D0ABC3C0B2BBDB64C9194161F55C764" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{DBEA502D-DD48-429B-AF9F-9C60363FB602}">
+                <File Id="fil15CE78417262F62F1123741E7F310A9A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-checked-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpC4C8B84D931051D155F1A45147CDADE5" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{74AD1EFE-26EC-4744-83BD-0ECAB78F2EF8}">
+                <File Id="fil641BEF42C71229373C6201A7C31191B1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-checked.png" />
+            </Component>
+            <Component Id="cmp0C67C78CB09167B208264674552B7911" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{8345438E-7374-47C1-8DF3-9C7C73BCB983}">
+                <File Id="fil661B6C2FE7CE4CA4D31BBA769578991F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-checked@2x.png" />
+            </Component>
+            <Component Id="cmp1CA460DF5A1BDA107FAC2AAA2559EAAF" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{2823BF45-81BF-45CB-99A8-D3998F06A244}">
+                <File Id="fil1BE334DD8281039A5FE4964EEB8370C5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-checked@3x.png" />
+            </Component>
+            <Component Id="cmpCB77D0C05E5311F90BF48A679ABA1420" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{9C012C4C-EE26-4FB8-8CF4-9644A9C09544}">
+                <File Id="fil95FD148E8415C5496D6A7E9173B56223" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-disabled-partiallyChecked.png" />
+            </Component>
+            <Component Id="cmp098000011F69787488D052F17920EEB9" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{081B5F79-4484-4646-A884-F46D3B9DB065}">
+                <File Id="fil87C59D805A8CEE5C04CF35C65534D9B9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-disabled-partiallyChecked@2x.png" />
+            </Component>
+            <Component Id="cmp4F5204F6133E6249A3032F041ACF7D7C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{5D638C61-4233-4448-A0DD-08FABBE8E6CA}">
+                <File Id="filA27889E8EF944DF2CA6DC7CA040CA47B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-disabled-partiallyChecked@3x.png" />
+            </Component>
+            <Component Id="cmpA89777871A5F01E81CD9115D8B9D9B10" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{93A4528E-7ACA-46E8-A13D-D4274C819369}">
+                <File Id="fil7CCAC3172D16CF3DF5ABC4BD6CF8EFB3" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-disabled.png" />
+            </Component>
+            <Component Id="cmp8F2D54F99D01E086D59673B37DA35418" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{F2879B1D-CC47-4480-921B-8F67006643E2}">
+                <File Id="fil7B8FBECD4E7951E116D55A34FD164BE5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-disabled@2x.png" />
+            </Component>
+            <Component Id="cmpFC7874C40B6F8C203ED18BE1276F9BA4" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{84C8C4E2-C36B-4898-A663-306E49639BA1}">
+                <File Id="fil47A5F7CB27F1BEA865F86F56470C4FF5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-disabled@3x.png" />
+            </Component>
+            <Component Id="cmpF9AF43E0D0C8C4E5A07BF0E3FFB016A5" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{2FB5CA54-804E-43C4-B2D9-377A4E459A5C}">
+                <File Id="fil6196F60A617432E2A022B312A254F3C5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-hovered-partiallyChecked.png" />
+            </Component>
+            <Component Id="cmp4E8B5EF8DD90DA097F607511B7D32EFA" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{A2241483-F8FD-4C84-8327-99CB072E3EAE}">
+                <File Id="filE2B70B75EACE54C50A7E591BAAC7ED43" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-hovered-partiallyChecked@2x.png" />
+            </Component>
+            <Component Id="cmp24CA1B3F0EE431F59A81E17C1B670486" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{EE598D56-63C2-4498-9A65-2A5C7AAA1C6D}">
+                <File Id="filC91400C1B02D6D931BEAD185C4AC91E6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-hovered-partiallyChecked@3x.png" />
+            </Component>
+            <Component Id="cmpE9A34918E1AE1A4840BAD164456326A9" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{5D73F7D1-B954-4995-8363-76BD26D591A1}">
+                <File Id="fil608F66180DB62CD05CFEF4E66F39F682" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-hovered.png" />
+            </Component>
+            <Component Id="cmpEB0A04A9194F9DDF1FBA5A30F14F8954" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{8DD599B2-2D91-40B4-AC6B-1D686CD9A2F2}">
+                <File Id="fil517E87E094D94408E64DA531C1538D4A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpBFA97B684982FADA35A0DC71739E4376" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{25654F48-EFDF-4294-968B-27355F2FECC7}">
+                <File Id="fil534D7905B31DBB3B3EF2F395641FB1AF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp78066EC3200C1ADB5610DD7FD88AFE40" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{D5C10680-1F67-464B-90D8-15A43F6D242E}">
+                <File Id="fil86078C6673D86083176ED93FC727EAD1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-partiallyChecked-pressed.png" />
+            </Component>
+            <Component Id="cmpCEE3F5A3112C69AD8BD25931F9578480" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{1F3198D7-F5D5-4F1C-898F-83E787F40BEE}">
+                <File Id="filE8C749B0D4BBE042016D2FAB4E04D196" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-partiallyChecked-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp49136828A93743710CE0F510081FE733" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{E0203291-2B7B-45BA-A333-B42CA844E313}">
+                <File Id="fil869FEE4D865649A0A314118DC95047B6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-partiallyChecked-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp14A47C7C7870279D51EFD92A7A230867" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{39C4FB53-A52C-412A-A0E5-0AE30F247427}">
+                <File Id="fil2EA6DE86F2D7950A5E195A5A46DC50DA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-partiallyChecked.png" />
+            </Component>
+            <Component Id="cmp1D766E55F46BC236790CF24F3B3AEED4" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{7F83C501-AC73-4168-A6EB-EE456D5FD61D}">
+                <File Id="filD2C83C8EF5E27F81D2CEC2FEADC7B94C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-partiallyChecked@2x.png" />
+            </Component>
+            <Component Id="cmp02A583DE7008B9AD27D5E2D31DE9C3ED" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{2A1F445F-9B32-4E18-A558-E15244253BB4}">
+                <File Id="filF5D1809038FC81664C2C380AD0DFCC25" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-partiallyChecked@3x.png" />
+            </Component>
+            <Component Id="cmpF19D8489507CCAE8EE83B2BB7D6E0BC1" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{0DD7BD02-328E-4BB7-B2D2-22F4A92D8C57}">
+                <File Id="filDBE9B08D0F63BD2FECBD05369BE30873" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-pressed.png" />
+            </Component>
+            <Component Id="cmp35B6785DC5C74134D40F66546202D5E5" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{0B7924A7-4F36-4E18-A9B8-89D86D1360A0}">
+                <File Id="fil4F5F13575040B722FF49B4C169E2BC57" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpB15F9BF7E07C69D5E2C580EEA1277091" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{063315E1-471D-4777-8115-0672B4417156}">
+                <File Id="fil8A63BA81346001734E560577757AF8A4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpB5F4B0385E23098DD53FA1F2EE9CA787" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{B79A2093-1350-44E6-BF06-70A49D6738D6}">
+                <File Id="fil6CCAEAB01F7F8D0A31B867676B542FFE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator.png" />
+            </Component>
+            <Component Id="cmpE52B74421A62A37BBBEBEA0A49A9A4DF" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{30C94D0E-FBC6-4FAD-A651-A6F3F54EE535}">
+                <File Id="fil4C5B0B628EF5FC75BBDC1F7731F58B3F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator@2x.png" />
+            </Component>
+            <Component Id="cmp2913087CA54D088AE5F61552E77C9CA8" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{6DE4C77C-5E84-4BE6-8FE5-8558693D7678}">
+                <File Id="filEB7AAB30E92B14EB88401103E4FDD8CF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\checkbox-indicator@3x.png" />
+            </Component>
+            <Component Id="cmp8AFF84A628E065B8E63FEAD7D8E78CB9" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{6BBB6E0E-BF3E-4637-8F66-4609321638E8}">
+                <File Id="fil8614BD1DD4165E0705D00ADFFC16DFBA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-disabled.png" />
+            </Component>
+            <Component Id="cmpCA8C1B14EE6E0BEF1BE8532B7A92FE07" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{B45EE4EE-C407-4AC6-9059-6DD6C05589A7}">
+                <File Id="fil3223A4BAF5FF8D736F2D70CC093C0A13" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp0B2D070DAE458DE664864AF883FE23C9" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{5A0DD074-9771-4C95-9754-E6D7F7F33F90}">
+                <File Id="fil036C6E39FDF9CF31F8E50014645A3A2C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp53D1E43331FC578E53717DEA2E886ED7" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{2CFC1E8B-4F3C-4419-A017-188B5610EB96}">
+                <File Id="fil41DF782A7D72075CEB4065A97012E2D1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-focused.png" />
+            </Component>
+            <Component Id="cmpB828856E6D46E3DBAB0EA7222109025C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{6A325737-A3DE-4839-847E-3DDAF3AF0121}">
+                <File Id="filE01C3F9723A28028EEFA29E32CC1308E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-focused@2x.png" />
+            </Component>
+            <Component Id="cmp0A53762348B686F2C9D455BE66994A4B" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{BA3A51A1-3914-447B-9A98-89ACCCC5A882}">
+                <File Id="filC30437409F11B87FD415EB412C4C7212" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-focused@3x.png" />
+            </Component>
+            <Component Id="cmpA4FD4475A32CB68D21EACDBB95CB5153" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{9C2F2B14-DD13-46D3-9F6A-DBE695FCCCBF}">
+                <File Id="fil6934C0D684ECA80435E4FC182EF23857" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-hovered-open.png" />
+            </Component>
+            <Component Id="cmp2F06C5E995467B762EB27189A368EBC8" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{B5A1D79D-2F29-4C21-8B37-711D4757C8CB}">
+                <File Id="fil1527F8BB3D78A2E01F982C58A1CC58FA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-hovered-open@2x.png" />
+            </Component>
+            <Component Id="cmp8870470BDFC4E0CABDCCEE8FB4F3EF57" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{4F614188-F83E-4BF4-B329-EA7A84579735}">
+                <File Id="fil08EE8F03134D1055276C69708057209F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-hovered-open@3x.png" />
+            </Component>
+            <Component Id="cmp89B59AA7AC0E949401356663ED1112C6" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{C3FD006C-5045-4CD9-8838-BC6D13DD3B60}">
+                <File Id="filFDFDE41231AB274C952FB95AF41E64ED" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-hovered.png" />
+            </Component>
+            <Component Id="cmpDC7CDF7F168DAEE92E5EB942DE5D6DC9" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{DD98C9A0-EE5C-4B30-892B-C66B57D6543B}">
+                <File Id="fil4F2845964E990015109A59ADFA30AF29" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp290632D87DC0778D3FBD57F5B0F58FE9" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{329E2C55-8090-4E57-A7DB-273C5256CD6A}">
+                <File Id="filECA632A9905D2E73D448845E599C770B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpDAD3B08F7B95A8D6DF1FFCB46DD732ED" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{23C30A57-58F1-4C78-933F-BF8D8D6BB7BB}">
+                <File Id="filA820DA0C79106E185778C352822FFFF3" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-open-pressed.png" />
+            </Component>
+            <Component Id="cmp80F0BB391C7EB44844FA3844E4C084A4" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{FC9810C2-1BD8-4701-8FBB-0AB729BAAB9F}">
+                <File Id="fil1727DFB3372D1E4B0A2AD9A9D6FD5C5D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-open-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpDDB4AA820024C33BD89303448BDDACB3" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{664CE36E-ED73-42CE-800B-9BBF82053881}">
+                <File Id="fil5A195750B74C3D5311B17A28C13B9B7C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-open-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp4572F101E15C9FBF5013C1AE8B63BB95" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{5F134A87-1642-4F67-AAFF-CF66841D803F}">
+                <File Id="filA945DB2836231EA0B0727F5BDE91E502" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-open.png" />
+            </Component>
+            <Component Id="cmp33819AB51A6A14396E6ABF92D930BDF9" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{BACFC060-D641-4048-AA0B-73637F72E55E}">
+                <File Id="filB251C26B75EA2CADEB9CE460C70F2E5F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-open@2x.png" />
+            </Component>
+            <Component Id="cmpEFD027837D0CDA89598C8B12256D780D" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{B55E50F3-B585-45A5-8F01-494707FAF7D1}">
+                <File Id="fil88EBB41350855968F0D33F5BCF74F64F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-open@3x.png" />
+            </Component>
+            <Component Id="cmp8FA1B5C24D430203C31FD37C7E824D5E" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{05C904FA-8533-4797-9DB6-25EFF62E4DCB}">
+                <File Id="filD1C9B9351F3F4D436101DDA1CD742E1F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-pressed.png" />
+            </Component>
+            <Component Id="cmp4B6D581E08F8F3D16E50B09B3940BDB8" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{A3CF325B-EB4A-4941-87D6-954053DAA0A8}">
+                <File Id="fil2FD1274548B88312C27752C8497F1B31" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpC1D7F35904471A327DA4D6DB9D28EE0A" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{948DEAE3-CBBF-4C64-AB6A-DF992CDCAE24}">
+                <File Id="filF0638C8410DE1C69722A4864336666F7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp5ABCFBDE0D384A722285E09331A6D55C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{99753314-A184-4EAA-B845-8F09E658CB98}">
+                <File Id="filB42F542FB912B675BB33E5DFAE843A72" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background.png" />
+            </Component>
+            <Component Id="cmpD4011DA99D59808AE2630740276F33FC" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{4261D6E8-5A10-4E5C-A561-4EF55A062266}">
+                <File Id="fil55A959C0F00B15C1196FA57CEB37EDA5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background@2x.png" />
+            </Component>
+            <Component Id="cmpF845119E2FBC6A8DE665A4193445F971" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{5C5158D8-9788-45C3-95FF-0EA34BAE0BDC}">
+                <File Id="filEC3479D99AC84D753E848E232D9C26D5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-background@3x.png" />
+            </Component>
+            <Component Id="cmp203BAC4ACC8F207D60E4FB10F6F7D62D" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{744435B1-0194-471F-81CF-8A5E4DA56438}">
+                <File Id="fil966AFFA62C238DB200788F04F9BDD9BC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-disabled.png" />
+            </Component>
+            <Component Id="cmp491816AF0FACEE8B1A9B0BE858768EA7" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{B620DB78-4EB5-4893-82BD-F535E7F69221}">
+                <File Id="filD544D808806618D8B040CE7B02B6D87E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp98BC93BA65FA126109AE213BEA711CD3" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{28E6D286-5205-43FA-8BBB-278A726C9025}">
+                <File Id="filAF0BA958DBC6867FC6D464EB5115E92A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-disabled@3x.png" />
+            </Component>
+            <Component Id="cmpDC004F75497A17C850BA45590A4EF3CB" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{42F900D9-C467-4244-9F5C-3093988F5627}">
+                <File Id="filCCC6E009894F2AFED5394C406C61A25A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-focused.png" />
+            </Component>
+            <Component Id="cmpCFCE6A6CA42B5BDBC495AFC88D7DB8E6" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{64165DBA-ADBE-48EA-AC74-CEF1FAE58E61}">
+                <File Id="filCD4E8B7FE1427AF5C4FFAC9752E32AEB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-focused@2x.png" />
+            </Component>
+            <Component Id="cmpDBBF33531C7E49BD06366F4F693705A5" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{13226ECD-3E1E-454E-99AF-86E3FC1A0429}">
+                <File Id="filD5CEFF86E39C4EA9F600EFCB95D6AEB8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-focused@3x.png" />
+            </Component>
+            <Component Id="cmp730DC46FBCB5B19A5A0BB9A28F257617" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{FA591A2F-E499-45EC-B01E-1027DA4B999A}">
+                <File Id="fil65AF893844FBD4D59DE319A0D0CDADCE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-hovered-open.png" />
+            </Component>
+            <Component Id="cmpF03FACA3DAD96D374B7C1DCF9F350C91" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{A9DA23CC-90ED-4E0B-A80C-9FEAD5E93589}">
+                <File Id="filF46C10E5D02095E9C646B8C58C40EFB0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-hovered-open@2x.png" />
+            </Component>
+            <Component Id="cmpA2E171F4C2BE868C0FF454F971A14776" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{E512AE3B-CEBD-41EE-B8B9-EEDF0B26D482}">
+                <File Id="fil55CD38E7DB4AAD96D650178205F56465" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-hovered-open@3x.png" />
+            </Component>
+            <Component Id="cmp08B234EEBBCA3EE12784B9ADB1B7E02D" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{BEC1B997-5776-45FC-A77D-9A34A4760ED3}">
+                <File Id="fil0FE1BFFE4C9427C47BE3536C9DE8E537" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-hovered.png" />
+            </Component>
+            <Component Id="cmpF7E61DD097EB60FE89A556BC6F80C041" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{03F97A2A-F07F-41E0-8555-E1CE7F617948}">
+                <File Id="fil31F88065E31A472D00CAD2B62A143FC6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpB05F4CEB225F91B0FF35B909C023786D" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{26E1B628-FA52-429C-9481-BE389C793DFA}">
+                <File Id="fil2D40C186282A39458BCA4D936807ADB5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpB06A34467D96269CB2734DFC8FD5C801" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{A62DBF14-5674-423B-B9D6-C2B0AD8E425C}">
+                <File Id="filBD293335C7F3D3F91C0BB7304284D6BE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-open-pressed.png" />
+            </Component>
+            <Component Id="cmpF07D7B5AEA83F03C3DA51D31F5D4EE30" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{738F2C49-A84E-4D15-96E2-D98DA58EDE49}">
+                <File Id="filBB8B2159F50290857FE75B14DC9DBC16" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-open-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp6A551D32C22CF30C8DBC69DB28FC65AE" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{63F44FB3-5C02-47D5-BB72-4223D4E527D0}">
+                <File Id="filDA531C6F27BFF56E472707D2A11AD328" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-open-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp6D93F93FD621961D7C6284F7A8A006C9" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{55C6D98C-D984-437D-B831-796163CC3623}">
+                <File Id="fil3E8CB4C6DC34DD732DA058E6543FC61B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-open.png" />
+            </Component>
+            <Component Id="cmpC95E0FF3C4D2C7141CDD13F43D86D87B" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{5C48AA50-F5BE-4581-BFBC-AF9C4E131058}">
+                <File Id="fil04ED812A500790F0B885CD42AC0A3A5F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-open@2x.png" />
+            </Component>
+            <Component Id="cmpFA3D23FB4A09B4E96562BC23A5E83AFF" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{673344EF-51E4-47C3-B53E-0E5E2B0A320A}">
+                <File Id="fil637E6875A6424C9265784479C3F8F072" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-open@3x.png" />
+            </Component>
+            <Component Id="cmp57DA9B4079C1C9519D09E30B38E9523A" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{DF95794F-2F57-4709-949F-FF2A2F2D02B0}">
+                <File Id="fil3C1C12A84DF74D0A3B7052A5165D3310" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-pressed.png" />
+            </Component>
+            <Component Id="cmp176F6F306E6AD288915DA1AEED2A75D0" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{BE68621D-D962-4AC6-9C5E-C31469AE32CC}">
+                <File Id="fil9952685C16F3C14A2C367DEC5B3A7C7D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp4A2CDBF078BF75A57F616CCC0819E0A9" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{5D142D79-1295-476F-848F-1B4E191E929B}">
+                <File Id="fil0535E7051133FD105AD928B45FB32AFD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp79A70D68566AF162204586C439BD1F07" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{FC8F39E1-7BE9-48B8-9BD5-C4310624CE14}">
+                <File Id="filC984AC2AE9DD845A0FD11A9AF87F34FA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator.png" />
+            </Component>
+            <Component Id="cmp585E1AD92C18E5B3E64599FA43F85687" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{2F66980A-AB4A-451C-A584-F0FA8990423A}">
+                <File Id="fil04BF6F7D53F3451186899FDFEACC63C4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator@2x.png" />
+            </Component>
+            <Component Id="cmp6B7BB62F24D1A5B2F41DFA95BC483E6B" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{A6F78151-E1A6-4B5A-A1F6-597B2F6B1977}">
+                <File Id="fil76452EF01BB4192FA0284A528D22049F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\combobox-indicator@3x.png" />
+            </Component>
+            <Component Id="cmp7645CFD74D6B830800085813AC680852" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{BFDD8A3D-CFCE-4193-BA5D-52A092536A39}">
+                <File Id="fil1A1B001221EFA7A6D0A0D805AB5CFC55" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-background-hovered-open.png" />
+            </Component>
+            <Component Id="cmpF7E81A68C097E6EA4BE7C2135ABF6E1B" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{ADB2D888-4501-43CA-98E8-99258BAED4DA}">
+                <File Id="fil9EE66CE1C1000AF49B19F2631687A16C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-background-hovered-open@2x.png" />
+            </Component>
+            <Component Id="cmpA10F20CF7B5FA2A5810FD216BDB87A3B" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{1C3F6FC4-AF94-4D70-A77E-46A71E7DDE16}">
+                <File Id="fil3A556E57CBC321CBC722F2DD27DB59F4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-background-hovered-open@3x.png" />
+            </Component>
+            <Component Id="cmpB7773AB65040394B1ED24FBC83666D96" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{48ADC294-A113-499E-99BF-F1037121A887}">
+                <File Id="filB48CB4DF540F44FA2A1659AAB2448CF4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-background-open-pressed.png" />
+            </Component>
+            <Component Id="cmp6C06A57C41BE23F108659DA83A0E43D7" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{4CDF2A05-D862-4247-AD14-70CA76553EBD}">
+                <File Id="fil7698B7573444F2A61F252194558A0209" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-background-open-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp3A1A8566BCA820C8DE4D693284480080" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{0C45B377-C412-4A45-8CF3-0A1F361B8D8A}">
+                <File Id="fil71BEB392B3972E7A776EFB8A52853F49" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-background-open-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp6A264543B9EF1F205CA0E3315A67323E" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{2AFA3C7F-4789-4B61-AAA5-8AFD82C14CC7}">
+                <File Id="filD62A58C36D5A0FAE2965C5900F071628" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-background-open.png" />
+            </Component>
+            <Component Id="cmp70E64C6B3F82327F15D8A3193C27C057" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{E4BFB371-550D-47E3-8B0B-CDBD71A0B5E4}">
+                <File Id="fil173BEC18653FBA80EB9B64D1D5B65E08" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-background-open@2x.png" />
+            </Component>
+            <Component Id="cmp0AAFB7AF134AFAD1CAE1B14E6D693C4E" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{C6622CA4-0336-449F-928F-8512D50B1737}">
+                <File Id="fil458A43A16E7C2DCE3D8A7F5EB7CE7139" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-background-open@3x.png" />
+            </Component>
+            <Component Id="cmpBFBA41B502A56B76CBB1C532F93877D5" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{B39386F6-4C39-4419-AD0D-52EAA4B68C45}">
+                <File Id="fil5BF95D24A1F75451205716A92B8427B5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-indicator-hovered-open.png" />
+            </Component>
+            <Component Id="cmp207831F910C3ED735C98F78B43129E1D" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{A401B192-74CB-4B38-BD3C-63E29AB82699}">
+                <File Id="fil0F1ED3DEA0663D80F592B38B04E841AB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-indicator-hovered-open@2x.png" />
+            </Component>
+            <Component Id="cmpC5EC103A8E3B91A3BDBD258407FC2813" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{EBC1B00A-6836-4C96-9A2C-B60FB79F9A98}">
+                <File Id="fil11245E35AE4EF7F9F710CEE404C478E7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-indicator-hovered-open@3x.png" />
+            </Component>
+            <Component Id="cmp31817EDAD3B390203A4633FEA0A45F12" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{C75565C1-1C30-4D31-8580-2E4E07356CE2}">
+                <File Id="fil466F0B165E9E404FBDECEE622C83C9A7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-indicator-open-pressed.png" />
+            </Component>
+            <Component Id="cmpE8BC1FDAE39C500B3956FF311434D45D" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{11992CF2-2856-4825-A4B3-920A8D1CD8D5}">
+                <File Id="fil44308388C928DC43EF19A126BD2BCA4A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-indicator-open-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp2BA87DF268DB213B989449193C33E9EA" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{9BDD2160-4015-481D-9A3F-306B2A9E138A}">
+                <File Id="fil38E2FC70747B8119CDA34AB61ACE8AC8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-indicator-open-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpFC9E835919B6F5EB765B3D582F2DDC8E" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{7EF9E155-FB7E-48C1-BBB3-E8BB5641FEDB}">
+                <File Id="filC764D67B03EEC76EB641C7D602B26FAA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-indicator-open.png" />
+            </Component>
+            <Component Id="cmp99F97B1C0A2003E9E6583426246E570F" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{8B78375B-7320-4BEF-80B3-0321B1179F57}">
+                <File Id="fil2FF3D8D500BBA7C4EA3B83EF5797860E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-indicator-open@2x.png" />
+            </Component>
+            <Component Id="cmp87ACA27A630356BEDFFC89A3C6EE2FD3" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{A81024D9-41F6-4E10-B5F4-E6E62E57C1F6}">
+                <File Id="filB3779BAB6A4FF31346C282FD521CB612" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-indicator-open@3x.png" />
+            </Component>
+            <Component Id="cmp07BEC5AD21EC759A90A9288728F47C7B" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{14084DAE-4942-4257-9134-CA7CA89BFBA6}">
+                <File Id="fil9BC3CB7F87C7B379C0C73A12CEEEE451" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-popup-background-hovered-open.png" />
+            </Component>
+            <Component Id="cmp4C91AEF888247A8D488BF0DB7AB42D6A" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{E7944F47-6EEA-4E92-8F10-E86EFE6BCE84}">
+                <File Id="fil3FF343D406263CC261205BD45F25D31B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-popup-background-hovered-open@2x.png" />
+            </Component>
+            <Component Id="cmp1A640590BDD2A6E46277E87071BB846B" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{D2B8ECE7-474A-4D37-94E6-4575F8536A26}">
+                <File Id="fil49613E57896D8D0EC47735EEF07CD79E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-popup-background-hovered-open@3x.png" />
+            </Component>
+            <Component Id="cmp014E71D1AA7A86EBA0D79C3C33601C0B" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{E65D7F36-91B1-484F-9DE9-FE48FF42BFC8}">
+                <File Id="filC118284BE8A39366EAD665FECD73B9B6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-popup-background-open-pressed.png" />
+            </Component>
+            <Component Id="cmp6C34A2DEFD311DE6C26AEA9157C27A58" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{F24E8F92-E6B7-448E-B809-ECC852B31987}">
+                <File Id="fil831626EE047C1DBD9C890D5D2BCD7083" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-popup-background-open-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpD4A712BCDCC13288FFBECF192CF4EC21" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{72D4D73F-68EC-4827-AFCE-E5F5163D38F8}">
+                <File Id="fil86ADD78F3BDD83BDCBB2E1C758CF20D0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-popup-background-open-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp5424A8A6BE80342ABB00CAA2A44546B5" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{38D50CF9-5EE8-4295-99A9-91B1D6D61244}">
+                <File Id="fil941CAEA57D54ABBECEFBB41C4DA68F70" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-popup-background-open.png" />
+            </Component>
+            <Component Id="cmpE6028B5BCC0FFE8A7F238A5329C3007C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{E265735D-1941-4882-90E4-318458CE37A4}">
+                <File Id="fil6F692E6639F6A09672A9F836017F9DA1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-popup-background-open@2x.png" />
+            </Component>
+            <Component Id="cmp1242AB5D742B0AC59FFA678728B83BEC" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{FBD5F92B-2928-41AC-8E78-3BB8D94E8923}">
+                <File Id="fil1B05D7BE3B6591515896E2B4823307A9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\editablecombobox-popup-background-open@3x.png" />
+            </Component>
+            <Component Id="cmp9F1E5F8FB05D6C07451822C827A083AE" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{C5595F9C-1B7E-48AF-A4C9-3E440395B87E}">
+                <File Id="filC662CF40C2F477C8E5D4A4EACADD2624" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\frame-background-disabled.png" />
+            </Component>
+            <Component Id="cmp317E99BFE7C3FF17FDDE649A5CF5B295" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{19DB0B69-B623-4F22-9FA9-6D0C36AD24C9}">
+                <File Id="filA052D58045BF9FC928B306DF5894E706" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\frame-background-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp35EA83D781C3225C9612055AFAE838E4" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{C4626FB4-B549-46D5-A822-51D71AE6EB29}">
+                <File Id="filCDBDAE46A4F5261EC293F58B5AE5D8FA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\frame-background-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp4295C6CD7F997BD2F923E9264B9102C8" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{A8AE7468-C68D-4B86-A5AB-08A55E9E0F2B}">
+                <File Id="fil894B0D13A444B5425D393BDCDDD6249D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\frame-background.png" />
+            </Component>
+            <Component Id="cmp32B0F227833DE99A3E07B58CBA31D578" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{8D7A8D6C-90C6-4505-AAB1-291C0A45A4E4}">
+                <File Id="filDA51F3F8C30B3924D693DF53D8328764" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\frame-background@2x.png" />
+            </Component>
+            <Component Id="cmpEFBB112AB4A47ECE3393A3C8E6FA4037" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{3C4139CD-1B41-465E-AB8C-934E7226FF8A}">
+                <File Id="filD385F036585A19E0F5D84AC6BA181478" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\frame-background@3x.png" />
+            </Component>
+            <Component Id="cmp8531ED596AF05A0B52992364251F2219" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{6F48F3AF-6C76-4BED-A767-A73B6CD3423D}">
+                <File Id="fil221B971138C5FFD1D1C66BABB2961B5B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\itemdelegate-background-highlighted-hovered.png" />
+            </Component>
+            <Component Id="cmp750B896193B1BFBC61B93C4119FB16C9" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{92ECB2BC-C8F5-41F1-B409-BD5C7F7986A5}">
+                <File Id="fil25EEAD492A6C7A772D62135E72425EBC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\itemdelegate-background-highlighted-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp3DFEF28996626CF69AB2129AFCCCC3D3" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{F48334D3-D1F8-47BD-BC61-AE4B68AA1DE0}">
+                <File Id="fil5D65483F078DDDC6F704488B52033AF9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\itemdelegate-background-highlighted-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpC14ADCBE9DECABB78ED4EBEED1352415" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{CB7C31C1-BA16-4A45-867E-98C5451A10DB}">
+                <File Id="filD7F5E46E6D82DE9B76016545D9024475" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\itemdelegate-background-highlighted-pressed.png" />
+            </Component>
+            <Component Id="cmpCAD9E60E33C32851C4608ACDDFE90228" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{6750AB98-79AA-417C-93A2-0AE22BCE49B7}">
+                <File Id="filDC0B9927554089235260A2855AC5AC64" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\itemdelegate-background-highlighted-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpD1804C1E42993C4F41EE659DAB4F90D3" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{8842E4EE-1211-4B29-9724-99B1DEECDCDA}">
+                <File Id="fil60F662DB31C3F5075A9AE785B37E676B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\itemdelegate-background-highlighted-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpB3401C345822C965030D92D9EF3FB5DF" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{0245D715-710C-4E85-8239-B0134F91CAF4}">
+                <File Id="fil8387A8CE19056846AD461505ED874E02" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\itemdelegate-background-highlighted.png" />
+            </Component>
+            <Component Id="cmp1035FAB8B87C63DE53F71263EA7A38D8" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{C4C57256-3EF8-4FCB-9219-E141CA6639DB}">
+                <File Id="fil5CE7D164E7207CEC33D8B3DABA1CC070" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\itemdelegate-background-highlighted@2x.png" />
+            </Component>
+            <Component Id="cmp8281B1FF4DC555CD75FD86C3747E1744" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{CD36E585-023E-4C3A-B947-7FA3A0FD3C01}">
+                <File Id="fil6C2D138930E4CD786712E3BD383620A8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\itemdelegate-background-highlighted@3x.png" />
+            </Component>
+            <Component Id="cmpAB142705AF1EE8B29FF8C922D020B0C0" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{3989148A-8BE5-4094-A690-2B1CA105E057}">
+                <File Id="fil53AF4F805D0DE17CA49EBDA97FC6B583" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\itemdelegate-background-hovered.png" />
+            </Component>
+            <Component Id="cmpCBB8A0FD2FD66DF2E4FEA2A1541A2D50" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{8CD98B42-0E74-4E9F-A993-C8F976D51829}">
+                <File Id="filAC3296F9EAEA6590DDEFA475D73AAA47" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\itemdelegate-background-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp973E1D87117F09B14B4839A990BD5322" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{69912240-32C5-419E-B9ED-F0514CF82518}">
+                <File Id="filD2E9158D77C3B796783BF157F3A2A8D8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\itemdelegate-background-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp2051627253877700ED27ADF098BB7C63" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{B4D5E677-0563-4534-94F5-0BA2B108476D}">
+                <File Id="fil1289200224161BBD27B215296536AD14" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\itemdelegate-background-pressed.png" />
+            </Component>
+            <Component Id="cmpA9406C8BE6186CCED97A939576199677" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{0B1AA01F-DB0E-4E32-88C6-F0DCBF5748B5}">
+                <File Id="fil1D8630701EC27B3D8376EEA0FB01C687" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\itemdelegate-background-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp725E4B62AABD8943C886F7FC5460B0F7" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{7575C57B-92B7-4CE0-9032-793FADBC6ED5}">
+                <File Id="filB9DCE900308ABAABA56954278A3EC8C6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\itemdelegate-background-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp03391101A892351A3AA3A7E204BCE52D" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{665C2D6E-41C6-4E5F-9579-0395C6409E0E}">
+                <File Id="filB308FCB3E76BC695F05435EBFBD281CB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-delegate-current-hovered.png" />
+            </Component>
+            <Component Id="cmpDB28079F3DA192E2A778A7F20073F679" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{2CB57124-5023-458C-BE53-7FB60D6FAC48}">
+                <File Id="filDB248A8CD1866948CC8A90FA5B621DD8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-delegate-current-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp03523304DCCB23E59F61DC6C5F47781D" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{57EF3BF6-C0FC-4282-AFED-FAF35C2200B2}">
+                <File Id="filC882FDBDF0362A640EAC16331BC40E2C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-delegate-current-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp024CCEB95F137838A04FBF308FF49125" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{5D6FACC0-873A-4314-99B2-5D8B229D5F3D}">
+                <File Id="filF61FF76920AAF28713B8F8D5C51C40C4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-delegate-current-pressed.png" />
+            </Component>
+            <Component Id="cmpBBBBC4AD594978F7FE76F32C98A8A9B7" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{D48F8FFB-16DB-49BB-B0DF-0E5E5F37BF2E}">
+                <File Id="fil68978A338FCBA7B09D5F80A6BFE31198" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-delegate-current-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpA97FA8F8EB3AB91D965D66ABA86CD437" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{12B4D48E-9947-4F26-AD6C-F800F874CFCE}">
+                <File Id="filDDD3F2FAF63E6A27267BC9AA282A101A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-delegate-current-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpF0259A115C868E7E21EA1C130806BC8C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{8EEDEA7D-0183-4C61-A106-254D8F762B3D}">
+                <File Id="fil3FEC67845A36643FB72C68764D66B82F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-delegate-current.png" />
+            </Component>
+            <Component Id="cmp3FC74C2616AEA12ADCC4EC8C1C3B43A9" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{7282B7FC-4FC9-4269-BF36-899E40B82659}">
+                <File Id="filAEF4F492779DB8FFBD631365342CB436" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-delegate-current@2x.png" />
+            </Component>
+            <Component Id="cmpF82B8254F364D1BCB89761F5296CAEA7" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{300E130D-8F4E-41CF-978C-53BA87CF04EF}">
+                <File Id="fil10C67B2B83205821E566329FF151E4EA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-delegate-current@3x.png" />
+            </Component>
+            <Component Id="cmpAFF68A7496539D9862885C0C28067135" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{3E1EBF20-AD54-4D3B-85B1-B443633A7750}">
+                <File Id="fil16F85EE6531C3F902426B279C578D5E7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-delegate-pressed.png" />
+            </Component>
+            <Component Id="cmp87A76E7E1A282A96BF8678AC10ED9D52" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{6B7A552C-C655-4D2E-9FE3-CF77860AD9F5}">
+                <File Id="filAD6A4D3D6535E9E03110F60E9AF98E1B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-delegate-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp9B9DD3D26119C878CAFC927258CEE77F" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{7156B24E-5727-4A52-88A8-30CD0F33F901}">
+                <File Id="fil14FF28116105E2BA3FE6B2C6CCD90A42" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-delegate-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp4FE147108E1ADB030CE76AE75AA2441D" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{275C96D9-9BC2-45E1-9219-7633BDDFBE29}">
+                <File Id="fil8F46E77AB82AC3D1F94E4E4151B32C89" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-disabled.png" />
+            </Component>
+            <Component Id="cmp617B8E071F6BFE57247FD0638C9E1011" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{406C6657-3B6A-44AC-9790-CB567040CAF8}">
+                <File Id="fil075360C13CD783692342FC1457E9DBEE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-disabled@2x.png" />
+            </Component>
+            <Component Id="cmpA8E8531D5F7493B7603CCA1C7993637F" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{6D40280B-B57E-4022-928C-4A49100F6502}">
+                <File Id="fil2E971E6958D7E11C96DCFB4E3974A2B5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp1FC66270AB328AA855F8630F06B43C40" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{7685F88B-4EA0-4E67-B355-F82E570A9933}">
+                <File Id="fil9F00B9FEEA3828060E978B5D8B409D79" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-hovered.png" />
+            </Component>
+            <Component Id="cmp0195741567E2A7D69979EC9BA893B15F" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{4DA85403-0763-4222-B55F-831CBF318BA4}">
+                <File Id="filA894BE789D6308A36977685702B000C5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp57E679994997915584905FC6DC27E704" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{D63450CE-B5C8-481A-901C-F949CC363B03}">
+                <File Id="filBA7056DCF2595B563E375DAAACAC7CAF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp3E7DA5F97D72A870F930764744C1070F" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{C632C410-368B-471E-9059-48B9BC81BB42}">
+                <File Id="filA5201B8C9501C6F9B12A48A498C2CBB0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator.png" />
+            </Component>
+            <Component Id="cmp0EF52DC7D4FBFA70C9A734E133E36098" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{F2AD3F0D-8A0E-400F-9762-D34640F5AA13}">
+                <File Id="fil12853B6CC0FC82B8160014F6420136A9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator@2x.png" />
+            </Component>
+            <Component Id="cmp822B1D3F6C0C5EE22018248C8DFCADB5" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{956C065A-BFDB-40C3-9063-A380B2DDB3EB}">
+                <File Id="filC02D4C511234091CF78B198E6354A8FD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\pageindicatordelegate-indicator@3x.png" />
+            </Component>
+            <Component Id="cmpD52E4CB10C7228F41BFA5FA93EE7BD36" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{098044F2-D4FE-4B0F-9F5E-3102C7712702}">
+                <File Id="fil61AA75F34C9306951B422FDCE2769DCC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\popup-background.png" />
+            </Component>
+            <Component Id="cmp01276998E094E8C03638E3647F776786" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{E53C4EFE-B432-46ED-A32C-C61A80D804D9}">
+                <File Id="filA521EE7750CA8BE3697F1751F41C5C19" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\popup-background@2x.png" />
+            </Component>
+            <Component Id="cmp6B7C57B85745633B7DCA395E5329702E" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{F39BF93C-C76D-4D5D-AD38-B809D139DA56}">
+                <File Id="fil0DA1E45B4A2BCE7735427AA503D76EDA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\popup-background@3x.png" />
+            </Component>
+            <Component Id="cmp3310A3C651D732D48419DDBFE47B0A3F" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{C23BAE3F-8988-4A54-8833-D6C8621B5ED5}">
+                <File Id="filCCF975D7C5FBB44C7CCD5A647145CB94" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\progressbar-groove-disabled.png" />
+            </Component>
+            <Component Id="cmpFA81AC5A5CF5A2913A929747C49DD4D4" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{940D2476-2327-4C3D-83E1-C311A2B7F62F}">
+                <File Id="filB6AE6888EBC28C4A17D971F2D906DB75" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\progressbar-groove-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp6C567EAA259227553D124204FCF9B569" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{406B2FA9-E7B9-4700-8ACF-83C3F3EADF31}">
+                <File Id="fil9EA083467DDCEDC2FAE3362F8D4C3772" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\progressbar-groove-disabled@3x.png" />
+            </Component>
+            <Component Id="cmpACEE6EBBE68D85216B2E52FF9E35055C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{E416F54D-2E50-445D-99D5-404691176B23}">
+                <File Id="filC6E326AF9E149C226612762B2FDB70FA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\progressbar-groove.png" />
+            </Component>
+            <Component Id="cmp9C787B79EFC3BEFC66F38BF653087786" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{3D049B58-2CD7-4FA4-AD21-20DBFE00D83E}">
+                <File Id="fil53AA2CED6652C732E48B50FD174EC75A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\progressbar-groove@2x.png" />
+            </Component>
+            <Component Id="cmp3DB8FD7FED80F57D0493DA2EB2CF4F79" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{7A0C5B92-98AD-421E-959F-FF918B6B1628}">
+                <File Id="fil4ACD9D35C5DB216856548FCF66551A64" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\progressbar-groove@3x.png" />
+            </Component>
+            <Component Id="cmpE3714750C0991EB75FE5CDCA0D4CB8C2" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{4E43CDA4-0A4C-42DD-AFA7-17188EEE9B5D}">
+                <File Id="filCEFA7CA4BF24C128F41E37474704C53B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-checked-disabled.png" />
+            </Component>
+            <Component Id="cmp5630F79816F62D9457CE8E8D22800467" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{0B52E307-54E9-4144-8C30-EDEC63FA557A}">
+                <File Id="filFDC1F4E9A6D62223E86384D03B3144CB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-checked-disabled@2x.png" />
+            </Component>
+            <Component Id="cmpEE784F4AF8D2F392C1FB1C919A05CBA8" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{4EC3448E-530E-4564-831B-72C62B2F7EC0}">
+                <File Id="fil45936727B960C7C96CF4A53DE35E28EE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-checked-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp33E2F3F087DD1A345254A290B2850659" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{9BBF86BC-511D-49D0-9816-4F0C3FD8D8A8}">
+                <File Id="filBC94B6E8E048FADE1AA000B66B30F143" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-checked-hovered.png" />
+            </Component>
+            <Component Id="cmpA300CCE0BB3920FD29D049FA68A490E4" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{150E267E-B2E0-43CC-B8AC-DB1F6455D11C}">
+                <File Id="fil9B49D3D0901DE31AB8F3540EC778F22A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-checked-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp36BA95B12F30ACF7634E0C660C237CF1" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{9444B34A-2F41-45A9-B9B1-72F1E135EA39}">
+                <File Id="filEA1F401E59BB1EFE37D952F907F406D4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-checked-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp91D053043462B452D078996D822A3DA5" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{D5CB8ABC-F05A-494D-B4F5-AA3B10EA41DE}">
+                <File Id="filDA304D21B596E3FDEF98E10D43E4EF4D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-checked-pressed.png" />
+            </Component>
+            <Component Id="cmp5D16F5E6DEAB88CC23A1B79C4CFFD09C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{BC37913E-FACA-4F10-BD84-7D15CD563794}">
+                <File Id="filBD305E2583BF4CB841B34DA652E36257" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-checked-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp973B81A7CC01861A735CFDB4D6D1A086" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{7122799B-6E0C-4AA0-B605-D423C30D3590}">
+                <File Id="fil187540D81174D7F88C4B4EA8F445834E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-checked-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp97092B396D34890A73A7D6A4870995B4" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{49A478D9-2952-4904-AECA-CDF6F733260D}">
+                <File Id="filFBEE1F5C44D6342BB4C357B39FCF3EFB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-checked.png" />
+            </Component>
+            <Component Id="cmp28E802312B6A7223D3ED9942900BC3E4" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{026AB5EE-0D67-4EF0-92C5-4D28CF2C5428}">
+                <File Id="filB0F62444A9E1F9ACA3077788330B2935" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-checked@2x.png" />
+            </Component>
+            <Component Id="cmp4D50306F849835974F5729B1F785D47C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{EAF1A292-E3A1-4529-8D5C-E4C6BA802DA9}">
+                <File Id="filB409116644982AB950677EFA30CC122A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-checked@3x.png" />
+            </Component>
+            <Component Id="cmp67DD605C7E7BAD158DD5032272D6F9A7" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{47A3D992-18F4-4CDC-B652-23E2910330CB}">
+                <File Id="filC59304985A88FA05DC217FCBDCADCA10" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-disabled.png" />
+            </Component>
+            <Component Id="cmpAD57C016C48F657486C5C3600A0FF7BA" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{EC76AAFF-6A02-43DC-AA58-C7B46075031B}">
+                <File Id="fil074BCEB29E99A91C764F7262158DE995" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp3369740539652CFDD8609288A374BA13" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{A914526A-96F1-422B-8E56-39ABE8F2C0C0}">
+                <File Id="fil8285692AFA3569043F2E676C064DC863" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp06B958C0DF21028CD59598362A56E1D1" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{7D9FA289-BD41-4E29-9B0E-96789D45CFBA}">
+                <File Id="fil03AF216FFFFF2D717D1554899F5E5BEA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-hovered.png" />
+            </Component>
+            <Component Id="cmpC4D419736D40F1D1840AA63160B755F3" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{A524C1B4-4A29-472F-BD1F-C0BA70B03023}">
+                <File Id="fil86A6E64EC4A7ECBBBC4D8F27CD39D7A5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp155652F86ED0AD67B64B410D2C9D3331" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{135A96DA-68C2-422E-B6A4-AD2D3539893B}">
+                <File Id="filC722BFCBA2103D933258448E8D9AD6FD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp0FABAF5CB59914A66FD351F3571679B7" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{44735819-E278-4915-8819-FB1C184E2A9E}">
+                <File Id="fil38CEB0562B877B342C344109513F0E09" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-pressed.png" />
+            </Component>
+            <Component Id="cmp1217271319171A9D82281D5D797657E0" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{43C8C189-D1EB-452D-B43B-B9663C7B487A}">
+                <File Id="fil0C157E6B0AAC892A0EBE49AFB6F81E86" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpA36878F2F46F0CCEC5693E4BD6885A1C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{2EC70507-F756-47EC-90D4-96D89CA0E647}">
+                <File Id="fil86C2DE8DD32A781369C12F2405FCD598" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp2A707DC7A147C40DBF13C3FDE4623062" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{D56D70DF-AF58-4ED3-B799-0592D2AD347E}">
+                <File Id="filD58A20C2A6F6D350C70B2C629E7BC540" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator.png" />
+            </Component>
+            <Component Id="cmp9411363060AF0E050527F43C58875AE8" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{21FDB680-4372-4ECD-B909-71ADD5945E00}">
+                <File Id="fil4E3C717CD75C65296124950A9FE2F294" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator@2x.png" />
+            </Component>
+            <Component Id="cmp35E38B7D838E8A861EA579164AF59F37" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{FF6EA4A4-99B2-435E-ACAA-35265596942F}">
+                <File Id="fil3727EB308F72D329AEFE531526D1396B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\radiobutton-indicator@3x.png" />
+            </Component>
+            <Component Id="cmp65F2A6CA473FFF182B1A911B08420A08" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{0E886B9F-3EC6-40D7-8BF6-DBE20AC27383}">
+                <File Id="fil24E37E85FFDD6FDB0BBF1055EC5A826E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-first-handle-disabled.png" />
+            </Component>
+            <Component Id="cmpB6976A52E6C93904F3D5CC211F2AD6F1" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{F413CB4A-444E-4544-9471-483D3983C47A}">
+                <File Id="fil71185CC04BA55B71F263F8253702DCED" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-first-handle-disabled@2x.png" />
+            </Component>
+            <Component Id="cmpE6D379812AF8976AC39F0D976DB8A61C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{B9868908-4381-4D07-874B-6865FCA44CA0}">
+                <File Id="filE4860053C7FB7820FEC5530C0F5FF715" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-first-handle-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp26552F97951E2813FA9B250FC14E27CC" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{5FAF7F5F-91DA-48E9-B5F4-02DEF29637E0}">
+                <File Id="fil7F99A9753980EBA2A7DEC8F04056AEBB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-first-handle-handle-pressed.png" />
+            </Component>
+            <Component Id="cmp23F8885CDDC70AD71D211641F3E35D02" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{BB1AD322-8D87-4C17-931D-1F2D62ADD170}">
+                <File Id="filC389041CCAEC1CF09BD710FB5E4AA68A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-first-handle-handle-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp35536054D5A18C4EAB378060409DCA1E" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{8359053D-28A1-4658-BE9E-F3E0668886A9}">
+                <File Id="fil37D810E450B6C755D2A40E8AEECACAFF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-first-handle-handle-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp26D91F59A01F8CB1E036B290E3C26A74" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{D7885F99-56E1-4E83-8613-2B32BF0DC179}">
+                <File Id="filA6BE1AE7E55EAA3993836AD57B73C03C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-first-handle-hovered.png" />
+            </Component>
+            <Component Id="cmp3F8F346B0372783FCF27018D20BEB908" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{B157B908-4F6A-44EB-99B7-68622FD2697F}">
+                <File Id="fil68BC62A6067B994045F57FA49A797564" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-first-handle-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp8A18F2A4A8A2A0B510DFD4AC495DCC1B" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{4A200F3B-B51C-43D6-8BAE-EFBDDA8A45E3}">
+                <File Id="fil81E6743256F4DE9A2761C1715DD3DC16" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-first-handle-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp3DE37AAFA65EEAA6C6AB4EF5034CB469" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{6F9F29C6-D883-40D5-B0B0-A13F6C05B077}">
+                <File Id="filEA40F50EA15FD844F7C837EDAA10155F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-first-handle.png" />
+            </Component>
+            <Component Id="cmp30616D951DB8C35094924BC5F6AF036F" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{41961C9A-B627-47C7-9469-1560594B294C}">
+                <File Id="fil30CA79E867A82D88FD4F88AFD0D21EAE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-first-handle@2x.png" />
+            </Component>
+            <Component Id="cmp7018902C5C27299FA98E4752879BF589" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{156AD610-071E-4B96-A267-02A7E95E5EEB}">
+                <File Id="fil4C48B47E27A3161F8166FD2F0A49736F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-first-handle@3x.png" />
+            </Component>
+            <Component Id="cmp4C2F9822D0A66A2D46A66F2C438F8DF2" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{13BB8E11-B15C-41E2-A03B-694FAFA8AA6F}">
+                <File Id="filAEB675B3A7CF2F52C2F0B1A3F6B3B9C5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-groove-disabled.png" />
+            </Component>
+            <Component Id="cmpE9AFBBD482EB14119D30909B77A2BC2C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{118681A5-FB6D-43B3-A549-4270F83F3AE2}">
+                <File Id="fil0171BDFBC7E1429C972A343ECEA2CE7E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-groove-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp71B151129189766D9F93F8DAA3D4907F" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{AAE18DF4-48E0-4A95-BE24-99B20F496783}">
+                <File Id="fil29EFB4AF6664D19527EB23D1045B6967" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-groove-disabled@3x.png" />
+            </Component>
+            <Component Id="cmpC9E761CDEB612668B6F38CA5C1E4261F" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{381C61FE-0DB8-4CEE-B125-A85353E861BE}">
+                <File Id="fil311917549971A7FAAF2B165895ED1810" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-groove-handle-pressed.png" />
+            </Component>
+            <Component Id="cmpA8290640A655C0AA32A9F4225DB7E21F" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{D1E96831-B528-40F0-93BD-0DA25F9E357B}">
+                <File Id="fil88B765286F4952AA06F55A474A3B0986" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-groove-handle-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp1170F01D9557AAD74B0C014B136A7C8E" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{C23A0AD6-84FD-4A15-BE90-1CF44E896A62}">
+                <File Id="filA80F85AD6F8FF2F93BE7FA407C621D5F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-groove-handle-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp37333B50ECDE098B356A1777AC12A360" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{D92B49D8-B9BD-4C71-AA4E-B0778D223EF3}">
+                <File Id="fil9DD3278352BA6764E5FED2FA1B3EBA0B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-groove-hovered.png" />
+            </Component>
+            <Component Id="cmp43002BC5641435FC3B6CC77EB238F792" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{400D31D1-F240-49FB-9C46-AA6CDAE45A2F}">
+                <File Id="fil7A804F10757E78F584F503B23B076C33" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-groove-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpDA19790DAEDA0EC6E03D31D30EF96C1F" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{AE8983DA-DC76-4CAF-AC9D-1A365577A70E}">
+                <File Id="filA6E3E16F0395C70B3D2BF5C4B5DF8EF2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-groove-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp02432ED987E9AADE96237944527FBF2F" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{7AA8D7DC-325F-43C3-AF31-14FC5EC31CD1}">
+                <File Id="filD524F9D101B634DA9FA6B1B864482758" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-groove.png" />
+            </Component>
+            <Component Id="cmp624C646F79623FFB94152ECABBE8106A" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{B3420DE9-D5AB-4A35-AA13-577AB7C44A0D}">
+                <File Id="filFAD13A71D3F6427BFF2453616A18C298" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-groove@2x.png" />
+            </Component>
+            <Component Id="cmpF55A1B82BB85294EA3829B72C07C4162" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{DFC001CC-AD6E-446E-95A6-7E55FD7E0211}">
+                <File Id="fil28C2F4BCA04FAF636DF18DABB74ABB28" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-groove@3x.png" />
+            </Component>
+            <Component Id="cmp842EEC47744D166BE26F4C96378D7613" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{051B5963-D0D7-4D1F-981A-8A178AEB63EC}">
+                <File Id="fil4A7BE9AAEA21F3E6EE8193328E9368AA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-second-handle-disabled.png" />
+            </Component>
+            <Component Id="cmp2EA25D3465C7D49952C5216AE463FFE1" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{DBAFA1BA-E457-4B40-B92E-F6D248BCCBA8}">
+                <File Id="fil952C987431AC696C1F7061879FC2F978" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-second-handle-disabled@2x.png" />
+            </Component>
+            <Component Id="cmpD9E6E949613027BD7772EDAF5D9128D3" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{E720A971-A5D0-4C63-BD22-878FEE727DCF}">
+                <File Id="filFC89F79ED8F89C4E3EBFB6089BEAFD42" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-second-handle-disabled@3x.png" />
+            </Component>
+            <Component Id="cmpFD421045565CA6FB907464ACA73D7DE9" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{0B368672-CB53-49FB-8DCC-6120F4E503C1}">
+                <File Id="fil5B9F1F4E64DD18051806EDAEF3B04333" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-second-handle-handle-pressed.png" />
+            </Component>
+            <Component Id="cmp32292D547E4DFA54934E2C11A970ACD8" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{51CFF523-435E-4ECF-8137-20DD69114CBF}">
+                <File Id="filF6687A52C04E3C802D6C7DDF6966D9A0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-second-handle-handle-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp21E8F11F6462ED62C61247206CAF9A80" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{E5E5A052-96E6-48E6-84A3-7C157F076CF3}">
+                <File Id="fil93223CD8F85AF26357A98D5275520848" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-second-handle-handle-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpEA35D7396B0CCF94534123320F1BC9DD" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{663AD35E-3217-4CAE-904C-3454E43AD916}">
+                <File Id="fil3EAD31F82DED0027CA6B8A5D91F73BD1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-second-handle-hovered.png" />
+            </Component>
+            <Component Id="cmpE2564D0FDA3CE196A95A11F0EBA291CA" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{F9DEC919-5C33-4094-8BE9-890EC2C62FDF}">
+                <File Id="fil31E02DDD3224BCB8E6076C8A6A4001D8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-second-handle-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpA4738E7F2B7FA76136DD9305ED36DA44" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{D44886D6-A406-4A53-B080-FA3095361C61}">
+                <File Id="fil875F7C71661B8AC833DDC44D5F68D4D0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-second-handle-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp44243D8DE0AEA7F22DA860D20CFE64FC" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{85875855-2731-4329-8722-668D14F585F1}">
+                <File Id="fil6BF2546284FF491C11B9D5901BFE803F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-second-handle.png" />
+            </Component>
+            <Component Id="cmpD96CB4E88B970481CE8401FC445187DB" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{DD36673F-3094-4E6F-BBF8-72A23823710B}">
+                <File Id="filDEB3A591920E9E81F8A7B4DBF31E7D19" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-second-handle@2x.png" />
+            </Component>
+            <Component Id="cmp852E4726A7179F7E87280CD418159848" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{8EFFCC57-0486-4CEA-B209-D9A5C587EBAC}">
+                <File Id="filCE008394FFA1428A86BEE5BD7C602E18" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\rangeslider-second-handle@3x.png" />
+            </Component>
+            <Component Id="cmpF2FA0DC18671B96E256E8BC6D6BE9748" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{4FDD3FF8-30C6-49E3-A68B-CF3450A85DBE}">
+                <File Id="filD0DAC4E495072460AF5F2168A748B557" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-groove-disabled.png" />
+            </Component>
+            <Component Id="cmp5A2DF6473FCC81F633F4108042C45584" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{67984FAE-04E0-441F-B7BB-68D98F47890D}">
+                <File Id="filE561D53AA66261586C435788B1F49D33" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-groove-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp8B5A5EA590A73DFA2E05F4731166D962" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{ED770DC5-3F4C-477B-88FD-2629C01A2313}">
+                <File Id="fil4D11793771746A6C9EBCDCAF748852A9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-groove-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp1EEF14145C2D588352AED7E5E28230C3" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{E8653A6A-8202-4AA2-99A7-534EEFC0B294}">
+                <File Id="fil5ED5A7031AAA55593EA93F3BB43DB5F4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-groove-hovered.png" />
+            </Component>
+            <Component Id="cmpD3413054AB0C1E4DC6EF480B9A29F017" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{9C4A99CC-85B7-4337-92AC-612399E62A36}">
+                <File Id="fil7EF8A0B070FFE1599D493609EC7890D9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-groove-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp206EFCF901B718F0C3EC7331E32A51AB" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{D6A9C085-02CC-4EB9-BC2C-F0356883E9A6}">
+                <File Id="fil0B1CAEC328022286BD3F1F6559067A63" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-groove-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp3DDEF11ADD37A99482A15968B2E96B62" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{81F2D06D-2AD9-4F3E-AA2A-4D3D86A933E1}">
+                <File Id="filEC6D28872EAB631FAD154AE7626E551F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-groove-pressed.png" />
+            </Component>
+            <Component Id="cmp73AE3FFB00747A87BC38057C85C14B66" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{3385AD72-7500-4B4A-901C-C7DB691EB83C}">
+                <File Id="fil4C9B0D62846FA121CEDEF691BC6209D1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-groove-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp060325DCAA18506A306435BC2B912706" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{89FC0127-B8E7-4620-B0F7-31BC48F4ABB8}">
+                <File Id="fil323235584295AE77FC2F6F95C6EF8559" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-groove-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpFC2B4C2A274A60A8A491988C9CC40E31" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{746FBB5B-4F14-4759-B0C6-18BF8CDED699}">
+                <File Id="filCA4B412D970CE19053A1D25A8653A4D3" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-groove.png" />
+            </Component>
+            <Component Id="cmp1DA8135F70CC5C468C820DB7C088804A" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{5825E996-324C-4FDF-AC96-F2556F901444}">
+                <File Id="fil4840FA09428392936A74B978B3630E13" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-groove@2x.png" />
+            </Component>
+            <Component Id="cmp6FA6EDDFBA9DF716CD7216E4D19FD51B" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{E0B5624E-5CAC-4C56-A6E5-808CF6F7BC53}">
+                <File Id="filEA0596FC1D28EA3BA283A20993F550B6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-groove@3x.png" />
+            </Component>
+            <Component Id="cmpF3F8861321960B16C39797EF1865D1F5" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{5DBA9CFC-C51E-4F0F-8342-013F66829944}">
+                <File Id="fil294C43C1D3EC8AE89C26CF6CED04C37F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-handle-disabled.png" />
+            </Component>
+            <Component Id="cmp71AB0D518E6824EEB2E8DFBF611B2A8D" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{22FD8061-BD71-4315-AF8B-D931E70CA7B6}">
+                <File Id="fil7F0F28F40BEA7FF9CFF2F389B9EBFB6A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-handle-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp0D48C3935D4A337BEACAD21696C75018" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{4823EC53-23E3-4587-9FBD-A593F26057F9}">
+                <File Id="fil9F5601C3CF8B2272005F0F8B44C599A4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-handle-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp33ADFD26671BA9128F71A4A84E41E89C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{915FB8D2-0D28-4AD7-A382-85D3A8DD5C15}">
+                <File Id="filDE5AA5700094EEDCAAC45085EBE5EBB5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-handle-hovered.png" />
+            </Component>
+            <Component Id="cmpB5AC46A9315F1177234D44D8EF9161C5" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{6BC90EC8-8816-4E16-BAE4-89A3ABF0766A}">
+                <File Id="fil15F09C33ED9E250EE5B5A8D4BCBF1FCC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-handle-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpF6C269C9780A2A473542719EB40E9390" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{1523F3E7-A377-4F7A-91D2-665D6EAC8A16}">
+                <File Id="filD3C72C3A5EF3ECC4D501606D3DAD4AC4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-handle-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpCDF760A0494A2FE0FD17553E0B218946" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{820A12C7-2D34-4760-B4ED-9F8A855B62FD}">
+                <File Id="fil42D8B23F4010F98B13C71F4D7B204259" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-handle-pressed.png" />
+            </Component>
+            <Component Id="cmp2596991E71AB422DF96844D8898669DF" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{26881890-66CE-477F-99FB-67BE5751BF16}">
+                <File Id="fil9DDF5CBEC56EA0083352B675BEF957A6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-handle-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp7CFD3FB7444787E7A3C2C0C70175CB8B" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{6B7D9CF8-6F1D-4049-9527-08B5B9905500}">
+                <File Id="fil8121B1E4B4016AD49B2B7E8DC9AAB835" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-handle-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp07BB8DC9B5158C2CEBE1883C78D0ABD6" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{5109AC40-CD9C-437A-B562-E6E754B2CF39}">
+                <File Id="fil31F9AB723A179D6BEB669D20B0086204" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-handle.png" />
+            </Component>
+            <Component Id="cmp5E61CDC94DD910FACFAECEC9A79EB922" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{A4B3C0C5-F587-4A1F-952B-19A640B991F9}">
+                <File Id="fil05316951DE19A19958B7652A6BD740F5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-handle@2x.png" />
+            </Component>
+            <Component Id="cmp48CC1434DDE3A45882D800CD42589210" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{4B98D60F-C85C-4EAB-8639-892B7B21CD3F}">
+                <File Id="filDB388FD4FE7F58AB09DB7ED6FF2B2285" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\slider-handle@3x.png" />
+            </Component>
+            <Component Id="cmpBDE94B614F7A4F31EA8A3E9F2CB4830A" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{B1FBD9E0-16A1-4BFF-BDAF-0458F7602A33}">
+                <File Id="filCDD1F4FBC896F8371D02134CE504ACD3" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-atlimit.png" />
+            </Component>
+            <Component Id="cmpF6DBA134DC342AD8633E3BD6E14D8048" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{1DDCB2FC-5DB7-4F9B-8914-DB919E0DD1E0}">
+                <File Id="fil6A7843C9D0F9E8D352EE5A5B01800227" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-atlimit@2x.png" />
+            </Component>
+            <Component Id="cmpE84FF1562E5F74550A6F2667F764F017" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{24CCC59F-223C-46EA-98D7-09CFF050E83A}">
+                <File Id="fil0037821B682C591BE1912F60317F58AF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-atlimit@3x.png" />
+            </Component>
+            <Component Id="cmp24EB8E873FFAD2B827D0F37C255888EA" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{020383E6-E348-4F4E-9097-98090F3AF4DE}">
+                <File Id="fil7E55ABA0E38D56A3C045C75212EF837D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-disabled.png" />
+            </Component>
+            <Component Id="cmpCD930EADC03A9F3949FF946371B6B8FA" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{A65BD944-1960-4947-BB1D-B6204A9A8458}">
+                <File Id="fil441DD5ECCA68E639A63E038C8257DCC3" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp5864A7A3D3E0145DA0544A3C7E307D25" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{24FE265E-50BF-461D-9635-4DA0FF53EBBA}">
+                <File Id="fil36A65381622B4C36DADB75CF33F20113" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp166E26309B63F62C1BB3AC06650BF629" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{0897D237-2593-4DAA-86A6-E2702B8FCBE6}">
+                <File Id="fil8EF7DC1519A3732EBBC6D65391B7F972" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-down-hovered.png" />
+            </Component>
+            <Component Id="cmpB6CD3DD1B6FA02D89E92708F9C180B72" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{D1230C97-451C-4A4B-BE73-651749668220}">
+                <File Id="filDEC894604D8ADDE42DCA62F47BC7569A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-down-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpD2388F038C9D89635A6D14537093935E" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{D42B7D9F-44FE-4280-8248-78D1E5083E6C}">
+                <File Id="fil1379A034068A30DD73BCB3071C757B09" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-down-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp9563B2D3D7F8AF356B0F906A6F77CF56" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{6DA7D884-C913-4A80-9A9E-943BA715D511}">
+                <File Id="filB2E794AD331D7F7B5E9BB239665C2395" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-down-pressed.png" />
+            </Component>
+            <Component Id="cmp20857FE4BE77EED914FE426F0BA11933" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{B4165C1B-9610-4289-932B-1EC7B42804DC}">
+                <File Id="fil43AF44EA351F65F06CBAFC077750FF2D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-down-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp04BE47EC15D0366A27ED78FF0AAC167A" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{C9EFE0D7-58DE-4EFC-8B8F-B59FB3175133}">
+                <File Id="fil34F4E6646F37DD108170026F8183AF7F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-down-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpEFAD02343F70EB07283B55A52902737E" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{5DA167F7-3146-484C-8122-CED415A0FE16}">
+                <File Id="fil9E8F8B2995B00601C0A2A6F9992B696D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-hovered.png" />
+            </Component>
+            <Component Id="cmp8A1E29FF2724CD76B9913E4A0C5115EE" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{AA76C6AD-D477-43F2-996E-38BDC87A83FD}">
+                <File Id="fil9210DADBBD821FD79F76DAF74030D319" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp2C684ABEA3D9ED220C7A7CA6A16163A9" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{D468F4D8-6144-4973-8B07-72A17B0E27BB}">
+                <File Id="fil1B2BC6F3CC06315351446567BFFA8517" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp6A7C3EF3B91E40C4190B64D327DC0671" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{E819EAD0-3C7C-4BD2-9FF1-4D2FD2B52034}">
+                <File Id="fil8DD0E1386C5D92EDF34B2BC281F2D46B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-up-hovered.png" />
+            </Component>
+            <Component Id="cmp666DC8564DF589AAE3087B2FBB60591B" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{89F19967-9D54-4DE6-8C3C-21C22BE1BF13}">
+                <File Id="fil48F660003DAA9AE3BB27BD19F04652D7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-up-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpE68B538C479672080A5023F76BEE0937" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{06ADCAA8-4618-415A-8261-7533A49A61A2}">
+                <File Id="fil39E66CC8FE29DF173E9F4210CAAEEA8F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-up-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp31048F315BF4DAF10E35D2AADE5F50FB" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{2256D419-B8C1-499E-B1D1-C0A2100E3FDC}">
+                <File Id="fil23A443C1D0D44251776CF8931AFD3D95" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-up-pressed.png" />
+            </Component>
+            <Component Id="cmp731E6E46A643B0FAE5F833BEA4C61E0E" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{FB5B1209-1F27-4EAF-89F0-0E96E4DD6B23}">
+                <File Id="fil7CBC474CA3BAE6648B13A925199728F4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-up-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp1105FD3864A6F629335C934D2E361610" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{1132FAB5-3F38-4164-944B-83DBBBED4D9E}">
+                <File Id="fil23066BA0ECA3405BB82E900901467DBB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background-up-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp331F1BE9B3AEED77E4E602345E22E74F" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{AE5EFC2A-799D-43D4-A57C-3BC7802A34AC}">
+                <File Id="fil5680D7D4E685CA2FC3F0A98E56FFC81B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background.png" />
+            </Component>
+            <Component Id="cmpE58A431C6F008AC9BEAB67266AB36A3A" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{91668E10-DFF4-47CA-88F1-CE1872F2F750}">
+                <File Id="filC860C2012DAE4679C3952C43D4BA2BFA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background@2x.png" />
+            </Component>
+            <Component Id="cmp81E94264F90CE31F5A8D7F9C94E7E518" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{35FC68C4-4994-4A71-9E75-9BFA8EF26E7E}">
+                <File Id="fil7F98D4260EAC10DBBA392685F5142983" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-background@3x.png" />
+            </Component>
+            <Component Id="cmpBA3CCCE70703EE52E3E60E2E8053F192" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{D855B7F0-674D-47F2-A373-02070A70BEE8}">
+                <File Id="fil53F905B42D0200024400237A6D9D73E3" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-atlimit.png" />
+            </Component>
+            <Component Id="cmp70465A86A2A9CC7014BECB9233AE1867" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{A21DDC10-E9FA-4DDE-A5E2-32565003E050}">
+                <File Id="fil0866F4CB793A762F6AA490B6E4D25322" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-atlimit@2x.png" />
+            </Component>
+            <Component Id="cmp84EC36935E8610B7FCAB565BA2BCAACE" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{A2E37820-D67E-498D-9F87-017CC791BBE4}">
+                <File Id="fil266DA530CF1E9CCF9219E3ECCE6A4DDE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-atlimit@3x.png" />
+            </Component>
+            <Component Id="cmp00CB1F0F3D485D980143AAAF367EAB6B" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{325FCBA3-6885-4BFA-89D2-61762BBD69DF}">
+                <File Id="fil583F31E6A44FF40C86CF9A1E16EFB6BC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-disabled.png" />
+            </Component>
+            <Component Id="cmp8A29AEA8908EE79AECE55F190FF095D1" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{800AD1EB-41F0-47C5-A561-5D65709CA23F}">
+                <File Id="filA72FBB10DC219D8D892CA28E0E5E4F88" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp5871B6D016D0363FBD34F30F9C56581B" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{2C8AACAF-ED7F-47BB-96B1-C7A1B5C246D2}">
+                <File Id="fil4F3D615D9DF77BCD0F0AE80ECF902E24" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp566B10B822D4FB321ACE7B8FAEEBE8D7" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{F09EAB10-C68F-4E68-968A-7C67C4B8C246}">
+                <File Id="fil82B849C1D80A32D91B4A7846C5F79343" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-down-hovered.png" />
+            </Component>
+            <Component Id="cmpD7058A528C65BDCB9B3298AB778AB490" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{C6D1B178-DE9D-4962-AA6E-7894055418D5}">
+                <File Id="fil8B49E37DE57FF6A7C8069CC059F81226" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-down-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpCC2AB4D18627B4399B73BEF7AB0B92F1" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{3F8EF9E7-9EBD-4DBD-B140-AC3F633D58B2}">
+                <File Id="filCBD8B7C3E3C9FEC5EE9E793CC4ACD291" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-down-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp47C9A3F94D01935DE5C53AB3E45B7FFC" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{A3700878-9567-4C6F-AB2C-A14D38C8439F}">
+                <File Id="fil497FBBC98DA61E35DEE2727D71660640" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-down-pressed.png" />
+            </Component>
+            <Component Id="cmpEF20229417C99A4337936CA53B9CBD47" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{2DE4158D-57E0-43B2-A9D9-09AC2ADF2FEA}">
+                <File Id="fil4A09F0C57722DBEE006B513450348E3A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-down-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpDAB67763894D37EDB147FBBBE428636D" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{9FD60062-93A0-4D8A-9ABC-6DA0E55B4AF2}">
+                <File Id="filF0D28747124EA24A6F85754DE4A21779" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-down-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp96B0348543625E331B97919096366254" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{578912FB-8BBA-4762-970E-3B8AEA4D522D}">
+                <File Id="filC1E99EF91E8CCEEF806D8BDA1A820EE8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-hovered.png" />
+            </Component>
+            <Component Id="cmpAFB8083501A61F8FF22DE01A5099BAA8" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{5D13A461-01BD-4C42-AABB-07426B172B29}">
+                <File Id="fil6C70321F049C59775848E7D308DBCF9E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpFE8760B06E7DBCE71CDD209A610F178A" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{FF941CF7-C28D-4026-933B-39A7B23972F8}">
+                <File Id="filEB5020A5CCA6CB701A9BFF2AD4DDEAEF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp61F2ABDC7D6C12BBD3DD48117E7491C4" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{A4107648-B11B-4EF0-BADE-B3F361FCC05A}">
+                <File Id="filEDF69A57F769545C8AF1E8417D63FA69" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-up-hovered.png" />
+            </Component>
+            <Component Id="cmp93585C1A026E58D18E5B05456FFD9C5E" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{75D6836F-A182-415A-B3A1-ABF2FEEF6B14}">
+                <File Id="filE5E42D76FCA867BDE4B79A9082F3167F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-up-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp8ACD418C67F8323C261E698042FA3FDA" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{F88B6AB0-71BD-4941-BE2F-C569582A8C99}">
+                <File Id="filE1ABD7BDF759EB2727978A324E3D7451" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-up-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpAC8A2E0D06CD762972BA50D195A078ED" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{824F43DE-2248-424C-9C5D-980BB9140FEF}">
+                <File Id="filF838412BD55E439F03F0B32E9BAB7777" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-up-pressed.png" />
+            </Component>
+            <Component Id="cmpE9163E62E1CDFC0E26DF227FEF987361" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{43776473-B36F-49C6-B556-247A691C7BCF}">
+                <File Id="fil2BE75CCBF1153A30CA70ED44F2AC3D6F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-up-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpB46F2E7591B38FC5B1767A3AD332BB72" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{8302063B-B5A7-460B-9C7F-27A717EF70A6}">
+                <File Id="filDA1B5634CC2160EDEF3369A288A08CF3" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background-up-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpC02A1534932DCC4FCB9A0889DDC29F26" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{5EC9A744-F932-43AC-AFD7-3DDFBEBA204A}">
+                <File Id="fil8A5BDB628F4ADA6E86A2FF0EE9607C25" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background.png" />
+            </Component>
+            <Component Id="cmp944D681487EFFC6926CAE34EAD7AF3A0" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{1FE5BCE2-EB57-4BEF-BE7C-E204B3306ED5}">
+                <File Id="fil70FE8F05B2A2C44FE4A860CDB417CE9C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background@2x.png" />
+            </Component>
+            <Component Id="cmpAFC615BDE7EDFB9C3DED43926A58A8C0" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{2846CB93-C890-47DE-AADB-8A14DDC07AC6}">
+                <File Id="filF8C7890943ECF171FC19FC9CAD57CA77" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-background@3x.png" />
+            </Component>
+            <Component Id="cmp3FBF9902EB0FE98F805785723891208A" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{1EC34B13-8259-451B-B3B0-724BDC4E2A48}">
+                <File Id="filD02B2D9F4F2C16B1A2A04E6AC48194DE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-atlimit.png" />
+            </Component>
+            <Component Id="cmp0DF8D89A989CBABD20BE6E25C1F4CE61" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{60992A0D-4862-4E59-A484-95FF1C1BE614}">
+                <File Id="fil382D0839CD6904B3B32FE3CC1666F206" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-atlimit@2x.png" />
+            </Component>
+            <Component Id="cmp4B2BBEAFE873D90BC8A9E22427A71353" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{C18DBC1E-B09F-4CD8-AC51-D9A1E64D9CC3}">
+                <File Id="filFF8B01198BB9E5D81A9C5A4568F7EA2F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-atlimit@3x.png" />
+            </Component>
+            <Component Id="cmpF22CCF2C5D14F4224759921D026FD711" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{33751C15-83B1-4C5C-BD27-AA4CE03C2507}">
+                <File Id="filBA4E3B13F9C9C581CE4E3CA3B4E35B66" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-disabled.png" />
+            </Component>
+            <Component Id="cmp35F75CF6C528046500E4375C016449D2" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{08016659-62E2-474C-AAFC-F166D7303D39}">
+                <File Id="fil1B911BEA779CE27ECB52DDE456D2319E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp69F55B5551617FBCBD31DED4ACD102FA" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{9ECA4DCB-7149-458C-8E86-773EE52F474B}">
+                <File Id="filEF0D4859F7AEC75BF4E09FEAA1FB658E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp89CC0A9E326FF29BF8C262FBA3E0A8F0" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{AB176201-C934-484E-85F4-879C0D5BE5F0}">
+                <File Id="filAACB3FCE6E4F2DF5DC6774CBCDCEF233" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-down-hovered.png" />
+            </Component>
+            <Component Id="cmp0E647EC00DB2A16061EA6EF3FDF870E1" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{871F975D-1A1A-476D-B763-DDB4DB975C91}">
+                <File Id="fil08C08268BDA59FE338674B81917FEE34" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-down-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp9F6E5DB51F46D9FCC69349C66804519B" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{FCCF2EF8-CFBB-4864-9551-076C9D0007A8}">
+                <File Id="fil8EB4D94F712A022C9ED43AB169F0625B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-down-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp8166E20A89FDDD112F44147645088872" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{81558351-B6E6-4A04-9BFB-8877D8DC9D93}">
+                <File Id="filFAB105F4CB17D5E57C9FE480754400B7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-down-pressed.png" />
+            </Component>
+            <Component Id="cmpAC64562E5A4F57AEC4CF2FAE97544896" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{2F0362F5-9C9C-4EF4-A833-EEA981ED3567}">
+                <File Id="fil699C89A8CF8224B060BB974AC196A5DF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-down-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp502CABD34A9021CE591ED9094FC8F2C2" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{7F2CAF6B-BF34-4B87-9CAD-821ACDE14F3A}">
+                <File Id="filF88561582A43FE868FF7077E12DD9735" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-down-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp52BA3AFEC375A6A90F239C4BFCCEB05C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{B36628EF-241D-4BF4-AC4E-FB2B08BE218F}">
+                <File Id="fil52E61E45226B4049D83C7EB3B3BF1F56" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-hovered.png" />
+            </Component>
+            <Component Id="cmp6C91026C4CC424A157C99F09EBBB87C4" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{5BDFC20C-0BF1-4998-A4FF-057C6DDDDCDB}">
+                <File Id="filD4140083D247D6B8DEB5C21B92F93CFA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpA46172D82A6200AD537824A6F0DD6154" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{E217E427-108A-4A71-A412-EEE00012F4C8}">
+                <File Id="filFB7AF8549A029D0B60393718B658CD40" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp43F01EA4CC10DD79FFA2BF77671F94A3" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{1FA00C9F-7C3A-424E-99E6-37568EE0C652}">
+                <File Id="filDE32043D81C36768B69AF61FEA5991EF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-up-hovered.png" />
+            </Component>
+            <Component Id="cmpA49CC1739ACD7C9BD17B7F1A2D2A35E3" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{892DD4FE-3D95-49B0-AF8A-774085381F55}">
+                <File Id="fil6A38490C55A9E57DAB4D04B11BBCA06C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-up-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp36F2887682E9132F47B371072EFB205D" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{C6227FDC-BC25-4F0A-A73F-BC816DED5088}">
+                <File Id="filA34CFBB92B28A11164F5D4B84D1CDA63" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-up-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp5A795A721BC284ACA9CB2F96FB9277B2" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{27C9584C-D256-4EC4-A6CD-6B09A181D18A}">
+                <File Id="fil5D20637633795B8FCB34A9AA8B6CCAE2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-up-pressed.png" />
+            </Component>
+            <Component Id="cmpD6CBCEDEB46967E42A0CB1D0A546C720" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{DD30F08E-3E62-4CA0-8A63-BF203ED50384}">
+                <File Id="filFE3E30ED1AE2C715935620C9B725E59C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-up-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpFCE6A6D2B9A03B92D33D67684320B937" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{084698E6-CDE8-4029-99DE-6A862E37E5A9}">
+                <File Id="fil8856A1F04C6A08E45FD2D6FB43785555" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon-up-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp9512AE7EDE9568877EAC8C00BA79CB92" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{89BA2A6C-8F19-45FB-B725-6994B7275136}">
+                <File Id="fil5247BD38119D20F67CE1083B177C2CA6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon.png" />
+            </Component>
+            <Component Id="cmpE6D3ECDE74EC1A4CD1D4984DE903787C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{057E8BA9-01F5-450C-A097-633358928A90}">
+                <File Id="fil8BD22C6257306D63C6C260624ECF5A0B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon@2x.png" />
+            </Component>
+            <Component Id="cmp58AF15620F93BF76A527B1787CF7FD5D" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{54816BEA-4F0E-4438-9F11-2E1F918B68E3}">
+                <File Id="fil6F83C31E497D97856EE85135EFFA870E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-down-icon@3x.png" />
+            </Component>
+            <Component Id="cmpEA445482015B87E9D2C4E79BBBA47234" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{FED36096-2B13-46BE-A81F-9E669BBFEC1A}">
+                <File Id="fil098C7E92147192DB4C0E6B44F528334B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-atlimit.png" />
+            </Component>
+            <Component Id="cmp8F51B2BC1F6471F80E6A39CCBC5841AF" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{5812F569-7BAD-4543-A575-C60CDCC6B355}">
+                <File Id="filF0CAB9525FC2B6B38CAAB05C6C9C849B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-atlimit@2x.png" />
+            </Component>
+            <Component Id="cmp0875D911D17D11E6B2C07BCBE7AEBCA2" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{58B6E075-8453-442B-B88C-F6EC9EDF4B0D}">
+                <File Id="fil79714E65E618D9765A6055B931ABCEA5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-atlimit@3x.png" />
+            </Component>
+            <Component Id="cmp96FDE3509ABC48640CE71490D2B41C7C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{E0027138-1AB7-4E54-9067-7D5021130B75}">
+                <File Id="filCABF9F8832E9293C4E15C9080DA34B09" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-disabled.png" />
+            </Component>
+            <Component Id="cmp9D3A98A1366E029226B4273ED510D958" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{5EC9CC08-0C97-4BE6-9A59-2588A05942F6}">
+                <File Id="filDED77DD669145F017C4A34D0621FA3F2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp6DE98C84A053E88915E8380C19BF9501" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{AC9AC466-792A-4863-98D7-A92AABD5FB87}">
+                <File Id="fil2F1157F48314CCFF60AF1C6F106CACAF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-disabled@3x.png" />
+            </Component>
+            <Component Id="cmpC59A19A6C4A3195C5E8C00563C0DDD92" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{FBFFF393-2C7C-49E7-9BC2-122ACEE906AE}">
+                <File Id="filF4EB1AF5C6DB263EF3B1989DBAB60861" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-down-hovered.png" />
+            </Component>
+            <Component Id="cmp59A68899B8D0137E27961851FA43039A" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{947990C9-3CE2-4A5E-AC64-CD2F0E934545}">
+                <File Id="fil2DC504428C2D974029334B0347756D71" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-down-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpF041130716E2460E019578ABE1F62625" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{9EC76F98-F789-4C9A-8CC5-27BAA3531277}">
+                <File Id="fil52500CBB41500960160373CF108525E3" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-down-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpA552AAB56276096AD5E92F1289F82B8F" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{11CC6D1E-D8E9-4A1B-9F65-FCCFD8445DB5}">
+                <File Id="fil0A9CAA2B80EAB07FC87AA1DA5BBF685A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-down-pressed.png" />
+            </Component>
+            <Component Id="cmp3A1ECB118BC3B34529DB9C162020D542" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{EC47FE0D-8B38-4586-B191-EC5F5477614B}">
+                <File Id="filF567F71CDC9E4631B527439B34FF2403" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-down-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp115BE4270F8D4A78BC2D79DAE19268FE" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{846760C3-A5C8-4CD1-8240-7706CAFE2A8A}">
+                <File Id="fil49BC7ABBB9004F52317464DE0E9F0B02" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-down-pressed@3x.png" />
+            </Component>
+            <Component Id="cmpD5B23AA07202B544B6CFA6661C7D1A4E" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{72CF37BB-3BBC-41E0-AB40-A9AC27586863}">
+                <File Id="fil308B0FD797DF30A315CDA68554C98944" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-hovered.png" />
+            </Component>
+            <Component Id="cmp6B1321D0AE9C9498ACB5C2FE97DDF2A9" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{4BAFC506-4A25-44DE-BECE-3186012CE84F}">
+                <File Id="fil2A1C86D3087BF090D980490CF6D70E18" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpF5632C8324BB43027251445B86F0EFC3" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{3938387D-7145-4E90-B804-F5582C15FD82}">
+                <File Id="filF5CA2C100E77D1A4B10D348A850B45EA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-hovered@3x.png" />
+            </Component>
+            <Component Id="cmpA3C45766D7CA1BC5562B080DCFA083D3" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{45836A06-479B-4C4C-A7B3-4C6F3DDDED85}">
+                <File Id="fil194925AB72A9C883A40330B03E067DCA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-up-hovered.png" />
+            </Component>
+            <Component Id="cmpC279B373BED398BEBB8AF253715231CF" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{B3E748C2-3A66-4CFC-976C-EC5414D89C87}">
+                <File Id="fil0B09EA9E11AB01F87FCD0EFB268B87F5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-up-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp5ABF5E188299E3E25093B57BD0320EBE" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{4A1A4EED-122A-4919-8141-F58E56F43A1E}">
+                <File Id="fil29808B22F5C2AF337565F89575174EFB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-up-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp9A22D175672721B0B8AB7ADA33F1E72A" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{AD7B2138-8549-4C54-B277-C6CC73835730}">
+                <File Id="fil979A5018D5580A3AD287AEDB9829D494" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-up-pressed.png" />
+            </Component>
+            <Component Id="cmpFFC78A8D87CC9DDB10113F483C175E24" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{6D48D30C-594B-4DF3-BEAF-A85B370763E4}">
+                <File Id="fil02BA19172CDE6F3B83718F34FB5B14CB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-up-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp46C9306CD545CE0FF1AD97F96F313FB9" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{3C50AA3E-A243-4AEE-A456-7C31F09F85E5}">
+                <File Id="fil02699C7FDEA890A30FCF313404D49D22" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background-up-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp6EE2C97C6DED461F3AC3EA0256AD3F91" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{AEF173A8-341D-47B5-9CD9-30AF8626E66D}">
+                <File Id="filED22FA56FEA710FCA7F71C9FC1F542EE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background.png" />
+            </Component>
+            <Component Id="cmp28CC5E21E75CE1B2E70A13543109262C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{6281B0DD-DE74-42E6-A4AD-1568EBE17089}">
+                <File Id="fil9791C1BC7856B629FF7068B0AA1C9484" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background@2x.png" />
+            </Component>
+            <Component Id="cmp364CF8E108E43499526CE14FACBA07F1" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{256EE68C-AC11-40E0-836F-679F5864D5E3}">
+                <File Id="fil547290A778522AA9D4CB10726E69EB70" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-background@3x.png" />
+            </Component>
+            <Component Id="cmp16629A9BA364B8D76398D28F596C3271" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{84B02452-82EC-4584-801A-7C29F8C454E2}">
+                <File Id="fil55B31C012BF22068DED580663287B0AE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-atlimit.png" />
+            </Component>
+            <Component Id="cmp8CDF96564D07012F94972CADA51C89C4" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{019BD1D4-8D8E-4387-BE44-707EC840D3D8}">
+                <File Id="fil8976CE6508017A6C6DB27CCE4CADB6A4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-atlimit@2x.png" />
+            </Component>
+            <Component Id="cmp2A13803997F6DB97F62AE933C0FAF193" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{0CD460C4-EB98-4150-AAD8-536A601E58B2}">
+                <File Id="fil033CE5DF0CDD138CA91D34402C7BD581" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-atlimit@3x.png" />
+            </Component>
+            <Component Id="cmpE36D35195DE030D9D6D020CC2B3A4FC1" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{6A69C132-2912-45E3-A9DF-A06A8EB91EA7}">
+                <File Id="fil0CA62A2ED5734B938DB61662F5A79843" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-disabled.png" />
+            </Component>
+            <Component Id="cmpA1A991FFE516DCB44DEF35BE1A6B6FD2" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{BBB69D9D-7DFE-48BC-B279-63F1B1AC571F}">
+                <File Id="fil4D49613FE086E3515833F0B28F5C23C7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-disabled@2x.png" />
+            </Component>
+            <Component Id="cmp7529FAA84B418A4F53ABA0EEBFFF145F" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{14F8FB43-87B0-4008-85D5-5D785216ACD9}">
+                <File Id="fil461C7B2D15EA492DA3FA6768A6B1E3CF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp8BB6FFBE326C4DC87EC05611AFFF04AB" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{62780EED-231D-47CA-8B08-64B0E8D4AF10}">
+                <File Id="fil0CCDECB47FD8E5A7244E33701E6EAD82" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-down-hovered.png" />
+            </Component>
+            <Component Id="cmp34BFC0621482C1243A75ABD3692C0373" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{E7A9153C-93C8-4444-9552-AC631370EA05}">
+                <File Id="fil57D98C0368007AA6CA4BF3D4DEA26F2C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-down-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp01470103A3984C11332EE20CE3136F07" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{423630C3-C69D-4D18-8B62-23B1B56644A9}">
+                <File Id="fil27440A6EC20BAEC806E6163CE1D1901C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-down-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp81ED2ADB0C87EB43FEB1703E87B83934" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{CD929FB4-9E5B-40A0-AB19-41CB16D7CEF4}">
+                <File Id="fil4542370EC53F27E2586ADC5922B3033A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-down-pressed.png" />
+            </Component>
+            <Component Id="cmpE44DE604300FA1796A9A377AE4E988CA" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{2E77893A-3010-4619-95D0-2FB27311D5C6}">
+                <File Id="filB4FF5A786AC755D32DF9AE23F29F23AB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-down-pressed@2x.png" />
+            </Component>
+            <Component Id="cmp62F2219A5542C10146D9818F372D9A26" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{771C5517-FC61-4E3D-9F13-B069E70C1B71}">
+                <File Id="fil2BA90A2BE65C7699D633D5C26E712437" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-down-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp666C43B90B099DDF74F5B44F61DAC8DF" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{893DB226-C496-48B4-93D9-ABD83FB8F561}">
+                <File Id="filD8C6AD35EF3FECEB66D05EA1F9C75F25" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-hovered.png" />
+            </Component>
+            <Component Id="cmpF25D259165D6DA774FEAF4FE5BBAF98E" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{8F3F2972-A2E1-4071-B022-6664C2DC6E89}">
+                <File Id="fil8A332A8766FDB68F7F9A2D83D8B8639F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp392233237FF1C42EE809E7EEEF03F537" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{918AED0D-C76D-4DDF-9585-48581E0FEBD4}">
+                <File Id="fil01F93B7F6823C69A2259FBC6364B2036" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp00532446B70312B5FC5F837CAAE6355C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{09930BA6-9A8B-45D5-8B61-B6B0D3DF9E02}">
+                <File Id="fil83B9331625349683A593C845328377C2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-up-hovered.png" />
+            </Component>
+            <Component Id="cmpBAC43FBF035E33D12ED50526E3D6B284" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{F2E796F2-7F1E-4802-A71A-E98633D7AE1F}">
+                <File Id="filF8CB8BD014D106C61634E3EEFC424501" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-up-hovered@2x.png" />
+            </Component>
+            <Component Id="cmp3FB551C47E3D5D52A696727CD9F7572A" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{B2BBEB31-42E7-4159-B65B-8CD1D68B32E3}">
+                <File Id="filAFF45579D3D59B71241E0B96D8391820" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-up-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp66C1DED73D1FEE9F644C3DB770A4990B" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{085D7411-EE45-4504-A0CF-D8A77E44CD04}">
+                <File Id="filF4FF2F2EAF11816F254CB33165AAC45F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-up-pressed.png" />
+            </Component>
+            <Component Id="cmp810ABAEA674AC72610C36B1E5234C5A7" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{08A2CD05-330E-4B07-97AC-8475887F5B9E}">
+                <File Id="filA9601C0B5C8E084C7901AA9138599B5E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-up-pressed@2x.png" />
+            </Component>
+            <Component Id="cmpA192FE3B89AAE15DA828E70B2136049C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{E29D47E2-948F-407E-9E38-CE19C27AEEA1}">
+                <File Id="fil5F713BB91B8164F600127F2BEAFDE8D3" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon-up-pressed@3x.png" />
+            </Component>
+            <Component Id="cmp64686C0C1E4A32BFA7EE728027CC65B7" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{979A9573-F719-497E-AE66-8E6435E7C580}">
+                <File Id="filF4473369595BA6385FF372D213D97E62" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon.png" />
+            </Component>
+            <Component Id="cmpC5B22EA71881F27FC1370FF747AB1EBE" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{220F2DBF-7F25-4DF5-B8B5-0A44AE1E01F8}">
+                <File Id="fil772A75F8EA49AC5EC5505F464CE72130" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon@2x.png" />
+            </Component>
+            <Component Id="cmp002CD26EE890DA583F3BC791D01AEA5B" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{19BD462D-4FFA-4C1C-BBD2-39BB0C577D38}">
+                <File Id="filC1D3409B0DF0F09D0F8CACFA3999A92E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\spinbox-indicator-up-icon@3x.png" />
+            </Component>
+            <Component Id="cmp8A34EBECCCDF41E5D047675628924B4E" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{78C9D4B7-F8B3-449D-994A-239C4C5B7F3A}">
+                <File Id="filE73846E8B4198D36BDAED82E69037E5A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textarea-background-disabled.png" />
+            </Component>
+            <Component Id="cmpAF49554C2090D013A41637583D7CC92E" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{E6F3175F-C98B-43AB-B10F-C63EF896AD83}">
+                <File Id="fil9453EB72AA9996E32CAE21C202A1D933" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textarea-background-disabled@2x.png" />
+            </Component>
+            <Component Id="cmpCDBC4BED599FBA3E0CA2F37C990B797D" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{B5266939-590A-4AE4-9996-EEE229236EE1}">
+                <File Id="filE55522224738DDBAAAAD03D23D5242CA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textarea-background-disabled@3x.png" />
+            </Component>
+            <Component Id="cmp32B813766166A01EE8EB84DA32F8A16C" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{B921C45B-5B3C-4177-9B6A-B46C9F4A1FA5}">
+                <File Id="filFDCAE644BBDBA569F154AF6DDB3592A5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textarea-background-focused.png" />
+            </Component>
+            <Component Id="cmp39AB34C969F55D1DC24C3CD35D6CB936" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{C02684C0-5C35-48A8-938C-FD4D8A35C3A4}">
+                <File Id="fil15D2BCE359E7BD06E2A02BCC94ADA661" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textarea-background-focused@2x.png" />
+            </Component>
+            <Component Id="cmp167552B2E2CADE6C01A5288F13C9BDF4" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{94F7B333-C139-48E9-A1BB-98388ADD53C9}">
+                <File Id="fil8114D7CA3F35A216B28BD1D820141FB4" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textarea-background-focused@3x.png" />
+            </Component>
+            <Component Id="cmpAC5111FB9A491996367AC90D0F43A7A3" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{7AA0081F-B12C-4D28-9B11-237BA7310C80}">
+                <File Id="fil4C0A389574355EAD5A0728F8AB60653C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textarea-background-hovered.png" />
+            </Component>
+            <Component Id="cmp975AD3DDFBC3626F4FB5760AFABA2FD9" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{2D985DB6-60F1-4E5E-A520-F0595BC0B30B}">
+                <File Id="fil1226F50D297D8F7B013A498582DDD3D5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textarea-background-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpD26D8A7BE4DF8EC53D7595ABF49F3F51" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{54117403-B42B-471B-BD2F-2DCD2BCCFAA6}">
+                <File Id="fil4C9C63F53734B2E74A6B07E841CC062E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textarea-background-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp7F0D2BDC54A320E878C0896DC235508E" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{44CF9F03-624B-440F-978F-24B43E1D4AE1}">
+                <File Id="fil4D8860EA28E074B2FC39303AC695ED08" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textarea-background.png" />
+            </Component>
+            <Component Id="cmpE395F9386EB23F629B6718629A3AF89E" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{F77A867F-DFBA-453E-A037-A6A2640B7A85}">
+                <File Id="filF219A234810ABCE7BB43699BEA6051FE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textarea-background@2x.png" />
+            </Component>
+            <Component Id="cmpA68458668284F3F187B2D45C291F1A92" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{A4A813E9-A6CC-42DD-A7CF-ED915F24687D}">
+                <File Id="fil23A85022253871649582769344A245E0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textarea-background@3x.png" />
+            </Component>
+            <Component Id="cmp232D72E011EB13371600445DA0C1913A" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{E1FEA992-A42F-4B0C-85EA-BE73DE891249}">
+                <File Id="filADE59BAE62A3431F54527499DC139ABE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textfield-background-disabled.png" />
+            </Component>
+            <Component Id="cmp83410DF6EEED4330BD90ED44052114C5" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{729264F5-091A-4684-9C13-413648227094}">
+                <File Id="fil82ABAAE51112A3A37DFEEEAD8B7E5B8F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textfield-background-disabled@2x.png" />
+            </Component>
+            <Component Id="cmpDD05232085E0555F43DF064256A8C222" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{89CC7C08-A45A-4407-B4EE-CFA88219FF85}">
+                <File Id="filFA532C9D968738F811B62A62013BF5D0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textfield-background-disabled@3x.png" />
+            </Component>
+            <Component Id="cmpA920ED4DE726C921437483E455345E8F" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{5435936C-3288-4870-8F41-9C57C7FF05FE}">
+                <File Id="filBC7FB9EF987B9A713F1652C549E1EDB1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textfield-background-focused.png" />
+            </Component>
+            <Component Id="cmp4527634A1747191513AFCED315D6857D" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{297D2D45-D079-4EFE-A417-BC3DB4112340}">
+                <File Id="filDA472E3A4C07A5CA2A740E9A1E89F6E5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textfield-background-focused@2x.png" />
+            </Component>
+            <Component Id="cmp69A6E1262442A6CDFDC5214EC5E9BEFB" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{2A8B55D5-9170-4F37-BF2B-37C3C3BF858A}">
+                <File Id="fil5CB8B26FFE66AB8CFEEC94231403CE38" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textfield-background-focused@3x.png" />
+            </Component>
+            <Component Id="cmp564A67BE61E2B5B4A900BA50E7909572" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{9DDF6A57-17B4-42AC-8293-0D140006777F}">
+                <File Id="fil88716CC042EDA76F08F38ED2268E72EE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textfield-background-hovered.png" />
+            </Component>
+            <Component Id="cmp7FB43793B17D69DE8755FBA97F62A889" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{E99554AF-6CA9-46B9-B1D1-67CD4BD704AD}">
+                <File Id="fil757F97CB9B3DF9490A32CD9DA55338EE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textfield-background-hovered@2x.png" />
+            </Component>
+            <Component Id="cmpBDCE28D63D42D8901C104CA5341B6CFA" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{17203B17-B5ED-4681-85DC-9E96528922EF}">
+                <File Id="fil9CF3912BDB30C7163BACBDAE5F7DDB1C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textfield-background-hovered@3x.png" />
+            </Component>
+            <Component Id="cmp7C4A03A8FA73AB736046551FD367748D" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{536797A5-E841-4DEF-A30D-45C083445C0B}">
+                <File Id="filF811ABFEED95AC03715A994454B1445A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textfield-background.png" />
+            </Component>
+            <Component Id="cmp81F9E20EE2F39641FCFB3343551F35A8" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{5676C70D-9F46-4417-B750-E3620FF0FE5E}">
+                <File Id="fil7247DC3C9D65D405434BB37DE5330876" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textfield-background@2x.png" />
+            </Component>
+            <Component Id="cmp7AA373C4D88B82C12665B6035B2F0C2F" Directory="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Guid="{FC79F185-1ED2-4326-BCF2-57930B52C0F9}">
+                <File Id="filB1565C10438AD5E0253B23EE77B17CC6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\FluentWinUI3\light\images\textfield-background@3x.png" />
             </Component>
             <Component Id="cmp93BBA84C3F04B42711C94532FDCAA4F3" Directory="dir1A86B48CD44E777E78B13993BE3DFC29" Guid="{29689046-1BFA-46B4-9C2D-FAB075D62EDA}">
                 <File Id="fil123F8809BA31C59BD88BF52E11E576EF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Fusion\ApplicationWindow.qml" />
@@ -925,8 +3443,8 @@
             <Component Id="cmpB7362BFEADB697DA93C3B0E9471FC933" Directory="dir4E741D8C175690CD9096A89077530C9C" Guid="{975DC03A-8740-47AD-9DAD-F90588A55336}">
                 <File Id="filC7915B57A913E31D3C4D427C6E2219F5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Imagine\impl\qtquickcontrols2imaginestyleimplplugin.dll" />
             </Component>
-            <Component Id="cmp7477DF3B20A2314AB9D9D7C2B37516D1" Directory="dir4E741D8C175690CD9096A89077530C9C" Guid="{5408DE80-60C4-4816-B640-A55A96AB29F4}">
-                <File Id="filBCA1409917679CAA35888D9AE61821D2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Imagine\impl\qtquickcontrols2imaginestyleimplplugin.qmltypes" />
+            <Component Id="cmpF01C48A1DB024CFA1F34E9EDAF67EF85" Directory="dir4E741D8C175690CD9096A89077530C9C" Guid="{680D20F4-8CB0-4221-8429-48D528335BB2}">
+                <File Id="fil74C24C33882A2395E541932869A1E38C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Imagine\impl\QuickControls2ImagineStyleImpl.qmltypes" />
             </Component>
             <Component Id="cmp11D7D79C97B237EC913F8032C8F836E4" Directory="dir171007FEE30C4A50EC7ED2CB58E0B5E3" Guid="{04471F08-242C-4659-9F1D-BE21CCA14AD9}">
                 <File Id="fil8E3F37E1853A667FFA38E60B8B1D9B85" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\impl\plugins.qmltypes" />
@@ -1330,14 +3848,38 @@
             <Component Id="cmpE68756474722B3F21FC5532D1062FB1D" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="{87B337BC-B684-4E21-A7DC-44654F236C27}">
                 <File Id="fil83C17F6A6B9AE52616089E09065D4409" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\CheckBox.qml" />
             </Component>
+            <Component Id="cmp573E90785328E25C126D9FC210060DD4" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="{CE7EF663-DDC2-4C99-B062-5BDAF4ED0EE4}">
+                <File Id="filB15EF166A5C6F9662F274CB0A571DB99" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\CheckDelegate.qml" />
+            </Component>
             <Component Id="cmp3296BF97A2E0EF541BB34170D2415F01" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="{9CA20EB9-A718-4F5B-BD78-C942B464D874}">
                 <File Id="filBCD6667BB8BBFA9456E666B4E33AB0B1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\ComboBox.qml" />
+            </Component>
+            <Component Id="cmp9223971C5152F6BCA532B25B943F2EA2" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="{FFD4DB67-13D3-4B3E-8395-77EDADDA68A8}">
+                <File Id="filC0C352B87091F1CBD51AC6033DF1C5CC" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\DelayButton.qml" />
             </Component>
             <Component Id="cmp8C1B3E8BDCD066E43D0D7711C6230BF0" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="{609CC4D5-3B31-49F2-B9C4-64D66B4624C5}">
                 <File Id="fil743C0CB7BC821AB1DE5E10195D4DD7F9" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\Frame.qml" />
             </Component>
             <Component Id="cmp7837CC5D7098081B4DF4FF165458173D" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="{4260D2BD-A5B7-4A95-A241-516C8847C29B}">
                 <File Id="fil71972C76D5C2B98132AF5B318815F12E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\GroupBox.qml" />
+            </Component>
+            <Component Id="cmpC7A59B8197710C7C23555DC5B2C03D2C" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="{53939503-073B-4FC1-BF80-F609A84F7558}">
+                <File Id="fil77B5E9BD9F3C2E2CFE8F35F5DDCB8796" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\ItemDelegate.qml" />
+            </Component>
+            <Component Id="cmpAF232299BF2345E15DD252C33E647E5A" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="{5F0634E4-E6B9-4B61-8B0C-6B46B8DFE2A1}">
+                <File Id="fil707F214EA36C5CDF0FD77A4C203D5B68" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\Menu.qml" />
+            </Component>
+            <Component Id="cmp79968B9D48EB04C96AE4EFA71A59D45E" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="{19DA3D4B-693A-4F32-A8DC-2182B1696BFE}">
+                <File Id="fil55225234A8763732B8FFA4E1E80EB904" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\MenuBar.qml" />
+            </Component>
+            <Component Id="cmpE38CBA961AA3932686834955AD290E45" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="{04F1A40E-7088-4B07-8242-4594F25707BC}">
+                <File Id="filC1567EE4365636D0F927E69520BC7F51" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\MenuBarItem.qml" />
+            </Component>
+            <Component Id="cmp7E5E3C6DD6A37CB0EB96DAFD4F0F6509" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="{DD678166-0BB6-4C98-A277-384E13A412A2}">
+                <File Id="filB068B277A34EDB70D41B7FF2FE327A63" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\MenuItem.qml" />
+            </Component>
+            <Component Id="cmp784CE875D48A2B308A4B05796233B6BF" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="{A2E6826B-0C05-4E3E-A743-BF70B67CE947}">
+                <File Id="filDEEE0B4BDDC15FCC60E2B8C522C1E59B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\MenuSeparator.qml" />
             </Component>
             <Component Id="cmpEDDCDA25E43BFDE157B14A1304F2881F" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="{8E82840D-4688-49B4-8D5D-6DD5B32D9290}">
                 <File Id="fil276159053BE57D0C24D41C849C2BAE91" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\plugins.qmltypes" />
@@ -1354,8 +3896,17 @@
             <Component Id="cmpC77F62D1E6B5F70004BAB55B363F9B11" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="{F5215D39-719F-4305-B165-ECB1704B9B25}">
                 <File Id="filAE22C9B5BA41390AC226359F794FC06C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\RadioButton.qml" />
             </Component>
+            <Component Id="cmpC225A268E189ACEA151BBD9269A23728" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="{7FC295C0-5BF5-4A7A-9587-2603B1915857}">
+                <File Id="fil1FB8C8E24B8FEF9F00C02CDA101C9939" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\RadioDelegate.qml" />
+            </Component>
+            <Component Id="cmp7CCF7BC987EA831EEE6FDC053D75168A" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="{FCD15C4D-FC5B-4DC9-828D-1C73B89451E9}">
+                <File Id="fil1C1756ACD1E5AE0E4287E9E09DE2AA12" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\RangeSlider.qml" />
+            </Component>
             <Component Id="cmpEF137D0A83F3A18031FFD79BFE04B9F2" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="{86874DED-ADB1-4AB8-9348-72A7FEA8E08E}">
                 <File Id="fil685FF36668F4A89EF52829644479A47D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\ScrollBar.qml" />
+            </Component>
+            <Component Id="cmpB70E96F1C8D6938A7613B75763C1A125" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="{DB9736CF-5651-49B6-81CE-4AF40ED55841}">
+                <File Id="fil41203CA31580AABA146D7E437207AA34" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\ScrollIndicator.qml" />
             </Component>
             <Component Id="cmpE22CC5E1ED8DF1A9868758098747EEFB" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="{59BD9DE6-C820-4AB8-BE92-82F515C134B9}">
                 <File Id="fil95C622A6C8EB1C2113128E62F1806D13" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\ScrollView.qml" />
@@ -1369,170 +3920,50 @@
             <Component Id="cmpDC4F51A305FA129D657009601950B7A3" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="{3FCC08CF-7ABD-4B1E-8711-76B69295AF17}">
                 <File Id="fil00A561FEF601BE682473E1310E50E3DB" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\SpinBox.qml" />
             </Component>
+            <Component Id="cmp3E41F91B9C56D88BE77D591D6EAAE077" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="{570539B0-DB8B-447F-907A-C3FC12051FEA}">
+                <File Id="fil1A7F5C04F469AFD7E7CE471E8CECCF03" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\Switch.qml" />
+            </Component>
+            <Component Id="cmp19B68115DB4EDB949ACD6A0207739BD2" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="{FDAA940D-FB22-4215-A33A-CE74DBC0B2E7}">
+                <File Id="filD8E27B7DB96DA6A974D46C355135C3CA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\SwitchDelegate.qml" />
+            </Component>
             <Component Id="cmpDF55645037117499DE465427DC8DF07D" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="{2FC0A47A-0E3A-4109-A691-0135CF115119}">
                 <File Id="filF35FCE92DDE8D63D8CFC96EEDBF8F66C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\TextArea.qml" />
             </Component>
             <Component Id="cmp2203A2072E1F1CCF26557C70F67B6390" Directory="dirB030248D75EA99E75698A1E011FE9CC0" Guid="{C3DCDE95-125D-449B-AB6E-0A46F5184BA6}">
                 <File Id="filE88281D540F6A3D22F1B131E68180E08" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\TextField.qml" />
             </Component>
-            <Component Id="cmpC437AB325C956B39F47527216D28546B" Directory="dir3390D3B4341886F0DA85EE3BA92439FF" Guid="{423D4EAD-FCE4-4E50-875B-6EB326325B7A}">
-                <File Id="filFC0B5707CF45175E2548BA04998F9D14" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\plugins.qmltypes" />
+            <Component Id="cmp19EDF8A8B3980854E236D1B24FEDE619" Directory="dir0EBECE38763539163E6070C0EF39AFCD" Guid="{DAE72011-B2C5-4329-8F08-D53CD08C0425}">
+                <File Id="filB1EA9478A8618149874C4A9E0263D9E5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\images\checkmark.png" />
             </Component>
-            <Component Id="cmpFD0F8FF1618CF94939B70BB1D4874BD5" Directory="dir3390D3B4341886F0DA85EE3BA92439FF" Guid="{CD7FFA98-9FFC-4EF7-8DDE-D3CE291FDD65}">
-                <File Id="fil326E1B5A831353646A2BA9A334652C8E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\qmldir" />
+            <Component Id="cmp6678D172E6D38A1F1A219600EF2922C1" Directory="dir0EBECE38763539163E6070C0EF39AFCD" Guid="{94DE3446-11A4-4D1F-85CE-8CBBDA8C6F54}">
+                <File Id="fil30568D60BDF8839DFF8E024E4E02FDA0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\images\checkmark@2x.png" />
             </Component>
-            <Component Id="cmp19505C3234633AD6D7F2A9FF634021A4" Directory="dir3390D3B4341886F0DA85EE3BA92439FF" Guid="{BF7BA44A-5DC2-4FD5-8E4F-6EBBF2706809}">
-                <File Id="fil6CA3AB34BE81C0480807D319DA4D1B52" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\qtquickdialogsplugin.dll" />
+            <Component Id="cmpA68BE8A79C9E0434E786E186A307B804" Directory="dir0EBECE38763539163E6070C0EF39AFCD" Guid="{A672A67F-CBC5-4ECC-BC21-E5099086740F}">
+                <File Id="filC83FDFC12FEC83DE08379AB6664B9A10" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\images\checkmark@3x.png" />
             </Component>
-            <Component Id="cmp26A12B2050D05AC837B4FE95D70CF62A" Directory="dir34D1D6742B95CCA4110D8968A4544048" Guid="{63AAB19B-A715-48A6-B172-DFB7BC3D99B8}">
-                <File Id="fil2EF39784619037E8CC60A1D82B089DB1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\plugins.qmltypes" />
+            <Component Id="cmpFB825A713BA4BE398C07BABBC39A5029" Directory="dir0EBECE38763539163E6070C0EF39AFCD" Guid="{0CC8C49F-9214-457D-85F2-4A5BB37D241E}">
+                <File Id="filF83D1A5F7E19E80617762C260AE59FA0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\images\menuarrow.png" />
             </Component>
-            <Component Id="cmp247A562FE0339C0E33051AE46663C848" Directory="dir34D1D6742B95CCA4110D8968A4544048" Guid="{E2093578-5F74-40CA-996A-EAB881D7E4C5}">
-                <File Id="fil73A709C03D74D3472D379DD8D232B321" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qmldir" />
+            <Component Id="cmpEE647176C26965984B6B1495B86EE483" Directory="dir0EBECE38763539163E6070C0EF39AFCD" Guid="{FF573BD4-BEAD-40FB-9BD7-DAA0E8F982F5}">
+                <File Id="fil7C4BA191B44FC399895EEB42997BB7BD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\images\menuarrow@2x.png" />
             </Component>
-            <Component Id="cmpD771E4FD8559DD19611671F07F50AE86" Directory="dir34D1D6742B95CCA4110D8968A4544048" Guid="{28A55D2A-96F7-48B0-97FA-95150B57B184}">
-                <File Id="filF7DDABE25D647E77D24BC54ABB437481" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qtquickdialogs2quickimplplugin.dll" />
+            <Component Id="cmp6539517EA2D786955A6A2ED0994C0DA2" Directory="dir0EBECE38763539163E6070C0EF39AFCD" Guid="{AB420F09-472D-4B3E-BF0E-E4EB960A1D55}">
+                <File Id="filD42A582CF1E7E31F0FA3E1A58B04B37D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\images\menuarrow@3x.png" />
             </Component>
-            <Component Id="cmp1F9B87E10A30CED8E63B585060A1FF8B" Directory="dir755D907146AC4C2DC7E3BE88C0F1A70F" Guid="{328E2F4C-9D60-42F2-8F2A-B703D89B2BDC}">
-                <File Id="filA0DF6F7D59B18B7A0A1AF7DA6AF2FF68" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\ColorDialog.qml" />
+            <Component Id="cmpA59B5F81CF1281A8F0604585490D0CE0" Directory="dir2682D39E9C78E1415E0A57E589F0A404" Guid="{14561D30-D811-4B79-9E13-45EEF88BA636}">
+                <File Id="filCF4ED0BD4E8AFB64873401A5F82183C8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\impl\CheckIndicator.qml" />
             </Component>
-            <Component Id="cmp5CC1A9822278627BA1C6F6C0810F05AF" Directory="dir755D907146AC4C2DC7E3BE88C0F1A70F" Guid="{3E34664B-49E3-4D8D-BA5F-8263B77D8EF0}">
-                <File Id="fil9352455FFAFA7537481F68705CDAB62A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\ColorInputs.qml" />
+            <Component Id="cmpD3A28840DD49BA3839529C97D123D9FD" Directory="dir2682D39E9C78E1415E0A57E589F0A404" Guid="{B6ABB397-A20D-46B5-9A6E-055255F18711}">
+                <File Id="fil9DFE3845A918EC7274D9BA9B492A9D36" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\impl\qmldir" />
             </Component>
-            <Component Id="cmpCD8E153BC6DC54FB225F0335FD2F1022" Directory="dir755D907146AC4C2DC7E3BE88C0F1A70F" Guid="{8C64BE40-2759-42C9-880A-5987F237B826}">
-                <File Id="fil93D2D8A8DBA12B61620EBAF03A9BE6D6" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\FileDialog.qml" />
+            <Component Id="cmp8FB17070703A07EC91BC91FDF959ED0C" Directory="dir2682D39E9C78E1415E0A57E589F0A404" Guid="{D1F2B8E3-CBB2-41E8-B952-C25F5DB37B65}">
+                <File Id="fil8CB29BF313A87B364A04AC86CA8D53BE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\impl\qtquickcontrols2windowsstyleimplplugin.dll" />
             </Component>
-            <Component Id="cmpA43D16647F1AFE697DD7E77561269215" Directory="dir755D907146AC4C2DC7E3BE88C0F1A70F" Guid="{2D3AAD29-5156-4656-B22B-EA8978EB267E}">
-                <File Id="fil209068D9C33B43DA14DC86382904CBEE" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\FileDialogDelegate.qml" />
+            <Component Id="cmp461865270D60DF2C469656EAE8AC71DD" Directory="dir2682D39E9C78E1415E0A57E589F0A404" Guid="{D15C1EAD-5DB7-46C7-BBAE-B4110D2D2B1C}">
+                <File Id="fil793F43FB6494FD5CC90AE96CD09CACAD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\impl\QuickControls2WindowsStyleImpl.qmltypes" />
             </Component>
-            <Component Id="cmpA5CBE15352FE008097BC876C40461A13" Directory="dir755D907146AC4C2DC7E3BE88C0F1A70F" Guid="{0BE9DEC1-610E-4064-9ED5-D0CF07BCA172}">
-                <File Id="fil4540A3A2DE480ED8F7FC352CFA54A0A3" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\FileDialogDelegateLabel.qml" />
-            </Component>
-            <Component Id="cmpBA80190D493F665368F7F2D88009CA35" Directory="dir755D907146AC4C2DC7E3BE88C0F1A70F" Guid="{F4E3BD0D-669B-4C94-A67E-70932CA1C056}">
-                <File Id="filD4C93FE2E3ECA41F2B088C15EE8E7B44" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\FolderBreadcrumbBar.qml" />
-            </Component>
-            <Component Id="cmp2B690A76E357815CD2278DADED472DCD" Directory="dir755D907146AC4C2DC7E3BE88C0F1A70F" Guid="{45BC2125-8EAF-4E5A-92B7-F180D1F61FD5}">
-                <File Id="fil0A290A43252CCACCDD06DC74AD3F0150" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\FolderDialog.qml" />
-            </Component>
-            <Component Id="cmpD2D023E7908B3EF1FBC9EE76B53FF954" Directory="dir755D907146AC4C2DC7E3BE88C0F1A70F" Guid="{DA2D5115-A89A-49E2-9D8E-E0429CA7D1E4}">
-                <File Id="fil9048C8B68F95216847AB9C2BB586267B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\FolderDialogDelegate.qml" />
-            </Component>
-            <Component Id="cmp3FD2DFA51DAE6BF8C71900CA48779DC8" Directory="dir755D907146AC4C2DC7E3BE88C0F1A70F" Guid="{677453BD-2E28-4147-8F6F-BA9C8695FAAD}">
-                <File Id="fil090B870ACCCB3E9AC35C9BE4A09AC383" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\FolderDialogDelegateLabel.qml" />
-            </Component>
-            <Component Id="cmp89D2DEE36502469CA5E9442966437A3E" Directory="dir755D907146AC4C2DC7E3BE88C0F1A70F" Guid="{928E1916-1B33-484E-82D8-18E2B52D5EDD}">
-                <File Id="filB7007AC91E08C3AF1B5D1FB0BF4E0D70" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\FontDialog.qml" />
-            </Component>
-            <Component Id="cmp23ABBE7C0C0AFCF242C44EDCA1D7A2B5" Directory="dir755D907146AC4C2DC7E3BE88C0F1A70F" Guid="{319256D6-A52A-482B-8209-0DF3C3DC72F6}">
-                <File Id="filBA3B6DBDD6BF053B67B4C49EEC242FCA" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\FontDialogContent.qml" />
-            </Component>
-            <Component Id="cmp0B0F513E9ED50F545C66F3A24CC92F08" Directory="dir755D907146AC4C2DC7E3BE88C0F1A70F" Guid="{577AF665-C115-49C7-916D-A4E8A73A3A84}">
-                <File Id="fil65FEDAF25F1E1AC39DC10AD70C88DAB8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\HueGradient.qml" />
-            </Component>
-            <Component Id="cmp41298595F02EF32949F1566F589B454C" Directory="dir755D907146AC4C2DC7E3BE88C0F1A70F" Guid="{9F15C0D0-2888-47CC-AB24-F11D538C2B78}">
-                <File Id="fil767F03E07565A9F69AF8C06A5EBADD4E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\MessageDialog.qml" />
-            </Component>
-            <Component Id="cmpF435AE4D59420FEEB320C8B81458D76C" Directory="dir755D907146AC4C2DC7E3BE88C0F1A70F" Guid="{F0988C83-68DF-45B3-AB03-0E17D6CD9D34}">
-                <File Id="fil85F4300A5F660E5B427FFD02F328EAF5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\PickerHandle.qml" />
-            </Component>
-            <Component Id="cmpC4C42A5D0D070431E5C9FEED80365921" Directory="dir755D907146AC4C2DC7E3BE88C0F1A70F" Guid="{669D74BA-A25E-45E3-99B9-9BCBD2CAD9F7}">
-                <File Id="fil67AAEC8993AE5CDEFC014103CC45F500" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\SaturationLightnessPicker.qml" />
-            </Component>
-            <Component Id="cmp69A36B9C73762AA365C1BC5F970FC8E5" Directory="dir929495D16D3C46BFD28C6AD595BCD701" Guid="{48AA48DA-1102-4ED3-8620-62CA6E74A5CE}">
-                <File Id="fil45A808D742A78F7A926AD621F7283728" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Fusion\ColorDialog.qml" />
-            </Component>
-            <Component Id="cmp7BBF58B50638FEB770B04C7F73171AC6" Directory="dir929495D16D3C46BFD28C6AD595BCD701" Guid="{6FBAEF6C-ABAE-4E97-A57C-9D748B9F9C6E}">
-                <File Id="fil7153DDC4143EAC85FD70680E09CE21A0" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Fusion\FileDialog.qml" />
-            </Component>
-            <Component Id="cmp773DC90FC00B0677B841101198BF6921" Directory="dir929495D16D3C46BFD28C6AD595BCD701" Guid="{1CC59C1A-29F1-490D-B1BA-1E0C4BC1DFE0}">
-                <File Id="fil87F4823E5A4E9CAD89C9F18EB7D940C2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Fusion\FileDialogDelegate.qml" />
-            </Component>
-            <Component Id="cmp93F9CB69ACD380F7D59D08819255322B" Directory="dir929495D16D3C46BFD28C6AD595BCD701" Guid="{CC385A86-C88F-409C-ADE0-7BCF8DD46C78}">
-                <File Id="filA3DF900A1D2C6A4D414885D446B5C70C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Fusion\FolderBreadcrumbBar.qml" />
-            </Component>
-            <Component Id="cmp29403D08CB444131141FF50C5977F801" Directory="dir929495D16D3C46BFD28C6AD595BCD701" Guid="{DC93624A-8F0D-47FA-BDB0-AF8A0781BBAC}">
-                <File Id="filEA8B9CAEBE85B9B32212D7D7AC61E3C8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Fusion\FolderDialog.qml" />
-            </Component>
-            <Component Id="cmp0F3406384273F4D43A9ECCF138617EFD" Directory="dir929495D16D3C46BFD28C6AD595BCD701" Guid="{6ABEA4A4-8047-4A2E-BBDD-60F9284879C0}">
-                <File Id="filE73DB30D303712F991084FF0EEB941F5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Fusion\FolderDialogDelegate.qml" />
-            </Component>
-            <Component Id="cmp1AD58D86AC860A01A93BF5C9248B5E0B" Directory="dir929495D16D3C46BFD28C6AD595BCD701" Guid="{94387038-5A74-48DA-8531-714A1BBFED7A}">
-                <File Id="fil36CA66A25F1D4A60DCA8851C04360F5A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Fusion\FontDialog.qml" />
-            </Component>
-            <Component Id="cmp2E10228540CA4421B670586FA6F602D4" Directory="dir929495D16D3C46BFD28C6AD595BCD701" Guid="{EAA4236A-7D79-420D-87D6-28ED23D6460A}">
-                <File Id="fil103C6B50716464DFCFF67BCDF19D268F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Fusion\MessageDialog.qml" />
-            </Component>
-            <Component Id="cmpB06D35D731CDFFF625B04E79D8E88BB4" Directory="dir8C28C0A2CF1DDABB1BF2872E8E6AE192" Guid="{3E057F8C-DF84-4681-BA6A-9562C0790EB5}">
-                <File Id="fil75D5FBD826D73921FABD447701DE184A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Imagine\ColorDialog.qml" />
-            </Component>
-            <Component Id="cmp53496C379F6D669E9DC8EE0F3AD3E17E" Directory="dir8C28C0A2CF1DDABB1BF2872E8E6AE192" Guid="{3150C6F6-6842-4B88-8DB9-9668D9EE0678}">
-                <File Id="filD95B88F29ACA98EBCB5B86D8F5FA2505" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Imagine\FileDialog.qml" />
-            </Component>
-            <Component Id="cmp94CCFDA09967CE02B01DF2FD85424408" Directory="dir8C28C0A2CF1DDABB1BF2872E8E6AE192" Guid="{805E967C-B9F5-48B9-8C87-7AA0E168B837}">
-                <File Id="fil1939DC9854DE81CAD586E8EA8C9F11A5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Imagine\FileDialogDelegate.qml" />
-            </Component>
-            <Component Id="cmp28FD3CFF63249E9A333566E0D4403C06" Directory="dir8C28C0A2CF1DDABB1BF2872E8E6AE192" Guid="{CF289DEF-97C5-4276-A5AA-759B1C43A151}">
-                <File Id="fil540156639772798B8D6CF3832BA6CEFF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Imagine\FolderBreadcrumbBar.qml" />
-            </Component>
-            <Component Id="cmp8FB0248D377F04FE065ED8D3F0956920" Directory="dir8C28C0A2CF1DDABB1BF2872E8E6AE192" Guid="{ECA74581-7195-4E89-9793-E0543CB65F84}">
-                <File Id="fil1B2FC023BAB032527FD158332D7A31A1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Imagine\FolderDialog.qml" />
-            </Component>
-            <Component Id="cmpEB30E27FA4A0E15D8110F522E6E24AB9" Directory="dir8C28C0A2CF1DDABB1BF2872E8E6AE192" Guid="{3BE4CCBF-C42C-4BA3-A90C-5F9D7095D942}">
-                <File Id="fil4C6AFCFFF15FA8BF18BBF16D8D04263A" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Imagine\FolderDialogDelegate.qml" />
-            </Component>
-            <Component Id="cmpE831C08038ED1CE79CB86EA78782321B" Directory="dir8C28C0A2CF1DDABB1BF2872E8E6AE192" Guid="{697E0CB1-6C86-46C1-9AF7-52E1A27E148D}">
-                <File Id="fil49DC57941DAE9D048E67CC9D4037E20F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Imagine\FontDialog.qml" />
-            </Component>
-            <Component Id="cmpC9A55BF0CB886578DBBE11A05E82098E" Directory="dir8C28C0A2CF1DDABB1BF2872E8E6AE192" Guid="{9F6224D1-093E-491F-9D48-2F4F8C48AB5E}">
-                <File Id="fil4366D0DAFCA17243777D0FC31A6D7CCF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Imagine\MessageDialog.qml" />
-            </Component>
-            <Component Id="cmp0ABC2788AE2935B5CB49F7CFC3447AE7" Directory="dirC980C9942B69E6635E4CF7C57652D12B" Guid="{24D9FA8D-6FE2-4501-AEE0-F3B9D673FA69}">
-                <File Id="filB61687597342BBBABAE1E94101F3EC6E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Material\ColorDialog.qml" />
-            </Component>
-            <Component Id="cmp1B66918327259E9332768B2CEDF63F3F" Directory="dirC980C9942B69E6635E4CF7C57652D12B" Guid="{31BF28D2-0A26-4183-832C-3E04A9860196}">
-                <File Id="fil62168DF788419AC877C9C1D54BABA7E2" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Material\FileDialog.qml" />
-            </Component>
-            <Component Id="cmp7D2F50F1ECA2513B10F2D9E268603803" Directory="dirC980C9942B69E6635E4CF7C57652D12B" Guid="{3D69E07B-58BE-4042-B7A2-EBA806B429D8}">
-                <File Id="fil5909CA77FA8E0522A5ABE19D201D339E" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Material\FileDialogDelegate.qml" />
-            </Component>
-            <Component Id="cmp54231F7DE8257F6F679C508C4A324029" Directory="dirC980C9942B69E6635E4CF7C57652D12B" Guid="{BFED6612-1F38-4694-84B1-4ABBE2D3EC74}">
-                <File Id="fil066B22B57C4829B076EF2637C8369609" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Material\FolderBreadcrumbBar.qml" />
-            </Component>
-            <Component Id="cmpEBBD3D3A57C898928DA40D237B8191AE" Directory="dirC980C9942B69E6635E4CF7C57652D12B" Guid="{C1A5A501-5258-4007-8304-8EE952E74938}">
-                <File Id="fil9364C24A62A278E0DF4A32219457A0E7" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Material\FolderDialog.qml" />
-            </Component>
-            <Component Id="cmp4CFF955FC6C7A59A9C3686F6EA07DEB2" Directory="dirC980C9942B69E6635E4CF7C57652D12B" Guid="{175127CE-5DA3-4EFF-BA4F-72B09E25F44D}">
-                <File Id="filFAB35638D14AAE200469B556D0704257" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Material\FolderDialogDelegate.qml" />
-            </Component>
-            <Component Id="cmpE18DF027A0BDBB96DACB63898F697766" Directory="dirC980C9942B69E6635E4CF7C57652D12B" Guid="{20DB0640-120F-4BA6-A307-9111CE086AF0}">
-                <File Id="filDA5275126CA3326219C5633BBAF43DA5" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Material\FontDialog.qml" />
-            </Component>
-            <Component Id="cmpFE745526AAA642BA836DA29C9F77ED9B" Directory="dirC980C9942B69E6635E4CF7C57652D12B" Guid="{DE8767C0-F5D4-4FFE-992A-08F3E4B0107D}">
-                <File Id="fil54D49371701AEB3AD847CDD309D9B185" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Material\MessageDialog.qml" />
-            </Component>
-            <Component Id="cmpD4B5BFCAFB6DC32B78A6C9AC75762ACC" Directory="dir8C55A2520B05F605E480B8F2F2039F1C" Guid="{972FC60C-F8D8-461B-BBFD-7DF6E7086DF2}">
-                <File Id="fil4D10401F2E4EA015EF5CE8BEA0AE7121" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Universal\ColorDialog.qml" />
-            </Component>
-            <Component Id="cmpC67BC79E14952488E29CF9E27BD202FB" Directory="dir8C55A2520B05F605E480B8F2F2039F1C" Guid="{2E2F47EC-9897-4C8E-8B29-7BFE9712BCFD}">
-                <File Id="fil35DAD56258028832AFB445B0E0263B84" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Universal\FileDialog.qml" />
-            </Component>
-            <Component Id="cmp9F8F91188C1B368A7FE7E51517C5ACC0" Directory="dir8C55A2520B05F605E480B8F2F2039F1C" Guid="{27628965-E859-46D5-B9D3-18142C281F2A}">
-                <File Id="filCCF6364980A7F563A9642915E70CB32B" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Universal\FileDialogDelegate.qml" />
-            </Component>
-            <Component Id="cmp24B89BE2A868B73CC480D3F15E9AA30B" Directory="dir8C55A2520B05F605E480B8F2F2039F1C" Guid="{9C323147-D535-45F2-B677-56AA821A240F}">
-                <File Id="fil39DD65F761C1D67E92728B9250518B4D" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Universal\FolderBreadcrumbBar.qml" />
-            </Component>
-            <Component Id="cmp48D9FBFB9413B749E8E5568D27D9E7BA" Directory="dir8C55A2520B05F605E480B8F2F2039F1C" Guid="{F1D9031B-220F-4833-8BB5-93B8463B2E8D}">
-                <File Id="fil620700542B96A19799BA7151FA3C37CF" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Universal\FolderDialog.qml" />
-            </Component>
-            <Component Id="cmpC5B074A0F5386F436C0457318AEBEAC8" Directory="dir8C55A2520B05F605E480B8F2F2039F1C" Guid="{874D7476-7737-47B9-A494-A9EA4DBFED08}">
-                <File Id="fil26FDE36A980B8A98EB003E08B71AAAFD" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Universal\FolderDialogDelegate.qml" />
-            </Component>
-            <Component Id="cmpA671B669F6A248C1F3648B5295D227F2" Directory="dir8C55A2520B05F605E480B8F2F2039F1C" Guid="{095D7121-4B02-4550-8D4C-E81FE6E6C015}">
-                <File Id="fil158685A04206B07FCFB74FDBDD3C4579" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Universal\FontDialog.qml" />
-            </Component>
-            <Component Id="cmp388F3D53B11EE0449503AEBC67192D85" Directory="dir8C55A2520B05F605E480B8F2F2039F1C" Guid="{8F932E16-3B5C-4B90-8049-90498387825E}">
-                <File Id="filF4BAFBB95A2A38BD425F65092CB041B8" KeyPath="yes" Source="SourceDir\qml\QtQuick\Dialogs\quickimpl\qml\+Universal\MessageDialog.qml" />
+            <Component Id="cmp8DD0CF3FAD30D8F599E7381E8F9E9A95" Directory="dir2682D39E9C78E1415E0A57E589F0A404" Guid="{BD317A96-8A94-49AF-AF6E-D6BB9D2112F7}">
+                <File Id="fil07B9AECD3C0996F5081301CB41F1BF49" KeyPath="yes" Source="SourceDir\qml\QtQuick\Controls\Windows\impl\SwitchIndicator.qml" />
             </Component>
             <Component Id="cmpED7844544FD113D2024E6D3A0A781CAE" Directory="dir7397A50E4D7D313615C4CF7C94C61160" Guid="{3999B85C-6807-4735-92CF-D5976160ED5C}">
                 <File Id="filDB53B5FD7BD0B0F1464E81D6A058D610" KeyPath="yes" Source="SourceDir\qml\QtQuick\Effects\effectsplugin.dll" />
@@ -1552,15 +3983,6 @@
             <Component Id="cmp4260C68CD0F932092808D3942F80E172" Directory="dir7EBA39754BD2CE291EC25825433A43D2" Guid="{6210CD29-AEE9-4A68-916C-B7B8A3EA3EBF}">
                 <File Id="fil11D74BAB954F6060FE25421FF4DF2D92" KeyPath="yes" Source="SourceDir\qml\QtQuick\Layouts\qquicklayoutsplugin.dll" />
             </Component>
-            <Component Id="cmpD7C080A5C7175B15B438D5E4851B9267" Directory="dirA6F6BC40CF508C5F92BB49483928E0FC" Guid="{C3694BA2-F15C-4396-90D8-C384C67F5367}">
-                <File Id="filDE9CEDD02770FA8D5A6B443C92AF13E2" KeyPath="yes" Source="SourceDir\qml\QtQuick\LocalStorage\plugins.qmltypes" />
-            </Component>
-            <Component Id="cmp6F365EE63059CFBDA7386B8F1B4B7E73" Directory="dirA6F6BC40CF508C5F92BB49483928E0FC" Guid="{4CAC376D-A372-4AEB-83E1-903A9A015526}">
-                <File Id="fil19E5C5D82A58C106C10F4EF71FBDC561" KeyPath="yes" Source="SourceDir\qml\QtQuick\LocalStorage\qmldir" />
-            </Component>
-            <Component Id="cmp56020DD868F550FF4C2761D9FCAF2820" Directory="dirA6F6BC40CF508C5F92BB49483928E0FC" Guid="{50781D85-0D79-446C-ADF7-AEF6B6324E71}">
-                <File Id="fil373F860BFC86DCA9B91B06DE6B8312C0" KeyPath="yes" Source="SourceDir\qml\QtQuick\LocalStorage\qmllocalstorageplugin.dll" />
-            </Component>
             <Component Id="cmpE6642776D930163E5B3F23D206815BB4" Directory="dirF7455B984D3CF2564DED2759788752A0" Guid="{C1F45943-5DF4-46B0-9C63-B2E15A012243}">
                 <File Id="filE1D8B4CEB7BAAD320C44F6CD0D7101AF" KeyPath="yes" Source="SourceDir\qml\QtQuick\NativeStyle\plugins.qmltypes" />
             </Component>
@@ -1569,57 +3991,6 @@
             </Component>
             <Component Id="cmp1052E5F49C616A54DF531B8121F3D962" Directory="dirF7455B984D3CF2564DED2759788752A0" Guid="{7D231850-64B7-452D-AE5E-458968F5D6DE}">
                 <File Id="fil4B9E63D0E3544A93D3C93F417E63A2D7" KeyPath="yes" Source="SourceDir\qml\QtQuick\NativeStyle\qtquickcontrols2nativestyleplugin.dll" />
-            </Component>
-            <Component Id="cmpC9C0D310B3B9C47633E52904919A68A3" Directory="dir3A2097370D43A6BEED9BF1FBE00B9935" Guid="{BFF61EA7-1CC6-4246-82E9-6D4E2E90FC5C}">
-                <File Id="fil4E74AF38A57B5DC51A0C8BAA7FA0248A" KeyPath="yes" Source="SourceDir\qml\QtQuick\NativeStyle\controls\DefaultButton.qml" />
-            </Component>
-            <Component Id="cmp8A89A151469884206970043CC9CF4D86" Directory="dir3A2097370D43A6BEED9BF1FBE00B9935" Guid="{F9E13138-F84A-4A0E-A101-1D1976C4142C}">
-                <File Id="fil8ABD292511F2D365661FA57136628A97" KeyPath="yes" Source="SourceDir\qml\QtQuick\NativeStyle\controls\DefaultCheckBox.qml" />
-            </Component>
-            <Component Id="cmp998E8AF42C18DDD09BFF57E42546A8D5" Directory="dir3A2097370D43A6BEED9BF1FBE00B9935" Guid="{77651B30-C65B-4363-82EF-A52A5F69FC3F}">
-                <File Id="filCAF57E8E6C8CC0D9A2780CDD88AD462B" KeyPath="yes" Source="SourceDir\qml\QtQuick\NativeStyle\controls\DefaultComboBox.qml" />
-            </Component>
-            <Component Id="cmpD499A28F8E9F6FEE97F97777DA6CB3AE" Directory="dir3A2097370D43A6BEED9BF1FBE00B9935" Guid="{BD1933FE-0A92-4AF8-99FC-4D2B2E89FF03}">
-                <File Id="fil8B58BB6E6F240EEB5AB919B5E8FF3FCC" KeyPath="yes" Source="SourceDir\qml\QtQuick\NativeStyle\controls\DefaultDial.qml" />
-            </Component>
-            <Component Id="cmpDBDF7121809130D7416E032EA09C16B0" Directory="dir3A2097370D43A6BEED9BF1FBE00B9935" Guid="{A1658F78-523C-48F9-9234-ECE710E1EDF2}">
-                <File Id="fil410E97B463184F448D3625740C057F2B" KeyPath="yes" Source="SourceDir\qml\QtQuick\NativeStyle\controls\DefaultFrame.qml" />
-            </Component>
-            <Component Id="cmp2948DD4EC5076256EF0BA0FE75947821" Directory="dir3A2097370D43A6BEED9BF1FBE00B9935" Guid="{1164C747-ED06-4891-B5B7-D2D2B57624B9}">
-                <File Id="fil514160DB4A8D6516426012B1E5DCA0C4" KeyPath="yes" Source="SourceDir\qml\QtQuick\NativeStyle\controls\DefaultGroupBox.qml" />
-            </Component>
-            <Component Id="cmpBAD2FDC63EF91AF984D6977B2A9641A7" Directory="dir3A2097370D43A6BEED9BF1FBE00B9935" Guid="{1DE5E90F-1543-44AE-AF50-710C30878686}">
-                <File Id="filC20F91CF453A8F4B5F75C95AADAFFDF4" KeyPath="yes" Source="SourceDir\qml\QtQuick\NativeStyle\controls\DefaultProgressBar.qml" />
-            </Component>
-            <Component Id="cmp6504A26398241286FD87575D3DDDEE30" Directory="dir3A2097370D43A6BEED9BF1FBE00B9935" Guid="{415D1FFC-2833-43B8-BDF7-B947F076AE0C}">
-                <File Id="fil82D83C5E4CA154FA270B4DA26EEB3BA6" KeyPath="yes" Source="SourceDir\qml\QtQuick\NativeStyle\controls\DefaultRadioButton.qml" />
-            </Component>
-            <Component Id="cmpF53E23CCF650110414BF5121E32F5801" Directory="dir3A2097370D43A6BEED9BF1FBE00B9935" Guid="{B6FF0EE3-BA67-45C0-8626-CC1B885ABC9D}">
-                <File Id="fil203E12EF4C14B14DFCDA757CA082B189" KeyPath="yes" Source="SourceDir\qml\QtQuick\NativeStyle\controls\DefaultScrollBar.qml" />
-            </Component>
-            <Component Id="cmpC43D383FA22807D352ED92706A3B7BB5" Directory="dir3A2097370D43A6BEED9BF1FBE00B9935" Guid="{D1FD9DD4-4BC3-43C3-8CD4-7885EAF5C33D}">
-                <File Id="fil336CE1259605D5F6DD75031302D1D172" KeyPath="yes" Source="SourceDir\qml\QtQuick\NativeStyle\controls\DefaultSlider.qml" />
-            </Component>
-            <Component Id="cmpE1F0EBE68EDB43973B9E52D9C0F96504" Directory="dir3A2097370D43A6BEED9BF1FBE00B9935" Guid="{0F889D31-D05F-4951-BADE-1855290932F4}">
-                <File Id="fil05CB3CD7C420EE0D632AB36B001DDC11" KeyPath="yes" Source="SourceDir\qml\QtQuick\NativeStyle\controls\DefaultSpinBox.qml" />
-            </Component>
-            <Component Id="cmp8D7D9681C26F0A7B52E3C668EA4BF45B" Directory="dir3A2097370D43A6BEED9BF1FBE00B9935" Guid="{475F3D95-92FE-4D21-A51C-CF14DED25C30}">
-                <File Id="fil6324820B417FACA7B03D7631F502BF76" KeyPath="yes" Source="SourceDir\qml\QtQuick\NativeStyle\controls\DefaultTextArea.qml" />
-            </Component>
-            <Component Id="cmpF20525D1576510B72940A1B3A2B872E9" Directory="dir3A2097370D43A6BEED9BF1FBE00B9935" Guid="{DA00649A-32EC-48E5-A2F0-4386BA48ACD1}">
-                <File Id="filE190EBA3C1D870E6CF7BCBFDC2EF4B9F" KeyPath="yes" Source="SourceDir\qml\QtQuick\NativeStyle\controls\DefaultTextField.qml" />
-            </Component>
-            <Component Id="cmp5C615FF3D38B0DAEA6E54192A348A499" Directory="dir3A2097370D43A6BEED9BF1FBE00B9935" Guid="{2396D282-E796-44DF-ACE2-956B3A75F412}">
-                <File Id="filB2DF42D1E5EA322F47250AD21CF4E4F5" KeyPath="yes" Source="SourceDir\qml\QtQuick\NativeStyle\controls\DefaultTreeViewDelegate.qml" />
-            </Component>
-            <Component Id="cmp18CB7E4808B561BE6CFA935B7A701259" Directory="dir2105A1F7199CAE1171E138FDED1D8E49" Guid="{4D3B1A28-867A-4687-9521-A94B79D36EDB}">
-                <File Id="filAF591582B9EB7D4C0EF0E76AB1774FE1" KeyPath="yes" Source="SourceDir\qml\QtQuick\Particles\particlesplugin.dll" />
-            </Component>
-            <Component Id="cmp4F76529422F947A88380E6330781E9A8" Directory="dir2105A1F7199CAE1171E138FDED1D8E49" Guid="{2C798851-B87F-46AA-B907-61F2AFA60733}">
-                <File Id="fil12011A3B6C5641C4DBB765FE3972890F" KeyPath="yes" Source="SourceDir\qml\QtQuick\Particles\plugins.qmltypes" />
-            </Component>
-            <Component Id="cmp79A247854241165CFF0438015FC92CBB" Directory="dir2105A1F7199CAE1171E138FDED1D8E49" Guid="{FFEC7B0E-C5F3-4005-97E4-F01BDD023AD5}">
-                <File Id="fil5CFE0F9500667BFD3E26D27A494DA78C" KeyPath="yes" Source="SourceDir\qml\QtQuick\Particles\qmldir" />
             </Component>
             <Component Id="cmp451BE08037AE1075B3D0480F83957794" Directory="dir96881D4937C7E7E8DC6A06696EF52C96" Guid="{F218CBB6-2DD5-41A1-9F56-1826C80A2C4B}">
                 <File Id="filA5E21912CAC2144F8A23EB7C07A64E50" KeyPath="yes" Source="SourceDir\qml\QtQuick\Shapes\plugins.qmltypes" />
@@ -1639,39 +4010,6 @@
             <Component Id="cmp6B89F1FC6840B89D467D2EBE8B043FE1" Directory="dirA16BBE5DE11DF2FD79B07E2965737D3E" Guid="{930C0CB5-3767-4247-A5D7-8A385FF0344E}">
                 <File Id="filED4C60CE9B81695ECE44D214DCBCCE02" KeyPath="yes" Source="SourceDir\qml\QtQuick\Templates\qtquicktemplates2plugin.dll" />
             </Component>
-            <Component Id="cmp69BEF3BE02352CA6B785101AAED71318" Directory="dir2C126EEEB46329DB6052C65B78F1DA75" Guid="{0EDF30C9-0CCB-480C-B957-604C01BA559B}">
-                <File Id="fil1760F73BD6E3E7286EB8F1D3A33C2073" KeyPath="yes" Source="SourceDir\qml\QtQuick\tooling\Component.qml" />
-            </Component>
-            <Component Id="cmp10D98830533C42F8706977851B39A3A0" Directory="dir2C126EEEB46329DB6052C65B78F1DA75" Guid="{7AC6A3ED-EA58-47A6-8AB3-BD7FA42C145E}">
-                <File Id="filBF176D7C05C63830AFF6998ABFB38A7B" KeyPath="yes" Source="SourceDir\qml\QtQuick\tooling\Enum.qml" />
-            </Component>
-            <Component Id="cmp15249FC563E9C8918952F7D1A2F805C9" Directory="dir2C126EEEB46329DB6052C65B78F1DA75" Guid="{4735B6BA-B771-4BAE-8C6C-C103E6B43A00}">
-                <File Id="fil2CAD05441DC803A5186E966A1DDA48C6" KeyPath="yes" Source="SourceDir\qml\QtQuick\tooling\Member.qml" />
-            </Component>
-            <Component Id="cmp4833C19054EF2E14E372AD2880495C73" Directory="dir2C126EEEB46329DB6052C65B78F1DA75" Guid="{A478AE0F-CF66-48F9-834F-F2C3724B6871}">
-                <File Id="fil43B1B5A91FA45D5C106A45D805FEFC40" KeyPath="yes" Source="SourceDir\qml\QtQuick\tooling\Method.qml" />
-            </Component>
-            <Component Id="cmp33AC2E102B879ECCC6316EF7AEFDBB99" Directory="dir2C126EEEB46329DB6052C65B78F1DA75" Guid="{29E6646A-D2DC-456F-B002-9874DAB30B8C}">
-                <File Id="fil95F6CB39A7A168DA09B6ABC8A860B095" KeyPath="yes" Source="SourceDir\qml\QtQuick\tooling\Module.qml" />
-            </Component>
-            <Component Id="cmpD956362F874FB96C3A0DFCADA1405E4B" Directory="dir2C126EEEB46329DB6052C65B78F1DA75" Guid="{E6D431BC-F544-4043-9220-D72E1095259A}">
-                <File Id="fil12BB133642A6251AFE56340C20C38432" KeyPath="yes" Source="SourceDir\qml\QtQuick\tooling\Parameter.qml" />
-            </Component>
-            <Component Id="cmp05C5F4FC22BE05FF20AF6B70F2648E30" Directory="dir2C126EEEB46329DB6052C65B78F1DA75" Guid="{21E2A211-764A-4061-8B3C-829FC6DA1E6D}">
-                <File Id="filC998D7BD8B71F6CD05288B0CF1CE0D63" KeyPath="yes" Source="SourceDir\qml\QtQuick\tooling\Property.qml" />
-            </Component>
-            <Component Id="cmpA5F05A0EC98A80D47E263C8226347F09" Directory="dir2C126EEEB46329DB6052C65B78F1DA75" Guid="{73B849AB-C9FB-4C1C-8FBF-FB6F5419BFFB}">
-                <File Id="filB09D42B54721DA6F6C88B761F67D1CD3" KeyPath="yes" Source="SourceDir\qml\QtQuick\tooling\qmldir" />
-            </Component>
-            <Component Id="cmp69C56DED012A8CF7146BB347775E1111" Directory="dir2C126EEEB46329DB6052C65B78F1DA75" Guid="{C4C7A555-20F9-4CF0-BAAB-85323CF95C89}">
-                <File Id="fil2C39EC74EEBD3E3FB173F25F6474B71B" KeyPath="yes" Source="SourceDir\qml\QtQuick\tooling\quicktooling.qmltypes" />
-            </Component>
-            <Component Id="cmp8CF4D885EDBD87E92F14AD9224A64585" Directory="dir2C126EEEB46329DB6052C65B78F1DA75" Guid="{9EDAA25D-41BD-4154-9191-AD91477441BD}">
-                <File Id="fil619C9C3A532439F43969D239FC47574E" KeyPath="yes" Source="SourceDir\qml\QtQuick\tooling\quicktoolingplugin.dll" />
-            </Component>
-            <Component Id="cmp40C935D75C83A908961342FA5F190AB4" Directory="dir2C126EEEB46329DB6052C65B78F1DA75" Guid="{2E64BF9B-123A-47A8-A4E3-93081043E53B}">
-                <File Id="fil9A187523ABDC241490F213412E806915" KeyPath="yes" Source="SourceDir\qml\QtQuick\tooling\Signal.qml" />
-            </Component>
             <Component Id="cmp3E281B1E4C74C596886969A2CCFF6DB0" Directory="dir27DABF0F34E48010C38FDC22DEE2453A" Guid="{7AA23465-D8C4-45CE-851F-89DCD7337756}">
                 <File Id="fil620C826946D01508C458662B95E34005" KeyPath="yes" Source="SourceDir\qml\QtQuick\Window\qmldir" />
             </Component>
@@ -1687,8 +4025,8 @@
             <Component Id="cmp072B7F91297F86D3BDCFBD50CEADEC08" Directory="dir30FC873BE970351C9459A1383DCBEA3D" Guid="{E785466E-0037-4442-BB43-1AABD9C60E9A}">
                 <File Id="fil830FE0B6AE85ABAD33F965FA48D2A9D4" KeyPath="yes" Source="SourceDir\qml\QtWebChannel\qmldir" />
             </Component>
-            <Component Id="cmpB9B4251EC70936E366F1ADEF4DBA9A35" Directory="dir30FC873BE970351C9459A1383DCBEA3D" Guid="{8E6F75FC-8222-46F4-92FC-8CCFE70EBE15}">
-                <File Id="fil2433013655774AC94A0236C340127486" KeyPath="yes" Source="SourceDir\qml\QtWebChannel\webchannelplugin.dll" />
+            <Component Id="cmpF6EF3D689902FFD67C9E9F76539478A0" Directory="dir30FC873BE970351C9459A1383DCBEA3D" Guid="{29CACC4A-A8D9-41E6-B4FE-C2A9340819FA}">
+                <File Id="fil61A21603A473D5195ECF714F1657AA8E" KeyPath="yes" Source="SourceDir\qml\QtWebChannel\webchannelquickplugin.dll" />
             </Component>
             <Component Id="cmp136E2541355213ECB53F1748901B5921" Directory="dirD4BB3B3030E6C19000CA3A1BC69B6F39" Guid="{014C3BF0-EB02-4DD8-97F0-AD47E1AE7F7C}">
                 <File Id="fil6E5C9BBEEE5288F679B12AE6A49657B2" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\plugins.qmltypes" />
@@ -1698,57 +4036,6 @@
             </Component>
             <Component Id="cmp8E3363215DF077EB827751DB665D9DD1" Directory="dirD4BB3B3030E6C19000CA3A1BC69B6F39" Guid="{F4497801-71D9-4FAA-AD8C-246C60056E11}">
                 <File Id="fil2497BDEBFF9ED845670AED37393D4EDD" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\qtwebenginequickplugin.dll" />
-            </Component>
-            <Component Id="cmp7A8772E58D71483AB938D78C8B7D1B79" Directory="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Guid="{174CCED6-2707-455C-B609-3AC085FB5C0F}">
-                <File Id="filE1BB18B10EE0470145DDDA0C5E4A3B99" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\ControlsDelegates\AlertDialog.qml" />
-            </Component>
-            <Component Id="cmpEE8B93301235F322A5BD23F0C50EED3F" Directory="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Guid="{D8884104-A700-4DE8-932C-DAC44019A5BA}">
-                <File Id="fil3D4C79F57FA6E2E2A3343868C653A6A5" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\ControlsDelegates\AuthenticationDialog.qml" />
-            </Component>
-            <Component Id="cmp2C69E47276AE27A52BD269FB9BE30AAD" Directory="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Guid="{20862762-B83A-45A1-A54F-A473A6D2A0CE}">
-                <File Id="fil80A7B2A5FCF793D0801C69BCBD98F249" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\ControlsDelegates\AutofillPopup.qml" />
-            </Component>
-            <Component Id="cmpA9795EC6D9B937B8A86B7B2846C91948" Directory="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Guid="{7A04DC39-26B9-4621-B5DF-0EE26A2002F3}">
-                <File Id="filA6C1CA6308618936A31EB03CEB74F27A" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\ControlsDelegates\ColorDialog.qml" />
-            </Component>
-            <Component Id="cmp59759C9323D1558B224AADEA2AAF9C64" Directory="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Guid="{506D8589-0CF9-4B8B-9547-DD0DEB5A1D7B}">
-                <File Id="fil651A6A58BA66409A10279997FDF431A7" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\ControlsDelegates\ConfirmDialog.qml" />
-            </Component>
-            <Component Id="cmp1B4AF93D806ADB8B732F2A27EB652B98" Directory="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Guid="{F5E54C76-0280-4DB1-9185-543360CE8900}">
-                <File Id="filF73B3538DC6FC52FF15D02C2C0E58D32" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\ControlsDelegates\DirectoryPicker.qml" />
-            </Component>
-            <Component Id="cmpF2CCD1A91F993653DF09C0E15EC64A4B" Directory="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Guid="{04F36E55-26C2-459C-AD01-8E83D61B9D8C}">
-                <File Id="fil74DBD34E74C737746E6CAB216E06D48F" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\ControlsDelegates\FilePicker.qml" />
-            </Component>
-            <Component Id="cmpA7D7583F9A23AD1D9C5E1762D7868578" Directory="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Guid="{1CE60DB8-9248-426A-84C8-4799ED25836A}">
-                <File Id="filD4288E12E49244FBBCD5FC5EFFE0298C" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\ControlsDelegates\Menu.qml" />
-            </Component>
-            <Component Id="cmp7101449A820EA328AA1A4D1B5E999A0C" Directory="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Guid="{722B6A0B-6A25-4C96-96E4-ECA98AD77354}">
-                <File Id="filBD111FAA5EF2C87B70E794D43B659AF2" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\ControlsDelegates\MenuItem.qml" />
-            </Component>
-            <Component Id="cmpAD3AF866463125CF8655A99CED3AA499" Directory="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Guid="{C163C7C3-A984-4066-9905-B95A02331E29}">
-                <File Id="fil98058066907D9EBDF12B81A4E59979BD" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\ControlsDelegates\MenuSeparator.qml" />
-            </Component>
-            <Component Id="cmpE19B99C56B831180E601BB3589E3F3EA" Directory="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Guid="{AC95A951-DDB9-405A-BA24-D6ECC311B113}">
-                <File Id="filE382C586DDB2EA853C109D8235DF6C4F" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\ControlsDelegates\PromptDialog.qml" />
-            </Component>
-            <Component Id="cmp4715158A523F0FB8C16A313FD382AFF9" Directory="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Guid="{9FA4AD8E-5518-41E7-B63D-81C9088F325E}">
-                <File Id="filA500F08171E7AD5EF0B2841D2A86F407" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\ControlsDelegates\qmldir" />
-            </Component>
-            <Component Id="cmp2696C32671FC8FBEF137F3AC34DE43FD" Directory="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Guid="{A3F13B40-4EE5-44EF-ABE1-DDD47E80E9AF}">
-                <File Id="filE6605EF825D5763D112ABD3139E76B74" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\ControlsDelegates\qtwebenginequickdelegatesplugin.dll" />
-            </Component>
-            <Component Id="cmp2E51274B580CEE17803AD1CE80B76947" Directory="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Guid="{683B1534-88D2-432A-8BD5-E2DDAC882438}">
-                <File Id="fil93F79CE6E26226D4196803E05887053C" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\ControlsDelegates\ToolTip.qml" />
-            </Component>
-            <Component Id="cmp90F62D3657982F0E2E1182816125FED6" Directory="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Guid="{CBCCE1CB-34C9-4823-82DC-715280147B8A}">
-                <File Id="fil61B872246F6A108B9B7BE4F4F7E90DE8" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\ControlsDelegates\TouchHandle.qml" />
-            </Component>
-            <Component Id="cmp14169E3CF5A8B218146130249FBB815D" Directory="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Guid="{B07EC381-AB58-4611-B885-80002E924066}">
-                <File Id="filFE30BDE0B2C918072AA010AE4AFF6C82" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\ControlsDelegates\TouchSelectionMenu.qml" />
-            </Component>
-            <Component Id="cmpB07E9D9CFF105AE7053ACEA3668A2A8E" Directory="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Guid="{5B162E9C-AE2D-4BC8-8042-DA311B80E5C9}">
-                <File Id="filB51A511EB7DCD4E087D230FD943C82DB" KeyPath="yes" Source="SourceDir\qml\QtWebEngine\ControlsDelegates\WebEngineQuickDelegatesQml.qmltypes" />
             </Component>
             <Component Id="cmp740EB509039EF4F9005AA06519EACF79" Directory="dirAB78018B8375BAA818F1C40C8D16F821" Guid="{684794E3-E1E9-4F45-9071-566EA41167BA}">
                 <File Id="fil22604A1353A5B198D4846DC21D1783C9" KeyPath="yes" Source="SourceDir\qml\QtWebView\plugins.qmltypes" />
@@ -1807,8 +4094,11 @@
             <Component Id="cmpC2267073DB55586843E13B823F6E0E8B" Directory="dir08941CEA6046320FCCF158F759AF80F2" Guid="{B7CB4FC1-BF14-47CF-AD7C-04B581B028F8}">
                 <File Id="filFDCD09910FB501B1A747E0A04B8D3E31" KeyPath="yes" Source="SourceDir\resources\qtwebengine_resources_200p.pak" />
             </Component>
-            <Component Id="cmp5DAC8E92F0D1CE1028B76D02F12152DE" Directory="dir3BC41331752E78D0C2719C277915294F" Guid="{3773817D-66C1-48E3-A370-333237394858}">
-                <File Id="fil4F3C3348649DA965E980E99B9E82B7FF" KeyPath="yes" Source="SourceDir\styles\qwindowsvistastyle.dll" />
+            <Component Id="cmpE92806CD1DBEE716B77AA561DD943FDD" Directory="dir08941CEA6046320FCCF158F759AF80F2" Guid="{013197E9-8D4C-4882-B57F-9C8E5E47F0A9}">
+                <File Id="fil36076BE7C94F9CC98F2D777B67200CE7" KeyPath="yes" Source="SourceDir\resources\v8_context_snapshot.bin" />
+            </Component>
+            <Component Id="cmp59B8D848C7C3855D56912CDC5BED1B97" Directory="dir3BC41331752E78D0C2719C277915294F" Guid="{1CC93D19-A636-4CF8-859B-EF6435E1E352}">
+                <File Id="fil8419D0503B0E38F93B832F060E1D88F4" KeyPath="yes" Source="SourceDir\styles\qmodernwindowsstyle.dll" />
             </Component>
             <Component Id="cmpD57693E12A6CF9AFDC034864F2950D6F" Directory="dir509C75F94B9AF6C35CA00410005C14EE" Guid="{F49F8C94-0B60-4F26-B9B0-345928B1C3BA}">
                 <File Id="filA3197B081536A45213DBC7CD12A615C4" KeyPath="yes" Source="SourceDir\tls\qcertonlybackend.dll" />
@@ -1981,6 +4271,16 @@
         </ComponentGroup>
     </Fragment>
     <Fragment>
+        <DirectoryRef Id="dir74C12D674F4D48CC8662780E32EF06CE">
+            <Directory Id="dir0986B5CAD2460321886B51FD51019567" Name="icons" />
+        </DirectoryRef>
+    </Fragment>
+    <Fragment>
+        <DirectoryRef Id="dirB030248D75EA99E75698A1E011FE9CC0">
+            <Directory Id="dir0EBECE38763539163E6070C0EF39AFCD" Name="images" />
+        </DirectoryRef>
+    </Fragment>
+    <Fragment>
         <DirectoryRef Id="dir175FB1A22F883092D2FC39E138CDC5FC">
             <Directory Id="dir171007FEE30C4A50EC7ED2CB58E0B5E3" Name="impl" />
         </DirectoryRef>
@@ -2001,8 +4301,8 @@
         </DirectoryRef>
     </Fragment>
     <Fragment>
-        <DirectoryRef Id="dir4B7D2A19DD0D33E235AA7BD43615A87E">
-            <Directory Id="dir2105A1F7199CAE1171E138FDED1D8E49" Name="Particles" />
+        <DirectoryRef Id="dirB030248D75EA99E75698A1E011FE9CC0">
+            <Directory Id="dir2682D39E9C78E1415E0A57E589F0A404" Name="impl" />
         </DirectoryRef>
     </Fragment>
     <Fragment>
@@ -2016,11 +4316,6 @@
         </DirectoryRef>
     </Fragment>
     <Fragment>
-        <DirectoryRef Id="dir4B7D2A19DD0D33E235AA7BD43615A87E">
-            <Directory Id="dir2C126EEEB46329DB6052C65B78F1DA75" Name="tooling" />
-        </DirectoryRef>
-    </Fragment>
-    <Fragment>
         <DirectoryRef Id="dir93F3A6F9A0F15C62D9983B7251AEF092">
             <Directory Id="dir2FA83874D84EB850CB9EC2829B8A3243" Name="GraphicalEffects" />
         </DirectoryRef>
@@ -2031,18 +4326,8 @@
         </DirectoryRef>
     </Fragment>
     <Fragment>
-        <DirectoryRef Id="dir4B7D2A19DD0D33E235AA7BD43615A87E">
-            <Directory Id="dir3390D3B4341886F0DA85EE3BA92439FF" Name="Dialogs" />
-        </DirectoryRef>
-    </Fragment>
-    <Fragment>
-        <DirectoryRef Id="dir3390D3B4341886F0DA85EE3BA92439FF">
-            <Directory Id="dir34D1D6742B95CCA4110D8968A4544048" Name="quickimpl" />
-        </DirectoryRef>
-    </Fragment>
-    <Fragment>
-        <DirectoryRef Id="dirF7455B984D3CF2564DED2759788752A0">
-            <Directory Id="dir3A2097370D43A6BEED9BF1FBE00B9935" Name="controls" />
+        <DirectoryRef Id="dir4C0AEAB06A20DFD201A07716B06C1B01">
+            <Directory Id="dir3C4F465FBDDD5BDFD3E942262340FFCC" Name="images" />
         </DirectoryRef>
     </Fragment>
     <Fragment>
@@ -2053,6 +4338,16 @@
     <Fragment>
         <DirectoryRef Id="dirC5F8EA44B55B774D108D66814D18D4D1">
             <Directory Id="dir4B7D2A19DD0D33E235AA7BD43615A87E" Name="QtQuick" />
+        </DirectoryRef>
+    </Fragment>
+    <Fragment>
+        <DirectoryRef Id="dir74C12D674F4D48CC8662780E32EF06CE">
+            <Directory Id="dir4C0AEAB06A20DFD201A07716B06C1B01" Name="dark" />
+        </DirectoryRef>
+    </Fragment>
+    <Fragment>
+        <DirectoryRef Id="dir5D9C5C438263983ED9371AEEDD3594D4">
+            <Directory Id="dir4CC50FC6BF1634D8DB5FF5CDB38D3D8D" Name="images" />
         </DirectoryRef>
     </Fragment>
     <Fragment>
@@ -2071,13 +4366,23 @@
         </DirectoryRef>
     </Fragment>
     <Fragment>
+        <DirectoryRef Id="dir74C12D674F4D48CC8662780E32EF06CE">
+            <Directory Id="dir5D9C5C438263983ED9371AEEDD3594D4" Name="light" />
+        </DirectoryRef>
+    </Fragment>
+    <Fragment>
+        <DirectoryRef Id="dir74C12D674F4D48CC8662780E32EF06CE">
+            <Directory Id="dir6760147796A3D8FCCEBCE06251BB6DC9" Name="impl" />
+        </DirectoryRef>
+    </Fragment>
+    <Fragment>
         <DirectoryRef Id="dir4B7D2A19DD0D33E235AA7BD43615A87E">
             <Directory Id="dir7397A50E4D7D313615C4CF7C94C61160" Name="Effects" />
         </DirectoryRef>
     </Fragment>
     <Fragment>
-        <DirectoryRef Id="dir34D1D6742B95CCA4110D8968A4544048">
-            <Directory Id="dir755D907146AC4C2DC7E3BE88C0F1A70F" Name="qml" />
+        <DirectoryRef Id="dir175FB1A22F883092D2FC39E138CDC5FC">
+            <Directory Id="dir74C12D674F4D48CC8662780E32EF06CE" Name="FluentWinUI3" />
         </DirectoryRef>
     </Fragment>
     <Fragment>
@@ -2096,18 +4401,8 @@
         </DirectoryRef>
     </Fragment>
     <Fragment>
-        <DirectoryRef Id="dir755D907146AC4C2DC7E3BE88C0F1A70F">
-            <Directory Id="dir8C28C0A2CF1DDABB1BF2872E8E6AE192" Name="+Imagine" />
-        </DirectoryRef>
-    </Fragment>
-    <Fragment>
-        <DirectoryRef Id="dir755D907146AC4C2DC7E3BE88C0F1A70F">
-            <Directory Id="dir8C55A2520B05F605E480B8F2F2039F1C" Name="+Universal" />
-        </DirectoryRef>
-    </Fragment>
-    <Fragment>
-        <DirectoryRef Id="dir755D907146AC4C2DC7E3BE88C0F1A70F">
-            <Directory Id="dir929495D16D3C46BFD28C6AD595BCD701" Name="+Fusion" />
+        <DirectoryRef Id="dirC5F8EA44B55B774D108D66814D18D4D1">
+            <Directory Id="dir831F2329F0F3ACEA4CAA1C1913D06297" Name="QML" />
         </DirectoryRef>
     </Fragment>
     <Fragment>
@@ -2131,11 +4426,6 @@
         </DirectoryRef>
     </Fragment>
     <Fragment>
-        <DirectoryRef Id="dirD4BB3B3030E6C19000CA3A1BC69B6F39">
-            <Directory Id="dir9A8AE25EE73C6EF6DEA0B7B52AA34AE6" Name="ControlsDelegates" />
-        </DirectoryRef>
-    </Fragment>
-    <Fragment>
         <DirectoryRef Id="dir1F7AD7AA9B228AED2E74CDD7C3088B5C">
             <Directory Id="dirA016FBC978C7F28C3C5CDBC06002A5D6" Name="qtwebengine_locales" />
         </DirectoryRef>
@@ -2148,11 +4438,6 @@
     <Fragment>
         <DirectoryRef Id="dir463F84444BF926F4998942302E2C59AF">
             <Directory Id="dirA55BCC7BED6B60785CEB74AFBA374495" Name="impl" />
-        </DirectoryRef>
-    </Fragment>
-    <Fragment>
-        <DirectoryRef Id="dir4B7D2A19DD0D33E235AA7BD43615A87E">
-            <Directory Id="dirA6F6BC40CF508C5F92BB49483928E0FC" Name="LocalStorage" />
         </DirectoryRef>
     </Fragment>
     <Fragment>
@@ -2173,21 +4458,6 @@
     <Fragment>
         <DirectoryRef Id="dir2B55988B75845F194F607E4ED40BB41B">
             <Directory Id="dirBF720220167083D5C665DD0D131194BE" Name="impl" />
-        </DirectoryRef>
-    </Fragment>
-    <Fragment>
-        <DirectoryRef Id="dir755D907146AC4C2DC7E3BE88C0F1A70F">
-            <Directory Id="dirC980C9942B69E6635E4CF7C57652D12B" Name="+Material" />
-        </DirectoryRef>
-    </Fragment>
-    <Fragment>
-        <DirectoryRef Id="dir92990262DE0ED5508C44523003A4B360">
-            <Directory Id="dirD3E9E07666E50DD0B119271684422637" Name="Base" />
-        </DirectoryRef>
-    </Fragment>
-    <Fragment>
-        <DirectoryRef Id="dir92990262DE0ED5508C44523003A4B360">
-            <Directory Id="dirD48123A7B6E2CFB660EC94F0CBE0276D" Name="XmlListModel" />
         </DirectoryRef>
     </Fragment>
     <Fragment>


### PR DESCRIPTION
Note that this drops support for macOS versions:

* 10.14 Mojave
* 10.15 Catalina
* 11 Big Sur

The minimum required by JackTrip 2.6.0 will be macOS 12 Monterey