### PR TITLE
Allow higher latency when using PLC auto headroom

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -3,6 +3,7 @@
   Description:
   - (added) OSC endpoint to get latencies for connected clients
   - (added) VS Mode reconnects to new server when session changes
+  - (updated) PLC auto headroom allows higher latency when necessary
   - (updated) VS Mode allow any two consecutive channels for input
   - (updated) VS Mode easier audio switching between stereo and mono
   - (updated) VS Mode latency statistics now include jitter buffer


### PR DESCRIPTION
PLC previously enforced a relatively low headroom cap, which prevented it from growing too large on poor quality Internet connections. We've found few people understand quality of service nor the implications of this. In this situation, I feel it's better to lean towards audio quality, forcing people to make adjustments to achieve low latency versus leaning towards low latency and frustrating people with audio distortion.