### PR TITLE
Fixing regressions that kick you out of a studio

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -1,7 +1,7 @@
-- Version: "2.6.0"
+- Version: "2.6.0-beta0"
   Date: 2025-xx-xx
   Description:
-  - (updated) Updating to Qt 6.8.1 for most builds
+  - (updated) Updating to Qt 6.8.2 for most builds
 - Version: "2.5.1"
   Date: 2025-01-30
   Description:

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -40,7 +40,7 @@
 
 #include "jacktrip_types.h"
 
-constexpr const char* const gVersion = "2.6.0";  ///< JackTrip version
+constexpr const char* const gVersion = "2.6.0-beta0";  ///< JackTrip version
 
 //*******************************************************************************
 /// \name Default Values

--- a/src/vs/Connected.qml
+++ b/src/vs/Connected.qml
@@ -60,6 +60,14 @@ Item {
 
     property bool isUsingRtAudio: audio.audioBackend == "RtAudio"
 
+    function hasAccessToken () {
+        return typeof auth.accessToken === 'string' && auth.accessToken !== null && auth.accessToken.length > 0;
+    }
+
+    function hasStudioId () {
+        return typeof virtualstudio.currentStudio.id === 'string' && virtualstudio.currentStudio.id !== null && virtualstudio.currentStudio.id.length > 0
+    }
+
     Loader {
         id: studioWebLoader
         anchors.top: parent.top
@@ -67,7 +75,7 @@ Item {
         anchors.left: parent.left
         anchors.bottom: deviceControlsGroup.top
 
-        source: auth.isAuthenticated && Boolean(auth.accessToken) && Boolean(virtualstudio.currentStudio.id) ? "Web.qml" : "WebNull.qml"
+        source: auth.isAuthenticated && hasAccessToken() && hasStudioId() ? "Web.qml" : "WebNull.qml"
     }
 
     DeviceControlsGroup {

--- a/src/vs/WebEngine.qml
+++ b/src/vs/WebEngine.qml
@@ -52,6 +52,8 @@ Item {
         anchors.fill: parent
         color: backgroundColour
 
+        property string studioId: virtualstudio.currentStudio.id
+
         WebEngineView {
             id: webEngineView
             anchors.fill: parent
@@ -59,7 +61,7 @@ Item {
             settings.javascriptCanPaste: true
             settings.screenCaptureEnabled: true
             profile.httpUserAgent: `JackTrip/${virtualstudio.versionString}`
-            url: `https://${virtualstudio.apiHost}/studios/${virtualstudio.currentStudio.id}/live`
+            url: `https://${virtualstudio.apiHost}/studios/${web.studioId}/live`
 
             // useful for debugging
             // onJavaScriptConsoleMessage: function(level, message, lineNumber, sourceID) {

--- a/src/vs/WebView.qml
+++ b/src/vs/WebView.qml
@@ -10,14 +10,13 @@ Item {
         id: web
         anchors.fill: parent
 
-        property string accessToken: auth.isAuthenticated && Boolean(auth.accessToken) ? auth.accessToken : ""
         property string studioId: virtualstudio.currentStudio.id
 
         WebView {
             id: webEngineView
             anchors.fill: parent
             httpUserAgent: `JackTrip/${virtualstudio.versionString}`
-            url: `https://${virtualstudio.apiHost}/studios/${studioId}/live?accessToken=${accessToken}`
+            url: `https://${virtualstudio.apiHost}/studios/${web.studioId}/live`
         }
     }
 }


### PR DESCRIPTION
Fixing regression where you get kicked out of a studio whenever there are websocket messages received

Fixing various conflicts with QML's property caching and a previous commit surrounding studioToJoin

Only emit currentStudioChanged when changes are made, versus every time we receive a websocket message

When there are changes to currentStudio, make sure we emit the signal before performing other actions, so that QML interface will have the latest values

Trigger reconnect if there is a server port change as well, not just if there is a server host change

Use QML to cache url property for web views, so that if currentStudio properties do change, it doesn't reset and kick you out

Bump version to 2.6.0-beta0 to differentiate from final release

Fix changelog for qt 6.8.2 update