### PR TITLE
Adding osc endpoint to get latencies for connected clients

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -110,7 +110,7 @@ jobs:
 
           - name: Linux-arm64-docker-shared
             release-name: Linux-arm64
-            runs-on: ubuntu-22.04
+            runs-on: ubuntu-22.04-arm
             system-rtaudio: false
             bundled-rtaudio: true
             nogui: false
@@ -146,7 +146,7 @@ jobs:
 
           - name: Linux-arm64-docker-nogui
             release-name: Linux-arm64-nogui
-            runs-on: ubuntu-22.04
+            runs-on: ubuntu-22.04-arm
             system-rtaudio: false
             bundled-rtaudio: true
             nogui: true
@@ -165,7 +165,7 @@ jobs:
 
           - name: Linux-arm32-docker-nogui
             release-name: Linux-arm32-nogui
-            runs-on: ubuntu-22.04
+            runs-on: ubuntu-22.04-arm
             system-rtaudio: false
             bundled-rtaudio: true
             nogui: true

--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -171,7 +171,7 @@ jobs:
             nogui: true
             novs: true
             weakjack: false
-            libsamplerate: false
+            libsamplerate: true
             jacktrip-path: jacktrip
             binary-path: binary
             build-system: docker
@@ -639,6 +639,7 @@ jobs:
             docker buildx build --target=artifact --progress=plain -f linux/Dockerfile.build --output type=local,dest=$BUILD_PATH \
               --platform "${{ matrix.docker-platform }}" --build-arg BUILD_CONTAINER="${{ matrix.docker-image }}" \
               --build-arg MESON_ARGS="$CONFIG_STRING" \
+              --build-arg USE_SYSTEM_LIBSAMPLERATE="1" \
               --build-arg VST3SDK_DOWNLOAD_URL="$VST3SDK_DOWNLOAD_URL" \
               --build-arg QT_DOWNLOAD_URL="$QT_DOWNLOAD_URL" .
           else

--- a/docs/Build/Linux.md
+++ b/docs/Build/Linux.md
@@ -134,6 +134,7 @@ available:
 * MESON_ARGS - arguments to build using meson
 * QT_DOWNLOAD_URL - path to qt6 download (optional)
 * VST3SDK_DOWNLOAD_URL - path to the VST3 SDK (optional)
+* USE_SYSTEM_LIBSAMPLERATE - dynamically link with libsamplerate
 
 For example:
 
@@ -171,6 +172,7 @@ arm32 static
 ```
 docker buildx build --target=artifact -f linux/Dockerfile.build --output type=local,dest=./ \
   --platform linux/arm/v7 --build-arg BUILD_CONTAINER=debian:buster \
+  --build-arg USE_SYSTEM_LIBSAMPLERATE=1 \
   --build-arg MESON_ARGS="-Ddefault_library=static -Drtaudio=enabled -Drtaudio:jack=disabled -Drtaudio:default_library=static -Drtaudio:alsa=enabled -Drtaudio:pulse=disabled -Drtaudio:werror=false -Dnogui=true -Dcpp_link_args='-no-pie'" \
   --build-arg QT_DOWNLOAD_URL=https://files.jacktrip.org/contrib/qt/qt-5.15.13-static-linux-arm32.tar.gz .
 ```

--- a/linux/Dockerfile.build
+++ b/linux/Dockerfile.build
@@ -3,9 +3,10 @@
 # this Dockerfile is used by GitHub CI to create linux builds
 # it requires these environment variables:
 #
-# BUILD_CONTAINER - Debian based container image to build with
-# MESON_ARGS      - arguments to build using meson
-# QT_DOWNLOAD_URL - path to qt download (optional)
+# BUILD_CONTAINER          - Debian based container image to build with
+# MESON_ARGS               - arguments to build using meson
+# QT_DOWNLOAD_URL          - path to qt download (optional)
+# USE_SYSTEM_LIBSAMPLERATE - dynamically link with libsamplerate
 
 # container image versions
 ARG BUILD_CONTAINER=ubuntu:20.04
@@ -24,6 +25,13 @@ RUN python3 -m pip install --upgrade pip \
   && python3 -m pip install meson pyyaml Jinja2
 
 WORKDIR /opt/jacktrip
+
+# install libsamplerate
+ARG USE_SYSTEM_LIBSAMPLERATE=""
+ENV USE_SYSTEM_LIBSAMPLERATE=$USE_SYSTEM_LIBSAMPLERATE
+RUN if [ -n "$USE_SYSTEM_LIBSAMPLERATE" ]; then \
+  apt-get install -yq --no-install-recommends libsamplerate-dev; \
+  fi
 
 # install qt
 ARG QT_DOWNLOAD_URL=""

--- a/src/AudioInterface.cpp
+++ b/src/AudioInterface.cpp
@@ -77,6 +77,8 @@ AudioInterface::AudioInterface(QVarLengthArray<int> InputChans,
     , mMonitorQueuePtr(NULL)
     , mAudioInputPacket(NULL)
     , mAudioOutputPacket(NULL)
+    , mAudioInputLatency(0)
+    , mAudioOutputLatency(0)
     , mLoopBack(false)
     , mProcessWithNetwork(processWithNetwork)
     , mMonitorStarted(false)

--- a/src/AudioInterface.cpp
+++ b/src/AudioInterface.cpp
@@ -77,13 +77,13 @@ AudioInterface::AudioInterface(QVarLengthArray<int> InputChans,
     , mMonitorQueuePtr(NULL)
     , mAudioInputPacket(NULL)
     , mAudioOutputPacket(NULL)
-    , mAudioInputLatency(0)
-    , mAudioOutputLatency(0)
     , mLoopBack(false)
     , mProcessWithNetwork(processWithNetwork)
     , mMonitorStarted(false)
     , mJackTrip(jacktrip)
     , mInputMixMode(InputMixMode)
+    , mAudioInputLatency(0)
+    , mAudioOutputLatency(0)
     , mProcessingAudio(false)
 {
 }

--- a/src/AudioInterface.h
+++ b/src/AudioInterface.h
@@ -315,6 +315,8 @@ class AudioInterface
     const std::string& getDevicesErrorMsg() const { return mErrorMsg; }
     const std::string& getDevicesWarningHelpUrl() const { return mWarningHelpUrl; }
     const std::string& getDevicesErrorHelpUrl() const { return mErrorHelpUrl; }
+    double getAudioInputLatency() const { return mAudioInputLatency; }
+    double getAudioOutputLatency() const { return mAudioOutputLatency; }
     bool highLatencyBufferSize() const { return getBufferSizeInSamples() > 256; }
     bool getHighLatencyFlag() const { return mHighLatencyFlag; }
     //------------------------------------------------------------------
@@ -370,6 +372,8 @@ class AudioInterface
    protected:
     JackTrip* mJackTrip;          ///< JackTrip Mediator Class pointer
     inputMixModeT mInputMixMode;  ///< Input mixing mode
+    double mAudioInputLatency;    ///< Latency of the audio input
+    double mAudioOutputLatency;   ///< Latency of the audio output
 
     void setDevicesWarningMsg(warningMessageT msg);
     void setDevicesErrorMsg(errorMessageT msg);

--- a/src/JackTripWorker.h
+++ b/src/JackTripWorker.h
@@ -136,7 +136,8 @@ class JackTripWorker : public QObject
     uint16_t getClientPort() { return mClientPort; }
     QString getClientAddress() { return mClientAddress; }
 
-    double getLatency() {
+    double getLatency()
+    {
         QMutexLocker lock(&mMutex);
         return mJackTrip.isNull() ? -1 : mJackTrip->getLatency();
     }

--- a/src/JackTripWorker.h
+++ b/src/JackTripWorker.h
@@ -136,6 +136,11 @@ class JackTripWorker : public QObject
     uint16_t getClientPort() { return mClientPort; }
     QString getClientAddress() { return mClientAddress; }
 
+    double getLatency() {
+        QMutexLocker lock(&mMutex);
+        return mJackTrip.isNull() ? -1 : mJackTrip->getLatency();
+    }
+
    private slots:
     void slotTest() { std::cout << "--- JackTripWorker TEST SLOT ---" << std::endl; }
     void receivedDataUDP();

--- a/src/OscServer.cpp
+++ b/src/OscServer.cpp
@@ -38,8 +38,7 @@
 
 #include <iostream>
 
-using std::cout;
-using std::endl;
+using namespace std;
 
 //*******************************************************************************
 OscServer::OscServer(quint16 port, QObject* parent) : QObject(parent), mPort(port) {}
@@ -91,8 +90,8 @@ void OscServer::readPendingDatagrams()
 
         mOscServerSocket->readDatagram(datagram.data(), datagram.size(), &sender,
                                        &senderPort);
-        qDebug() << "Received datagram from" << sender << ":" << senderPort;
-        qDebug() << "  - Data:" << datagram;
+        // qDebug() << "Received datagram from" << sender << ":" << senderPort;
+        // qDebug() << "  - Data:" << datagram;
 #ifndef NO_OSCPP
         handlePacket(OSCPP::Server::Packet(datagram.data(), datagram.size()), sender, senderPort);
 #endif  // NO_OSCPP
@@ -126,29 +125,31 @@ void OscServer::handlePacket(const OSCPP::Server::Packet& packet, const QHostAdd
             if (msg == "/config") {
                 const char* key   = args.string();
                 const float value = args.float32();
-                cout << "Config received - key (" << key << ") value (" << value << ")"
+                cout << "OSC: Config received - key (" << key << ") value (" << value << ")"
                      << endl;
                 if (strcmp("queueBuffer", key) == 0) {
                     emit signalQueueBufferChanged(static_cast<int>(value));
                 }
             } else if (msg == "/get") {
                 const char* key   = args.string();
-                cout << "Get request received - key (" << key << ")"
+                cout << "OSC: Get request received - key (" << key << ")"
                      << endl;
                 if (strcmp("latency", key) == 0) {
                     emit signalLatencyRequested(sender, senderPort);
                 }
             } else {
                 // Simply print unknown messages
-                cout << "Unknown message:" << msg.address() << endl;
+                cerr << "OSC: Unknown message:" << msg.address() << endl;
             }
         }
-    } catch (std::exception& e) {
-        cout << "Exception:" << e.what() << endl;
+    } catch (exception& e) {
+        cerr << "OSC: Exception:" << e.what() << endl;
     }
 }
+#endif  // NO_OSCPP
 
 void OscServer::sendLatencyResponse(const QHostAddress& sender, quint16 senderPort, QVector<QString>& clientNames, QVector<double>& latencies) {
+#ifndef NO_OSCPP
     QByteArray datagram;
     datagram.resize(64 * 1024);
 
@@ -166,5 +167,5 @@ void OscServer::sendLatencyResponse(const QHostAddress& sender, quint16 senderPo
 
     datagram.resize(packet.size());
     mOscServerSocket->writeDatagram(datagram, sender, senderPort);
-}
 #endif  // NO_OSCPP
+}

--- a/src/OscServer.cpp
+++ b/src/OscServer.cpp
@@ -93,7 +93,8 @@ void OscServer::readPendingDatagrams()
         // qDebug() << "Received datagram from" << sender << ":" << senderPort;
         // qDebug() << "  - Data:" << datagram;
 #ifndef NO_OSCPP
-        handlePacket(OSCPP::Server::Packet(datagram.data(), datagram.size()), sender, senderPort);
+        handlePacket(OSCPP::Server::Packet(datagram.data(), datagram.size()), sender,
+                     senderPort);
 #endif  // NO_OSCPP
         // Send a reply back to the client
         // QByteArray replyData("Reply from server");
@@ -103,7 +104,8 @@ void OscServer::readPendingDatagrams()
 
 //*******************************************************************************
 #ifndef NO_OSCPP
-void OscServer::handlePacket(const OSCPP::Server::Packet& packet, const QHostAddress& sender, quint16 senderPort)
+void OscServer::handlePacket(const OSCPP::Server::Packet& packet,
+                             const QHostAddress& sender, quint16 senderPort)
 {
     try {
         if (packet.isBundle()) {
@@ -125,15 +127,14 @@ void OscServer::handlePacket(const OSCPP::Server::Packet& packet, const QHostAdd
             if (msg == "/config") {
                 const char* key   = args.string();
                 const float value = args.float32();
-                cout << "OSC: Config received - key (" << key << ") value (" << value << ")"
-                     << endl;
+                cout << "OSC: Config received - key (" << key << ") value (" << value
+                     << ")" << endl;
                 if (strcmp("queueBuffer", key) == 0) {
                     emit signalQueueBufferChanged(static_cast<int>(value));
                 }
             } else if (msg == "/get") {
-                const char* key   = args.string();
-                cout << "OSC: Get request received - key (" << key << ")"
-                     << endl;
+                const char* key = args.string();
+                cout << "OSC: Get request received - key (" << key << ")" << endl;
                 if (strcmp("latency", key) == 0) {
                     emit signalLatencyRequested(sender, senderPort);
                 }
@@ -148,7 +149,10 @@ void OscServer::handlePacket(const OSCPP::Server::Packet& packet, const QHostAdd
 }
 #endif  // NO_OSCPP
 
-void OscServer::sendLatencyResponse(const QHostAddress& sender, quint16 senderPort, QVector<QString>& clientNames, QVector<double>& latencies) {
+void OscServer::sendLatencyResponse(const QHostAddress& sender, quint16 senderPort,
+                                    QVector<QString>& clientNames,
+                                    QVector<double>& latencies)
+{
 #ifndef NO_OSCPP
     QByteArray datagram;
     datagram.resize(64 * 1024);

--- a/src/OscServer.h
+++ b/src/OscServer.h
@@ -37,9 +37,12 @@
 #ifndef __OSCSERVER_H__
 #define __OSCSERVER_H__
 
+#include <QHostAddress>
 #include <QObject>
+#include <QString>
 #include <QUdpSocket>
 #include <QtCore>
+#include <QVector>
 
 #ifndef NO_OSCPP
 #include "oscpp/client.hpp"
@@ -57,6 +60,7 @@ class OscServer : public QObject
     virtual ~OscServer();
     void start();
     void stop();
+    void sendLatencyResponse(const QHostAddress& sender, quint16 senderPort, QVector<QString>& clientNames, QVector<double>& latencies);
 
     static size_t makeConfigPacket(void* buffer, size_t size, const char* key,
                                    float value)
@@ -83,6 +87,7 @@ class OscServer : public QObject
     }
    signals:
     void signalQueueBufferChanged(int queueBufferSize);
+    void signalLatencyRequested(QHostAddress sender, quint16 senderPort);
 
    private slots:
     void readPendingDatagrams();
@@ -90,7 +95,7 @@ class OscServer : public QObject
    private:
     void closeSocket();
 #ifndef NO_OSCPP
-    void handlePacket(const OSCPP::Server::Packet& packet);
+    void handlePacket(const OSCPP::Server::Packet& packet, const QHostAddress& sender, quint16 senderPort);
 #endif  // NO_OSCPP
 
     QSharedPointer<QUdpSocket> mOscServerSocket;

--- a/src/OscServer.h
+++ b/src/OscServer.h
@@ -41,8 +41,8 @@
 #include <QObject>
 #include <QString>
 #include <QUdpSocket>
-#include <QtCore>
 #include <QVector>
+#include <QtCore>
 
 #ifndef NO_OSCPP
 #include "oscpp/client.hpp"
@@ -60,7 +60,8 @@ class OscServer : public QObject
     virtual ~OscServer();
     void start();
     void stop();
-    void sendLatencyResponse(const QHostAddress& sender, quint16 senderPort, QVector<QString>& clientNames, QVector<double>& latencies);
+    void sendLatencyResponse(const QHostAddress& sender, quint16 senderPort,
+                             QVector<QString>& clientNames, QVector<double>& latencies);
 
     static size_t makeConfigPacket(void* buffer, size_t size, const char* key,
                                    float value)
@@ -95,7 +96,8 @@ class OscServer : public QObject
    private:
     void closeSocket();
 #ifndef NO_OSCPP
-    void handlePacket(const OSCPP::Server::Packet& packet, const QHostAddress& sender, quint16 senderPort);
+    void handlePacket(const OSCPP::Server::Packet& packet, const QHostAddress& sender,
+                      quint16 senderPort);
 #endif  // NO_OSCPP
 
     QSharedPointer<QUdpSocket> mOscServerSocket;

--- a/src/RtAudioInterface.cpp
+++ b/src/RtAudioInterface.cpp
@@ -491,6 +491,15 @@ void RtAudioInterface::setup(bool verbose)
         setDevicesWarningMsg(AudioInterface::DEVICE_WARN_BUFFER_LATENCY);
     }
 
+    if (mDuplexMode) {
+        // duplex mode returns sum of input and output latencies
+        mAudioInputLatency = static_cast<double>(mRtAudioInput->getStreamLatency()) / 2;
+        mAudioOutputLatency = mAudioInputLatency;
+    } else {
+        mAudioInputLatency = mRtAudioInput->getStreamLatency();
+        mAudioOutputLatency = mRtAudioOutput->getStreamLatency();
+    }
+
     // Setup parent class
     // This MUST be after buffer size is finalized, so that plugins
     // are initialized with the correct settings

--- a/src/RtAudioInterface.cpp
+++ b/src/RtAudioInterface.cpp
@@ -493,10 +493,10 @@ void RtAudioInterface::setup(bool verbose)
 
     if (mDuplexMode) {
         // duplex mode returns sum of input and output latencies
-        mAudioInputLatency = static_cast<double>(mRtAudioInput->getStreamLatency()) / 2;
+        mAudioInputLatency  = static_cast<double>(mRtAudioInput->getStreamLatency()) / 2;
         mAudioOutputLatency = mAudioInputLatency;
     } else {
-        mAudioInputLatency = mRtAudioInput->getStreamLatency();
+        mAudioInputLatency  = mRtAudioInput->getStreamLatency();
         mAudioOutputLatency = mRtAudioOutput->getStreamLatency();
     }
 

--- a/src/UdpHubListener.cpp
+++ b/src/UdpHubListener.cpp
@@ -379,6 +379,25 @@ void UdpHubListener::queueBufferChanged(int queueBufferSize)
     }
 }
 
+void UdpHubListener::handleLatencyRequest(const QHostAddress& sender, quint16 senderPort) {
+    QVector<QString> clientNames;
+    QVector<double> latencies;
+    getClientLatencies(clientNames, latencies);
+    if (mOscServer != nullptr) {
+        mOscServer->sendLatencyResponse(sender, senderPort, clientNames, latencies);
+    }
+}
+
+void UdpHubListener::getClientLatencies(QVector<QString>& clientNames, QVector<double>& latencies) {
+    QMutexLocker lock(&mMutex);
+    for (int i = 0; i < gMaxThreads; i++) {
+        if (mJTWorkers->at(i) != nullptr) {
+            clientNames.append(mJTWorkers->at(i)->getAssignedClientName());
+            latencies.append(mJTWorkers->at(i)->getLatency());
+        }
+    }
+}
+
 //*******************************************************************************
 // Returns 0 on error
 int UdpHubListener::readClientUdpPort(QSslSocket* clientConnection, QString& clientName)

--- a/src/UdpHubListener.cpp
+++ b/src/UdpHubListener.cpp
@@ -379,7 +379,8 @@ void UdpHubListener::queueBufferChanged(int queueBufferSize)
     }
 }
 
-void UdpHubListener::handleLatencyRequest(const QHostAddress& sender, quint16 senderPort) {
+void UdpHubListener::handleLatencyRequest(const QHostAddress& sender, quint16 senderPort)
+{
     QVector<QString> clientNames;
     QVector<double> latencies;
     getClientLatencies(clientNames, latencies);
@@ -388,7 +389,9 @@ void UdpHubListener::handleLatencyRequest(const QHostAddress& sender, quint16 se
     }
 }
 
-void UdpHubListener::getClientLatencies(QVector<QString>& clientNames, QVector<double>& latencies) {
+void UdpHubListener::getClientLatencies(QVector<QString>& clientNames,
+                                        QVector<double>& latencies)
+{
     QMutexLocker lock(&mMutex);
     for (int i = 0; i < gMaxThreads; i++) {
         if (mJTWorkers->at(i) != nullptr) {

--- a/src/UdpHubListener.h
+++ b/src/UdpHubListener.h
@@ -40,9 +40,11 @@
 
 #include <QHostAddress>
 #include <QMutex>
+#include <QString>
 #include <QThread>
 #include <QThreadPool>
 #include <QUdpSocket>
+#include <QVector>
 #include <fstream>
 #include <iostream>
 #include <stdexcept>
@@ -86,6 +88,7 @@ class UdpHubListener : public QObject
 #endif
     int releaseThread(int id);
     void releaseDuplicateThreads(JackTripWorker* worker, uint16_t actual_peer_port);
+    void getClientLatencies(QVector<QString>& clientNames, QVector<double>& latencies);
 
     void setConnectDefaultAudioPorts(bool connectDefaultAudioPorts)
     {
@@ -111,6 +114,7 @@ class UdpHubListener : public QObject
     void receivedNewConnection();
     void stopCheck();
     void queueBufferChanged(int queueBufferSize);
+    void handleLatencyRequest(const QHostAddress& sender, quint16 senderPort);
 
    signals:
     void signalStarted();
@@ -139,6 +143,8 @@ class UdpHubListener : public QObject
 
         QObject::connect(mOscServer, &OscServer::signalQueueBufferChanged, this,
                          &UdpHubListener::queueBufferChanged, Qt::QueuedConnection);
+        QObject::connect(mOscServer, &OscServer::signalLatencyRequested, this,
+                         &UdpHubListener::handleLatencyRequest, Qt::QueuedConnection);
     };
 
     /**

--- a/src/vs/vsAudio.cpp
+++ b/src/vs/vsAudio.cpp
@@ -863,6 +863,11 @@ AudioInterface* VsAudio::newAudioInterface(JackTrip* jackTripPtr)
     std::cout << "                      or: " << AudioBufferSizeInBytes << " bytes"
               << std::endl;
     std::cout << gPrintSeparator << std::endl;
+    std::cout << "The Audio Input Latency is : " << ifPtr->getAudioInputLatency()
+              << std::endl;
+    std::cout << "The Audio Output Latency is: " << ifPtr->getAudioOutputLatency()
+              << std::endl;
+    std::cout << gPrintSeparator << std::endl;
     std::cout << "The Number of Channels is: " << ifPtr->getNumInputChannels()
               << std::endl;
     std::cout << gPrintSeparator << std::endl;


### PR DESCRIPTION
Adding support to save and print audio device latency for RtAudio. This value seems quite suspect, so only printing it out for now.

Use system libsamplerate for Linux builds