### PR TITLE
Always allow selection between mono/stereo/mixtomono when > 1 channels

### DIFF
--- a/src/vs/AudioSettings.qml
+++ b/src/vs/AudioSettings.qml
@@ -452,7 +452,6 @@ Rectangle {
                 delegate: ItemDelegate {
                     required property var modelData
                     required property int index
-                    width: parent.width
                     contentItem: Text {
                         text: modelData.label
                     }


### PR DESCRIPTION
This makes it a lot easier to switch between mono and stereo without having to first find a specific channel (or pair). And not being able to change it when having a mono channel selected is confusing.

Also allow any two consecutive channels to be used, versus every other two consective channels (for example, allow "2 & 3" not just "1 & 2" and "3 & 4").