### PR TITLE
Don't reset device warnings and errors when stopping audio

### DIFF
--- a/src/RtAudioInterface.cpp
+++ b/src/RtAudioInterface.cpp
@@ -804,9 +804,6 @@ int RtAudioInterface::stopProcess()
         return (-1);
     }
 
-    AudioInterface::setDevicesWarningMsg(AudioInterface::DEVICE_WARN_NONE);
-    AudioInterface::setDevicesErrorMsg(AudioInterface::DEVICE_ERR_NONE);
-
     return 0;
 }
 

--- a/src/vs/FeedbackSurvey.qml
+++ b/src/vs/FeedbackSurvey.qml
@@ -371,7 +371,7 @@ Item {
                     anchors.topMargin: 16 * virtualstudio.uiScale
                     anchors.horizontalCenter: parent.horizontalCenter
                     width: parent.width
-                    text: "Your feedback has been recorded."
+                    text: "Your feedback has been sent."
                     font {family: "Poppins"; pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale }
                     horizontalAlignment: Text.AlignHCenter
                     color: textColour

--- a/src/vs/virtualstudio.cpp
+++ b/src/vs/virtualstudio.cpp
@@ -655,26 +655,22 @@ void VirtualStudio::collectFeedbackSurvey(QString serverId, int rating, QString 
 #endif
 
     feedback.insert(QStringLiteral("osVersion"), QSysInfo::prettyProductName());
-    QString sysInfo = QString("[platform=%1").arg(QSysInfo::prettyProductName());
 #ifdef RT_AUDIO
     QString inputDevice =
         QString::fromStdString(m_audioConfigPtr->getInputDevice().toStdString());
     if (!inputDevice.isEmpty()) {
-        sysInfo.append(QString(",input=%1").arg(inputDevice));
+        feedback.insert(QStringLiteral("inputDevice"), inputDevice);
     }
     QString outputDevice =
         QString::fromStdString(m_audioConfigPtr->getOutputDevice().toStdString());
     if (!outputDevice.isEmpty()) {
-        sysInfo.append(QString(",output=%1").arg(outputDevice));
+        feedback.insert(QStringLiteral("outputDevice"), outputDevice);
     }
 #endif
-    sysInfo.append("]");
 
     feedback.insert(QStringLiteral("rating"), rating);
-    if (message.isEmpty()) {
-        feedback.insert(QStringLiteral("message"), sysInfo);
-    } else {
-        feedback.insert(QStringLiteral("message"), message + " " + sysInfo);
+    if (!message.isEmpty()) {
+        feedback.insert(QStringLiteral("message"), message);
     }
 
     QString deviceIssues  = "";
@@ -687,11 +683,11 @@ void VirtualStudio::collectFeedbackSurvey(QString serverId, int rating, QString 
     }
     if (!deviceIssues.isEmpty()) {
         feedback.insert(QStringLiteral("deviceIssues"), deviceIssues);
-        message.append(" (deviceIssues=" + deviceIssues + ")");
     }
 
     QJsonDocument data = QJsonDocument(feedback);
     m_api->submitServerFeedback(serverId, data.toJson());
+    std::cout << "Sent feedback: " << data.toJson().toStdString() << std::endl;
     return;
 }
 
@@ -1564,7 +1560,7 @@ void VirtualStudio::handleWebsocketMessage(const QString& msg)
             if (serverEnabled && serverHostOrPortUpdated) {
                 std::cout << "Reconnecting audio to " << serverHost.toStdString() << ":"
                           << serverPort << std::endl;
-                triggerReconnect(true);
+                triggerReconnect(false);
             }
         } else {
             if (serverEnabled && serverStatus == QLatin1String("Ready")


### PR DESCRIPTION
This allows us to preserve the previous state for feedback survey responses.

Cleaning up feedback survey messages by splitting more things out into different fields.

No need to rescan devices when reconnecting to a new server on session change.