### PR TITLE
Add a Linux x64 debug build to CI releases

### DIFF
--- a/.github/workflows/jacktrip.yml
+++ b/.github/workflows/jacktrip.yml
@@ -115,6 +115,26 @@ jobs:
             vst3sdk-version: '3.7.13'
             vst3sdk-arch: amd64
 
+          # same as Linux-x64-docker-shared, but keeps debug symbols so that crashes
+          # reported by users can be turned into readable stack traces
+          - name: Linux-x64-docker-debug
+            release-name: Linux-x64-debug
+            runs-on: ubuntu-22.04
+            system-rtaudio: false
+            bundled-rtaudio: true
+            nogui: false
+            weakjack: false
+            libsamplerate: true
+            webrtc: false
+            webtransport: false
+            jacktrip-path: jacktrip
+            binary-path: binary
+            build-system: docker
+            docker-image: ubuntu:jammy-20240911.1
+            docker-platform: linux/amd64
+            meson-library-type: shared
+            debug-symbols: true # do not strip; bundle the crash capture helpers
+
           - name: Linux-arm64-docker-shared
             release-name: Linux-arm64
             runs-on: ubuntu-22.04-arm
@@ -656,6 +676,12 @@ jobs:
           else
             MESON_CONFIG="-Dmsquic=disabled $MESON_CONFIG"
           fi
+          if [[ "${{ matrix.debug-symbols }}" == true ]]; then
+            # mirror the build info string meson derives from git, so that crash
+            # reports make it obvious they came from the debug build
+            BUILD_INFO="$(git describe --tags 2>/dev/null || echo ${{ steps.set-version.outputs.version }})-$(git rev-parse --short HEAD)-debug"
+            MESON_CONFIG="-Dbuildinfo=$BUILD_INFO $MESON_CONFIG"
+          fi
           if [[ -n "${{ matrix.macosx-architectures }}" ]]; then
             # TODO: for now, just assume that we want universal if it is not empty
             if [[ -n "${{ matrix.macosx-deployment-target }}" ]]; then
@@ -696,6 +722,7 @@ jobs:
             docker buildx build --target=artifact --progress=plain -f linux/Dockerfile.build --output type=local,dest=$BUILD_PATH \
               --platform "${{ matrix.docker-platform }}" --build-arg BUILD_CONTAINER="${{ matrix.docker-image }}" \
               --build-arg MESON_ARGS="$CONFIG_STRING" \
+              --build-arg DEBUG_SYMBOLS="${{ matrix.debug-symbols }}" \
               --build-arg USE_SYSTEM_LIBSAMPLERATE="1" \
               --build-arg VST3SDK_DOWNLOAD_URL="$VST3SDK_DOWNLOAD_URL" \
               --build-arg QT_DOWNLOAD_URL="$QT_DOWNLOAD_URL" .
@@ -892,6 +919,38 @@ jobs:
               cp $GITHUB_WORKSPACE/linux/icons/jacktrip.svg $BUILD_PATH/org.jacktrip.JackTrip.svg
               cp $GITHUB_WORKSPACE/linux/icons/jacktrip_48x48.png $BUILD_PATH/org.jacktrip.JackTrip.png
               zip -j $ZIPFILE $DESKTOP_FILE_PATH $BUILD_PATH/jacktrip.1.gz $BUILD_PATH/org.jacktrip.JackTrip.svg $BUILD_PATH/org.jacktrip.JackTrip.png $GITHUB_WORKSPACE/linux/README.md
+            fi
+            if [[ "${{ matrix.debug-symbols }}" == true ]]; then
+              # ship the crash capture helpers, install instructions and enough
+              # provenance to match a core file back to this exact binary
+              BUILD_ID=$(readelf -n $BINFILE 2>/dev/null | awk '/Build ID/ {print $3}')
+              cp $GITHUB_WORKSPACE/linux/README.md $BUILD_PATH/INSTALL.md
+              cat > $BUILD_PATH/BUILD-INFO.txt <<EOF
+          JackTrip debug build
+          ====================
+
+          Version     : ${{ steps.set-version.outputs.version }}
+          Git commit  : $GITHUB_SHA
+          GNU build ID: $BUILD_ID
+          Built by    : $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+          Built on    : $(date -u '+%Y-%m-%d %H:%M:%S UTC')
+          Container   : ${{ matrix.docker-image }} (${{ matrix.docker-platform }})
+
+          This binary uses the same meson configuration and optimisation level as the
+          official Linux x64 release. The only differences are that it is compiled with
+          -g3 -fno-omit-frame-pointer and is not stripped, so code generation should
+          match the release build.
+
+          To read a core file produced by this binary:
+
+              gdb ./jacktrip /path/to/core
+              (gdb) thread apply all bt full
+          EOF
+              zip -j $ZIPFILE $BUILD_PATH/BUILD-INFO.txt $BUILD_PATH/INSTALL.md \
+                $GITHUB_WORKSPACE/linux/debug/README.md $GITHUB_WORKSPACE/linux/debug/crash.gdb \
+                $GITHUB_WORKSPACE/linux/debug/run-under-gdb.sh \
+                $GITHUB_WORKSPACE/linux/debug/run-with-coredump.sh \
+                $GITHUB_WORKSPACE/linux/debug/enable-core-dumps.sh
             fi
             cd $GITHUB_WORKSPACE # we need to be in the root project directory for adding licenses
             if [[ "${{ runner.os }}" == "Windows" ]]; then

--- a/linux/Dockerfile.build
+++ b/linux/Dockerfile.build
@@ -72,6 +72,10 @@ RUN if [ -n "$VST3SDK_DOWNLOAD_URL" ]; then \
 COPY . ./
 ARG MESON_ARGS=""
 ENV MESON_ARGS=$MESON_ARGS
+# when set, keep debug symbols in the binary instead of stripping it. Optimisation
+# level and defines are unchanged, so the generated code matches the release build.
+ARG DEBUG_SYMBOLS=""
+ENV DEBUG_SYMBOLS=$DEBUG_SYMBOLS
 ENV BUILD_PATH="/opt/jacktrip/builddir"
 RUN if [ -n "$QT_DOWNLOAD_URL" ]; then \
   export QT_PATH="/opt/$(echo $QT_DOWNLOAD_URL | sed -e 's,.*/qt/\(qt-[.0-9]*\-[a-z]*\).*,\1,')"; \
@@ -80,13 +84,17 @@ RUN if [ -n "$QT_DOWNLOAD_URL" ]; then \
   export CMAKE_PREFIX_PATH="$QT_PATH"; fi \
   && if [ -n "$VST3SDK_DOWNLOAD_URL" ]; then \
   export MESON_ARGS="-Dvst-sdkdir=${VST3SDK_INSTALL_PATH}/vst3sdk $MESON_ARGS"; fi \
+  && if [ -n "$DEBUG_SYMBOLS" ]; then \
+  export CFLAGS="-g3 -fno-omit-frame-pointer $CFLAGS"; \
+  export CXXFLAGS="-g3 -fno-omit-frame-pointer $CXXFLAGS"; fi \
   && export SSL_CERT_FILE=$(python3 -m certifi) \
   && meson setup --buildtype release $MESON_ARGS $BUILD_PATH \
   && meson compile -C $BUILD_PATH -v \
   && mkdir -p $BUILD_PATH/src/vst3 \
-  && strip $BUILD_PATH/jacktrip \
-  && if [ -n "$VST3SDK_DOWNLOAD_URL" ]; then \
-  strip $BUILD_PATH/src/vst3/JackTrip.vst3; fi
+  && if [ -z "$DEBUG_SYMBOLS" ]; then \
+  strip $BUILD_PATH/jacktrip; \
+  if [ -n "$VST3SDK_DOWNLOAD_URL" ]; then \
+  strip $BUILD_PATH/src/vst3/JackTrip.vst3; fi; fi
 
 FROM scratch AS artifact
 

--- a/linux/debug/README.md
+++ b/linux/debug/README.md
@@ -31,8 +31,10 @@ sudo apt install gdb        # or: sudo dnf install gdb
 ./run-under-gdb.sh
 ```
 
-Then reproduce the problem, repeating it until the crash happens — intermittent
-crashes can take several tries.
+This opens the normal JackTrip window, exactly as if you had started JackTrip by
+hand — gdb just watches it from the outside. Reproduce the problem the way you
+normally hit it, repeating until the crash happens; intermittent crashes can take
+several tries.
 
 When it crashes, the script leaves these files in the current directory:
 
@@ -42,7 +44,8 @@ When it crashes, the script leaves these files in the current directory:
 Send us the `.log` file. If a core file is there too, compress it first
 (`gzip core.*`) — it is large, and it compresses down a lot.
 
-If JackTrip exits normally without crashing, the log will say so; run it again.
+If JackTrip exits normally, or you stop it with Ctrl-C, the log says so instead of
+reporting a crash. Just run the script again.
 
 ---
 
@@ -83,9 +86,9 @@ In rough order of usefulness:
 5. What you were doing, whether it had ever worked before, which audio device and
    backend you were using, and roughly how often it happens.
 
-Both scripts run JackTrip in verbose mode, so the logs include your audio device names
-and the studio you connected to. Have a look through them before posting them
-anywhere public.
+The logs contain JackTrip's normal console output, which names your audio devices and
+the studio you connected to. Have a look through them before posting them anywhere
+public.
 
 ## Notes
 

--- a/linux/debug/README.md
+++ b/linux/debug/README.md
@@ -1,0 +1,98 @@
+# JackTrip debug build — how to capture a crash
+
+This is the same JackTrip as the matching regular Linux release, rebuilt with full
+debug symbols so that a crash produces a usable stack trace. It is built with the
+same compiler optimisations and the same feature set as the release build — the only
+difference is that the debug information needed to read a crash dump is left in the
+binary, which is why the file is much larger than usual.
+
+`BUILD-INFO.txt` records exactly which commit it was built from. Please include that
+file, or the version it names, in any report.
+
+It needs the same Qt 6 packages as the regular JackTrip Linux build — `INSTALL.md`
+in this archive lists them. If your normal JackTrip runs, this one will too.
+
+If you unpacked this with a graphical archive tool, the helper scripts may have lost
+their executable bit. Restore it with:
+
+```bash
+chmod +x *.sh
+```
+
+---
+
+## Option A — run it under gdb (easiest, and gives us the most useful result)
+
+This is the recommended path: gdb catches the crash as it happens and writes both a
+readable backtrace and a core file.
+
+```bash
+sudo apt install gdb        # or: sudo dnf install gdb
+./run-under-gdb.sh
+```
+
+Then reproduce the problem, repeating it until the crash happens — intermittent
+crashes can take several tries.
+
+When it crashes, the script leaves these files in the current directory:
+
+- `jacktrip-gdb-<timestamp>.log` — the backtrace. **This is the important one.**
+- `core.<pid>` — the core dump, if gdb managed to write one.
+
+Send us the `.log` file. If a core file is there too, compress it first
+(`gzip core.*`) — it is large, and it compresses down a lot.
+
+If JackTrip exits normally without crashing, the log will say so; run it again.
+
+---
+
+## Option B — plain core dump, no gdb
+
+Use this if you would rather not run under gdb. Ubuntu hands core dumps to apport by
+default, which does not keep them anywhere useful for a program that was not
+installed from a package, so the core dump destination has to be changed first.
+
+```bash
+sudo ./enable-core-dumps.sh      # asks for your password; change is temporary
+./run-with-coredump.sh
+```
+
+Reproduce the crash. Core files are written to `/tmp/cores/`, named
+`core.<program>.<pid>.<timestamp>`.
+
+Send us the core file for `jacktrip` (gzip it first — `gzip /tmp/cores/core.jacktrip.*`)
+along with `jacktrip-run-<timestamp>.log`.
+
+The core dump setting reverts on reboot. To undo it right away:
+
+```bash
+sudo ./enable-core-dumps.sh --restore
+```
+
+---
+
+## What to send back
+
+In rough order of usefulness:
+
+1. `jacktrip-gdb-<timestamp>.log` (Option A) — a backtrace is often enough on its own.
+2. The gzipped core file, if you have one.
+3. The console log (`jacktrip-run-<timestamp>.log`) — verbose output from the run that
+   crashed, which shows how far things got.
+4. `BUILD-INFO.txt`, so we know exactly which build produced the crash.
+5. What you were doing, whether it had ever worked before, which audio device and
+   backend you were using, and roughly how often it happens.
+
+Both scripts run JackTrip in verbose mode, so the logs include your audio device names
+and the studio you connected to. Have a look through them before posting them
+anywhere public.
+
+## Notes
+
+- JackTrip's UI is built on QtWebEngine, which runs helper processes. If the crash is
+  in one of those rather than in JackTrip itself, you may get a core file named
+  `core.QtWebEngineProc...` — that is still useful, please send it.
+- Nothing here installs anything or replaces an existing JackTrip installation. It all
+  runs from the directory you unpacked it into.
+
+Please report any security concerns to vulnerabilities@jacktrip.org

--- a/linux/debug/crash.gdb
+++ b/linux/debug/crash.gdb
@@ -1,27 +1,38 @@
-# gdb command file used by run-under-gdb.sh
 set pagination off
 set confirm off
 set backtrace past-main on
+# Signals JackTrip and its Qt/Chromium threads use routinely. Stopping on any of
+# these would end the session before the real crash ever happens.
 handle SIGPIPE nostop noprint pass
-
+handle SIGUSR1 nostop noprint pass
+handle SIGUSR2 nostop noprint pass
 run
-
 # $_exitcode is void if the program did not exit on its own, i.e. it was
 # stopped by a fatal signal.
 if $_isvoid($_exitcode)
-  echo \n========== CRASH DETAILS BELOW ==========\n
-  info program
-  echo \n---------- faulting thread ----------\n
-  bt full
-  echo \n---------- registers ----------\n
-  info registers
-  echo \n---------- all threads ----------\n
-  thread apply all bt full
-  echo \n---------- loaded libraries ----------\n
-  info sharedlibrary
-  echo \n---------- writing core file ----------\n
-  generate-core-file
-  echo \n========== END OF CRASH DETAILS ==========\n
+  # si_signo 2 is SIGINT: the user stopped it from the keyboard, which is
+  # not a crash and produces no useful backtrace.
+  set $sig = 0
+  if !$_isvoid($_siginfo)
+    set $sig = $_siginfo.si_signo
+  end
+  if $sig == 2
+    echo \n---------- JackTrip was interrupted, not a crash ----------\n
+  else
+    echo \n========== CRASH DETAILS BELOW ==========\n
+    info program
+    echo \n---------- faulting thread ----------\n
+    bt full
+    echo \n---------- registers ----------\n
+    info registers
+    echo \n---------- all threads ----------\n
+    thread apply all bt full
+    echo \n---------- loaded libraries ----------\n
+    info sharedlibrary
+    echo \n---------- writing core file ----------\n
+    generate-core-file
+    echo \n========== END OF CRASH DETAILS ==========\n
+  end
 else
   echo \n---------- JackTrip exited on its own, no crash was captured ----------\n
 end

--- a/linux/debug/crash.gdb
+++ b/linux/debug/crash.gdb
@@ -1,0 +1,28 @@
+# gdb command file used by run-under-gdb.sh
+set pagination off
+set confirm off
+set backtrace past-main on
+handle SIGPIPE nostop noprint pass
+
+run
+
+# $_exitcode is void if the program did not exit on its own, i.e. it was
+# stopped by a fatal signal.
+if $_isvoid($_exitcode)
+  echo \n========== CRASH DETAILS BELOW ==========\n
+  info program
+  echo \n---------- faulting thread ----------\n
+  bt full
+  echo \n---------- registers ----------\n
+  info registers
+  echo \n---------- all threads ----------\n
+  thread apply all bt full
+  echo \n---------- loaded libraries ----------\n
+  info sharedlibrary
+  echo \n---------- writing core file ----------\n
+  generate-core-file
+  echo \n========== END OF CRASH DETAILS ==========\n
+else
+  echo \n---------- JackTrip exited on its own, no crash was captured ----------\n
+end
+quit

--- a/linux/debug/enable-core-dumps.sh
+++ b/linux/debug/enable-core-dumps.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Point kernel core dumps at /tmp/cores instead of apport, which on Ubuntu does not
+# keep usable core files for programs that were not installed from a package.
+#
+#   sudo ./enable-core-dumps.sh            enable
+#   sudo ./enable-core-dumps.sh --restore  put the previous setting back
+#
+# The change is not permanent: it reverts by itself on the next reboot.
+
+set -euo pipefail
+
+BACKUP="/var/tmp/jacktrip-core-pattern.bak"
+CORE_DIR="/tmp/cores"
+PATTERN="$CORE_DIR/core.%e.%p.%t"
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "This script needs root. Run it as:  sudo $0 ${*:-}" >&2
+    exit 1
+fi
+
+if [ "${1:-}" = "--restore" ]; then
+    if [ -f "$BACKUP" ]; then
+        sysctl -w "kernel.core_pattern=$(cat "$BACKUP")" >/dev/null
+        rm -f "$BACKUP"
+        echo "Restored core_pattern to: $(cat /proc/sys/kernel/core_pattern)"
+    else
+        echo "No saved setting found. Rebooting also restores the default." >&2
+        exit 1
+    fi
+    exit 0
+fi
+
+if [ ! -f "$BACKUP" ]; then
+    cat /proc/sys/kernel/core_pattern > "$BACKUP"
+fi
+
+mkdir -p "$CORE_DIR"
+chmod 1777 "$CORE_DIR"
+sysctl -w "kernel.core_pattern=$PATTERN" >/dev/null
+
+echo "Core dumps will now be written to $CORE_DIR/"
+echo "  current pattern: $(cat /proc/sys/kernel/core_pattern)"
+echo "  previous pattern saved in $BACKUP"
+echo
+echo "Now run ./run-with-coredump.sh (as your normal user, not with sudo)."

--- a/linux/debug/run-under-gdb.sh
+++ b/linux/debug/run-under-gdb.sh
@@ -18,17 +18,27 @@ LOG="jacktrip-gdb-$TIMESTAMP.log"
 # Allow gdb to write a core file of unlimited size.
 ulimit -c unlimited
 
+# With no arguments JackTrip starts its normal window, which is where the crashes
+# we are chasing happen. Passing any option at all puts it into command line mode
+# instead, so --gui is added explicitly here. Extra arguments are still honoured
+# for anyone who needs them.
+if [ "$#" -eq 0 ]; then
+    set -- --gui
+fi
+
 echo "Logging to $LOG"
 echo "Reproduce the problem now: connect to a studio as you normally would."
 echo "If it does not crash, quit JackTrip and run this script again."
 echo
 
-gdb -q -batch -x crash.gdb --args ./jacktrip -V "$@" 2>&1 | tee "$LOG"
+gdb -q -batch -x crash.gdb --args ./jacktrip "$@" 2>&1 | tee "$LOG"
 
 echo
 echo "==================================================================="
 if grep -q "CRASH DETAILS BELOW" "$LOG"; then
     echo "A crash was captured."
+elif grep -q "was interrupted, not a crash" "$LOG"; then
+    echo "No crash this time — JackTrip was interrupted from the keyboard."
 else
     echo "No crash this time — JackTrip exited on its own."
 fi

--- a/linux/debug/run-under-gdb.sh
+++ b/linux/debug/run-under-gdb.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Run the JackTrip debug build under gdb so that a crash produces a readable
+# backtrace (and a core file, if gdb can write one).
+#
+# Usage: ./run-under-gdb.sh [extra jacktrip arguments]
+
+set -uo pipefail
+cd "$(dirname "$(readlink -f "$0")")"
+
+if ! command -v gdb >/dev/null 2>&1; then
+    echo "gdb is not installed. Install it with:  sudo apt install gdb" >&2
+    exit 1
+fi
+
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+LOG="jacktrip-gdb-$TIMESTAMP.log"
+
+# Allow gdb to write a core file of unlimited size.
+ulimit -c unlimited
+
+echo "Logging to $LOG"
+echo "Reproduce the problem now: connect to a studio as you normally would."
+echo "If it does not crash, quit JackTrip and run this script again."
+echo
+
+gdb -q -batch -x crash.gdb --args ./jacktrip -V "$@" 2>&1 | tee "$LOG"
+
+echo
+echo "==================================================================="
+if grep -q "CRASH DETAILS BELOW" "$LOG"; then
+    echo "A crash was captured."
+else
+    echo "No crash this time — JackTrip exited on its own."
+fi
+echo "Saved log: $(pwd)/$LOG"
+if ls core.* >/dev/null 2>&1; then
+    echo "Core file(s):"
+    ls -lh core.* | awk '{print "    "$9"  ("$5")"}'
+    echo "Please gzip the core file before sending it:  gzip core.*"
+else
+    echo "No core file was written (that is OK — the log is the important part)."
+fi
+echo "Please send the log file back to us."
+echo "==================================================================="

--- a/linux/debug/run-with-coredump.sh
+++ b/linux/debug/run-with-coredump.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Run the JackTrip debug build with core dumps enabled and verbose logging.
+# Run ./enable-core-dumps.sh (with sudo) once before using this.
+#
+# Usage: ./run-with-coredump.sh [extra jacktrip arguments]
+
+set -uo pipefail
+cd "$(dirname "$(readlink -f "$0")")"
+
+PATTERN=$(cat /proc/sys/kernel/core_pattern)
+case "$PATTERN" in
+    /*) : ;;
+    *)
+        echo "WARNING: core dumps are still being sent to apport:"
+        echo "    $PATTERN"
+        echo "A crash will most likely NOT leave a core file behind."
+        echo "Run 'sudo ./enable-core-dumps.sh' first, or use ./run-under-gdb.sh instead."
+        echo
+        read -r -p "Continue anyway? [y/N] " reply
+        [ "$reply" = "y" ] || [ "$reply" = "Y" ] || exit 1
+        ;;
+esac
+
+ulimit -c unlimited
+
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+LOG="jacktrip-run-$TIMESTAMP.log"
+
+echo "Core dump pattern: $PATTERN"
+echo "Logging to $LOG"
+echo "Reproduce the crash now (connect to a studio)."
+echo
+
+./jacktrip -V "$@" 2>&1 | tee "$LOG"
+STATUS=${PIPESTATUS[0]}
+
+echo
+echo "==================================================================="
+echo "JackTrip exited with status $STATUS"
+if [ "$STATUS" -ge 128 ]; then
+    echo "That looks like a crash (signal $((STATUS - 128)))."
+fi
+echo "Saved log: $(pwd)/$LOG"
+case "$PATTERN" in
+    /*) CORE_DIR=$(dirname "$PATTERN") ;;
+    *)  CORE_DIR="/tmp/cores" ;;
+esac
+CORES=$(ls -t "$CORE_DIR"/core.* 2>/dev/null | head -5)
+if [ -n "$CORES" ]; then
+    echo "Recent core files:"
+    ls -lh $CORES | awk '{print "    "$9"  ("$5")"}'
+    echo "Please gzip the newest one before sending it:  gzip <path>"
+else
+    echo "No core file found in $CORE_DIR/."
+fi
+echo "==================================================================="

--- a/linux/debug/run-with-coredump.sh
+++ b/linux/debug/run-with-coredump.sh
@@ -23,6 +23,12 @@ esac
 
 ulimit -c unlimited
 
+# JackTrip only starts its normal window when it is given no options at all, so
+# --gui is added explicitly. Extra arguments are still honoured.
+if [ "$#" -eq 0 ]; then
+    set -- --gui
+fi
+
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 LOG="jacktrip-run-$TIMESTAMP.log"
 
@@ -31,7 +37,7 @@ echo "Logging to $LOG"
 echo "Reproduce the crash now (connect to a studio)."
 echo
 
-./jacktrip -V "$@" 2>&1 | tee "$LOG"
+./jacktrip "$@" 2>&1 | tee "$LOG"
 STATUS=${PIPESTATUS[0]}
 
 echo


### PR DESCRIPTION
## Why

A user reported an intermittent segfault when first connecting to a studio on Ubuntu. The released Linux binary is stripped, so neither a core dump nor a backtrace from the field is readable, and there is no supported way to hand someone a symbolised build. This adds one as a release artifact.

## What

A second Linux x64 artifact, `JackTrip-<version>-Linux-x64-debug-binary.zip`, built from the same source with the same meson configuration, optimisation level and defines as the regular Linux x64 release. The only differences are `-g3 -fno-omit-frame-pointer` and skipping `strip`, so code generation should match the release build — deliberately *not* a `--buildtype debug` build, since flipping asserts and Qt debug output on can easily make a timing sensitive bug stop reproducing.

- **`linux/Dockerfile.build`** — new `DEBUG_SYMBOLS` build arg: adds the debug flags before `meson setup` and skips both `strip` calls.
- **`.github/workflows/jacktrip.yml`**
  - new `Linux-x64-docker-debug` matrix entry (release name `Linux-x64-debug`), a clone of `Linux-x64-docker-shared` plus `debug-symbols: true`. It omits `vst3sdk-version`, so it skips the VST3 SDK download and plugin build.
  - debug builds get `-Dbuildinfo=<git-describe>-<sha>-debug`, so a crash log's `Build Info:` line identifies itself. It mirrors meson's own default format with a `-debug` suffix.
  - the packaging step generates `BUILD-INFO.txt` (version, commit, GNU build ID, workflow run URL, container image) and bundles the crash capture helpers plus `linux/README.md` as `INSTALL.md` for the Qt dependency list.
- **`linux/debug/`** — helper scripts and instructions for a reporter: run under gdb (writes a symbolised backtrace and a core file), or capture a plain core dump. The latter needs a `kernel.core_pattern` change, since Ubuntu hands core dumps to apport, which keeps nothing usable for a program that was not installed from a package.

`deploy_gh` picks the zip up through its existing `JackTrip*/*` glob. `deploy_jtl` downloads artifacts by exact name, so the auto update manifests are unaffected and the app will never offer a debug build as an update.

## Testing

- Built the equivalent configuration locally on Ubuntu 24.04 and confirmed the binary carries usable DWARF (`JackTrip::startProcess` → `src/JackTrip.cpp:551`).
- Exercised the gdb wrapper end to end: clean exit against the real binary reports no crash; a deliberate SIGSEGV in a threaded stand-in produced a fully symbolised backtrace with locals, all-thread traces and a valid core file.
- Extracted the modified workflow steps, substituted the `${{ }}` expressions as Actions would, and ran them against a build dir holding the debug binary. Resulting zip is 23 MB, exec bits intact on the scripts, `BUILD-INFO.txt` renders correctly.
- Diffed the same generated steps against this workflow before the change for `Linux-x64-docker-shared`: the only differences on the release path are the two new guard blocks, both false, and `DEBUG_SYMBOLS=""`.
- The four branches of the rewritten strip/flags logic were exercised as a standalone shell snippet.

- The container path has now run for real in this PR's CI. `Linux-x64-docker-debug` passed in 4m16s and its artifact is a 59 MB unstripped binary `with debug_info, not stripped`, build ID `44779cef…` matching the one recorded in `BUILD-INFO.txt`, alongside the helper scripts with their exec bits, `INSTALL.md`, `LICENSE.md` and `LICENSES/`.

## Follow-up in this branch: the helpers did not capture the crash

The first round of reports from the user came back with nothing useful, and both causes were in `linux/debug/`, not in the CI plumbing:

- JackTrip only opens its window when given no command line options at all (`src/main.cpp:112`), so `./jacktrip -V` — what the scripts ran — started it in command line server mode. The crash being chased is in the studio connect path in the GUI, so it could not be reproduced under gdb at all. The scripts now pass `--gui` explicitly and no longer force verbose mode, so the run matches how the crash is actually hit.
- The user then stopped the session with Ctrl-C and the script announced that a crash had been captured. gdb stops on SIGINT, which leaves `$_exitcode` void, and the old check could not tell that apart from a fatal signal. `crash.gdb` now reads `$_siginfo.si_signo` and reports an interrupt as such, and passes through SIGUSR1/SIGUSR2 so that a routine Qt or Chromium signal cannot end the session before the real crash.

Both were verified against a stand-in binary covering all four outcomes: SIGSEGV and a glibc double-free abort produce full backtraces and a core file, an externally delivered SIGINT reports an interrupt, and a clean exit reports no crash. `--gui` was smoke tested against the real debug binary under `QT_QPA_PLATFORM=offscreen`.

## Trade-off worth a look

As written this builds on every push and PR, which adds a second full Linux docker build to the matrix. I went that way for consistency with the other entries and so a break in the debug packaging path shows up on the PR rather than at release time. Restricting it to tags needs a dynamic matrix or per-step guards rather than a one-line change — happy to do that if the CI minutes matter more. An arm64 debug variant is a straight copy of the entry if it is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E93unmTPC5QLaPZURiWK1E
