### PR TITLE
VS Mode improvements to audio quality override settings

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -1,20 +1,21 @@
-- Version: "2.5.2"
+- Version: "2.6.0"
   Date: 2025-04-22
   Description:
   - (added) OSC endpoint to get latencies for connected clients
-  - (added) VS Mode reconnects to new server when session changes
   - (updated) PLC auto headroom allows higher latency when necessary
   - (updated) VS Mode allow any two consecutive channels for input
   - (updated) VS Mode easier audio switching between stereo and mono
   - (updated) VS Mode latency statistics now include jitter buffer
+  - (updated) VS Mode improvements to audio quality override settings
   - (updated) VS Mode temporarily disabling feedback detection
-  - (fixed) VS Mode - kicked out of sessions due to studio change
-  - (fixed) VS Mode - bugs with reconnecting due to audio changes
-  - (fixed) VS Mode - strange error message during startup on Linux
-  - (fixed) VS Mode - empty studio list when starting up
-  - (fixed) VS Mode - building with CMake
-  - (fixed) Building aarch64 or armv7 on Alpine Linux
-  - (fixed) Building using Qt 6.9 release candidates
+  - (fixed) VS Mode kicked out of sessions due to studio change
+  - (fixed) VS Mode recognizes changes to server host and port
+  - (fixed) VS Mode bugs with reconnecting due to audio changes
+  - (fixed) VS Mode strange error message during startup on Linux
+  - (fixed) VS Mode empty studio list when starting up
+  - (fixed) Ability to build VS Mode using CMake
+  - (fixed) Ability to build aarch64 or armv7 on Alpine Linux
+  - (fixed) Ability to build using Qt 6.9 release candidates
   - (fixed) Ability to disable the use of libsamplerate
   - (fixed) Ignore timestamps when generating jacktrip.1.gz
 - Version: "2.5.1"

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -40,7 +40,7 @@
 
 #include "jacktrip_types.h"
 
-constexpr const char* const gVersion = "2.5.2";  ///< JackTrip version
+constexpr const char* const gVersion = "2.6.0";  ///< JackTrip version
 
 //*******************************************************************************
 /// \name Default Values

--- a/src/vs/virtualstudio.cpp
+++ b/src/vs/virtualstudio.cpp
@@ -1162,6 +1162,9 @@ void VirtualStudio::triggerReconnect(bool refresh)
         return;
     }
 
+    std::cout << "Reconnecting audio to " << m_currentStudio.host().toStdString() << ":"
+              << m_currentStudio.port() << std::endl;
+
     // this needs to be synchronous to avoid both trying
     // to use the audio interfaces at the same time
     // note that connectionFinished() checks m_reconnectState
@@ -1556,19 +1559,11 @@ void VirtualStudio::handleWebsocketMessage(const QString& msg)
     }
 
     if (m_onConnectedScreen) {
-        if (m_jackTripRunning) {
-            if (serverEnabled && serverHostOrPortUpdated) {
-                std::cout << "Reconnecting audio to " << serverHost.toStdString() << ":"
-                          << serverPort << std::endl;
-                triggerReconnect(false);
-            }
-        } else {
-            if (serverEnabled && serverStatus == QLatin1String("Ready")
-                && serverHost != "" && serverPort != 0) {
-                std::cout << "Connecting audio to " << serverHost.toStdString() << ":"
-                          << serverPort << std::endl;
-                completeConnection();
-            }
+        if (!m_jackTripRunning && serverEnabled && serverStatus == QLatin1String("Ready")
+            && serverHost != "" && serverPort != 0) {
+            std::cout << "Connecting audio to " << serverHost.toStdString() << ":"
+                      << serverPort << std::endl;
+            completeConnection();
         }
     }
 }


### PR DESCRIPTION
Don't trigger reconnect when server host or port changes. I think it's better to trigger this via webchannel from the user interface so that the switchover happens simultaneously. Otherwise, the audio audio would reconnect right away despite having a warning and delay in the user interface.

Bumping version to 2.6.0 since all this has grown to be a bit more changes than strictly "bug fixes"

![Screenshot (747)](https://github.com/user-attachments/assets/86468fa3-4f48-4933-b667-672ba8133423)

![Screenshot (748)](https://github.com/user-attachments/assets/8c2e2616-a82a-42e8-9fa0-f40a3ac6271d)
