### PR TITLE
Ignore timestamps recording in gzip metadata

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -530,7 +530,7 @@ if (host_machine.system() == 'linux')
 			custom_target('jacktrip.1.gz',
 				input: manfile,
 				output: 'jacktrip.1.gz',
-				command: [gzip, '-k', '-f', '@INPUT@'],
+				command: [gzip, '-k', '-f', '-n', '@INPUT@'],
 				install: true,
 				install_dir: get_option('mandir') / 'man1')
 		endif


### PR DESCRIPTION
Use the `-n / --noname` option to ignore non-deterministric information, such as timestamps, in gzip metadata.

This is required for [reproducible builds](https://reproducible-builds.org/).