### PR TITLE
Only use glitches for increasing auto headroom

### DIFF
--- a/src/RtAudioInterface.cpp
+++ b/src/RtAudioInterface.cpp
@@ -512,6 +512,23 @@ void RtAudioInterface::setup(bool verbose)
 }
 
 //*******************************************************************************
+bool RtAudioInterface::sampleRateChanged() const
+{
+    // TODO: this doesn't seem to work, at least on macos
+    // sanity check
+    if (mRtAudioInput.isNull() || mRtAudioInput->getStreamSampleRate() != mInSampleRate) {
+        return true;
+    }
+    if (!mDuplexMode) {
+        if (mRtAudioOutput.isNull()
+            || mRtAudioOutput->getStreamSampleRate() != mOutSampleRate) {
+            return true;
+        }
+    }
+    return false;
+}
+
+//*******************************************************************************
 void RtAudioInterface::printDevices()
 {
     QVector<RtAudioDevice> devices;

--- a/src/RtAudioInterface.h
+++ b/src/RtAudioInterface.h
@@ -99,6 +99,9 @@ class RtAudioInterface : public AudioInterface
     /// \brief This has no effect in RtAudio
     virtual void connectDefaultPorts() {}
 
+    /// returns true if the current device sample rates do not match what is expected
+    bool sampleRateChanged() const;
+
     // returns number of available input audio devices
     unsigned int getNumInputDevices() const;
 

--- a/src/vs/ChangeDevices.qml
+++ b/src/vs/ChangeDevices.qml
@@ -203,7 +203,7 @@ Rectangle {
             anchors.left: useStudioQueueBuffer.left
             background: Rectangle {
                 radius: 6 * virtualstudio.uiScale
-                color: queueBufferAutoButton.down ? browserButtonPressedColour : (queueBufferAutoButton.hovered ? browserButtonHoverColour : (autoQueueBuffer ? "#FF0000" : browserButtonColour))
+                color: autoQueueBuffer ? "#FFFFFF" : browserButtonColour
             }
             onClicked: {
                 if (autoQueueBuffer) {
@@ -217,7 +217,7 @@ Rectangle {
                 text: "Auto"
                 font { family: "Poppins"; pixelSize: fontMedium * virtualstudio.fontScale * virtualstudio.uiScale}
                 anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter }
-                color: textColour
+                color: "#000000"
             }
 
             visible: useStudioQueueBuffer.checkState != Qt.Checked
@@ -233,7 +233,7 @@ Rectangle {
             to: 250
             stepSize: 1
             padding: 0
-            visible: !autoQueueBuffer && useStudioQueueBuffer.checkState != Qt.Checked
+            visible: useStudioQueueBuffer.checkState != Qt.Checked
 
             anchors.top: useStudioQueueBuffer.bottom
             anchors.topMargin: 16 * virtualstudio.uiScale
@@ -267,6 +267,7 @@ Rectangle {
                 radius: 13 * virtualstudio.uiScale
                 color: queueBufferSlider.pressed ? sliderPressedColour : sliderColour
                 border.color: buttonStroke
+                visible: !autoQueueBuffer
             }
         }
 
@@ -279,7 +280,7 @@ Rectangle {
             text: "Lower Latency"
             font { family: "Poppins"; pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale }
             color: textColour
-            visible: !autoQueueBuffer && useStudioQueueBuffer.checkState != Qt.Checked
+            visible: useStudioQueueBuffer.checkState != Qt.Checked
         }
 
         Text {
@@ -291,7 +292,7 @@ Rectangle {
             text: "Higher Quality"
             font { family: "Poppins"; pixelSize: fontSmall * virtualstudio.fontScale * virtualstudio.uiScale }
             color: textColour
-            visible: !autoQueueBuffer && useStudioQueueBuffer.checkState != Qt.Checked
+            visible: useStudioQueueBuffer.checkState != Qt.Checked
         }
     }
 


### PR DESCRIPTION
Requiring a skipped packets that exceeded tolerance by less than past millisecond was kind of arbitrary, and we want to start preferring quality over latency whenever auto is enabled.

There is an edge case where if someone has sustained packet loss (say 1%) due to a really bad connection, it's going to keep bumping headroom until it hits max allowed. But that seems quite rare and if it is the case, they can always use the slider to adjust.

Updated max headroom calculation to use 10ms greater than the last good packet used, as opposed to a fixed value of 100ms. That was also quite arbitrary. This is perhaps slightly less so?

Ensure that we don't log in Regulator unless gVerbose is set (-V). Some of these happen inside the audio callback thread, which is one place you should never log outside of testing.

Updated the ChangeDevices page to clean up the Auto button for the Audio quality slider a little bit. It was kind of jumpy and awkward previously.

Added a RtAudioInterface::sampleRateChanged method to try and detect this, but the condition doesn't seem to be getting detected by RtAudio..