### PR TITLE
Only redirect cout and cerr while classic mode is in use

### DIFF
--- a/src/UserInterface.cpp
+++ b/src/UserInterface.cpp
@@ -179,7 +179,8 @@ void UserInterface::start(QApplication* app)
     QObject::connect(m_classic_ui.data(), &QJackTrip::signalExit, app,
                      &QCoreApplication::quit, Qt::QueuedConnection);
 #ifdef NO_VS
-    m_classic_ui->show();
+    // classic mode is the only mode this build has
+    setMode(MODE_CLASSIC);
 #endif  // NO_VS
 #endif  // NO_CLASSIC
 
@@ -259,6 +260,9 @@ void UserInterface::setMode(uiModeT m)
         if (m_vs_ui->windowState() == "login")
             m_vs_ui->login();
 #ifndef NO_CLASSIC
+        // classic mode's debug window captures std::cout and std::cerr for the
+        // whole application, so give them back while it isn't being used
+        m_classic_ui->detachDebugOutput();
         if (m_uiMode == MODE_CLASSIC)
             m_classic_ui->hide();
 #endif  // NO_CLASSIC
@@ -267,6 +271,7 @@ void UserInterface::setMode(uiModeT m)
         break;
     case MODE_CLASSIC:
 #ifndef NO_CLASSIC
+        m_classic_ui->attachDebugOutput();
         m_classic_ui->show();
 #ifndef NO_VS
         m_vs_ui->hide();

--- a/src/gui/qjacktrip.cpp
+++ b/src/gui/qjacktrip.cpp
@@ -73,9 +73,10 @@ QJackTrip::QJackTrip(UserInterface& interface, QWidget* parent)
 {
     m_ui->setupUi(this);
 
-    // Set up our debug window, and relay everything to our real cout.
-    std::cout.rdbuf(m_debugDialog->getOutputStream()->rdbuf());
-    std::cerr.rdbuf(m_debugDialog->getOutputStream(1)->rdbuf());
+    // Set up our debug window so that it relays everything to our real cout.
+    // Note that std::cout and std::cerr are not redirected to it here: that is
+    // global to the application, so it only happens once classic mode is
+    // actually entered. See attachDebugOutput().
     m_debugDialog->setRelayStream(&m_realCout);
     m_debugDialog->setRelayStream(&m_realCerr, 1);
 
@@ -2052,11 +2053,37 @@ JackTrip::hubConnectionModeT QJackTrip::hubModeFromPatchType(
     }
 }
 
+void QJackTrip::attachDebugOutput()
+{
+    if (m_debugOutputAttached) {
+        return;
+    }
+
+    std::cout.rdbuf(m_debugDialog->getOutputStream()->rdbuf());
+    std::cerr.rdbuf(m_debugDialog->getOutputStream(1)->rdbuf());
+    m_debugOutputAttached = true;
+}
+
+void QJackTrip::detachDebugOutput()
+{
+    if (!m_debugOutputAttached) {
+        return;
+    }
+
+    // Push out anything the debug window is still holding on to, so that a
+    // partial line doesn't sit there until classic mode is next used.
+    std::cout.flush();
+    std::cerr.flush();
+
+    std::cout.rdbuf(m_realCout.rdbuf());
+    std::cerr.rdbuf(m_realCerr.rdbuf());
+    m_debugOutputAttached = false;
+}
+
 QJackTrip::~QJackTrip()
 {
     // Restore cout. (Stops a crash on exit.)
-    std::cout.rdbuf(m_realCout.rdbuf());
-    std::cerr.rdbuf(m_realCerr.rdbuf());
+    detachDebugOutput();
 }
 
 QCoreApplication* QJackTrip::createApplication(int& argc, char* argv[])

--- a/src/gui/qjacktrip.h
+++ b/src/gui/qjacktrip.h
@@ -67,6 +67,18 @@ class QJackTrip : public QMainWindow
     void showEvent(QShowEvent* event) override;
     static QCoreApplication* createApplication(int& argc, char* argv[]);
 
+    /** \brief Redirects std::cout and std::cerr to the classic mode debug window.
+     *
+     * This affects the whole application, so it is only done while classic mode
+     * is actually in use. UserInterface::setMode() takes care of calling this
+     * and detachDebugOutput() at the right times. Both are safe to call more
+     * than once.
+     */
+    void attachDebugOutput();
+
+    /// \brief Restores std::cout and std::cerr to where they pointed at startup.
+    void detachDebugOutput();
+
    signals:
     void signalExit();
 
@@ -127,6 +139,7 @@ class QJackTrip : public QMainWindow
     QScopedPointer<QGridLayout> m_outputLayout;
     std::ostream m_realCout;
     std::ostream m_realCerr;
+    bool m_debugOutputAttached = false;
     QString m_assignedClientName;
     bool m_jackTripRunning;
     bool m_isExiting;


### PR DESCRIPTION
Follow-up to #1502.

## Problem

`QJackTrip`'s constructor redirects `std::cout` and `std::cerr` into its debug window:

```cpp
std::cout.rdbuf(m_debugDialog->getOutputStream()->rdbuf());
std::cerr.rdbuf(m_debugDialog->getOutputStream(1)->rdbuf());
```

`UserInterface::start()` constructs `QJackTrip` unconditionally whenever `NO_CLASSIC` is undefined, i.e. in the official release. Redirecting `std::cout` is global to the process, so this was in effect for the entire run even in Virtual Studio sessions where the classic window is never shown — every log line from every thread was being funnelled through a widget the user can't see and doesn't have open.

That indirection is what turned an unsynchronized buffer into the heap corruption fixed in #1502. Even with the buffer now thread safe, a Virtual Studio session has no reason to route its output through classic mode's plumbing.

## Change

Move the redirect out of the constructor into `attachDebugOutput()` / `detachDebugOutput()`, and drive them from `UserInterface::setMode()` — the single point where the mode is decided at startup and where classic and Virtual Studio switch at runtime:

| Path | Result |
|---|---|
| startup, saved mode is classic, or `--classic` | attach |
| startup, deeplink or first run or saved mode is VS | never attached |
| `VirtualStudio::toClassicMode()` | attach |
| `QJackTrip::virtualStudioMode()`, deeplink switch to VS | detach |
| `~QJackTrip` | detach |

Details worth calling out:

- Both are guarded by a flag, so repeated calls are harmless — `setMode()` is reachable more than once for the same mode.
- `m_realCout` / `m_realCerr` are still captured once at construction, *before* any redirect happens, so detaching restores the genuine originals no matter how often the mode is toggled. Re-capturing at attach time would eventually save the `textbuf` itself.
- `detachDebugOutput()` flushes before swapping. The buffer accumulates until a newline now, so without this a partial line would sit there until classic mode was next entered.
- The destructor goes through `detachDebugOutput()`, keeping the existing restore-on-exit behaviour (and now flushing rather than discarding).

`NO_VS` builds never called `setMode()` at all — `start()` showed the classic window directly. It now goes through `setMode(MODE_CLASSIC)`, which gets them the redirect they had before and also leaves `m_uiMode` set correctly instead of stuck at `MODE_UNSET`.

## No output is lost

In Virtual Studio mode the debug window already relayed everything it captured to the real cout via `setRelayStream`, so the terminal saw it either way. Virtual Studio's `qtMessageHandler` writes `qDebug()` output to `std::cerr` and to the log file; the file is unaffected, and stderr now reaches the terminal directly instead of via the hidden widget.

The one visible difference: in classic mode, `std::cout` written between `QJackTrip` construction and the mode being resolved no longer lands in the Debug window. In practice that window is empty — `VirtualStudio`'s constructor uses `qDebug()`, and its message handler isn't installed until after that point.

## Verification

Builds clean in all three GUI configurations against Qt 6.4.2:

- default (classic + VS)
- `-Dnovs=true` (classic only, exercises the `NO_VS` start path)
- `-Dnoclassic=true` (VS only, exercises the `NO_CLASSIC` guards in `setMode()`)

`clang-format` 13 reports no diff on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E93unmTPC5QLaPZURiWK1E
