### PR TITLE
Log client name with UDP port

### DIFF
--- a/src/UdpHubListener.cpp
+++ b/src/UdpHubListener.cpp
@@ -325,7 +325,8 @@ void UdpHubListener::receivedClientInfo(QSslSocket* clientConnection)
     // Assign server port and send it to Client
     if (id != -1) {
         cout << "JackTrip HUB SERVER: Sending Final UDP Port to Client: "
-             << mJTWorkers->at(id)->getServerPort() << endl;
+             << clientName.toStdString() << " = " << mJTWorkers->at(id)->getServerPort()
+             << endl;
     }
 
     if (id == -1


### PR DESCRIPTION
This is important because it is the name used in jack.

Otherwise, this never gets logged anywhere.