### PR TITLE
Replacing qDebug() with cout for Audio Socket reconnect

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -59,7 +59,7 @@ jobs:
       matrix:
         include:
           - name: Linux-x64-qmake-gcc-static
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-22.04
             system-rtaudio: false
             bundled-rtaudio: true # set either system-rtaudio or bundled-rtaudio as true, not both
             nogui: false
@@ -78,11 +78,12 @@ jobs:
             qt-type: 'static'
             qt-arch: 'amd64'
 
-          - name: Linux-x64-meson-gcc-shared-nortaudio # meson shared build without rtaudio
+          - name: Linux-x64-meson-gcc-shared-nortaudio # meson shared build without vs or rtaudio
             runs-on: ubuntu-22.04
             system-rtaudio: false
             bundled-rtaudio: false
             nogui: false
+            novs: true
             weakjack: false
             libsamplerate: true
             # jacktrip-path: jacktrip

--- a/src/AudioSocket.cpp
+++ b/src/AudioSocket.cpp
@@ -585,7 +585,7 @@ void AudioSocketWorker::receiveAudio()
 void AudioSocketWorker::scheduleReconnect()
 {
     if (mRetryConnection) {
-        qDebug() << "Attempting to reconnect audio socket";
+        cout << "Attempting to reconnect audio socket" << endl;
         if (mTimerPtr.isNull()) {
             mTimerPtr.reset(new QTimer);
             QObject::connect(mTimerPtr.data(), &QTimer::timeout, this,


### PR DESCRIPTION
Bumping ubuntu-20.04 to ubuntu-22.04 for qmake static build, since 20.04 is no longer supported by GitHub

Disabling vs mode for Linux-x64-meson-gcc-shared-nortaudio build since ubuntu-22.04 has qt 5.13 (not sure how this worked before?)