### PR TITLE
Try using runneradmin path recommended by ssl.com for CKA

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -766,8 +766,8 @@ jobs:
           CRED_ID: ${{ secrets.ESIGNER_CREDENTIAL_ID }}
           SHA1: ${{ secrets.SSL_COM_SHA1 }}
           PASSWORD: ${{ secrets.SSL_COM_PWD }}
-          MASTER_KEY_FILE: ${{ github.workspace }}\CKA\master.key
-          INSTALL_DIR: ${{ github.workspace }}\CKA
+          MASTER_KEY_FILE: C:\Users\runneradmin\eSignerCKA\master.key
+          INSTALL_DIR: C:\Users\runneradmin\eSignerCKA
         run: |
           cd win
           echo Downloading Cloud Key Adapter...

--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -1,3 +1,7 @@
+- Version: "2.7.1-beta2"
+  Date: 2025-06-30
+  Description:
+  - (updated) Updated version to test upgrade process
 - Version: "2.7.1-beta1"
   Date: 2025-06-30
   Description:
@@ -13,7 +17,7 @@
   - (updated) Upgraded all builds to use Qt 6.8.3
   - (updated) Audio Bridge VST3 SDK updated to 3.7.13
   - (updated) Use static Qt build when creating VST3 plugin on OSX
-  - (updated) Improved filters to blacklist iPhone microphones
+  - (updated) Improved filters to blocklist iPhone microphones
   - (fixed) VS Mode potential crash when shutting down
   - (fixed) VS Mode shows too many options for stereo devices
   - (fixed) Potential Audio Bridge deadlocks on Windows
@@ -88,7 +92,7 @@
   - (updated) VS Mode improved messaging while loading studios
   - (fixed) VS Mode possible failures when loading studios
   - (fixed) VS Mode studio refresh updated to avoid jumpiness
-  - (fixed) VS Mode blacklisted iPhone microphone device
+  - (fixed) VS Mode blocklisted iPhone microphone device
   - (fixed) Race condition in automatic patching for JACK
   - (fixed) Missing files in Linux binary zip file
 - Version: "2.3.1"
@@ -133,7 +137,7 @@
   - (added) New container images for JackTrip hub server
   - (fixed) Support for audio interfaces on OSX with multiple channels
   - (fixed) Hub server crashes when trying to rebind ports
-  - (fixed) VS Mode blacklisted Generic Low Latency ASIO Driver
+  - (fixed) VS Mode blocklisted Generic Low Latency ASIO Driver
   - (fixed) VS Mode inconsistent initial connection state 
 - Version: "2.2.2"
   Date: 2024-02-09
@@ -199,7 +203,7 @@
   - (updated) Improved user experience when using the RtAudio backend
   - (fixed) Crashes when audio interfaces don't support buffer size
   - (fixed) Crashes when audio interfaces are unplugged while active
-  - (fixed) Blacklisting Steinberg Generic ASIO driver due to crashes
+  - (fixed) Blocklisting Steinberg Generic ASIO driver due to crashes
   - (fixed) Bugs with Virtual Studio deep links and connections stats
   - (fixed) VS Settings will now revert back when Cancel is selected
   - (fixed) VS Mode device levels no longer reset on first registration

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -40,7 +40,7 @@
 
 #include "jacktrip_types.h"
 
-constexpr const char* const gVersion = "2.7.1-beta1";  ///< JackTrip version
+constexpr const char* const gVersion = "2.7.1-beta2";  ///< JackTrip version
 
 //*******************************************************************************
 /// \name Default Values


### PR DESCRIPTION
Signing seems to have randomly stopped working, despite zero changes. Even re-running the same builds that worked before has started failing. Maybe it has something to do with using the workspace directory versus the path from ssl.com's [example here](https://www.ssl.com/how-to/how-to-integrate-esigner-cka-with-ci-cd-tools-for-automated-code-signing/)

Bump version to 2.7.1-beta2 to test upgrades