### PR TITLE
Use atomic<int> for glitch counter shared across threads

### DIFF
--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -290,6 +290,7 @@ class Regulator : public RingBuffer
     double mMsecTolerance     = 64;
     int mLastSeqNumOut        = -1;
     std::atomic<int> mLastSeqNumIn;
+    std::atomic<int> mLastGlitches;
     QElapsedTimer mIncomingTimer;
     std::vector<double> mIncomingTiming;
     int mFPPratioNumerator;
@@ -298,7 +299,6 @@ class Regulator : public RingBuffer
     bool mSkipAutoHeadroom        = true;
     int mSkipped                  = 0;
     int mLastSkipped              = 0;
-    int mLastGlitches             = 0;
     int mStatsGlitches            = 0;
     double mLastMaxLatency        = 0;
     double mStatsMaxLatency       = 0;


### PR DESCRIPTION
This only impacts stats when using -I

I've seen evidence of the reported glitches not making sense because I think the stats thread is using a cached value on arm64