### PR TITLE
Fix heap overflow when the JACK server changes its buffer size

### DIFF
--- a/src/AudioInterface.cpp
+++ b/src/AudioInterface.cpp
@@ -74,6 +74,9 @@ AudioInterface::AudioInterface(QVarLengthArray<int> InputChans,
     , mBitResolutionMode(AudioBitResolution)
     , mSampleRate(gDefaultSampleRate)
     , mBufferSizeInSamples(gDefaultBufferSizeInSamples)
+    , mAllocatedFrames(0)
+    , mBufferSizeMismatchReported(false)
+    , mSizeInBytesPerChannel(0)
     , mMonitorQueuePtr(NULL)
     , mAudioInputPacket(NULL)
     , mAudioOutputPacket(NULL)
@@ -115,8 +118,13 @@ AudioInterface::~AudioInterface()
 void AudioInterface::setup(bool /*verbose*/)
 {
     // Allocate buffer memory to read and write
-    mSizeInBytesPerChannel = getSizeInBytesPerChannel();
+    // Take a single snapshot of the period size and derive every allocation below
+    // from it. Backends such as JACK report the server's *current* period size,
+    // which can change while we are running, so remember what we allocated for and
+    // never size or index these buffers from a fresh query afterwards.
     int nframes            = getBufferSizeInSamples();
+    mAllocatedFrames       = nframes;
+    mSizeInBytesPerChannel = size_t(nframes) * getAudioBitResolution() / 8;
     int size_audio_input   = int(mSizeInBytesPerChannel * mInputChans.size());
     int size_audio_output  = int(mSizeInBytesPerChannel * mOutputChans.size());
 #ifdef WAIR               // WAIR
@@ -173,6 +181,14 @@ void AudioInterface::setup(bool /*verbose*/)
 //*******************************************************************************
 size_t AudioInterface::getSizeInBytesPerChannel() const
 {
+    if (mAllocatedFrames > 0) {
+        // Once setup() has run this must stay fixed: the network packet size and
+        // the ring buffer slot sizes are derived from it, and packets are copied
+        // in and out of buffers that were allocated for this many bytes. Deriving
+        // it from the current period size instead would overrun them if the audio
+        // server changed its period after we were set up.
+        return mSizeInBytesPerChannel;
+    }
     return (getBufferSizeInSamples() * getAudioBitResolution() / 8);
 }
 
@@ -186,14 +202,32 @@ void AudioInterface::callback(QVarLengthArray<sample_t*>& in_buffer,
 }
 
 //*******************************************************************************
+bool AudioInterface::framesFitAllocatedBuffers(unsigned int n_frames)
+{
+    if (n_frames <= mAllocatedFrames) {
+        return true;
+    }
+    // The backend handed us a larger period than setup() allocated for. The packet
+    // and process buffers are all indexed by n_frames, so carrying on would write
+    // several kilobytes past the end of them and corrupt the heap. Drop the period
+    // instead. The backend is expected to notice the change and stop the stream;
+    // this is the last line of defence if it does not.
+    if (!mBufferSizeMismatchReported) {
+        mBufferSizeMismatchReported = true;
+        std::cerr << "*** AudioInterface: the audio period grew to " << n_frames
+                  << " frames, but the audio buffers were allocated for "
+                  << mAllocatedFrames << ". Dropping audio to avoid corrupting memory.\n";
+    }
+    return false;
+}
+
+//*******************************************************************************
 void AudioInterface::audioInputCallback(QVarLengthArray<sample_t*>& in_buffer,
                                         unsigned int n_frames)
 {
     // in_buffer is "in" from local audio hardware
-    if (getBufferSizeInSamples() < n_frames) {  // allocated in constructor above
-        std::cerr << "*** AudioInterface::audioInputCallback n_frames = " << n_frames
-                  << " larger than expected = " << getBufferSizeInSamples() << "\n";
-        exit(1);
+    if (!framesFitAllocatedBuffers(n_frames)) {
+        return;
     }
 
 #ifndef WAIR
@@ -235,11 +269,13 @@ void AudioInterface::audioInputCallback(QVarLengthArray<sample_t*>& in_buffer,
 void AudioInterface::audioOutputCallback(QVarLengthArray<sample_t*>& out_buffer,
                                          unsigned int n_frames)
 {
-    // in_buffer is "in" from local audio hardware
-    if (getBufferSizeInSamples() < n_frames) {  // allocated in constructor above
-        std::cerr << "*** AudioInterface::audioOutputCallback n_frames = " << n_frames
-                  << " larger than expected = " << getBufferSizeInSamples() << "\n";
-        exit(1);
+    // out_buffer is "out" to local audio hardware
+    if (!framesFitAllocatedBuffers(n_frames)) {
+        // the hardware buffers are ours to fill, so hand back silence
+        for (int i = 0; i < mOutputChans.size(); i++) {
+            std::memset(out_buffer[i], 0, sizeof(sample_t) * n_frames);
+        }
+        return;
     }
 
     // 1) First, process incoming packets
@@ -406,6 +442,13 @@ void AudioInterface::audioOutputCallback(QVarLengthArray<sample_t*>& out_buffer,
 void AudioInterface::broadcastCallback(QVarLengthArray<sample_t*>& mon_buffer,
                                        unsigned int n_frames)
 {
+    if (!framesFitAllocatedBuffers(n_frames)) {
+        for (int i = 0; i < mOutputChans.size(); i++) {
+            std::memset(mon_buffer[i], 0, sizeof(sample_t) * n_frames);
+        }
+        return;
+    }
+
     /// \todo cast *mInBuffer[i] to the bit resolution
     // Output Process (from NETWORK to JACK)
     // ----------------------------------------------------------------

--- a/src/AudioInterface.h
+++ b/src/AudioInterface.h
@@ -291,6 +291,14 @@ class AudioInterface
     virtual QVarLengthArray<int> getOutputChannels() const { return mOutputChans; }
     virtual inputMixModeT getInputMixMode() const { return mInputMixMode; }
     virtual uint32_t getBufferSizeInSamples() const { return mBufferSizeInSamples; }
+    /** \brief Get the number of frames per period the audio buffers were allocated for
+     *
+     * This is a snapshot taken by setup(). It can differ from
+     * getBufferSizeInSamples() if the audio server changes its period size
+     * afterwards. Anything that indexes into the buffers allocated by setup()
+     * must be bounded by this value, not by the current period size.
+     */
+    uint32_t getAllocatedBufferSizeInSamples() const { return mAllocatedFrames; }
     virtual uint32_t getDeviceID() const { return mDeviceID; }
     virtual std::string getInputDevice() const { return mInputDeviceName; }
     virtual std::string getOutputDevice() const { return mOutputDeviceName; }
@@ -328,6 +336,14 @@ class AudioInterface
     /// \brief Compute the process to send packets
     void computeProcessToNetwork(QVarLengthArray<sample_t*>& in_buffer,
                                  unsigned int n_frames);
+    /** \brief Check that a period handed to us by the audio backend fits the
+     * buffers that setup() allocated
+     *
+     * Returns false, and logs once, if it does not. Callers must bail out in
+     * that case: every buffer allocated by setup() is indexed with n_frames, so
+     * processing a larger period would write past the end of them.
+     */
+    bool framesFitAllocatedBuffers(unsigned int n_frames);
 
     QVarLengthArray<int> mInputChans;
     QVarLengthArray<int> mOutputChans;
@@ -345,7 +361,9 @@ class AudioInterface
     uint32_t mDeviceID;      ///< RTAudio DeviceID
     std::string mInputDeviceName, mOutputDeviceName;  ///< RTAudio device names
     uint32_t mBufferSizeInSamples;                    ///< Buffer size in samples
-    size_t mSizeInBytesPerChannel;                    ///< Size in bytes per audio channel
+    uint32_t mAllocatedFrames;  ///< Frames per period the buffers below were sized for
+    bool mBufferSizeMismatchReported;  ///< True once a period size growth has been logged
+    size_t mSizeInBytesPerChannel;     ///< Size in bytes per audio channel
     QVector<QSharedPointer<ProcessPlugin> >
         mProcessPluginsFromNetwork;  ///< Vector of ProcessPlugin<EM>s</EM>
     QVector<QSharedPointer<ProcessPlugin> >

--- a/src/JackAudioInterface.cpp
+++ b/src/JackAudioInterface.cpp
@@ -162,6 +162,21 @@ void JackAudioInterface::setupClient()
     // Set function to call if Jack shuts down
     jack_on_info_shutdown(mClient, this->jackShutdown, this);
 
+    // Record the server's period size, the same way RtAudioInterface records what
+    // openStream() actually gave it, and ask to be told if it ever changes.
+    // Everything AudioInterface::setup() allocates is sized from this value, and
+    // the audio callbacks index into those buffers using the period the server
+    // hands them, so we cannot let the two drift apart. JACK requires the
+    // callback to be registered before the client is activated.
+    setBufferSize(jack_get_buffer_size(mClient));
+    if (jack_set_buffer_size_callback(
+            mClient, JackAudioInterface::wrapperBufferSizeCallback, this)
+        != 0) {
+        std::cerr << "WARNING: Could not set the Jack buffer size callback; "
+                     "buffer size changes will not be detected"
+                  << std::endl;
+    }
+
     // Create input and output channels
     createChannels();
 
@@ -228,18 +243,6 @@ void JackAudioInterface::createChannels()
 uint32_t JackAudioInterface::getSampleRate() const
 {
     return jack_get_sample_rate(mClient);
-}
-
-//*******************************************************************************
-uint32_t JackAudioInterface::getBufferSizeInSamples() const
-{
-    return jack_get_buffer_size(mClient);
-}
-
-//*******************************************************************************
-size_t JackAudioInterface::getSizeInBytesPerChannel() const
-{
-    return (getBufferSizeInSamples() * getAudioBitResolution() / 8);
 }
 
 //*******************************************************************************
@@ -367,6 +370,40 @@ int JackAudioInterface::processCallback(jack_nframes_t nframes)
 int JackAudioInterface::wrapperProcessCallback(jack_nframes_t nframes, void* arg)
 {
     return static_cast<JackAudioInterface*>(arg)->processCallback(nframes);
+}
+
+//*******************************************************************************
+int JackAudioInterface::bufferSizeCallback(jack_nframes_t nframes)
+{
+    const uint32_t configured = getBufferSizeInSamples();
+    if (configured == nframes) {
+        // the notification JACK sends when the callback is first registered
+        return 0;
+    }
+
+    // The audio buffers, the network packet size and the ring buffers were all
+    // sized for a period of `configured` frames, and the peer was told that size
+    // when the connection was negotiated, so there is no way to keep processing
+    // with a different one. Stop the way we would for a server shutdown; the
+    // session can then be started again at the new period size. The recorded
+    // buffer size is deliberately left alone so that nothing downstream shifts
+    // under us while we are tearing down.
+    std::string errorMsg = "The Jack server changed its buffer size from "
+                           + std::to_string(configured) + " to " + std::to_string(nframes)
+                           + " frames";
+    mErrorMsg            = errorMsg;
+    if (mErrorCallback) {
+        mErrorCallback(errorMsg);
+    }
+    std::cerr << errorMsg << "; stopping audio." << std::endl;
+    JackTrip::sAudioStopped = true;
+    return 0;
+}
+
+//*******************************************************************************
+int JackAudioInterface::wrapperBufferSizeCallback(jack_nframes_t nframes, void* arg)
+{
+    return static_cast<JackAudioInterface*>(arg)->bufferSizeCallback(nframes);
 }
 
 //*******************************************************************************

--- a/src/JackAudioInterface.h
+++ b/src/JackAudioInterface.h
@@ -112,7 +112,7 @@ class JackAudioInterface : public AudioInterface
     }
     virtual void setBufferSizeInSamples(uint32_t /*buf_size*/) override
     {
-        std::cout << "WARNING: Setting the Sample Rate in Jack mode has no effect."
+        std::cout << "WARNING: Setting the Buffer Size in Jack mode has no effect."
                   << std::endl;
     }
     virtual void enableBroadcastOutput() override { mBroadcast = true; }
@@ -123,15 +123,6 @@ class JackAudioInterface : public AudioInterface
     virtual QString getAssignedClientName() final { return mAssignedClientName; }
     /// \brief Get the Jack Server Sampling Rate, in samples/second
     virtual uint32_t getSampleRate() const override;
-    /// \brief Get the Jack Server Buffer Size, in samples
-    virtual uint32_t getBufferSizeInSamples() const override;
-    /// \brief Get the Jack Server Buffer Size, in bytes
-    virtual uint32_t getBufferSizeInBytes() const
-    {
-        return (getBufferSizeInSamples() * getAudioBitResolution() / 8);
-    }
-    /// \brief Get size of each audio per channel, in bytes
-    virtual size_t getSizeInBytesPerChannel() const override;
     //------------------------------------------------------------------
 
    private:
@@ -177,6 +168,17 @@ class JackAudioInterface : public AudioInterface
      */
     // reference : http://article.gmane.org/gmane.comp.audio.jackit/12873
     static int wrapperProcessCallback(jack_nframes_t nframes, void* arg);
+    /** \brief JACK buffer size callback
+     *
+     * Called from a JACK notification thread, never the process thread, whenever
+     * the server is about to change the period size. Everything downstream of
+     * AudioInterface::setup() -- the packet buffers, the network packet size and
+     * the ring buffers -- is sized from the period in use when the client was set
+     * up, so a change means we have to stop rather than carry on.
+     */
+    int bufferSizeCallback(jack_nframes_t nframes);
+    /// \brief Wrapper to cast the member bufferSizeCallback to a static function pointer
+    static int wrapperBufferSizeCallback(jack_nframes_t nframes, void* arg);
 
     int mNumFrames;  ///< Buffer block size, in samples
 

--- a/src/JackTrip.cpp
+++ b/src/JackTrip.cpp
@@ -1627,9 +1627,6 @@ void JackTrip::putHeaderInIncomingPacket(int8_t* full_packet, int8_t* audio_pack
 
     int8_t* audio_part;
     audio_part = full_packet + mPacketHeader->getHeaderSizeInBytes();
-    // std::memcpy(audio_part, audio_packet, mAudioInterface->getBufferSizeInBytes());
-    // std::memcpy(audio_part, audio_packet, mAudioInterface->getSizeInBytesPerChannel() *
-    // mNumChans);
     std::memcpy(audio_part, audio_packet, getTotalAudioOutputPacketSizeInBytes());
 }
 
@@ -1642,9 +1639,6 @@ void JackTrip::putHeaderInOutgoingPacket(int8_t* full_packet, int8_t* audio_pack
 
     int8_t* audio_part;
     audio_part = full_packet + mPacketHeader->getHeaderSizeInBytes();
-    // std::memcpy(audio_part, audio_packet, mAudioInterface->getBufferSizeInBytes());
-    // std::memcpy(audio_part, audio_packet, mAudioInterface->getSizeInBytesPerChannel() *
-    // mNumChans);
     std::memcpy(audio_part, audio_packet, getTotalAudioInputPacketSizeInBytes());
 }
 


### PR DESCRIPTION
## The bug

`AudioInterface::setup()` sizes the packet and process buffers from the audio period in use at the time, but `JackAudioInterface::getBufferSizeInSamples()` called `jack_get_buffer_size()` live on every invocation. When the server changed its period afterwards — which PipeWire's JACK emulation does when it renegotiates the graph quantum — the audio callbacks kept indexing those buffers with the new, larger `n_frames` while the allocations stayed at the old size.

The guard meant to catch this was inert:

```cpp
if (getBufferSizeInSamples() < n_frames) {  // allocated in constructor above
    ...
    exit(1);
}
```

For JACK it re-queried the same live server value, so the two were equal by construction and it never fired.

A 128 → 512 frame change writes **4096 bytes into the 1024-byte `mAudioInputPacket`**.

## Evidence

From user-supplied core dumps, all at the same point in the connection flow:

| run | symptom |
|---|---|
| run5 | SIGSEGV in `QQuickItem::isVisible()` |

In run5 the 4096-byte overwrite began exactly at `mAudioInputPacket` (a `0x400` chunk) and swallowed a live `QQuickItem`, whose `d_ptr` became float sample data. The next mouse-move walked the QML item tree into it. The overwritten bytes decode as 2 ch × 512 frames — the planar monitor copy in the upper half, the interleaved 16-bit network packet in the lower half, with frames 128–511 clipped to ±32767 because `computeProcessToNetwork` was also reading past the end of the 512-byte `mInProcessBuffer`.

## The fix

Bind the buffers to what was allocated, not to what the server currently reports.

- `setup()` snapshots the period into `mAllocatedFrames` and derives `mSizeInBytesPerChannel` and every allocation from it.
- `getSizeInBytesPerChannel()` returns that snapshot once `setup()` has run. The network packet size and ring-buffer slot sizes come from it, so it must not move — deriving it live also overran `mBuffer` in `UdpDataProtocol::sendPacketRedundancy()` (found by ASAN after the first round of fixes).
- `framesFitAllocatedBuffers()` replaces the two broken checks and adds one to `broadcastCallback()`. It logs once and drops the period rather than calling `exit(1)` from the real-time thread; output callbacks write silence.
- `JackAudioInterface` records the period with `setBufferSize()` in `setupClient()` — the way `RtAudioInterface` records what `openStream()` actually gave it — and no longer overrides `getBufferSizeInSamples()`. Its `getSizeInBytesPerChannel()` override was identical to the base and is gone.
- `JackAudioInterface` registers `jack_set_buffer_size_callback()` before activation. A change reports through the existing error path and sets `JackTrip::sAudioStopped` so the session tears down cleanly. The recorded size is deliberately left alone so nothing shifts downstream during teardown.

## Verification

Against an isolated `jackd -n jttest -d dummy -p 128` server, forcing the period to 512 with `jack_bufsize`, using an AddressSanitizer build:

**Before**
```
ERROR: AddressSanitizer: heap-buffer-overflow
READ of size 4 ... 0 bytes after 512-byte region
  #0 AudioInterface::computeProcessToNetwork  AudioInterface.cpp:534
  #1 AudioInterface::audioInputCallback       AudioInterface.cpp:230
  allocated by AudioInterface::setup(bool)    AudioInterface.cpp:162
```
The non-ASAN build simply kept running — no error, no exit.

**After** — zero ASAN errors:
```
The Jack server changed its buffer size from 128 to 512 frames; stopping audio.
*** AudioInterface: the audio period grew to 512 frames, but the audio buffers
    were allocated for 128. Dropping audio to avoid corrupting memory.
sending exit packet / Peer Stopped / JackTrip Processes STOPPED!
Error: The Jack server changed its buffer size from 128 to 512 frames
```
Both layers fire: the notification-thread handler stops the session, and the RT-path guard catches the one callback that raced in before teardown finished. A 12-second connected run with no period change is also clean, so the happy path is unaffected.

## Drive-by cleanups

- Removed the unused `JackAudioInterface::getBufferSizeInBytes()`. Its only references were two commented-out lines in `JackTrip.cpp` (removed with it). It duplicated `getSizeInBytesPerChannel()` and was misnamed — it returned bytes *per channel* at the network bit resolution, not the size of a JACK buffer.
- Fixed the copy-pasted "Sample Rate" wording in the `setBufferSizeInSamples()` warning.

## Notes for review

- `RtAudioInterface` has the same shape of risk but not the bug: `setBufferSize()` is called before `AudioInterface::setup()`, so its snapshot is already correct. The new guard covers it either way.
- I could not run `clang-format` locally (not installed). Column limits were checked by hand and the surrounding alignment style matched, but CI's clang-format-13 is the authority.
- `meson test` reports "No tests defined" in this configuration — the two test files build only under the vst3 subproject — so verification is the manual ASAN reproduction above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E93unmTPC5QLaPZURiWK1E
