### PR TITLE
Make textbuf thread safe to fix heap corruption in GUI builds

### DIFF
--- a/src/gui/textbuf.cpp
+++ b/src/gui/textbuf.cpp
@@ -25,6 +25,8 @@
 
 #include "textbuf.h"
 
+#include <cstring>
+
 void textbuf::setOutStream(std::ostream* output)
 {
     m_outStream = output;
@@ -32,38 +34,71 @@ void textbuf::setOutStream(std::ostream* output)
 
 int textbuf::overflow(int c)
 {
-    // Output our buffer.
-    putChars(pbase(), pptr());
-
+    // We run unbuffered, so every single character written to the stream
+    // arrives here rather than in a put area shared between threads.
     if (c != traits_t::eof()) {
-        char out = c;
-        putChars(&out, &out + 1);
+        const char out = traits_t::to_char_type(c);
+        appendChars(&out, 1);
     }
-
-    // Set buffer to empty again
-    setp(m_buf, m_buf + BUF_SIZE);
 
     return c;
 }
 
+std::streamsize textbuf::xsputn(const char* s, std::streamsize n)
+{
+    // The base class implementation of this copies into the put area, which
+    // isn't safe to share between threads, so accumulate the characters
+    // ourselves instead.
+    if (n <= 0) {
+        return 0;
+    }
+
+    appendChars(s, static_cast<size_t>(n));
+    return n;
+}
+
 int textbuf::sync()
 {
-    // Flush our buffer.
-    putChars(pbase(), pptr());
-    setp(m_buf, m_buf + BUF_SIZE);
+    QMutexLocker lock(&m_mutex);
+    flushLocked();
     return 0;
+}
+
+void textbuf::appendChars(const char* s, size_t n)
+{
+    QMutexLocker lock(&m_mutex);
+    m_pending.append(s, n);
+
+    // Flush complete lines as they arrive so that output still shows up
+    // promptly for callers that end a line with "\n" rather than std::endl.
+    if (m_pending.size() >= MAX_PENDING || memchr(s, '\n', n) != nullptr) {
+        flushLocked();
+    }
+}
+
+void textbuf::flushLocked()
+{
+    if (m_pending.empty()) {
+        return;
+    }
+
+    putChars(m_pending.data(), m_pending.data() + m_pending.size());
+    m_pending.clear();
 }
 
 void textbuf::putChars(const char* begin, const char* end)
 {
+    const qsizetype length = end - begin;
+
     if (m_outStream) {
-        for (const char* c = begin; c < end; c++) {
-            *m_outStream << *c;
-        }
+        // Write the whole block in one call. Relaying character by character
+        // lets output from different threads interleave mid-line, which makes
+        // the console logs users send us hard to read.
+        m_outStream->write(begin, length);
         m_outStream->flush();
     }
 
     // Send a signal here rather than writing directly to our
     // QTextEdit to avoid any issues with threading.
-    emit outputString(QString(QByteArray(begin, end - begin)));
+    emit outputString(QString(QByteArray(begin, length)));
 }

--- a/src/gui/textbuf.h
+++ b/src/gui/textbuf.h
@@ -26,11 +26,19 @@
 #ifndef TEXTBUF_H
 #define TEXTBUF_H
 
+#include <QMutex>
 #include <QPlainTextEdit>
 #include <iostream>
 #include <streambuf>
+#include <string>
 
 // Extension of a stream buffer to output to a QTextEdit via a signal
+//
+// std::cout and std::cerr are redirected here (see QJackTrip's constructor) and
+// are written to from every thread in the application, so this buffer has to be
+// thread safe. It deliberately runs unbuffered: with a null put area, the base
+// class never touches a shared character array of its own, and every write is
+// funnelled through overflow() and xsputn(), which serialise on m_mutex.
 class textbuf
     : public QObject
     , public std::basic_streambuf<char, std::char_traits<char>>
@@ -40,7 +48,8 @@ class textbuf
    public:
     textbuf(QObject* parent = nullptr) : QObject(parent)
     {
-        setp(m_buf, m_buf + BUF_SIZE);
+        // run unbuffered; see the note above
+        setp(nullptr, nullptr);
     }
 
     void setOutStream(std::ostream* output);
@@ -50,16 +59,24 @@ class textbuf
 
    protected:
     virtual int overflow(int c = traits_t::eof());
+    virtual std::streamsize xsputn(const char* s, std::streamsize n);
     virtual int sync();
 
    private:
     typedef std::char_traits<char> traits_t;
 
-    static const size_t BUF_SIZE = 64;
-    char m_buf[BUF_SIZE];
+    // flush unconditionally once this much output is pending, so that a caller
+    // that never flushes and never emits a newline can't grow m_pending forever
+    static const size_t MAX_PENDING = 8192;
+
+    QMutex m_mutex;
+    std::string m_pending;
 
     std::ostream* m_outStream = nullptr;
 
+    void appendChars(const char* s, size_t n);
+    // both require m_mutex to be held by the caller
+    void flushLocked();
     void putChars(const char* begin, const char* end);
 };
 


### PR DESCRIPTION
## Problem

Users have reported the GUI app aborting shortly after joining a studio, with glibc heap-consistency messages:

| Report | Abort message | Frame it surfaced in |
|---|---|---|
| run3 | `malloc(): unaligned tcache chunk detected` | `MessageDialog::receiveOutput` → `QTextCursor::insertText` → `malloc` |
| run4 | `free(): invalid pointer` | `libQt6WebEngineCore` → `free` |

Two unrelated victims, one symptom: the heap was already corrupted before either allocation ran. Neither stack is where the damage was caused.

## Root cause

`QJackTrip`'s constructor redirects `std::cout` and `std::cerr` into a `textbuf` so debug output can be shown in the GUI:

```cpp
// src/gui/qjacktrip.cpp
std::cout.rdbuf(m_debugDialog->getOutputStream()->rdbuf());
std::cerr.rdbuf(m_debugDialog->getOutputStream(1)->rdbuf());
```

This isn't limited to classic mode — `UserInterface::start()` constructs `QJackTrip` unconditionally whenever `NO_CLASSIC` is undefined, i.e. in the official release, so it applies to Virtual Studio sessions too.

`textbuf` handed `std::basic_streambuf` a fixed 64-byte member array as its put area and did **no locking at all**. JackTrip logs to `std::cout` from every thread it runs (84 sites in `JackTrip.cpp`, 34 in `UdpDataProtocol.cpp`, 14 in `Regulator.cpp`, plus the audio path), so libstdc++'s `basic_streambuf::xsputn` — which `textbuf` did not override — runs this concurrently on several threads:

```cpp
const streamsize __buf_len = this->epptr() - this->pptr();
...
traits_type::copy(this->pptr(), __s, __len);   // pptr() re-read here
```

If `pptr()` moves between those two statements, the copy writes past the end of the array. A racing `setp(m_buf, m_buf + BUF_SIZE)` in `overflow()`/`sync()` makes that trivially reachable, and a racing `pbump` can drive `pptr` past `epptr` so `__buf_len` goes negative and the `copy` becomes a `memcpy` with a huge `size_t`.

The layout makes the consequence precise:

```
sizeof(textbuf)=152  offsetof(m_buf)=80  offsetof(m_outStream)=144
```

`m_buf` spans bytes 80–143 of a 152-byte heap object. Overrunning it by ≥9 bytes overwrites `m_outStream`; by ≥25 bytes it writes ASCII log text over the **adjacent chunk's malloc header**. An ASCII byte pattern in a size field is never 16-byte aligned — which is literally the check that fired in run3.

## Why it fires at connection setup

`JackTrip::completeConnection()` starts the data protocol receiver thread, and then — with that thread already logging — calls `AudioInterface::initPlugins()`. That message ends in `"\n"` rather than `std::endl`, so it does not flush: it parks 58 of the 64 bytes in the shared buffer and leaves them there. The receiver thread then writes into a buffer it believes is empty. The console log shows the collision exactly:

```
Server Address set to: 34.156.253.41 Port: 61003            <- main thread, completeConnection()
Waiting for Peer...                                          <- UDP RECEIVER thread
Initializing Faust plugins (have 5) at sampling rate 48000   <- MAIN thread, "\n", no flush
Received Connection from Peer!                               <- UDP RECEIVER thread
PLC is in auto mode and has been set with variable headroom  <- UDP RECEIVER thread
malloc(): unaligned tcache chunk detected
```

The `Regulator` PLC line is a bystander — it's just the next thing the receiver thread printed. Nothing in `Regulator`, `JitterBuffer` or the audio path is at fault.

## Fix

Run the buffer **unbuffered** (`setp(nullptr, nullptr)`), so the base class has no shared put area to copy into, and funnel every write through `overflow()` and a new `xsputn()` override that append to a `std::string` behind a `QMutex`.

- Pending output is flushed on newline, so callers that use `"\n"` instead of `std::endl` still show up promptly.
- It's also flushed at `MAX_PENDING` (8 KB) so the accumulator can't grow without bound if something never flushes and never emits a newline.
- `putChars` now relays to the real stdout with a single `write()` rather than a character at a time. With several threads logging, per-character relaying interleaves mid-line and makes the console logs users send us hard to read.
- `end - begin` can no longer go negative, which removes a second hazard: Qt 6 treats a negative `QByteArray` size as "null-terminated" and would read off the end of the buffer.

## Verification

An 8-thread stress test built directly against `src/gui/textbuf.{h,cpp}`, mimicking the real logging pattern (some `std::endl`, some bare `"\n"`):

**Before** — AddressSanitizer:
```
ERROR: AddressSanitizer: heap-buffer-overflow ... READ of size 1 at ... thread T4
    #0 textbuf::putChars(char const*, char const*) textbuf.cpp:61
    #1 textbuf::overflow(int) textbuf.cpp:36
0x50e000000298 is located 0 bytes after 152-byte region
```
ThreadSanitizer reports 5 data races, the first inside `basic_streambuf::xsputn`'s `memcpy` — the exact mechanism above.

**After**: 10/10 runs clean under ASan, and clean under TSan.

Also confirms the computed layout: the overflow lands *0 bytes after a 152-byte region*, matching `sizeof(textbuf)` exactly.

Full GUI build (`-Dnogui=false`, classic + VS, Qt 6.4.2) compiles clean; `clang-format` 13 reports no diff on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E93unmTPC5QLaPZURiWK1E