### PR TITLE
Fix potential double delete in volume meters

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -1,22 +1,20 @@
-- Version: "2.7.0-beta2"
-  Date: 2025-06-26
+- Version: "2.7.0"
+  Date: 2025-06-29
   Description:
   - (added) Audio Bridge Audio Unit for macOS
-  - (update) PLC auto headroom adjustments and bug fixes
-  - (fixed) Potential Audio Bridge deadlocks on Windows
-  - (fixed) VS Mode potential crash when shutting down
-  - (fixed) Include man page in Linux binary zip file
-- Version: "2.7.0-beta1"
-  Date: 2025-06-07
-  Description:
   - (added) VS Mode ability to share specific screens or windows
-  - (updated) Upgraded all builds to use Qt 6.8.3
-  - (updated) Improved filters to blacklist iPhone microphones
-  - (updated) Use static Qt build when creating VST3 plugin on OSX
-  - (updated) Audio Bridge VST3 SDK updated to 3.7.13
   - (updated) VS Mode reduced bandwidth for small video windows
   - (updated) VS Mode enabled disk storage for WebEngine
+  - (updated) PLC auto headroom adjustments and bug fixes
+  - (updated) Upgraded all builds to use Qt 6.8.3
+  - (updated) Audio Bridge VST3 SDK updated to 3.7.13
+  - (updated) Use static Qt build when creating VST3 plugin on OSX
+  - (updated) Improved filters to blacklist iPhone microphones
+  - (fixed) VS Mode potential crash when shutting down
   - (fixed) VS Mode shows too many options for stereo devices
+  - (fixed) Potential Audio Bridge deadlocks on Windows
+  - (fixed) Potential double delete in volume meters
+  - (fixed) Include man page in Linux shared binary zip file
 - Version: "2.6.0"
   Date: 2025-04-22
   Description:

--- a/src/UdpHubListener.cpp
+++ b/src/UdpHubListener.cpp
@@ -238,7 +238,7 @@ void UdpHubListener::receivedNewConnection()
 {
     QSslSocket* clientSocket =
         static_cast<QSslSocket*>(mTcpServer.nextPendingConnection());
-    connect(clientSocket, &QAbstractSocket::readyRead, this, [=] {
+    connect(clientSocket, &QAbstractSocket::readyRead, this, [this, clientSocket] {
         receivedClientInfo(clientSocket);
     });
     cout << "JackTrip HUB SERVER: Client Connection Received!" << endl;

--- a/src/gui/about.cpp
+++ b/src/gui/about.cpp
@@ -46,7 +46,7 @@ const QString About::s_buildID = QLatin1String("");
 About::About(QWidget* parent) : QDialog(parent), m_ui(new Ui::About)
 {
     m_ui->setupUi(this);
-    connect(m_ui->closeButton, &QPushButton::clicked, this, [=]() {
+    connect(m_ui->closeButton, &QPushButton::clicked, this, [this]() {
         this->done(0);
     });
 

--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -101,7 +101,7 @@ QJackTrip::QJackTrip(UserInterface& interface, QWidget* parent)
     connect(m_ui->certEdit, &QLineEdit::textChanged, this, &QJackTrip::authFilesChanged);
     connect(m_ui->keyEdit, &QLineEdit::textChanged, this, &QJackTrip::authFilesChanged);
     connect(m_ui->credsEdit, &QLineEdit::textChanged, this, &QJackTrip::authFilesChanged);
-    connect(m_ui->aboutButton, &QPushButton::clicked, this, [=]() {
+    connect(m_ui->aboutButton, &QPushButton::clicked, this, [this]() {
         About about(this);
         about.exec();
     });
@@ -117,7 +117,7 @@ QJackTrip::QJackTrip(UserInterface& interface, QWidget* parent)
     m_ui->vsModeButton->setVisible(true);
 #endif
     connect(m_ui->autoPatchComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged),
-            this, [=]() {
+            this, [this]() {
                 if (m_ui->autoPatchComboBox->currentIndex() == CLIENTFOFI
                     || m_ui->autoPatchComboBox->currentIndex() == FULLMIX) {
                     m_ui->patchServerCheckBox->setEnabled(true);
@@ -125,14 +125,14 @@ QJackTrip::QJackTrip(UserInterface& interface, QWidget* parent)
                     m_ui->patchServerCheckBox->setEnabled(false);
                 }
             });
-    connect(m_ui->authCheckBox, &QCHECKBOX_STATE_CHANGED, this, [=]() {
+    connect(m_ui->authCheckBox, &QCHECKBOX_STATE_CHANGED, this, [this]() {
         m_ui->usernameLabel->setEnabled(m_ui->authCheckBox->isChecked());
         m_ui->usernameEdit->setEnabled(m_ui->authCheckBox->isChecked());
         m_ui->passwordLabel->setEnabled(m_ui->authCheckBox->isChecked());
         m_ui->passwordEdit->setEnabled(m_ui->authCheckBox->isChecked());
         credentialsChanged();
     });
-    connect(m_ui->requireAuthCheckBox, &QCHECKBOX_STATE_CHANGED, this, [=]() {
+    connect(m_ui->requireAuthCheckBox, &QCHECKBOX_STATE_CHANGED, this, [this]() {
         m_ui->certLabel->setEnabled(m_ui->requireAuthCheckBox->isChecked());
         m_ui->certEdit->setEnabled(m_ui->requireAuthCheckBox->isChecked());
         m_ui->certBrowse->setEnabled(m_ui->requireAuthCheckBox->isChecked());
@@ -144,21 +144,21 @@ QJackTrip::QJackTrip(UserInterface& interface, QWidget* parent)
         m_ui->credsBrowse->setEnabled(m_ui->requireAuthCheckBox->isChecked());
         authFilesChanged();
     });
-    connect(m_ui->ioStatsCheckBox, &QCHECKBOX_STATE_CHANGED, this, [=]() {
+    connect(m_ui->ioStatsCheckBox, &QCHECKBOX_STATE_CHANGED, this, [this]() {
         m_ui->ioStatsLabel->setEnabled(m_ui->ioStatsCheckBox->isChecked());
         m_ui->ioStatsSpinBox->setEnabled(m_ui->ioStatsCheckBox->isChecked());
         if (!m_ui->ioStatsCheckBox->isChecked()) {
             m_statsDialog->hide();
         }
     });
-    connect(m_ui->verboseCheckBox, &QCHECKBOX_STATE_CHANGED, this, [=]() {
+    connect(m_ui->verboseCheckBox, &QCHECKBOX_STATE_CHANGED, this, [this]() {
         gVerboseFlag = m_ui->verboseCheckBox->isChecked();
         if (!gVerboseFlag) {
             m_debugDialog->hide();
             m_debugDialog->clearOutput();
         }
     });
-    connect(m_ui->jitterCheckBox, &QCHECKBOX_STATE_CHANGED, this, [=]() {
+    connect(m_ui->jitterCheckBox, &QCHECKBOX_STATE_CHANGED, this, [this]() {
         m_ui->broadcastCheckBox->setEnabled(m_ui->jitterCheckBox->isChecked());
         m_ui->broadcastQueueLabel->setEnabled(m_ui->jitterCheckBox->isChecked()
                                               && m_ui->broadcastCheckBox->isChecked());
@@ -183,13 +183,13 @@ QJackTrip::QJackTrip(UserInterface& interface, QWidget* parent)
             m_autoQueueIndicator.setText(QStringLiteral("Auto queue: disabled"));
         }
     });
-    connect(m_ui->broadcastCheckBox, &QCHECKBOX_STATE_CHANGED, this, [=]() {
+    connect(m_ui->broadcastCheckBox, &QCHECKBOX_STATE_CHANGED, this, [this]() {
         m_ui->broadcastQueueLabel->setEnabled(m_ui->jitterCheckBox->isChecked()
                                               && m_ui->broadcastCheckBox->isChecked());
         m_ui->broadcastQueueSpinBox->setEnabled(m_ui->jitterCheckBox->isChecked()
                                                 && m_ui->broadcastCheckBox->isChecked());
     });
-    connect(m_ui->autoQueueCheckBox, &QCHECKBOX_STATE_CHANGED, this, [=]() {
+    connect(m_ui->autoQueueCheckBox, &QCHECKBOX_STATE_CHANGED, this, [this]() {
         m_ui->autoQueueLabel->setEnabled(m_ui->jitterCheckBox->isChecked()
                                          && m_ui->autoQueueCheckBox->isChecked());
         m_ui->autoQueueSpinBox->setEnabled(m_ui->jitterCheckBox->isChecked()
@@ -205,34 +205,34 @@ QJackTrip::QJackTrip(UserInterface& interface, QWidget* parent)
         }
     });
 
-    connect(m_ui->inFreeverbCheckBox, &QCHECKBOX_STATE_CHANGED, this, [=]() {
+    connect(m_ui->inFreeverbCheckBox, &QCHECKBOX_STATE_CHANGED, this, [this]() {
         m_ui->inFreeverbLabel->setEnabled(m_ui->inFreeverbCheckBox->isChecked());
         m_ui->inFreeverbWetnessSlider->setEnabled(m_ui->inFreeverbCheckBox->isChecked());
     });
-    connect(m_ui->inZitarevCheckBox, &QCHECKBOX_STATE_CHANGED, this, [=]() {
+    connect(m_ui->inZitarevCheckBox, &QCHECKBOX_STATE_CHANGED, this, [this]() {
         m_ui->inZitarevLabel->setEnabled(m_ui->inZitarevCheckBox->isChecked());
         m_ui->inZitarevWetnessSlider->setEnabled(m_ui->inZitarevCheckBox->isChecked());
     });
 
-    connect(m_ui->outFreeverbCheckBox, &QCHECKBOX_STATE_CHANGED, this, [=]() {
+    connect(m_ui->outFreeverbCheckBox, &QCHECKBOX_STATE_CHANGED, this, [this]() {
         m_ui->outFreeverbLabel->setEnabled(m_ui->outFreeverbCheckBox->isChecked());
         m_ui->outFreeverbWetnessSlider->setEnabled(
             m_ui->outFreeverbCheckBox->isChecked());
     });
-    connect(m_ui->outZitarevCheckBox, &QCHECKBOX_STATE_CHANGED, this, [=]() {
+    connect(m_ui->outZitarevCheckBox, &QCHECKBOX_STATE_CHANGED, this, [this]() {
         m_ui->outZitarevLabel->setEnabled(m_ui->outZitarevCheckBox->isChecked());
         m_ui->outZitarevWetnessSlider->setEnabled(m_ui->outZitarevCheckBox->isChecked());
     });
-    connect(m_ui->outLimiterCheckBox, &QCHECKBOX_STATE_CHANGED, this, [=]() {
+    connect(m_ui->outLimiterCheckBox, &QCHECKBOX_STATE_CHANGED, this, [this]() {
         m_ui->outLimiterLabel->setEnabled(m_ui->outLimiterCheckBox->isChecked());
         m_ui->outClientsSpinBox->setEnabled(m_ui->outLimiterCheckBox->isChecked());
     });
 
-    connect(m_ui->connectScriptCheckBox, &QCHECKBOX_STATE_CHANGED, this, [=]() {
+    connect(m_ui->connectScriptCheckBox, &QCHECKBOX_STATE_CHANGED, this, [this]() {
         m_ui->connectScriptEdit->setEnabled(m_ui->connectScriptCheckBox->isChecked());
         m_ui->connectScriptBrowse->setEnabled(m_ui->connectScriptCheckBox->isChecked());
     });
-    connect(m_ui->disconnectScriptCheckBox, &QCHECKBOX_STATE_CHANGED, this, [=]() {
+    connect(m_ui->disconnectScriptCheckBox, &QCHECKBOX_STATE_CHANGED, this, [this]() {
         m_ui->disconnectScriptEdit->setEnabled(
             m_ui->disconnectScriptCheckBox->isChecked());
         m_ui->disconnectScriptBrowse->setEnabled(
@@ -260,7 +260,7 @@ QJackTrip::QJackTrip(UserInterface& interface, QWidget* parent)
 
 #ifdef RT_AUDIO
     connect(m_ui->backendComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged),
-            this, [=](int index) {
+            this, [this](int index) {
                 if (index == 1) {
                     m_ui->sampleRateComboBox->setEnabled(true);
                     m_ui->sampleRateLabel->setEnabled(true);
@@ -287,7 +287,7 @@ QJackTrip::QJackTrip(UserInterface& interface, QWidget* parent)
                     m_ui->backendWarningLabel->setVisible(false);
                 }
             });
-    connect(m_ui->refreshDevicesButton, &QPushButton::clicked, this, [=]() {
+    connect(m_ui->refreshDevicesButton, &QPushButton::clicked, this, [this]() {
         populateDeviceMenu(m_ui->inputDeviceComboBox, true);
         populateDeviceMenu(m_ui->outputDeviceComboBox, false);
     });
@@ -432,9 +432,10 @@ void QJackTrip::showEvent(QShowEvent* event)
                     "will automatically be re-enabled.)");
                 msgBox.setWindowTitle(QStringLiteral("JACK Not Available"));
                 msgBox.setCheckBox(dontBugMe);
-                QObject::connect(dontBugMe, &QCHECKBOX_STATE_CHANGED, this, [=]() {
-                    m_hideWarning = dontBugMe->isChecked();
-                });
+                QObject::connect(dontBugMe, &QCHECKBOX_STATE_CHANGED, this,
+                                 [this, dontBugMe]() {
+                                     m_hideWarning = dontBugMe->isChecked();
+                                 });
                 msgBox.exec();
                 if (m_hideWarning) {
                     settings.setValue(QStringLiteral("HideJackWarning"), true);

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -40,7 +40,7 @@
 
 #include "jacktrip_types.h"
 
-constexpr const char* const gVersion = "2.7.0-beta2";  ///< JackTrip version
+constexpr const char* const gVersion = "2.7.0";  ///< JackTrip version
 
 //*******************************************************************************
 /// \name Default Values

--- a/src/vs/vsAuth.cpp
+++ b/src/vs/vsAuth.cpp
@@ -93,7 +93,7 @@ void VsAuth::initializedCodeFlow(QString code, QString verificationUrl)
 void VsAuth::fetchUserInfo(QString accessToken)
 {
     QNetworkReply* reply = m_api->getAuth0UserInfo();
-    connect(reply, &QNetworkReply::finished, this, [=]() {
+    connect(reply, &QNetworkReply::finished, this, [this, reply, accessToken]() {
         if (reply->error() != QNetworkReply::NoError) {
             std::cout << "VsAuth::fetchUserInfo Error: "
                       << reply->errorString().toStdString() << std::endl;
@@ -138,7 +138,7 @@ void VsAuth::refreshAccessToken(QString refreshToken)
     // send request
     QNetworkReply* reply = m_networkAccessManager->post(request, data.toUtf8());
 
-    connect(reply, &QNetworkReply::finished, this, [=]() {
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
         QByteArray buffer = reply->readAll();
 
         // Error: failed to get device code

--- a/src/vs/vsDevice.cpp
+++ b/src/vs/vsDevice.cpp
@@ -81,7 +81,7 @@ void VsDevice::registerApp()
 
     // check if device exists
     QNetworkReply* reply = m_api->getDevice(m_appID);
-    connect(reply, &QNetworkReply::finished, this, [=]() {
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
         // Got error
         if (reply->error() != QNetworkReply::NoError) {
             QVariant statusCode =
@@ -255,7 +255,7 @@ void VsDevice::updateState(const QString& serverId)
     };
     QJsonDocument request = QJsonDocument(json);
     QNetworkReply* reply  = m_api->updateDevice(m_appID, request.toJson());
-    connect(reply, &QNetworkReply::finished, this, [=]() {
+    connect(reply, &QNetworkReply::finished, this, [reply]() {
         if (reply->error() != QNetworkReply::NoError) {
             std::cout << "Error: " << reply->errorString().toStdString() << std::endl;
         }
@@ -281,7 +281,7 @@ void VsDevice::sendLevels()
 
     QJsonDocument request = QJsonDocument(json);
     QNetworkReply* reply  = m_api->updateDevice(m_appID, request.toJson());
-    connect(reply, &QNetworkReply::finished, this, [=]() {
+    connect(reply, &QNetworkReply::finished, this, [reply]() {
         if (reply->error() != QNetworkReply::NoError) {
             std::cout << "Error: " << reply->errorString().toStdString() << std::endl;
         }
@@ -563,7 +563,7 @@ void VsDevice::registerJTAsDevice()
     QJsonDocument request = QJsonDocument(json);
 
     QNetworkReply* reply = m_api->postDevice(request.toJson());
-    connect(reply, &QNetworkReply::finished, this, [=]() {
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
         if (reply->error() != QNetworkReply::NoError) {
             std::cout << "Error: " << reply->errorString().toStdString() << std::endl;
             reply->deleteLater();

--- a/src/vs/vsDeviceCodeFlow.cpp
+++ b/src/vs/vsDeviceCodeFlow.cpp
@@ -81,7 +81,7 @@ void VsDeviceCodeFlow::initDeviceAuthorizationCodeFlow()
 
     // send request
     QNetworkReply* reply = m_netManager->post(request, data.toUtf8());
-    connect(reply, &QNetworkReply::finished, this, [=]() {
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
         bool success = processDeviceCodeNetworkReply(reply);
         if (success) {
             // notify success along with user code and verification URL
@@ -136,7 +136,7 @@ void VsDeviceCodeFlow::onPollingTimerTick()
 
     // send send request for token
     QNetworkReply* reply = m_netManager->post(request, data.toUtf8());
-    connect(reply, &QNetworkReply::finished, this, [=]() {
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
         bool success = processPollingOAuthTokenNetworkReply(reply);
         if (m_authenticationError) {
             // shouldn't happen


### PR DESCRIPTION
The Meter class can be destructed before the 5 second timer expires, causing a crash due to double delete.

Updated lambda bindings to be more explcit to comply with the latest c++20 standard (fixes compiler warnings).

Updated version and changelog for upcoming 2.7.0 release