### PR TITLE
Fixing order of destruction to fix seg fault when shutting down

### DIFF
--- a/src/vs/virtualstudio.cpp
+++ b/src/vs/virtualstudio.cpp
@@ -1900,17 +1900,23 @@ void VirtualStudio::detectedFeedbackLoop()
 VirtualStudio::~VirtualStudio()
 {
     QDesktopServices::unsetUrlHandler("jacktrip");
+
     // close the window
     m_view.reset();
+
     // stop the audio worker thread before destructing other things
-    if (!m_audioConfigPtr.isNull()) {
-        m_audioConfigPtr->disconnect();
-        m_audioConfigPtr.reset();
-    }
+    m_audioConfigPtr->stopWorker();
+
     // stop device and corresponding threads
     if (!m_devicePtr.isNull()) {
         m_devicePtr->disconnect();
         m_devicePtr.reset();
+    }
+
+    // reset VsAudio after VsDevice since it holds a smart pointer
+    if (!m_audioConfigPtr.isNull()) {
+        m_audioConfigPtr->disconnect();
+        m_audioConfigPtr.reset();
     }
 }
 

--- a/src/vs/vsAudio.cpp
+++ b/src/vs/vsAudio.cpp
@@ -177,11 +177,17 @@ VsAudio::VsAudio(QObject* parent)
 
 VsAudio::~VsAudio()
 {
+    stopWorker();
+}
+
+void VsAudio::stopWorker()
+{
     if (m_workerThreadPtr == nullptr)
         return;
     m_workerThreadPtr->quit();
     WaitForSignal(m_workerThreadPtr, &QThread::finished);
     m_workerThreadPtr->deleteLater();
+    m_workerThreadPtr = nullptr;
 }
 
 bool VsAudio::backendAvailable() const

--- a/src/vs/vsAudio.h
+++ b/src/vs/vsAudio.h
@@ -145,6 +145,7 @@ class VsAudio : public QObject
     // allow VirtualStudio to get Permissions to bind to QML view
     VsPermissions& getPermissions() { return *m_permissionsPtr; }
     VsAudioWorker& getWorker() { return *m_audioWorkerPtr; }
+    void stopWorker();
 
     //  allow VirtualStudio to create new audio interfaces
     AudioInterface* newAudioInterface(JackTrip* jackTripPtr = nullptr);


### PR DESCRIPTION
Stop vsAudio worker thread, then destruct VsDevice, then VsAudio