### PR TITLE
Don't update mXferBuffer when processing packet as a glitch

### DIFF
--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -681,7 +681,7 @@ bool Regulator::pullPacket()
                                 numSkipped += NumSlots;
                             mLastSeqNumOut = prevSkipped;
                             // use the previous valid skipped packet for training
-                            memcpy(mXfrBuffer, mSlots[mLastSeqNumOut], mPeerBytes);
+                            // memcpy(mXfrBuffer, mSlots[mLastSeqNumOut], mPeerBytes);
                         } else {
                             // increment last out to the previous packet
                             numSkipped--;
@@ -691,12 +691,12 @@ bool Regulator::pullPacket()
                             // ensure timing is sane; don't miscalculate missing packets
                             mIncomingTiming[mLastSeqNumOut] = mIncomingTiming[next];
                             // use the next "real" packet for training
-                            memcpy(mXfrBuffer, mSlots[next], mPeerBytes);
+                            // memcpy(mXfrBuffer, mSlots[next], mPeerBytes);
                         }
                     } else {
                         // it's unlikely we'll be able the use to use it next time
                         mLastSeqNumOut = next;
-                        memcpy(mXfrBuffer, mSlots[mLastSeqNumOut], mPeerBytes);
+                        // memcpy(mXfrBuffer, mSlots[mLastSeqNumOut], mPeerBytes);
                     }
                     pullStat->plcOverruns += numSkipped;
                     pullStat->plcUnderruns++;


### PR DESCRIPTION
bugfix/plc-skipped-training started updating this whenever we had a valid packet but processed a glitch due to tolerance being exceeded. Burg seems to use this buffer even when the glitch flag is true, so I had thought that maybe we should keep it updated with the latest known value?

This reverts behavior to only update mXferBuffer when a packet is not being processed as a glitch. It will stay the same value for any sequential glitch processing.