### PR TITLE
Add --logtofile and make the log message handler thread safe

### DIFF
--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -101,7 +101,8 @@ enum JTLongOptIDS {
     OPT_GUI,
     OPT_CLASSIC_GUI,
     OPT_DEEPLINK,
-    OPT_ICESERVERS
+    OPT_ICESERVERS,
+    OPT_LOGTOFILE
 };
 
 //*******************************************************************************
@@ -215,6 +216,7 @@ void Settings::parseInput(int argc, char** argv)
          OPT_DEEPLINK},  // Deeplink URL (should be in the form jacktrip://...)
         {"iceservers", required_argument, NULL,
          OPT_ICESERVERS},  // ICE servers for WebRTC NAT traversal
+        {"logtofile", no_argument, NULL, OPT_LOGTOFILE},  // Write log messages to a file
         {NULL, 0, NULL, 0}};
 
     // Parse Command Line Arguments
@@ -701,6 +703,9 @@ void Settings::parseInput(int argc, char** argv)
         case OPT_ICESERVERS:
             mIceServers = optarg;
             break;
+        case OPT_LOGTOFILE:
+            mLogToFile = true;
+            break;
         case ':': {
             printUsage();
             printf("*** Missing option argument *** see above for usage\n\n");
@@ -973,6 +978,7 @@ void Settings::printUsage()
     cout << " --gui                                    Force JackTrip to run with the GUI. If not using VirtualStudio mode, command line switches in the required arguments, optional arguments (except -l, -j, -L, --appendthreadid), audio patching, and authentication sections will be honoured, and default settings will be used where arguments aren't supplied. Options from other sections will be ignored (and the last used settings will be loaded), except for -V, and the --version and --help switches which will override this." << endl;
     cout << " --classic-gui                            Force JackTrip to run with the Classic Mode GUI." << endl;
     cout << " --deeplink                               Handle a deeplink URL in the format jacktrip://join/<studio_id> by connecting as a hub client" << endl;
+    cout << " --logtofile                              Also write log messages to log.txt in the application data directory. Disabled by default; log messages are always written to the console." << endl;
     cout << endl;
     cout << "HELP ARGUMENTS: " << endl;
     cout << " -v, --version                            Prints Version Number" << endl;

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -119,6 +119,7 @@ class Settings : public QObject
     QString getPassword() { return mPassword; }
     const QString& getDeeplink() const { return mDeeplink; }
     QString getIceServers() { return mIceServers; }
+    bool getLogToFile() const { return mLogToFile; }
 
    private:
     void disableEcho(bool disabled);
@@ -127,6 +128,7 @@ class Settings : public QObject
     bool mGuiEnabled          = false;
     bool mGuiIgnoresArguments = false;
     bool mGuiForceClassicMode = false;
+    bool mLogToFile           = false;
 
     JackTrip::jacktripModeT mJackTripMode =
         JackTrip::SERVER;  ///< JackTrip::jacktripModeT

--- a/src/vs/virtualstudio.cpp
+++ b/src/vs/virtualstudio.cpp
@@ -44,6 +44,7 @@
 #include <QFile>
 #include <QFontDatabase>
 #include <QMessageBox>
+#include <QMutex>
 #include <QNetworkCookie>
 #include <QQmlContext>
 #include <QQmlEngine>
@@ -93,16 +94,43 @@ const QString jackTripBuildInfo = QLatin1String(TO_STRING(JACKTRIP_BUILD_INFO));
 const QString jackTripBuildInfo = QLatin1String("");
 #endif
 
-static QTextStream* ts;
+// Only used when file logging is enabled with --logtofile. logMutex guards the
+// stream and file below, as well as the std::cerr write in qtMessageHandler().
+static QMutex logMutex;
+static QTextStream* ts = nullptr;
 static QFile outFile;
 
 void qtMessageHandler([[maybe_unused]] QtMsgType type,
                       [[maybe_unused]] const QMessageLogContext& context,
                       const QString& msg)
 {
+    // This is called from any thread that logs, including the audio worker.
+    // QTextStream is reentrant but not thread safe: without this lock,
+    // concurrent writes race on its internal buffer, and the flush performed by
+    // Qt::endl frees the buffer that another thread is still appending to.
+    // (Qt guards against a handler recursing into itself on the same thread, so
+    // a non-recursive mutex is enough here.)
+    QMutexLocker lock(&logMutex);
+
     std::cerr << msg.toStdString() << std::endl;
+
     // Writes to file in order to debug bundles and executables
-    *ts << msg << Qt::endl;
+    if (ts != nullptr) {
+        *ts << msg << Qt::endl;
+    }
+}
+
+static void stopLoggingToFile()
+{
+    // Stop new messages from reaching the handler before tearing anything down.
+    // A thread that has already read the handler pointer will block on the
+    // mutex, then find a null stream and skip the file write.
+    qInstallMessageHandler(nullptr);
+
+    QMutexLocker lock(&logMutex);
+    delete ts;
+    ts = nullptr;
+    outFile.close();
 }
 
 VirtualStudio::VirtualStudio(UserInterface& parent)
@@ -238,20 +266,26 @@ VirtualStudio::VirtualStudio(UserInterface& parent)
     connect(m_view.get(), &VsQuickView::windowClose, this, &VirtualStudio::exit,
             Qt::QueuedConnection);
 
-    // Log to file
-    QString logPath(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation));
-    QDir logDir;
-    if (!logDir.exists(logPath)) {
-        logDir.mkpath(logPath);
+    // Log to file, but only if it was asked for with --logtofile. Installing a
+    // message handler is global to the process, so we leave Qt's default one in
+    // place (which still writes to the console) unless it is actually wanted.
+    if (m_interface.getSettings().getLogToFile()) {
+        QString logPath(
+            QStandardPaths::writableLocation(QStandardPaths::AppDataLocation));
+        QDir logDir;
+        if (!logDir.exists(logPath)) {
+            logDir.mkpath(logPath);
+        }
+        QString fileLoc(logPath.append("/log.txt"));
+        qDebug() << "Log file location:" << fileLoc;
+        outFile.setFileName(fileLoc);
+        if (!outFile.open(QIODevice::WriteOnly | QIODevice::Append)) {
+            qDebug() << "Log file open failed:" << outFile.errorString();
+        } else {
+            ts = new QTextStream(&outFile);
+            qInstallMessageHandler(qtMessageHandler);
+        }
     }
-    QString fileLoc(logPath.append("/log.txt"));
-    qDebug() << "Log file location:" << fileLoc;
-    outFile.setFileName(fileLoc);
-    if (!outFile.open(QIODevice::WriteOnly | QIODevice::Append)) {
-        qDebug() << "Log file open failed:" << outFile.errorString();
-    }
-    ts = new QTextStream(&outFile);
-    qInstallMessageHandler(qtMessageHandler);
 
     // prepare handler for deep link requests
     m_deepLinkPtr.reset(new VsDeeplink());
@@ -1896,6 +1930,11 @@ void VirtualStudio::detectedFeedbackLoop()
 
 VirtualStudio::~VirtualStudio()
 {
+    // Do this first: the message handler is installed for the life of the
+    // process otherwise, and would keep writing through outFile after it has
+    // been destroyed during static teardown.
+    stopLoggingToFile();
+
     QDesktopServices::unsetUrlHandler("jacktrip");
 
     // close the window


### PR DESCRIPTION
Follows #1502 and #1503. Two changes to Virtual Studio's log handler: make it thread safe, and make writing the log file opt-in.

## Problem 1 — the handler corrupts the heap

`src/vs/virtualstudio.cpp` installed a process-global Qt message handler writing to a global `QTextStream` with no locking:

```cpp
static QTextStream* ts;
static QFile outFile;

void qtMessageHandler(QtMsgType type, const QMessageLogContext& context, const QString& msg)
{
    std::cerr << msg.toStdString() << std::endl;
    // Writes to file in order to debug bundles and executables
    *ts << msg << Qt::endl;
}
```

`qDebug()` is called from several threads. `VsAudio`'s constructor starts the `VsAudioWorker` thread (`vsAudio.cpp:146-148`) from `VirtualStudio`'s **member-init list**, i.e. before the handler is even installed, and that worker logs from `openAudioInterface()` / `closeAudioInterface()` (`vsAudio.cpp:848`, `857`, `812`) while the main thread is logging too.

`QTextStream` is documented reentrant, **not thread safe**. The two halves of that one statement fight each other:

| Thread | Doing | Effect on the shared write buffer |
|---|---|---|
| T5 | `Qt::endl` → `Qt::flush(QTextStream&)` | **frees** the buffer |
| T6 | `<< msg` → `QString::append` → `QArrayData::reallocateUnaligned` | **reallocs** the same block |

AddressSanitizer, on an 8-thread reproduction using the handler verbatim:

```
ERROR: AddressSanitizer: attempting double-free on 0x50d000006ab0 in thread T6:
    #1 QArrayData::reallocateUnaligned(...)          <- realloc
    #3 QString::append(QChar const*, long long)
    #5 QTextStream::operator<<(QString const&)
    #6 qtMessageHandler(...)

0x50d000006ab0 is located 0 bytes inside of 130-byte region
freed by thread T5 here:
    #2 Qt::flush(QTextStream&)                       <- the flush
    #3 operator<<(QTextStream&, QTextStream& (*)(QTextStream&)) qtextstream.h:193
    #4 qtMessageHandler(...)
```

It corrupts on the **first iteration**, in **10 runs out of 10**, splitting between `double-free` and `heap-use-after-free`. ThreadSanitizer reports the same race.

This was live in the sessions behind #1502. run3's own log shows the interleaving during the connection sequence that aborted:

```
Opened websocket: "wss://.../api/servers/..."   <- qDebug, main thread
Connecting audio to 34.156.253.41:4464          <- std::cout, main thread
Using JACK backend                              <- qDebug, VsAudioWorker THREAD
```

So this is a second, independent corruption source that was active alongside the `textbuf` overflow — and given its victim is a `QString` buffer, it is at least as good a match for run3 dying inside `QString::reallocData`. The `textbuf` fix alone may not have resolved the reported crash.

**Fix:** guard the handler with a `QMutex`.

Worth noting for review: a mutex here looks like it should risk self-deadlock, because a failed `outFile.open()` makes every write emit `QIODevice::write: device not open` from *inside* the handler. I tested it — Qt 6's `qt_message_print` has a per-thread recursion guard that bypasses a custom handler already running on that thread and writes straight to stderr. So a non-recursive `QMutex` is correct and no re-entrancy guard is needed. Taking the lock around the `std::cerr` write as well stops messages from different threads interleaving mid-line on the console.

## Problem 2 — the handler outlives the file

`qInstallMessageHandler` was never uninstalled and `ts` was never deleted, so the handler stayed reachable after `outFile` was destroyed during static teardown. I confirmed it **is** still invoked after `main()` returns, and at that point the warning it produces reads `QIODevice::write (QObject)` rather than `(QFile, "…")` — the vtable has already been downgraded by destruction, so it is calling through a destroyed object.

**Fix:** `stopLoggingToFile()`, called first thing in `~VirtualStudio()`. It uninstalls the handler *before* taking the lock, so any call already in flight completes, and any thread that had already read the handler pointer then finds a null stream and skips the file write.

## New `--logtofile` switch

Writing the log file is now opt-in and **disabled by default**. Installing a message handler affects the whole process, so Qt's default handler is left in place unless the file log was actually asked for.

```
 --logtofile    Also write log messages to log.txt in the application data
                directory. Disabled by default; log messages are always
                written to the console.
```

Added as `OPT_LOGTOFILE` alongside the other GUI switches in `Settings`, with a `getLogToFile()` accessor. Like `--gui` / `--classic-gui` / `--deeplink` it does not set `mGuiIgnoresArguments`, since it is honoured in GUI mode.

The handler is also no longer installed when the log file fails to open. Previously `ts = new QTextStream(&outFile)` and `qInstallMessageHandler` ran regardless, leaving the handler writing to a closed device on every message.

### Behaviour note

With the flag off there is no custom handler, so `qDebug()` goes to Qt's default handler, which writes to the C `stderr` stream rather than `std::cerr`. Console output is unchanged, but in **classic** mode `qDebug()` output no longer lands in the Debug window, which captures `std::cerr`. In practice that window is driven almost entirely by the `std::cout`/`std::cerr` call sites in `JackTrip.cpp`, `UdpDataProtocol.cpp` etc. rather than by `qDebug()`, which is mostly Virtual Studio code. Easy to revisit if you'd rather always install a handler and gate only the file write.

## Verification

The real handler and `stopLoggingToFile()` were extracted verbatim from the tree into an 8-thread harness (8 × 3000 iterations × 2 messages):

- **ASan: 0/10 runs fail** (was 10/10)
- **TSan: 0 data races**
- All 48,000 lines written — the lock costs no messages
- A message emitted after `stopLoggingToFile()` is correctly not written to the file, and does not crash

Builds clean in all three GUI configurations — default (classic + VS), `-Dnovs=true`, `-Dnoclassic=true` — against Qt 6.4.2. `--logtofile` is accepted and documented in `--help`; unknown flags still error, confirming it is really registered. `clang-format` 13 reports no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E93unmTPC5QLaPZURiWK1E
