### PR TITLE
Wait for authentication to finish before refreshing studios

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -1,5 +1,5 @@
 - Version: "2.5.2"
-  Date: 2025-04-18
+  Date: 2025-04-22
   Description:
   - (added) OSC endpoint to get latencies for connected clients
   - (added) VS Mode reconnects to new server when session changes
@@ -10,6 +10,7 @@
   - (fixed) VS Mode - kicked out of sessions due to studio change
   - (fixed) VS Mode - bugs with reconnecting due to audio changes
   - (fixed) VS Mode - strange error message during startup on Linux
+  - (fixed) VS Mode - empty studio list when starting up
   - (fixed) VS Mode - building with CMake
   - (fixed) Building aarch64 or armv7 on Alpine Linux
   - (fixed) Building using Qt 6.9 release candidates

--- a/src/vs/virtualstudio.cpp
+++ b/src/vs/virtualstudio.cpp
@@ -592,7 +592,7 @@ void VirtualStudio::setWindowState(QString state)
     m_windowState = state;
     // refresh studio list if navigating to browse window
     // only if user id is empty (edge case for when logging in)
-    if (m_windowState == "browse" && !m_userId.isEmpty()) {
+    if (m_windowState == "browse" && m_auth->isAuthenticated()) {
         // schedule studio refresh instead of doing it now
         // just to reduce risk of running into a deadlock
         emit scheduleStudioRefresh(-1, false);
@@ -1624,7 +1624,7 @@ void VirtualStudio::resetState()
 void VirtualStudio::refreshStudios(int index, bool signalRefresh)
 {
     // user id is required for retrieval of subscriptions
-    if (m_userId.isEmpty()) {
+    if (!m_auth->isAuthenticated()) {
         std::cerr << "Studio refresh cancelled due to empty user id" << std::endl;
         return;
     }


### PR DESCRIPTION
UserId is stored in settings, and may be non-empty before an authentication token is received. This can cause the studio refresh to fail, and the list to be empty.