### PR TITLE
VS Mode shows too many options for stereo devices

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -1,12 +1,14 @@
 - Version: "2.7.0-beta1"
-  Date: 2025-06-05
+  Date: 2025-06-07
   Description:
+  - (added) VS Mode ability to share specific screens or windows
   - (updated) Upgraded all builds to use Qt 6.8.3
   - (updated) Improved filters to blacklist iPhone microphones
   - (updated) Use static Qt build when creating VST3 plugin on OSX
   - (updated) Audio Bridge VST3 SDK updated to 3.7.13
   - (updated) VS Mode reduced bandwidth for small video windows
   - (updated) VS Mode enabled disk storage for WebEngine
+  - (fixed) VS Mode shows too many options for stereo devices
 - Version: "2.6.0"
   Date: 2025-04-22
   Description:

--- a/src/vs/vsAudio.cpp
+++ b/src/vs/vsAudio.cpp
@@ -1319,7 +1319,7 @@ void VsAudioWorker::validateInputDevicesState()
             element.insert(QString::fromStdString("numChannels"), QVariant(1).toInt());
             inputChannelsComboModel.push_back(element);
         }
-        for (int i = 0; i < numDevicesChannelsAvailable; i++) {
+        for (int i = 0; i < numDevicesChannelsAvailable - 1; i++) {
             QJsonObject element = QJsonObject();
             element.insert(
                 QString::fromStdString("label"),
@@ -1426,7 +1426,7 @@ void VsAudioWorker::validateOutputDevicesState()
         // set the output channels selector to have the options based on the currently
         // selected device
         QJsonArray outputChannelsComboModel;
-        for (int i = 0; i < numDevicesChannelsAvailable; i++) {
+        for (int i = 0; i < numDevicesChannelsAvailable - 1; i++) {
             QJsonObject element = QJsonObject();
             element.insert(
                 QString::fromStdString("label"),


### PR DESCRIPTION
i.e. if a device has two channels, it allows you to chose from:

1, 2, 1 & 2, 2 & 3

(even though there is no channel 3)