### PR TITLE
Add Back/Refresh/Open in Browser buttons to Browse.qml footer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,15 @@
 
 JackTrip is a high-quality audio network performance system for bidirectional, uncompressed audio streaming over the Internet. It's a C++20 desktop application using Qt 6, supporting Linux, macOS and Windows.
 
+## Branching
+
+Always create new branches from the latest commit on the `dev` branch:
+
+```bash
+git fetch origin
+git checkout -b your-branch-name origin/dev
+```
+
 ## Build Commands
 
 **Build system**: Meson (primary). CMake exists but is legacy/unsupported.

--- a/src/vs/Browse.qml
+++ b/src/vs/Browse.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Controls
 import QtWebEngine
+import Qt5Compat.GraphicalEffects
 
 Item {
     width: parent.width; height: parent.height
@@ -12,6 +13,7 @@ Item {
     }
 
     property int buttonHeight: 25
+    property int iconButtonSize: 32
     property int buttonWidth: 103
     property int extraSettingsButtonWidth: 16
     property int emptyListMessageWidth: 450
@@ -22,6 +24,8 @@ Item {
 
     property string backgroundColour: virtualstudio.darkMode ? "#272525" : "#FAFBFB"
     property string textColour: virtualstudio.darkMode ? "#FAFBFB" : "#0F0D0D"
+    property string toolTipBackgroundColour: virtualstudio.darkMode ? "#323232" : "#F3F3F3"
+    property int fontTiny: 8
 
     property string browseDiscoverUrl: `https://${virtualstudio.apiHost === "test.jacktrip.com" ? "next-test.jacktrip.com" : "www.jacktrip.com"}/discover`
     property string browseStudiosUrl: `https://${virtualstudio.apiHost === "test.jacktrip.com" ? "next-test.jacktrip.com" : "www.jacktrip.com"}/studios`
@@ -100,6 +104,7 @@ Item {
             text: "My Studios"
             icon { source: "squares-2x2.svg"; color: resolvedTextColor }
             onClicked: { if (webLoader.item) webLoader.item.url = browseStudiosUrl }
+            enabled: !(webLoader.item && webLoader.item.url.toString().startsWith(browseStudiosUrl))
             display: AbstractButton.TextBesideIcon
             fontSize: fontMedium
             leftPadding: 0
@@ -115,6 +120,7 @@ Item {
             text: "Discover"
             icon { source: "public.svg"; color: resolvedTextColor }
             onClicked: { if (webLoader.item) webLoader.item.url = browseDiscoverUrl }
+            enabled: !(webLoader.item && webLoader.item.url.toString().startsWith(browseDiscoverUrl))
             display: AbstractButton.TextBesideIcon
             fontSize: fontMedium
             leftPadding: 0
@@ -126,33 +132,191 @@ Item {
         }
 
         StyledButton {
-            id: aboutButton
-            text: "About"
-            icon { source: "question-mark-circle.svg"; color: resolvedTextColor }
-            onClicked: { virtualstudio.showAbout() }
-            display: AbstractButton.TextBesideIcon
-            fontSize: fontMedium
-            leftPadding: 0
-            rightPadding: 4
-            spacing: 0
+            id: goBackButton
+            icon { source: "arrow-left.svg"; color: resolvedTextColor; width: iconButtonSize * virtualstudio.uiScale; height: iconButtonSize * virtualstudio.uiScale }
+            onClicked: { if (webLoader.item) webLoader.item.goBack() }
+            enabled: webLoader.item && webLoader.item.canGoBack
+            display: AbstractButton.IconOnly
+            showBorder: false
             anchors.verticalCenter: parent.verticalCenter
-            x: parent.width - ((230 + extraSettingsButtonWidth) * virtualstudio.uiScale)
-            width: buttonWidth * virtualstudio.uiScale; height: buttonHeight * virtualstudio.uiScale
+            x: parent.width - (16 + iconButtonSize * 6 + 8 * 5) * virtualstudio.uiScale
+            width: iconButtonSize * virtualstudio.uiScale; height: buttonHeight * virtualstudio.uiScale
+
+            ToolTip {
+                visible: goBackButton.hovered
+                delay: 500
+                contentItem: Text {
+                    text: qsTr("Go Back")
+                    font { family: "Poppins"; pixelSize: fontTiny * virtualstudio.fontScale * virtualstudio.uiScale }
+                    color: textColour
+                }
+                background: Rectangle {
+                    color: toolTipBackgroundColour
+                    radius: 4
+                    layer.enabled: true
+                    layer.effect: Glow {
+                        radius: 8
+                        color: "#66000000"
+                        transparentBorder: true
+                    }
+                }
+            }
+        }
+
+        StyledButton {
+            id: goForwardButton
+            icon { source: "arrow-right.svg"; color: resolvedTextColor; width: iconButtonSize * virtualstudio.uiScale; height: iconButtonSize * virtualstudio.uiScale }
+            onClicked: { if (webLoader.item) webLoader.item.goForward() }
+            enabled: webLoader.item && webLoader.item.canGoForward
+            display: AbstractButton.IconOnly
+            showBorder: false
+            anchors.verticalCenter: parent.verticalCenter
+            x: parent.width - (16 + iconButtonSize * 5 + 8 * 4) * virtualstudio.uiScale
+            width: iconButtonSize * virtualstudio.uiScale; height: buttonHeight * virtualstudio.uiScale
+
+            ToolTip {
+                visible: goForwardButton.hovered
+                delay: 500
+                contentItem: Text {
+                    text: qsTr("Go Forward")
+                    font { family: "Poppins"; pixelSize: fontTiny * virtualstudio.fontScale * virtualstudio.uiScale }
+                    color: textColour
+                }
+                background: Rectangle {
+                    color: toolTipBackgroundColour
+                    radius: 4
+                    layer.enabled: true
+                    layer.effect: Glow {
+                        radius: 8
+                        color: "#66000000"
+                        transparentBorder: true
+                    }
+                }
+            }
+        }
+
+        StyledButton {
+            id: refreshButton
+            icon { source: "refresh.svg"; color: resolvedTextColor; width: iconButtonSize * virtualstudio.uiScale; height: iconButtonSize * virtualstudio.uiScale }
+            onClicked: { if (webLoader.item) webLoader.item.reload() }
+            display: AbstractButton.IconOnly
+            showBorder: false
+            anchors.verticalCenter: parent.verticalCenter
+            x: parent.width - (16 + iconButtonSize * 4 + 8 * 3) * virtualstudio.uiScale
+            width: iconButtonSize * virtualstudio.uiScale; height: buttonHeight * virtualstudio.uiScale
+
+            ToolTip {
+                visible: refreshButton.hovered
+                delay: 500
+                contentItem: Text {
+                    text: qsTr("Refresh")
+                    font { family: "Poppins"; pixelSize: fontTiny * virtualstudio.fontScale * virtualstudio.uiScale }
+                    color: textColour
+                }
+                background: Rectangle {
+                    color: toolTipBackgroundColour
+                    radius: 4
+                    layer.enabled: true
+                    layer.effect: Glow {
+                        radius: 8
+                        color: "#66000000"
+                        transparentBorder: true
+                    }
+                }
+            }
+        }
+
+        StyledButton {
+            id: openInBrowserButton
+            icon { source: "arrow-top-right-on-square.svg"; color: resolvedTextColor; width: iconButtonSize * virtualstudio.uiScale; height: iconButtonSize * virtualstudio.uiScale }
+            onClicked: { if (webLoader.item) Qt.openUrlExternally(webLoader.item.url) }
+            display: AbstractButton.IconOnly
+            showBorder: false
+            anchors.verticalCenter: parent.verticalCenter
+            x: parent.width - (16 + iconButtonSize * 3 + 8 * 2) * virtualstudio.uiScale
+            width: iconButtonSize * virtualstudio.uiScale; height: buttonHeight * virtualstudio.uiScale
+
+            ToolTip {
+                visible: openInBrowserButton.hovered
+                delay: 500
+                contentItem: Text {
+                    text: qsTr("Open in Browser")
+                    font { family: "Poppins"; pixelSize: fontTiny * virtualstudio.fontScale * virtualstudio.uiScale }
+                    color: textColour
+                }
+                background: Rectangle {
+                    color: toolTipBackgroundColour
+                    radius: 4
+                    layer.enabled: true
+                    layer.effect: Glow {
+                        radius: 8
+                        color: "#66000000"
+                        transparentBorder: true
+                    }
+                }
+            }
+        }
+
+        StyledButton {
+            id: aboutButton
+            icon { source: "question-mark-circle.svg"; color: resolvedTextColor; width: iconButtonSize * virtualstudio.uiScale; height: iconButtonSize * virtualstudio.uiScale }
+            onClicked: { virtualstudio.showAbout() }
+            display: AbstractButton.IconOnly
+            showBorder: false
+            anchors.verticalCenter: parent.verticalCenter
+            x: parent.width - (16 + iconButtonSize * 2 + 8) * virtualstudio.uiScale
+            width: iconButtonSize * virtualstudio.uiScale; height: buttonHeight * virtualstudio.uiScale
+
+            ToolTip {
+                visible: aboutButton.hovered
+                delay: 500
+                contentItem: Text {
+                    text: qsTr("About")
+                    font { family: "Poppins"; pixelSize: fontTiny * virtualstudio.fontScale * virtualstudio.uiScale }
+                    color: textColour
+                }
+                background: Rectangle {
+                    color: toolTipBackgroundColour
+                    radius: 4
+                    layer.enabled: true
+                    layer.effect: Glow {
+                        radius: 8
+                        color: "#66000000"
+                        transparentBorder: true
+                    }
+                }
+            }
         }
 
         StyledButton {
             id: settingsButton
-            text: "Settings"
-            icon { source: "cog.svg"; color: resolvedTextColor }
+            icon { source: "cog.svg"; color: resolvedTextColor; width: iconButtonSize * virtualstudio.uiScale; height: iconButtonSize * virtualstudio.uiScale }
             onClicked: { virtualstudio.windowState = "settings"; audio.startAudio(); }
-            display: AbstractButton.TextBesideIcon
-            fontSize: fontMedium
-            leftPadding: 0
-            rightPadding: 4
-            spacing: 0
+            display: AbstractButton.IconOnly
+            showBorder: false
             anchors.verticalCenter: parent.verticalCenter
-            x: parent.width - ((119 + extraSettingsButtonWidth) * virtualstudio.uiScale)
-            width: (buttonWidth + extraSettingsButtonWidth) * virtualstudio.uiScale; height: buttonHeight * virtualstudio.uiScale
+            x: parent.width - (16 + iconButtonSize) * virtualstudio.uiScale
+            width: iconButtonSize * virtualstudio.uiScale; height: buttonHeight * virtualstudio.uiScale
+
+            ToolTip {
+                visible: settingsButton.hovered
+                delay: 500
+                contentItem: Text {
+                    text: qsTr("Settings")
+                    font { family: "Poppins"; pixelSize: fontTiny * virtualstudio.fontScale * virtualstudio.uiScale }
+                    color: textColour
+                }
+                background: Rectangle {
+                    color: toolTipBackgroundColour
+                    radius: 4
+                    layer.enabled: true
+                    layer.effect: Glow {
+                        radius: 8
+                        color: "#66000000"
+                        transparentBorder: true
+                    }
+                }
+            }
         }
     }
 

--- a/src/vs/arrow-left.svg
+++ b/src/vs/arrow-left.svg
@@ -1,0 +1,4 @@
+<!-- Heroicons (MIT) https://heroicons.com -->
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18" />
+</svg>

--- a/src/vs/arrow-right.svg
+++ b/src/vs/arrow-right.svg
@@ -1,0 +1,4 @@
+<!-- Heroicons (MIT) https://heroicons.com -->
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3" />
+</svg>

--- a/src/vs/arrow-top-right-on-square.svg
+++ b/src/vs/arrow-top-right-on-square.svg
@@ -1,0 +1,4 @@
+<!-- Heroicons (MIT) https://heroicons.com -->
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+</svg>

--- a/src/vs/vs.qrc
+++ b/src/vs/vs.qrc
@@ -60,6 +60,9 @@
     <file>quiet.svg</file>
     <file>loud.svg</file>
     <file>refresh.svg</file>
+    <file>arrow-left.svg</file>
+    <file>arrow-right.svg</file>
+    <file>arrow-top-right-on-square.svg</file>
     <file>ethernet.svg</file>
     <file>networkCheck.svg</file>
     <file>externalMic.svg</file>


### PR DESCRIPTION
- Add arrow-left.svg and arrow-top-right-on-square.svg icons from Heroicons (MIT)
- Register new SVG files in vs.qrc
- Add three icon-only StyledButtons after Discover button:
  - Go Back: navigates back in WebEngineView history (disabled when cannot go back)
  - Go Forward: navigates forward in WebEngineView history (disabled when cannot go forward)
  - Refresh: reloads current page
  - Open in Browser: opens current URL in external browser
- Add ToolTips with hover delay for each button
- Add toolTipBackgroundColour and fontTiny properties for tooltip styling

Resolves JAC-3031

<img width="797" height="179" alt="Screenshot 2026-03-15 at 8 59 02 PM" src="https://github.com/user-attachments/assets/c8ba18ce-21f5-4d87-8481-dd251d210ae4" />