### PR TITLE
Accelerate increases to auto headroom when we know it will help

### DIFF
--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -304,7 +304,7 @@ class Regulator : public RingBuffer
     double mStatsMaxLatency       = 0;
     double mStatsMaxPLCdspElapsed = 0;
     double mCurrentHeadroom       = 0;
-    double mAutoHeadroomStartTime = 6000.0;
+    double mAutoHeadroomStartTime = 4000.0;
     double mAutoHeadroom          = -1;
     Time* mTime                   = nullptr;
 


### PR DESCRIPTION
We previously would never increase auto headroom by more than 1ms for every 2 second interval.

This patch allows auto headroom to increase more rapidly, when we have skipped good packets that we could have preserved. It adjusts it by enough that tolerance would have covered all of the good packets we skipped, or by at least 1ms.

Don't count packet latencies during the warmup period. I'm also shortening the "warm up period" from 3+3=6 ms to 2+2=4ms, because 6ms seems a bit too long to wait before it starts making adjustments.