### PR TITLE
Don't glitch on the first good packet if previous was a glitch

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -1,7 +1,9 @@
 - Version: "2.7.0-beta2"
-  Date: 2025-06-20
+  Date: 2025-06-26
   Description:
   - (added) Audio Bridge Audio Unit for macOS
+  - (update) PLC auto headroom adjustments and bug fixes
+  - (fixed) Potential Audio Bridge deadlocks on Windows
   - (fixed) VS Mode potential crash when shutting down
   - (fixed) Include man page in Linux binary zip file
 - Version: "2.7.0-beta1"

--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -141,7 +141,6 @@ class Channel
     int mWptr;
     int mRing;
     std::vector<float> mZeros;
-    bool lastWasGlitch;
     int mCoeffsSize;
     int mTailSize;
 };
@@ -296,6 +295,7 @@ class Regulator : public RingBuffer
     int mFPPratioDenominator;
     bool mAuto                    = false;
     bool mSkipAutoHeadroom        = true;
+    bool mLastWasGlitch           = false;
     int mSkipped                  = 0;
     int mLastSkipped              = 0;
     int mLastGlitches             = 0;


### PR DESCRIPTION
If the previous call returned a predicted result (glitch), and we have a good packet available, don't process it as a glitch.

Updated changelog for 2.7.0-beta2 release