### PR TITLE
Require TLS for the WebRTC signaling WebSocket

### DIFF
--- a/docs/Documentation/NetworkProtocol.md
+++ b/docs/Documentation/NetworkProtocol.md
@@ -4,7 +4,7 @@ This document describes JackTrip’s **on-the-wire protocol** as implemented in 
 
 ### Scope and non-goals
 
-- **In scope**: the real-time **UDP audio stream**, its headers and payload layout, the optional **UDP redundancy** framing, the small **UDP “stop” control packet**, the **TCP handshake** used by hub/ping-server style deployments (including the authentication variant), the **WebRTC data channel transport** (used by webtrip and the hub server’s WebRTC path), and the **WebTransport transport** (HTTP/3 over QUIC datagrams).
+- **In scope**: the real-time **UDP audio stream**, its headers and payload layout, the optional **UDP redundancy** framing, the small **UDP “stop” control packet**, the **TCP handshake** used by hub/ping-server style deployments (including the authentication variant), the **WebRTC data channel transport** (used by the hub server’s WebRTC path), and the **WebTransport transport** (HTTP/3 over QUIC datagrams).
 - **Out of scope**: local-only IPC (e.g. `QLocalSocket` “AudioSocket”), OSC control, and any higher-level application semantics outside packet exchange.
 
 ### Transports at a glance
@@ -12,7 +12,7 @@ This document describes JackTrip’s **on-the-wire protocol** as implemented in 
 - **UDP (audio)**: real-time audio is sent as UDP datagrams containing `PacketHeader` + raw audio payload.
 - **UDP (control)**: a small fixed-size “stop” datagram is used to signal shutdown.
 - **TCP (hub/ping-server handshake)**: a short-lived TCP connection is used to exchange ephemeral UDP port information (and optionally do TLS + credentials). The client sends 4 bytes representing the port number it is binding to, and the server responds by sending 4 bytes representing its own port number.
-- **WebRTC data channel (audio)**: webtrip and the JackTrip hub server’s WebRTC path use a WebRTC data channel to carry the same packet format (header + planar audio payload) as the UDP stream. The same interleaving conversion applies. See `WebRtcDataProtocol.cpp`.
+- **WebRTC data channel (audio)**: JackTrip hub server’s WebRTC path uses a WebRTC data channel to carry the same packet format (header + planar audio payload) as the UDP stream. Signaling uses an encrypted WebSocket (`wss://`) on the hub TCP port; plain `ws://` is not accepted. The same interleaving conversion applies. See `WebRtcDataProtocol.cpp`.
 - **WebTransport / QUIC datagrams (audio)**: the hub server’s WebTransport path uses HTTP/3 over QUIC (via msquic) with unreliable QUIC datagrams (RFC 9221) to carry the same packet format as the UDP stream. The WebTransport session is established with an HTTP/3 CONNECT request before audio flows. See `src/webtransport/` and `src/http3/`.
 
 ---
@@ -251,14 +251,60 @@ JackTrip's WebRTC path carries the same audio packet format as the UDP stream bu
 
 The data channel is configured for **unordered, unreliable** delivery — equivalent to UDP semantics — to minimise latency. Retransmissions and head-of-line blocking are explicitly disabled.
 
-### Protocol detection on the TCP connection
+### Transport requirement: encrypted WebSocket (WSS)
 
-The hub server reuses the existing TCP handshake socket to multiplex both legacy UDP clients and WebRTC clients. On initial connection the server inspects the first bytes received:
+WebRTC clients **must** connect using an encrypted WebSocket (`wss://`). Plain-text WebSocket (`ws://`) is not accepted. This requirement exists because browsers only allow `wss://` from HTTPS pages, and because the TLS layer is what allows the server to multiplex WebRTC and legacy binary clients on the same port (see "Protocol detection" below).
 
-- **Legacy UDP client**: sends a raw 32-bit little-endian port number → normal hub/ping-server handshake proceeds.
-- **WebRTC client**: sends a JSON object containing a `"protocol"` field → the server switches into WebRTC signaling mode on the same socket.
+The server must be started with `--certfile` and `--keyfile` for WebRTC connections to succeed. Without a loaded TLS certificate, any TLS ClientHello is rejected with a logged error and the connection is closed.
 
-See `WebRtcSignalingProtocol::isWebRtcSignaling()` in `src/webrtc/WebRtcSignalingProtocol.cpp`.
+### Protocol detection on the hub TCP port
+
+The hub server multiplexes three connection types on a single TCP listen port. The server inspects the first three bytes of each new connection to route it correctly:
+
+| First 3 bytes (hex)             | Interpretation                                                                    |
+| ------------------------------- | --------------------------------------------------------------------------------- |
+| `16 03 01` through `16 03 04`   | TLS ClientHello (browser `wss://`) — start TLS handshake; re-detect after decrypt |
+| Anything else                   | Legacy binary hub protocol — read 32-bit LE port number                           |
+
+After the TLS handshake completes the server inspects the first decrypted bytes:
+
+| Decrypted content              | Interpretation                                               |
+| ------------------------------ | ------------------------------------------------------------ |
+| `GET /ping …`                  | Health-check endpoint — responds `{"status":"OK"}` and closes |
+| `GET /webrtc …`                | HTTP WebSocket upgrade → WebRTC signaling path               |
+| Other `GET …`                  | Unsupported path — responds HTTP 404 and closes              |
+| Other binary data              | Authenticated binary hub protocol (credentials follow)       |
+
+**Why 3 bytes are needed for unambiguous TLS detection**
+
+The binary protocol sends a 32-bit little-endian port number (≤ 65535) as its first 4 bytes, which means bytes 2 and 3 are always `0x00`. TLS record headers always have byte 2 set to `0x01`–`0x04` (the TLS minor version). Checking only the first byte would produce false positives: port 22 (`{0x16, 0x00, …}`) and port 790 (`{0x16, 0x03, 0x00, …}`) both start with byte sequences that overlap with TLS. Requiring all three bytes `{0x16, 0x03, 0x01–0x04}` is provably collision-free with any valid port number.
+
+See `UdpHubListener::readyRead()` in `src/UdpHubListener.cpp`.
+
+### Health-check endpoint (`GET /ping`)
+
+The hub server exposes a simple health-check endpoint on the same TLS port as WebRTC signaling. It is useful for diagnosing TLS and HTTP connectivity issues before attempting a WebSocket upgrade.
+
+**Request:**
+```
+GET /ping HTTP/1.1
+```
+
+**Response:**
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 15
+Connection: close
+
+{"status":"OK"}
+```
+
+The connection is closed immediately after the response is sent. The endpoint is only available when the binary is built with `WEBRTC_SUPPORT` and when TLS is configured (`--certfile` / `--keyfile`). A plain `curl` command can verify connectivity:
+
+```bash
+curl -k https://<host>:<port>/ping
+```
 
 ### Signaling message framing
 
@@ -270,13 +316,15 @@ All signaling messages are JSON objects framed with a **4-byte big-endian length
 
 ### Signaling flow
 
-1. Client sends `PROTOCOL_DETECT` message: `{"type": "protocol_detect", "protocol": 2, "clientName": "…", "version": 1}`.
-2. Server responds with its own `PROTOCOL_DETECT` acknowledgement.
-3. Client sends an `OFFER` message containing its SDP.
-4. Server sets the remote description, generates an answer, and sends an `ANSWER` message.
-5. Both sides exchange `ICE_CANDIDATE` messages as ICE candidates are gathered.
-6. ICE + DTLS handshake completes; the data channel (label `"audio"`) opens.
-7. Audio datagrams flow bidirectionally over the data channel.
+1. Client opens a TLS connection to the hub TCP port (`wss://`). The server detects the TLS ClientHello by its 3-byte record header and performs the TLS handshake.
+2. Client sends an HTTP `GET /webrtc` request with `Upgrade: websocket` headers. The server upgrades the connection to a WebSocket.
+3. Client sends `PROTOCOL_DETECT` message: `{"type": "protocol_detect", "protocol": 2, "clientName": "…", "version": 1}`.
+4. Server responds with its own `PROTOCOL_DETECT` acknowledgement.
+5. Client sends an `OFFER` message containing its SDP.
+6. Server sets the remote description, generates an answer, and sends an `ANSWER` message.
+7. Both sides exchange `ICE_CANDIDATE` messages as ICE candidates are gathered.
+8. ICE + DTLS handshake completes; the data channel (label `"audio"`) opens.
+9. Audio datagrams flow bidirectionally over the data channel.
 
 Either side can send a `HANGUP` message to terminate the session.
 

--- a/src/SslServer.cpp
+++ b/src/SslServer.cpp
@@ -46,14 +46,23 @@ void SslServer::incomingConnection(qintptr socketDescriptor)
     // an SslSocket rather than a regular socket.
     QSslSocket* sslSocket = new QSslSocket(this);
     sslSocket->setSocketDescriptor(socketDescriptor);
-    sslSocket->setLocalCertificate(m_certificate);
+    // Send the full certificate chain (leaf + intermediates) so browsers can
+    // verify trust all the way to a root CA. setLocalCertificate sends only the
+    // leaf cert, which causes browsers to reject the connection when intermediate
+    // CA certs are not already in their trust store.
+    sslSocket->setLocalCertificateChain(m_certificateChain);
     sslSocket->setPrivateKey(m_privateKey);
     this->addPendingConnection(sslSocket);
 }
 
 void SslServer::setCertificate(const QSslCertificate& certificate)
 {
-    m_certificate = certificate;
+    m_certificateChain = {certificate};
+}
+
+void SslServer::setCertificateChain(const QList<QSslCertificate>& chain)
+{
+    m_certificateChain = chain;
 }
 
 void SslServer::setPrivateKey(const QSslKey& key)

--- a/src/SslServer.h
+++ b/src/SslServer.h
@@ -37,6 +37,7 @@
 #ifndef __SSLSERVER_H__
 #define __SSLSERVER_H__
 
+#include <QList>
 #include <QSslCertificate>
 #include <QSslKey>
 #include <QTcpServer>
@@ -51,10 +52,11 @@ class SslServer : public QTcpServer
 
     void incomingConnection(qintptr socketDescriptor) override;
     void setCertificate(const QSslCertificate& certificate);
+    void setCertificateChain(const QList<QSslCertificate>& chain);
     void setPrivateKey(const QSslKey& key);
 
    private:
-    QSslCertificate m_certificate;
+    QList<QSslCertificate> m_certificateChain;
     QSslKey m_privateKey;
 };
 

--- a/src/UdpHubListener.cpp
+++ b/src/UdpHubListener.cpp
@@ -171,9 +171,9 @@ void UdpHubListener::start()
         return;
     }
 
-    if (mRequireAuth) {
-        cout << "JackTrip HUB SERVER: Enabling authentication" << endl;
-        // Check that SSL is available
+    // Load TLS cert+key whenever both files are provided — needed for mRequireAuth and
+    // for accepting WebRTC WSS (wss://) connections via TLS sniffing on port 4464.
+    if (!mCertFile.isEmpty() && !mKeyFile.isEmpty()) {
         bool error = false;
         QString error_message;
         if (!QSslSocket::supportsSsl()) {
@@ -183,21 +183,21 @@ void UdpHubListener::start()
                 "libraries\ninstalled to enable authentication.";
         }
 
-        if (mCertFile.isEmpty()) {
-            error         = true;
-            error_message = QStringLiteral("No certificate file specified.");
-        } else if (mKeyFile.isEmpty()) {
-            error         = true;
-            error_message = QStringLiteral("No private key file specified.");
-        }
-
-        // Load our certificate and private key
         if (!error) {
             QFile certFile(mCertFile);
             if (certFile.open(QIODevice::ReadOnly)) {
-                QSslCertificate cert(certFile.readAll());
-                if (!cert.isNull()) {
-                    mTcpServer.setCertificate(cert);
+                // Read all PEM blocks from the file so that the full certificate
+                // chain (leaf + any intermediate CA certs) is sent to clients.
+                // Using QSslCertificate(data) would silently read only the first
+                // block, leaving out intermediates that browsers need to verify trust.
+                QList<QSslCertificate> chain =
+                    QSslCertificate::fromData(certFile.readAll());
+                if (!chain.isEmpty() && !chain.first().isNull()) {
+                    mTcpServer.setCertificateChain(chain);
+                    if (chain.size() > 1) {
+                        cout << "JackTrip HUB SERVER: Loaded certificate chain ("
+                             << chain.size() << " certificates)" << endl;
+                    }
                 } else {
                     error         = true;
                     error_message = QStringLiteral("Unable to load certificate file.");
@@ -225,6 +225,30 @@ void UdpHubListener::start()
             }
         }
 
+        if (error) {
+            if (mRequireAuth) {
+                emit signalError(error_message);
+                return;
+            }
+            cerr << "JackTrip HUB SERVER: TLS certificate loading failed: "
+                 << error_message.toStdString() << endl;
+        } else {
+            mTlsConfigured = true;
+        }
+    }
+
+    if (mRequireAuth) {
+        cout << "JackTrip HUB SERVER: Enabling authentication" << endl;
+        bool error = false;
+        QString error_message;
+        if (mCertFile.isEmpty()) {
+            error         = true;
+            error_message = QStringLiteral("No certificate file specified.");
+        } else if (mKeyFile.isEmpty()) {
+            error         = true;
+            error_message = QStringLiteral("No private key file specified.");
+        }
+
         if (!error) {
             QFileInfo credsInfo(mCredsFile);
             if (!credsInfo.exists() || !credsInfo.isFile()) {
@@ -243,7 +267,12 @@ void UdpHubListener::start()
     startOscServer();
 
 #ifdef WEBRTC_SUPPORT
-    cout << "JackTrip HUB SERVER: WebRTC data channels enabled" << endl;
+    if (mTlsConfigured) {
+        cout << "JackTrip HUB SERVER: WebRTC data channels enabled" << endl;
+    } else {
+        cout << "JackTrip HUB SERVER: WebRTC data channels disabled (no TLS certificate)"
+             << endl;
+    }
 #endif
 
 #ifdef WEBTRANSPORT_SUPPORT
@@ -259,17 +288,12 @@ void UdpHubListener::start()
                 }
             });
         if (mHttp3Server->start()) {
-            cout << "JackTrip HUB SERVER: WebTransport (QUIC) enabled on UDP port "
-                 << mServerPort << endl;
+            cout << "JackTrip HUB SERVER: WebTransport enabled" << endl;
         } else {
-            cerr << "JackTrip HUB SERVER: Failed to initialize WebTransport (QUIC)"
-                 << endl;
+            cerr << "JackTrip HUB SERVER: Failed to initialize WebTransport" << endl;
             delete mHttp3Server;
             mHttp3Server = nullptr;
         }
-    } else if (mRequireAuth) {
-        cerr << "JackTrip HUB SERVER: WebTransport disabled (using cert for auth only)"
-             << endl;
     } else {
         cout << "JackTrip HUB SERVER: WebTransport disabled (no TLS certificate)" << endl;
     }
@@ -299,33 +323,36 @@ void UdpHubListener::receivedNewConnection()
 
 void UdpHubListener::readyRead(QSslSocket* clientConnection)
 {
-#ifdef WEBRTC_SUPPORT
     if (!clientConnection->isEncrypted()) {
-        // Check for HTTP-based upgrade requests (starts with "GET" or "CONNECT")
-        // These are WebRTC clients using WebSocket for signaling
-        // Note: WebTransport now uses QUIC (UDP) directly via msquic
-        QByteArray peekData = clientConnection->peek(512);
-
-        if (peekData.startsWith("GET") || peekData.startsWith("CONNECT")) {
-            // Disconnect all signals from this socket to UdpHubListener
-            // before transferring ownership
-            disconnect(clientConnection, nullptr, this, nullptr);
-
-            // This looks like an HTTP/WebSocket request for WebRTC
-            // Create a WebRTC worker - this will create a peer connection
-            // that manages the signaling internally
-            // Note: ownership of clientConnection is transferred to the peer connection
-            int workerId = createWebRtcWorker(clientConnection);
-            if (workerId < 0) {
-                cerr << "JackTrip HUB SERVER: No available slots for WebRTC client"
+        // Detect TLS ClientHello by inspecting the 3-byte TLS record header:
+        //   { 0x16, 0x03, minor } where minor is 0x01–0x04 (TLS 1.0–1.3).
+        // Checking 3 bytes is unambiguous: a valid port number sent by the binary hub
+        // protocol (a 32-bit LE integer ≤ 65535) requires bytes[2] == 0x00, so no valid
+        // port can collide with the TLS prefix. Port 22 (byte[0] == 0x16) and port 790
+        // (bytes[0,1] == {0x16, 0x03}) are the nearest false-positives with a shorter
+        // check; both are ruled out by the third byte. Wait for 3 bytes if they have
+        // not yet arrived rather than making a premature decision.
+        QByteArray header = clientConnection->peek(3);
+        if (header.size() < 3) {
+            return;
+        }
+        if (static_cast<unsigned char>(header[0]) == 0x16
+            && static_cast<unsigned char>(header[1]) == 0x03
+            && static_cast<unsigned char>(header[2]) >= 0x01
+            && static_cast<unsigned char>(header[2]) <= 0x04) {
+            cout << "JackTrip HUB SERVER: TLS ClientHello detected" << endl;
+            if (!mTlsConfigured) {
+                cerr << "JackTrip HUB SERVER: Received TLS ClientHello but no "
+                        "certificate is configured. Closing connection."
                      << endl;
                 clientConnection->close();
                 clientConnection->deleteLater();
+                return;
             }
+            clientConnection->startServerEncryption();
             return;
         }
     }
-#endif  // WEBRTC_SUPPORT
 
     QHostAddress PeerAddress = clientConnection->peerAddress();
     cout << "JackTrip HUB SERVER: Client Connect Received from Address : "
@@ -334,7 +361,6 @@ void UdpHubListener::readyRead(QSslSocket* clientConnection)
     // Get UDP port from client
     // ------------------------
     QString clientName = QString();
-    cout << "JackTrip HUB SERVER: Reading data from Client..." << endl;
     int peer_udp_port;
     if (!clientConnection->isEncrypted()) {
         if (clientConnection->bytesAvailable() < (int)sizeof(qint32)) {
@@ -374,6 +400,59 @@ void UdpHubListener::readyRead(QSslSocket* clientConnection)
             return;
         }
     } else {
+        // Socket is in SSL mode. Check for a WebSocket upgrade before falling through to
+        // the binary authentication flow — browsers send HTTP GET after the TLS
+        // handshake.
+#ifdef WEBRTC_SUPPORT
+        QByteArray peekData = clientConnection->peek(512);
+        if (peekData.startsWith("GET")) {
+            // Extract the request line to check for the /ping health-check endpoint.
+            // This lets browser clients verify TLS + HTTP connectivity before
+            // attempting a WebSocket upgrade, which is useful for diagnosing
+            // connection issues.
+            QByteArray requestLine = peekData.left(peekData.indexOf('\r'));
+            if (requestLine.contains(" /ping ") || requestLine.endsWith(" /ping")) {
+                cout << "JackTrip HUB SERVER: Responding to /ping health check" << endl;
+                static const char kPingResponse[] =
+                    "HTTP/1.1 200 OK\r\n"
+                    "Content-Type: application/json\r\n"
+                    "Content-Length: 15\r\n"
+                    "Connection: close\r\n"
+                    "\r\n"
+                    "{\"status\":\"OK\"}";
+                clientConnection->write(kPingResponse, sizeof(kPingResponse) - 1);
+                clientConnection->flush();
+                clientConnection->disconnectFromHost();
+                return;
+            } else if (requestLine.contains(" /webrtc ")
+                       || requestLine.endsWith(" /webrtc")) {
+                cout << "JackTrip HUB SERVER: WebRTC connection detected" << endl;
+                disconnect(clientConnection, nullptr, this, nullptr);
+                int workerId = createWebRtcWorker(clientConnection);
+                if (workerId < 0) {
+                    cerr << "JackTrip HUB SERVER: No available slots for WebRTC client"
+                         << endl;
+                    clientConnection->close();
+                    clientConnection->deleteLater();
+                }
+                return;
+            } else {
+                // respond with 404 Not Found
+                static const char kBadRequestResponse[] =
+                    "HTTP/1.1 404 Not Found\r\n"
+                    "Content-Type: application/json\r\n"
+                    "Content-Length: 19\r\n"
+                    "Connection: close\r\n"
+                    "\r\n"
+                    "{\"status\":\"Bad Request\"}";
+                clientConnection->write(kBadRequestResponse,
+                                        sizeof(kBadRequestResponse) - 1);
+                clientConnection->flush();
+                clientConnection->disconnectFromHost();
+                return;
+            }
+        }
+#endif  // WEBRTC_SUPPORT
         // This branch executes when our socket is already in SSL mode and we're expecting
         // to read our authentication data.
         peer_udp_port = checkAuthAndReadPort(clientConnection, clientName);

--- a/src/UdpHubListener.h
+++ b/src/UdpHubListener.h
@@ -203,7 +203,8 @@ class UdpHubListener : public QObject
     // addressPortNameTriple mActiveAddress[gMaxThreads]; ///< Active address pool
     // addresses QHash<QString, uint16_t> mActiveAddressPortPair;
 
-    bool mRequireAuth;
+    bool mRequireAuth   = false;
+    bool mTlsConfigured = false;
     QString mCertFile;
     QString mKeyFile;
     QString mCredsFile;


### PR DESCRIPTION
Web browsers don't support unencrypted WebSockets to remote hosts, even if referred from an unencrypted web page. So there really is no use case where this would work without TLS.

Read and send full certificate chain in PEM file, not just the first