### PR TITLE
Fix for segmentation fault observed on OSX when sending deeplinks

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -12,6 +12,7 @@
   - (fixed) Use DSCP value of 46 instead of 56 for UDP packets
   - (fixed) Added guards to protect against buffer overflows
   - (fixed) Deep links were sometimes being ignored on Windows
+  - (fixed) Sending deep links caused segmentation fault on OSX
   - (fixed) Stats timer lifecycle issues
 - Version: "2.7.2"
   Date: 2026-02-06

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,6 +46,7 @@
 #include "jacktrip_globals.h"
 
 #ifndef NO_GUI
+#include "SocketClient.h"
 #include "UserInterface.h"
 #endif
 
@@ -175,6 +176,30 @@ int main(int argc, char* argv[])
         // Start the GUI
         cliSettings.reset(new Settings(true));
         cliSettings->parseInput(argc, argv);
+        if (!cliSettings->getDeeplink().isEmpty()) {
+            SocketClient c;
+            if (c.connect()) {
+                if (!c.sendHeader(QStringLiteral("deeplink"))) {
+                    std::cerr << "Failed to send deeplink header" << std::endl;
+                    c.close();
+                    return 1;
+                }
+                QLocalSocket& s          = c.getSocket();
+                QByteArray deepLinkBytes = cliSettings->getDeeplink().toLocal8Bit();
+                qint64 bytesWritten      = s.write(deepLinkBytes);
+                s.flush();
+                s.waitForBytesWritten(1000);
+                if (bytesWritten != deepLinkBytes.size()) {
+                    std::cerr << "Failed to send deeplink" << std::endl;
+                    c.close();
+                    return 1;
+                }
+                std::cout << "sent deeplink: " << cliSettings->getDeeplink().toStdString()
+                          << std::endl;
+                c.close();
+                return 0;
+            }
+        }
         interface.reset(new UserInterface(cliSettings));
         interface->start(guiApp);
         return app->exec();

--- a/src/vs/virtualstudio.cpp
+++ b/src/vs/virtualstudio.cpp
@@ -69,7 +69,6 @@
 #include "../AudioSocket.h"
 #include "../JackTrip.h"
 #include "../Settings.h"
-#include "../SocketClient.h"
 #include "../SocketServer.h"
 #include "../jacktrip_globals.h"
 #include "JTApplication.h"
@@ -254,38 +253,11 @@ VirtualStudio::VirtualStudio(UserInterface& parent)
     ts = new QTextStream(&outFile);
     qInstallMessageHandler(qtMessageHandler);
 
-    // check if started with a deep link to handle jacktrip://join/<StudioID>
-    QString deepLinkStr = m_interface.getSettings().getDeeplink();
-    if (!deepLinkStr.isEmpty()) {
-        // started with a deep link; check if another instance is already running
-        SocketClient c;
-        if (c.connect()) {
-            // existing instance found; send deeplink to it and exit
-            if (!c.sendHeader("deeplink")) {
-                c.close();
-                std::cerr << "Failed to send deeplink header" << std::endl;
-                std::exit(1);
-            }
-            QLocalSocket& s          = c.getSocket();
-            QByteArray deepLinkBytes = deepLinkStr.toLocal8Bit();
-            qint64 bytesWritten      = s.write(deepLinkBytes);
-            s.flush();
-            s.waitForBytesWritten(1000);
-            if (bytesWritten != deepLinkBytes.size()) {
-                c.close();
-                std::cerr << "Failed to send deeplink" << std::endl;
-                std::exit(1);
-            }
-            std::cout << "sent deeplink: " << deepLinkStr.toStdString() << std::endl;
-            c.close();
-            std::exit(0);
-        }
-    }
-
     // prepare handler for deep link requests
     m_deepLinkPtr.reset(new VsDeeplink());
     QObject::connect(m_deepLinkPtr.get(), &VsDeeplink::signalVsDeeplink, this,
                      &VirtualStudio::handleDeeplinkRequest, Qt::QueuedConnection);
+    QString deepLinkStr = m_interface.getSettings().getDeeplink();
     if (!deepLinkStr.isEmpty()) {
         QUrl deepLinkUrl(deepLinkStr);
         m_deepLinkPtr->handleUrl(deepLinkUrl);


### PR DESCRIPTION
This moves the deeplink sending up earlier into main rather than calling std::exit() from within the VirtualStudio constructor.