### PR TITLE
Fix for race condition involving WebRTC ICE candidates

### DIFF
--- a/src/JackTrip.h
+++ b/src/JackTrip.h
@@ -655,8 +655,7 @@ class JackTrip : public QObject
      */
     void slotUdpWaitingTooLongClientGoneProbably(int wait_msec)
     {
-        int wait_time = 10000;  // msec
-        if (!(wait_msec % wait_time)) {
+        if (!(wait_msec % gClientGoneTimeoutMs)) {
             std::cerr << "UDP WAITED MORE THAN 10 seconds." << std::endl;
             if (mStopOnTimeout) {
                 stop(QStringLiteral("No network data received for 10 seconds"));

--- a/src/jacktrip_globals.h
+++ b/src/jacktrip_globals.h
@@ -88,6 +88,8 @@ constexpr const char* gDefaultLocalAddress = "";
 constexpr int gDefaultRedundancy           = 1;
 constexpr int gTimeOutMultiThreadedServer  = 10000;  // seconds
 constexpr int gUdpWaitTimeout              = 512;    // milliseconds
+constexpr int gClientGoneTimeoutMs =
+    10000;  ///< Close session after this many ms with no received packets
 //@}
 
 //*******************************************************************************

--- a/src/webrtc/WebRtcDataProtocol.cpp
+++ b/src/webrtc/WebRtcDataProtocol.cpp
@@ -522,4 +522,12 @@ void WebRtcDataProtocol::printWaitedTooLong(int wait_msec)
                  << "ms) for data..." << endl;
         }
     }
+    // After gClientGoneTimeoutMs with no received packets the client is probably gone.
+    // Close the data channel so cleanup happens promptly.
+    // Mirrors slotUdpWaitingTooLongClientGoneProbably.
+    if (wait_msec >= gClientGoneTimeoutMs && mDataChannel && mDataChannel->isOpen()) {
+        cerr << "WebRTC: No packets for " << wait_msec
+             << "ms — closing data channel (client probably gone)" << endl;
+        mDataChannel->close();
+    }
 }

--- a/src/webrtc/WebRtcPeerConnection.cpp
+++ b/src/webrtc/WebRtcPeerConnection.cpp
@@ -64,6 +64,7 @@ WebRtcPeerConnection::WebRtcPeerConnection(const QStringList& iceServers,
     , mPortRangeEnd(portRangeEnd)
     , mState(STATE_NEW)
     , mIsOfferer(false)
+    , mRemoteDescriptionSet(false)
 {
     initPeerConnection();
 }
@@ -80,6 +81,7 @@ WebRtcPeerConnection::WebRtcPeerConnection(QSslSocket* signalingSocket,
     , mPortRangeEnd(portRangeEnd)
     , mState(STATE_NEW)
     , mIsOfferer(false)
+    , mRemoteDescriptionSet(false)
 {
     initPeerConnection();
 
@@ -308,6 +310,11 @@ bool WebRtcPeerConnection::setRemoteOffer(const QString& sdp)
 
         rtc::Description description(sdp.toStdString(), rtc::Description::Type::Offer);
         mPeerConnection->setRemoteDescription(description);
+        mRemoteDescriptionSet = true;
+
+        // Flush any candidates that arrived before the offer (trickle ICE buffering).
+        // Some clients (e.g. Safari) send ICE candidates before the SDP offer.
+        flushPendingCandidates();
 
         return true;
 
@@ -332,6 +339,22 @@ bool WebRtcPeerConnection::addRemoteCandidate(const QString& candidate,
         return false;
     }
 
+    // Queue the candidate if setRemoteDescription hasn't been called yet.
+    // Safari (and some other implementations) send ICE candidates before the
+    // SDP offer via trickle ICE, so we must buffer them and apply them once
+    // the remote description is set.
+    if (!mRemoteDescriptionSet) {
+        mPendingCandidates.append(qMakePair(candidate, sdpMid));
+        return true;
+    }
+
+    return applyRemoteCandidate(candidate, sdpMid);
+}
+
+//*******************************************************************************
+bool WebRtcPeerConnection::applyRemoteCandidate(const QString& candidate,
+                                                const QString& sdpMid)
+{
     try {
         rtc::Candidate cand(candidate.toStdString(), sdpMid.toStdString());
         mPeerConnection->addRemoteCandidate(cand);
@@ -341,6 +364,15 @@ bool WebRtcPeerConnection::addRemoteCandidate(const QString& candidate,
         cerr << "Failed to add remote candidate: " << e.what() << endl;
         return false;
     }
+}
+
+//*******************************************************************************
+void WebRtcPeerConnection::flushPendingCandidates()
+{
+    for (const auto& pending : mPendingCandidates) {
+        applyRemoteCandidate(pending.first, pending.second);
+    }
+    mPendingCandidates.clear();
 }
 
 //*******************************************************************************

--- a/src/webrtc/WebRtcPeerConnection.h
+++ b/src/webrtc/WebRtcPeerConnection.h
@@ -38,7 +38,9 @@
 #ifndef __WEBRTCPEERCONNECTION_H__
 #define __WEBRTCPEERCONNECTION_H__
 
+#include <QList>
 #include <QObject>
+#include <QPair>
 #include <QString>
 #include <QStringList>
 #include <memory>
@@ -247,6 +249,12 @@ class WebRtcPeerConnection : public QObject
     // Create data channel with appropriate settings for audio
     std::shared_ptr<rtc::DataChannel> createAudioDataChannel(const QString& label);
 
+    // Apply a single remote candidate (requires remote description to be set)
+    bool applyRemoteCandidate(const QString& candidate, const QString& sdpMid);
+
+    // Flush candidates that were queued before the remote description was set
+    void flushPendingCandidates();
+
     // State management
     void setState(ConnectionState state);
 
@@ -267,7 +275,11 @@ class WebRtcPeerConnection : public QObject
     ConnectionState mState;
     QString mLocalDescription;
     QString mPeerAddress;
-    bool mIsOfferer;  // true if we created the offer
+    bool mIsOfferer;             // true if we created the offer
+    bool mRemoteDescriptionSet;  // true after setRemoteDescription has been called
+
+    // Candidates received before setRemoteDescription was called (trickle ICE buffering)
+    QList<QPair<QString, QString>> mPendingCandidates;
 };
 
 #endif  // __WEBRTCPEERCONNECTION_H__

--- a/src/webtransport/WebTransportDataProtocol.cpp
+++ b/src/webtransport/WebTransportDataProtocol.cpp
@@ -92,6 +92,15 @@ WebTransportDataProtocol::WebTransportDataProtocol(JackTrip* jacktrip,
         // Connect to session closed signal (non-audio path, Qt signal is fine)
         connect(mSession, &WebTransportSession::sessionClosed, this,
                 &WebTransportDataProtocol::onSessionClosed, Qt::QueuedConnection);
+
+        // Also stop loops when the session fails (transport-initiated shutdown sets
+        // STATE_FAILED, which prevents SHUTDOWN_COMPLETE from emitting sessionClosed)
+        connect(
+            mSession, &WebTransportSession::sessionFailed, this,
+            [this](const QString&) {
+                this->onSessionClosed();
+            },
+            Qt::QueuedConnection);
     }
 
     // Connect waiting too long signal
@@ -399,6 +408,14 @@ void WebTransportDataProtocol::runReceiver(int full_packet_size)
             emit signalWaitingTooLong(timeSinceLastPacket);
         }
     }
+
+    // If the loop exited because mStopped was set (e.g., exit control packet) but the
+    // session is still open, close it explicitly. This fires sessionClosed on both the
+    // RECEIVER and SENDER instances, stopping the sender and triggering full cleanup.
+    // Mirrors the printWaitedTooLong path for idle timeout.
+    if (mStopped && mSession && mSession->isConnected()) {
+        mSession->close();
+    }
 }
 
 //*******************************************************************************
@@ -520,9 +537,13 @@ void WebTransportDataProtocol::processReceivedPacket(int8_t* packet, int packet_
 //*******************************************************************************
 void WebTransportDataProtocol::processControlPacket(const char* buf, size_t size)
 {
+    if (size != static_cast<size_t>(mControlPacketSize)) {
+        return;
+    }
+
     // Check for exit signal (all 0xFF)
     bool isExit = true;
-    for (size_t i = 0; i < size && i < 8; i++) {
+    for (size_t i = 0; i < size; i++) {
         if (static_cast<uint8_t>(buf[i]) != 0xFF) {
             isExit = false;
             break;
@@ -565,6 +586,15 @@ void WebTransportDataProtocol::printWaitedTooLong(int wait_msec)
         cerr << "WebTransportDataProtocol: Waited " << wait_msec << " ms for packet"
              << endl;
     }
+
+    // After 10 seconds of no received packets the client is probably gone.
+    // Actively close the session so cleanup happens promptly rather than waiting
+    // for the QUIC idle timeout (~30s). Mirrors slotUdpWaitingTooLongClientGoneProbably.
+    if (wait_msec >= gClientGoneTimeoutMs && mSession && mSession->isConnected()) {
+        cerr << "WebTransportDataProtocol: No packets for " << wait_msec
+             << "ms — closing session (client probably gone)" << endl;
+        mSession->close();
+    }
 }
 
 //*******************************************************************************
@@ -584,14 +614,15 @@ void WebTransportDataProtocol::onDatagramReceived(const uint8_t* data, size_t le
         return;
     }
 
-    // Reset timeout counter atomically
-    mTimeSinceLastPacket.store(0);
-
-    // Check for control packet
+    // Check for control packet BEFORE resetting the idle timer so that exit packets
+    // don't appear as audio activity and suppress the printWaitedTooLong fallback.
     if (len == static_cast<size_t>(mControlPacketSize)) {
         processControlPacket(reinterpret_cast<const char*>(data), len);
         return;
     }
+
+    // Reset timeout counter atomically (audio packets only)
+    mTimeSinceLastPacket.store(0);
 
     if (len < sizeof(DefaultHeaderStruct)) {
         return;


### PR DESCRIPTION
Pretty easy to trigger in Safari or Firefox

Failed to add remote candidate: Got a remote candidate without remote description

Updated WebRTC and WebTransport connections to time out after 10s