### PR TITLE
Fix wrong-slot cleanup for WebRTC/WebTransport hub workers

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -475,6 +475,17 @@ if found_msquic
 		'src/webtransport/WebTransportSession.h',
 		'src/webtransport/WebTransportDataProtocol.h'
 	]
+	# msquic is statically linked against its own OpenSSL (libcrypto.a/libssl.a).
+	# Without this flag those ~2700 OpenSSL symbols land in the executable's dynamic
+	# symbol table and interpose the system libssl/libcrypto that Qt dlopens at runtime.
+	# The result: Qt parses an X509 with one OpenSSL while SSL_CTX_use_certificate runs
+	# against the other, so server-side TLS fails with "Error loading local certificate"
+	# (empty OpenSSL detail) and the WebRTC/ping handshake hangs. Keeping static-archive
+	# symbols local stops the interposition. GNU ld / lld only; harmless on the BSD-style
+	# macOS linker path, so restrict to Linux where the conflict occurs.
+	if host_machine.system() == 'linux'
+		link_args += '-Wl,--exclude-libs,ALL'
+	endif
 endif
 
 if host_machine.system() == 'darwin'

--- a/plans/defer-webtransport-worker-creation.md
+++ b/plans/defer-webtransport-worker-creation.md
@@ -1,0 +1,160 @@
+# Plan: Defer WebTransport worker creation until session is established
+
+## Background / motivation
+
+The HUB server currently allocates a full `JackTripWorker` for **every incoming QUIC
+connection**, at `QUIC_LISTENER_EVENT_NEW_CONNECTION` — i.e. *before* the QUIC/TLS
+handshake and HTTP/3 `CONNECT` complete.
+
+Observed symptom: Firefox on Fedora opens **two** QUIC connections from the same client
+IP (different source ports). One completes the WebTransport handshake and streams audio;
+the other is abandoned and dies with `SHUTDOWN_INITIATED_BY_TRANSPORT` ("Transport
+shutdown"). Because a worker is created up-front, the abandoned connection:
+
+- transiently bumps `mTotalRunningThreads` (the misleading `Total Running Threads: 2`
+  for a single client),
+- allocates a heavyweight `JackTrip` instance (audio interface, ring buffers) that is
+  immediately torn down,
+- produces "session failed" / shutdown log spam.
+
+This is benign today (the original wrong-slot cleanup bug was fixed by assigning the
+worker's slot id in `createWorker`, see `UdpHubListener::createWorker` →
+`worker->setID(id)`), but it is wasteful and noisy. It also makes the server fragile to
+any client (or scanner/probe) that opens speculative or half-open QUIC connections, not
+just Firefox.
+
+**Goal:** only the lightweight `WebTransportSession` is created at `NEW_CONNECTION`. The
+heavyweight `JackTripWorker` + slot allocation is deferred until the session actually
+reaches `sessionEstablished` (HTTP/3 `CONNECT` accepted with status 200). Connections that
+never establish never consume a worker slot or bump the thread count.
+
+## Current flow (for reference)
+
+1. `Http3Server` listener callback `QUIC_LISTENER_EVENT_NEW_CONNECTION`
+   (`src/http3/Http3Server.cpp:239`) accepts the connection, sets its config, then invokes
+   `mConnectionCallback(connection, addr, port)`.
+2. That callback is `UdpHubListener::createWebTransportWorker(...)`
+   (`src/UdpHubListener.cpp:991`), which:
+   - calls `createWorker()` → finds a free slot, `new JackTripWorker`, `setID(id)`,
+     `mTotalRunningThreads++`, stores in `mJTWorkers[id]`;
+   - `worker->moveToThread(listenerThread)`;
+   - connects `signalRemoveThread → handleWorkerRemoval`;
+   - `new WebTransportSession(quicApi, connection, addr, port, nullptr)` — the session
+     registers itself as the QUIC connection callback handler in its constructor
+     (`src/webtransport/WebTransportSession.cpp:122`);
+   - `session->moveToThread(listenerThread)`;
+   - `worker->createWebTransportSession(session)` — reparents session to worker and wires
+     `sessionEstablished/Closed/Failed` to the worker's slots
+     (`src/JackTripWorker.cpp:607`).
+3. On `sessionEstablished`, `JackTripWorker::onWebTransportSessionEstablished()` configures
+   `JackTrip` (ports, channels, protocol) but does **not** start audio yet.
+4. On the first datagram, `receivedFirstPacketWebTransport → processPeerSettings →
+   startProcess` actually starts the audio pipeline (`mRunning = true`).
+
+The key insight: **the `WebTransportSession` must exist at `NEW_CONNECTION`** (it is the
+QUIC callback handler — without it, nothing services the handshake). But the
+`JackTripWorker` is only needed once the session is established.
+
+## Proposed design
+
+### Ownership of the pending session
+
+Introduce a "pending session" stage owned by `UdpHubListener` (it already owns the
+`Http3Server` and is the connection delegate):
+
+- Add a container, e.g. `QHash<WebTransportSession*, /*placeholder*/ bool>` or simply a
+  `QSet<WebTransportSession*> mPendingWtSessions`, guarded by `mMutex`.
+- At `NEW_CONNECTION` (replace `createWebTransportWorker`):
+  1. `auto* session = new WebTransportSession(quicApi, connection, addr, port, nullptr);`
+  2. `session->moveToThread(this->thread());`
+  3. Connect, with `Qt::QueuedConnection`:
+     - `session->sessionEstablished → UdpHubListener::onWebTransportSessionEstablished(session)`
+     - `session->sessionFailed     → UdpHubListener::onPendingSessionGone(session)`
+     - `session->sessionClosed     → UdpHubListener::onPendingSessionGone(session)`
+  4. Insert into `mPendingWtSessions`.
+  5. **Do not** call `createWorker()`, do not bump `mTotalRunningThreads`.
+
+   Because `sessionEstablished` is connected via a queued connection, it is delivered on
+   the listener thread's event loop, so worker creation happens on the right thread.
+
+### Promotion to a worker (on establish)
+
+`UdpHubListener::onWebTransportSessionEstablished(WebTransportSession* session)`:
+
+1. Under `mMutex`, remove `session` from `mPendingWtSessions`. If it was not present
+   (already failed/closed), bail out.
+2. `int id = createWorker(tempName);` (this assigns slot + `setID(id)` +
+   `mTotalRunningThreads++`).
+   - If `id < 0` (no free slots), `session->close(); session->deleteLater();` and return —
+     reject gracefully.
+3. `JackTripWorker* worker = mJTWorkers->at(id);`
+4. `worker->moveToThread(this->thread());`
+5. `connect(worker, signalRemoveThread, this, handleWorkerRemoval, QueuedConnection);`
+6. **Re-wire the session to the worker.** The session is already CONNECTED, so the
+   worker's `createWebTransportSession()` "already connected → onWebTransportSessionEstablished"
+   fast-path (`src/JackTripWorker.cpp:644`) will run and configure `JackTrip`. Verify the
+   signal connections set up inside `createWebTransportSession` (sessionEstablished/Closed/
+   Failed → worker slots) plus the datagram callback are correct given the session is
+   already established. The `isConnected()` branch already exists for exactly this case.
+7. Disconnect the temporary `UdpHubListener`-side session signal connections from step
+   "pending" (so they don't double-fire alongside the worker's connections).
+
+### Cleanup of a pending session that never establishes (on fail/close)
+
+`UdpHubListener::onPendingSessionGone(WebTransportSession* session)`:
+
+1. Under `mMutex`, if `session` is still in `mPendingWtSessions`, erase it and
+   `session->deleteLater();`. No worker, no thread-count change, minimal logging
+   (gate behind `gVerboseFlag`).
+2. If it is **not** in the set, it was already promoted to a worker — ignore (the worker's
+   own `onWebTransportSessionFailed/Closed` path handles teardown).
+
+### Thread-safety notes
+
+- The session is created on the msquic thread (the listener callback runs there), then
+  `moveToThread(this->thread())`. All subsequent signal handling is queued onto the
+  listener thread — same pattern as today.
+- `mPendingWtSessions` mutations must be under `mMutex` (consistent with `mJTWorkers`
+  access).
+- There is an inherent race: `sessionFailed` and `sessionEstablished` could both be
+  emitted. Using set membership as the single source of truth (whoever removes it first
+  wins) resolves it: establish promotes, fail/close frees, and the second handler sees the
+  session is no longer pending and no-ops.
+
+## Files to change
+
+| File | Change |
+|------|--------|
+| `src/UdpHubListener.h` | Add `QSet<WebTransportSession*> mPendingWtSessions;` member; declare `onWebTransportSessionEstablished(WebTransportSession*)` and `onPendingSessionGone(WebTransportSession*)` slots; keep/retire `createWebTransportWorker`. |
+| `src/UdpHubListener.cpp` | Replace `createWebTransportWorker` body with "create pending session only"; add the two new slots; ensure the `Http3Server` connection callback (`src/UdpHubListener.cpp:289`) calls the new entry point. |
+| `src/JackTripWorker.cpp` / `.h` | Likely no structural change — `createWebTransportSession()` already handles the "already connected" case. Confirm the established-on-attach path fully configures and that no second `sessionEstablished` is required. |
+| `src/webtransport/WebTransportSession.*` | No change expected; it already emits `sessionEstablished/Failed/Closed` and self-registers as the QUIC handler. |
+
+## Testing / verification
+
+1. **Single Chrome/Safari client (baseline):** one QUIC connection → `Total Running
+   Threads: 1`, audio streams. No regression.
+2. **Firefox on Fedora (repro case):** two QUIC connections; the abandoned one should now
+   produce **no** worker and **no** thread-count bump. Expect at most a single gated
+   "pending session failed" verbose line, and `Total Running Threads: 1`.
+3. **Slot exhaustion:** with `-p N` and N active clients, an additional establishing
+   session should be rejected cleanly (`session->close()`), not crash.
+4. **Rapid connect/disconnect:** client that connects and immediately drops mid-handshake
+   — pending session is freed, no leak. Watch for the
+   `WebTransportDataProtocol::stop: thread did not finish within 1s` warning (should not
+   appear).
+5. **Probe/scan:** point a QUIC scanner at the port — connections that never send a
+   `CONNECT` should be reaped by msquic idle timeout with no worker allocation.
+6. Run under `-V` (verbose) to confirm the gated diagnostics tell a coherent story:
+   pending-created → established → worker N, or pending-created → gone.
+
+## Out of scope / notes
+
+- This does **not** address *why* Firefox-on-Fedora opens a second connection — that is a
+  client/browser behavior (suspected Firefox QUIC connection racing) and cannot be fixed
+  server-side. This plan only makes the server robust and quiet in the face of it.
+- The same up-front-allocation pattern exists for **WebRTC** (`createWebRtcWorker`,
+  `src/UdpHubListener.cpp:948`). If WebRTC shows similar speculative-connection churn, a
+  parallel deferral could be applied, but it is not covered here.
+- Keep the `mID`/slot-assignment fix (`createWorker` → `setID(id)`) regardless; it is
+  independent and already correct.

--- a/src/JMess.cpp
+++ b/src/JMess.cpp
@@ -55,11 +55,9 @@ JMess::JMess()
     mClient = jack_client_open("lsp", JackNoStartServer, &mStatus);
     if (mClient == NULL) {
         if (mStatus & JackServerFailed) {
-            std::cerr << "JACK server not running"
-                      << "\n";
+            std::cerr << "JACK server not running" << "\n";
         } else {
-            std::cerr << "jack_client_open() failed, "
-                      << "status = 0x%2.0x\n"
+            std::cerr << "jack_client_open() failed, " << "status = 0x%2.0x\n"
                       << mStatus << "\n";
         }
         exit(1);
@@ -74,8 +72,7 @@ JMess::JMess()
 JMess::~JMess()
 {
     if (jack_client_close(mClient))
-        std::cerr << "ERROR: Could not close the hidden jmess jack client."
-                  << "\n";
+        std::cerr << "ERROR: Could not close the hidden jmess jack client." << "\n";
 }
 
 //*******************************************************************************

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -1269,6 +1269,10 @@ void JackTrip::stop(const QString& errorMessage)
     mStopped          = true;
     // Make sure we're only run once
     if (mHasShutdown) {
+        if (gVerboseFlag) {
+            std::cout << "JackTrip::stop: already shut down, ignoring duplicate call"
+                      << std::endl;
+        }
         return;
     }
     mHasShutdown = true;

--- a/src/JackTripWorker.cpp
+++ b/src/JackTripWorker.cpp
@@ -754,8 +754,8 @@ void JackTripWorker::onWebTransportSessionFailed(const QString& reason)
         cout << "JackTripWorker: worker=" << mID << " failure state mRunning=" << mRunning
              << " mSpawning=" << mSpawning;
         if (mWebTransportSession) {
-            cout << " peer=" << mWebTransportSession->getPeerAddress().toStdString() << ":"
-                 << mWebTransportSession->getPeerPort();
+            cout << " peer=" << mWebTransportSession->getPeerAddress().toStdString()
+                 << ":" << mWebTransportSession->getPeerPort();
         }
         cout << endl;
     }

--- a/src/JackTripWorker.cpp
+++ b/src/JackTripWorker.cpp
@@ -229,6 +229,10 @@ void JackTripWorker::start()
 void JackTripWorker::stopThread()
 {
     QMutexLocker locker(&mMutex);
+    if (gVerboseFlag) {
+        cout << "JackTripWorker::stopThread: worker=" << mID << " mRunning=" << mRunning
+             << " mSpawning=" << mSpawning << endl;
+    }
     if (mRunning) {
         mRunning = false;
         mJackTrip->slotStopProcesses();
@@ -680,6 +684,12 @@ void JackTripWorker::onWebTransportSessionEstablished()
     QString peerAddress = mWebTransportSession->getPeerAddress();
     mClientName         = mWebTransportSession->getClientName();
 
+    if (gVerboseFlag) {
+        cout << "JackTripWorker::onWebTransportSessionEstablished: worker=" << mID
+             << " peer=" << peerAddress.toStdString() << ":"
+             << mWebTransportSession->getPeerPort() << endl;
+    }
+
     // Get the base port from the hub listener and calculate the server port
     int basePort             = mUdpHubListener->getBasePort();
     uint16_t serverPort      = static_cast<uint16_t>(basePort + mID);
@@ -723,6 +733,11 @@ void JackTripWorker::onWebTransportSessionEstablished()
 //*******************************************************************************
 void JackTripWorker::onWebTransportSessionClosed()
 {
+    if (gVerboseFlag) {
+        cout << "JackTripWorker::onWebTransportSessionClosed: worker=" << mID
+             << " mRunning=" << mRunning << " mSpawning=" << mSpawning << endl;
+    }
+
     // Stop the JackTrip process
     stopThread();
 
@@ -735,6 +750,15 @@ void JackTripWorker::onWebTransportSessionFailed(const QString& reason)
 {
     cerr << "JackTripWorker: WebTransport session failed for worker " << mID << ": "
          << reason.toStdString() << endl;
+    if (gVerboseFlag) {
+        cout << "JackTripWorker: worker=" << mID << " failure state mRunning=" << mRunning
+             << " mSpawning=" << mSpawning;
+        if (mWebTransportSession) {
+            cout << " peer=" << mWebTransportSession->getPeerAddress().toStdString() << ":"
+                 << mWebTransportSession->getPeerPort();
+        }
+        cout << endl;
+    }
 
     // Stop the thread and signal removal
     stopThread();

--- a/src/JackTripWorker.h
+++ b/src/JackTripWorker.h
@@ -111,6 +111,11 @@ class JackTripWorker : public QObject
     /// Stop thread
     void stopThread();
     int getID() { return mID; }
+    /// \brief Assign this worker's slot id. Must be called right after construction so
+    /// releaseThread()/getServerPort() operate on the correct slot. The UDP path sets this
+    /// via setJackTrip(); WebRTC/WebTransport rely on this setter since they call
+    /// setJackTrip() only later (and with their own mID).
+    void setID(int id) { mID = id; }
 
     void setBufferStrategy(int BufferStrategy) { mBufferStrategy = BufferStrategy; }
     void setNetIssuesSimulation(double loss, double jitter, double delay_rel)

--- a/src/JackTripWorker.h
+++ b/src/JackTripWorker.h
@@ -112,8 +112,8 @@ class JackTripWorker : public QObject
     void stopThread();
     int getID() { return mID; }
     /// \brief Assign this worker's slot id. Must be called right after construction so
-    /// releaseThread()/getServerPort() operate on the correct slot. The UDP path sets this
-    /// via setJackTrip(); WebRTC/WebTransport rely on this setter since they call
+    /// releaseThread()/getServerPort() operate on the correct slot. The UDP path sets
+    /// this via setJackTrip(); WebRTC/WebTransport rely on this setter since they call
     /// setJackTrip() only later (and with their own mID).
     void setID(int id) { mID = id; }
 

--- a/src/UdpHubListener.cpp
+++ b/src/UdpHubListener.cpp
@@ -40,6 +40,7 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QMutexLocker>
+#include <QSslError>
 #include <QSslKey>
 #include <QSslSocket>
 #include <QStringList>
@@ -326,6 +327,31 @@ void UdpHubListener::receivedNewConnection()
     connect(clientSocket, &QAbstractSocket::readyRead, this, [this, clientSocket] {
         readyRead(clientSocket);
     });
+
+    // Surface TLS handshake and socket failures when running verbose. Without these
+    // handlers a failed handshake produces no output, making the connection appear to
+    // hang after "TLS ClientHello detected" (see the OpenSSL symbol-interposition bug
+    // fixed via -Wl,--exclude-libs,ALL in meson.build).
+    if (gVerboseFlag) {
+        connect(clientSocket,
+                QOverload<const QList<QSslError>&>::of(&QSslSocket::sslErrors), this,
+                [clientSocket](const QList<QSslError>& errors) {
+                    cerr << "JackTrip HUB SERVER: TLS handshake error(s) for "
+                         << clientSocket->peerAddress().toString().toStdString() << ":"
+                         << endl;
+                    for (const QSslError& e : errors) {
+                        cerr << "JackTrip HUB SERVER:   - "
+                             << e.errorString().toStdString() << endl;
+                    }
+                });
+        connect(clientSocket, &QAbstractSocket::errorOccurred, this,
+                [clientSocket](QAbstractSocket::SocketError) {
+                    cerr << "JackTrip HUB SERVER: Socket error for "
+                         << clientSocket->peerAddress().toString().toStdString() << ": "
+                         << clientSocket->errorString().toStdString() << endl;
+                });
+    }
+
     cout << "JackTrip HUB SERVER: Client Connection Received!" << endl;
 }
 
@@ -772,10 +798,11 @@ int UdpHubListener::createWorker(QString& clientName)
     JackTripWorker* worker = new JackTripWorker(this, mBufferQueueLength, mUnderRunMode,
                                                 mAudioBitResolution, clientName);
 
-    // Assign the slot id immediately. The UDP path also sets this later via setJackTrip(),
-    // but WebRTC/WebTransport never pass a real id to setJackTrip() (they pass their own
-    // mID), so without this every WebRTC/WebTransport worker would keep the default id 0 —
-    // causing releaseThread()/getServerPort() to operate on the wrong slot.
+    // Assign the slot id immediately. The UDP path also sets this later via
+    // setJackTrip(), but WebRTC/WebTransport never pass a real id to setJackTrip() (they
+    // pass their own mID), so without this every WebRTC/WebTransport worker would keep
+    // the default id 0 — causing releaseThread()/getServerPort() to operate on the wrong
+    // slot.
     worker->setID(id);
 
     if (mIOStatTimeout > 0) {

--- a/src/UdpHubListener.cpp
+++ b/src/UdpHubListener.cpp
@@ -772,6 +772,12 @@ int UdpHubListener::createWorker(QString& clientName)
     JackTripWorker* worker = new JackTripWorker(this, mBufferQueueLength, mUnderRunMode,
                                                 mAudioBitResolution, clientName);
 
+    // Assign the slot id immediately. The UDP path also sets this later via setJackTrip(),
+    // but WebRTC/WebTransport never pass a real id to setJackTrip() (they pass their own
+    // mID), so without this every WebRTC/WebTransport worker would keep the default id 0 —
+    // causing releaseThread()/getServerPort() to operate on the wrong slot.
+    worker->setID(id);
+
     if (mIOStatTimeout > 0) {
         worker->setIOStatTimeout(mIOStatTimeout);
         worker->setIOStatStream(mIOStatStream);
@@ -991,6 +997,12 @@ int UdpHubListener::createWebTransportWorker(HQUIC connection,
     if (id < 0) {
         cerr << "UdpHubListener: createWorker failed - no available slots" << endl;
         return -1;  // No available slots
+    }
+
+    if (gVerboseFlag) {
+        cout << "UdpHubListener: created WebTransport worker " << id
+             << " for QUIC connection " << connection << " from "
+             << peerAddress.toString().toStdString() << ":" << peerPort << endl;
     }
 
     JackTripWorker* worker = mJTWorkers->at(id);

--- a/src/webtransport/WebTransportDataProtocol.cpp
+++ b/src/webtransport/WebTransportDataProtocol.cpp
@@ -151,7 +151,8 @@ void WebTransportDataProtocol::stop()
         if (!wait(1000)) {
             // The monitor thread should exit promptly once mStopped is set; a timeout
             // here means it is wedged, so surface it even outside verbose mode.
-            cerr << "WebTransportDataProtocol::stop: thread did not finish within 1s (mode="
+            cerr << "WebTransportDataProtocol::stop: thread did not finish within 1s "
+                    "(mode="
                  << (mRunMode == SENDER ? "SENDER" : "RECEIVER") << ")" << endl;
         }
     }

--- a/src/webtransport/WebTransportDataProtocol.cpp
+++ b/src/webtransport/WebTransportDataProtocol.cpp
@@ -139,11 +139,21 @@ WebTransportDataProtocol::~WebTransportDataProtocol()
 //*******************************************************************************
 void WebTransportDataProtocol::stop()
 {
+    if (gVerboseFlag) {
+        cout << "WebTransportDataProtocol::stop: mode="
+             << (mRunMode == SENDER ? "SENDER" : "RECEIVER")
+             << " isRunning=" << isRunning() << endl;
+    }
     mStopped = true;
 
     // Wait for thread to finish
     if (isRunning()) {
-        wait(1000);
+        if (!wait(1000)) {
+            // The monitor thread should exit promptly once mStopped is set; a timeout
+            // here means it is wedged, so surface it even outside verbose mode.
+            cerr << "WebTransportDataProtocol::stop: thread did not finish within 1s (mode="
+                 << (mRunMode == SENDER ? "SENDER" : "RECEIVER") << ")" << endl;
+        }
     }
 }
 
@@ -409,6 +419,12 @@ void WebTransportDataProtocol::runReceiver(int full_packet_size)
         }
     }
 
+    if (gVerboseFlag) {
+        cout << "WebTransportDataProtocol::runReceiver: loop exited"
+             << " mStopped=" << mStopped << " mSessionConnected=" << mSessionConnected
+             << endl;
+    }
+
     // If the loop exited because mStopped was set (e.g., exit control packet) but the
     // session is still open, close it explicitly. This fires sessionClosed on both the
     // RECEIVER and SENDER instances, stopping the sender and triggering full cleanup.
@@ -432,8 +448,11 @@ void WebTransportDataProtocol::runSender(int full_packet_size)
         QThread::msleep(100);
     }
 
-    if (gVerboseFlag)
-        cout << "WebTransportDataProtocol::runSender: Exiting" << endl;
+    if (gVerboseFlag) {
+        cout << "WebTransportDataProtocol::runSender: loop exited"
+             << " mStopped=" << mStopped << " mSessionConnected=" << mSessionConnected
+             << endl;
+    }
 
     // Send exit packets using pool buffer
     int bufferIndex = acquirePoolBuffer();

--- a/src/webtransport/WebTransportSession.cpp
+++ b/src/webtransport/WebTransportSession.cpp
@@ -287,7 +287,12 @@ void WebTransportSession::close()
 {
     std::lock_guard<std::mutex> lock(mMutex);
 
-    if (mState == STATE_SHUTTING_DOWN || mState == STATE_DISCONNECTED) {
+    if (mState == STATE_SHUTTING_DOWN || mState == STATE_DISCONNECTED
+        || mState == STATE_FAILED) {
+        // STATE_FAILED means the transport already initiated shutdown; MsQuic will fire
+        // SHUTDOWN_COMPLETE on its own — no need to call ConnectionShutdown again, and
+        // transitioning to STATE_SHUTTING_DOWN here would cause SHUTDOWN_COMPLETE to
+        // emit sessionClosed in addition to the already-emitted sessionFailed.
         return;
     }
 


### PR DESCRIPTION
WebRTC and WebTransport workers never had their slot id assigned: mID defaults to 0 and was only set inside setJackTrip(), which those paths call with their own (still-default) mID. The UDP path passes the real id; the others did not. Result: every WebRTC/WebTransport worker kept id 0, so releaseThread(mID)/getServerPort() operated on the wrong slot. When a failed connection cleaned up, it freed slot 0 — often the *active* audio worker — leaving the real client's pipeline running with no peer.

Fix by assigning the slot id in createWorker() (worker->setID(id)) so all transports get the correct id at construction.

Also guard WebTransportSession::close() against STATE_FAILED: the transport already initiated shutdown, so re-entering SHUTTING_DOWN caused a duplicate sessionClosed -> signalRemoveThread and a spurious "sender is not a JackTripWorker" error.

Diagnostic logging added during investigation is gated behind gVerboseFlag; the thread-wedged warning in WebTransportDataProtocol::stop() stays unconditional since it only fires on a real hang.

Adds plans/defer-webtransport-worker-creation.md documenting a follow-up refactor to defer heavyweight worker creation until a WebTransport session is established, so speculative/abandoned QUIC connections (e.g. Firefox's second connection) no longer churn a worker slot.