### PR TITLE
Regulator updates to further minimize unnecessary glitches

### DIFF
--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -236,7 +236,8 @@ class Regulator : public RingBuffer
    private:
     void pushPacket(const int8_t* buf, int seq_num);
     void updatePushStats(int seq_num);
-    bool pullPacket();    // returns true if PLC prediction
+    bool pullPacket();  // returns true if PLC prediction
+    bool underrun(const double now, const int lastSeqNumIn);
     bool enableWorker();  // returns true if worker was enabled
     void updateTolerance(int glitches, int skipped);
     void setFPPratio(int len);
@@ -288,6 +289,7 @@ class Regulator : public RingBuffer
     StdDev* pullStat          = nullptr;
     double mMsecTolerance     = 64;
     int mLastSeqNumOut        = -1;
+    int mStashedPacket        = -1;
     std::atomic<int> mLastSeqNumIn;
     QElapsedTimer mIncomingTimer;
     std::vector<double> mIncomingTiming;


### PR DESCRIPTION
This builds upon the refinement introduced by:
https://github.com/jacktrip/jacktrip/pull/1437

That PR allowed us to use a good packet ignoring skips if the previous callback was serviced using a prediction (glitch).

However, we were still effectively throwing out the next good packet whenever there were skips and the previous callback was not serviced using a prediction.

This PR takes a slightly different approach by allowing us to stash and use the next good packet on the following callback. This also helps slow down jumping sequence numbers when there are multiple skipped packets in a row (which causes abrupt drops in latency).

This also addresses a special case where we are only skipping a single good packet due to tolerance. Rather than returning a prediction, we allow it to use the packet.

For this to work, we need to ease the tolerance restrictions slightly by allowing it to sometimes expand by the duration of an additional packet. Effectively, this also means that tolerance restrictions alone will only cause glitches when the skew exceeds at least one packet in duration.

My initial testing indicates that these changes significantly reduce glitch counts, by as much as 2x, resulting in a slightly improved signal (at least to my ears).

sudo tc qdisc add dev eth0 root netem slot distribution pareto 0.1ms 3.0ms loss 10%