### PR TITLE
Temporarily disabling support for feedback detection in meson builds

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -559,6 +559,8 @@ jobs:
         if: matrix.build-system == 'meson' || matrix.build-system == 'docker'
         shell: bash
         run: |
+          # temporarily disable support for feedback detection
+          MESON_CONFIG="-Dnofeedback=true"
           if [[ "${{ matrix.system-rtaudio }}" == true ]] || [[ "${{ matrix.bundled-rtaudio }}" == true ]]; then 
             MESON_CONFIG="-Drtaudio=enabled $MESON_CONFIG"
           fi

--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -7,6 +7,7 @@
   - (updated) VS Mode allow any two consecutive channels for input
   - (updated) VS Mode easier audio switching between stereo and mono
   - (updated) VS Mode latency statistics now include jitter buffer
+  - (updated) VS Mode temporarily disabling feedback detection
   - (fixed) VS Mode - kicked out of sessions due to studio change
   - (fixed) VS Mode - bugs with reconnecting due to audio changes
   - (fixed) VS Mode - strange error message during startup on Linux


### PR DESCRIPTION
I keep coming across crashes with backtraces pointing to `Analyzer::onTick`. Also, this feature never really worked all that well: I regularly hear complaints about it triggering when it shouldn't and I've also seen it not trigger when it should. I think it's best to just remove this until we have time to put more effort into it.