### PR TITLE
Adding some more constraints on the growth of auto headroom

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -365,7 +365,8 @@ jobs:
           if [[ "${{ matrix.build-system }}" == "meson" ]]; then
             sudo apt-get install --yes help2man
             python -m pip install --upgrade pip
-            pip install meson pyyaml Jinja2
+            # meson 1.11.0 broke qt support, so use 1.10.2 until it's fixed
+            pip install meson==1.10.2 pyyaml Jinja2
           fi
           if [[ "${{ matrix.libsamplerate }}" == true ]]; then
             sudo apt-get install --yes libsamplerate-dev
@@ -399,7 +400,8 @@ jobs:
             brew install help2man
             # use pip to install meson to avoid python dependency conflicts in HomeBrew
             python -m pip install --upgrade pip
-            pip install meson
+            # meson 1.11.0 broke qt support, so use 1.10.2 until it's fixed
+            pip install meson==1.10.2
           fi
       - name: Use Msys utils for Windows
         if: runner.os == 'Windows'

--- a/linux/Dockerfile.build
+++ b/linux/Dockerfile.build
@@ -27,7 +27,7 @@ RUN apt-get update \
   && apt-get install -yq --no-install-recommends help2man clang-tidy desktop-file-utils
 RUN python3 -m pip install --upgrade pip \
   && python3 -m pip install --upgrade certifi \
-  && python3 -m pip install meson pyyaml Jinja2
+  && python3 -m pip install meson==1.10.2 pyyaml Jinja2
 
 WORKDIR /opt/jacktrip
 

--- a/src/Regulator.cpp
+++ b/src/Regulator.cpp
@@ -98,7 +98,7 @@ constexpr int HISTFPP      = 128;    // default FPP when calibrating burg window
 
 constexpr int NumSlots   = 4096;   // NumSlots looped for recent arrivals
 constexpr double AutoMax = 250.0;  // msec bounds on insane IPI, like ethernet unplugged
-constexpr double AutoInitDur = 2000.0;  // kick in auto after this many msec
+constexpr double AutoInitDur = 3000.0;  // kick in auto after this many msec
 constexpr double AutoInitValFactor =
     0.5;  // scale for initial mMsecTolerance during init phase if unspecified
 
@@ -503,11 +503,12 @@ void Regulator::updateTolerance(int glitches, int skipped)
             } else {
                 // don't increase headroom two intervals in a row
                 mSkipAutoHeadroom = true;
-                if (mLastMaxLatency > mMsecTolerance + 1) {
-                    // increase headroom enough to cover any skipped packets
+                if (mLastMaxLatency > mMsecTolerance + 3.0) {
+                    // special case to grow headroom faster to catch up
                     mCurrentHeadroom = std::min<double>(
                         maxHeadroom,
-                        mCurrentHeadroom + std::ceil(mLastMaxLatency - mMsecTolerance));
+                        mCurrentHeadroom
+                            + std::ceil((mLastMaxLatency - mMsecTolerance) / 2.0));
                 } else {
                     ++mCurrentHeadroom;
                 }
@@ -572,7 +573,8 @@ void Regulator::updatePushStats(int seq_num)
                 // a calculated tolerance. Otherwise, the switch can
                 // sometimes cause it to bump headroom prematurely even
                 // though there are no real audio glitches.
-                mStatsMaxLatency = 0;  // ignore during warmup
+                mLastMaxLatency  = 0;  // ignore during warmup
+                mStatsMaxLatency = 0;
                 updateTolerance(0, 0);
             } else {
                 mLastMaxLatency  = mStatsMaxLatency;  // only set after warmup
@@ -599,7 +601,7 @@ void Regulator::setQueueBufferLength(int queueBuffer)
         mAutoHeadroom          = -1;
         mCurrentHeadroom       = 0;
         mSkipAutoHeadroom      = true;
-        mAutoHeadroomStartTime = pushStat ? (pushStat->lastTime + AutoInitDur) : 4000.0;
+        mAutoHeadroomStartTime = pushStat ? (pushStat->lastTime + AutoInitDur) : 6000.0;
     } else {
         mAutoHeadroom    = std::abs(queueBuffer);
         mCurrentHeadroom = mAutoHeadroom;

--- a/src/Regulator.h
+++ b/src/Regulator.h
@@ -306,7 +306,7 @@ class Regulator : public RingBuffer
     double mStatsMaxLatency       = 0;
     double mStatsMaxPLCdspElapsed = 0;
     double mCurrentHeadroom       = 0;
-    double mAutoHeadroomStartTime = 4000.0;
+    double mAutoHeadroomStartTime = 6000.0;
     double mAutoHeadroom          = -1;
     Time* mTime                   = nullptr;
 

--- a/src/jacktrip_globals.cpp
+++ b/src/jacktrip_globals.cpp
@@ -169,7 +169,7 @@ void setRealtimeProcessPriority()
             priority = "idle";
             break;
         case NORMAL_PRIORITY_CLASS:
-            priority = "high";
+            priority = "normal";
             break;
         case REALTIME_PRIORITY_CLASS:
             priority = "realtime";


### PR DESCRIPTION
Give a little bit more adjustment time during startup. Especially for Windows (which has poor kernel scheduling) I have observed it can take a little longer for things to stabalize. Even on a very fast and powerful computer.

Half the adjustment when growing headroom by more than 1ms. This just adds a little more safety over it growing too fast.

Zero both mLastMaxLatency and mStatsMaxLatency during warmup period.

Fix log typo when setting realtime priority on windows.